### PR TITLE
Fix docker run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Start the interactive console and submit a query:
 VAST exists as Docker container:
 
     docker pull mavam/vast
-    docker run --rm -t -i vast /bin/bash
+    docker run --rm -t -i mavam/vast /bin/bash
     > vast -h
 
 For instructions on how to build VAST manually, read on.


### PR DESCRIPTION
Cool for the docker config, thanks!

```
$ sudo docker pull mavam/vast
Pulling repository mavam/vast
a6fdc7f0bbe0: Pulling dependent layers
a6fdc7f0bbe0: Download complete
b3553b91f79f: Download complete
ca63a3899a99: Download complete
ff01d67c9471: Download complete
7428bd008763: Download complete
c7c7108e0ad8: Download complete
826544226fdc: Download complete
0d3e2cbe500d: Download complete
ba794415edc2: Download complete
0b7ec444f0f7: Download complete
dbaa51ad03b6: Download complete
dda50c66e1ad: Download complete
7901c927927d: Download complete
210ddc122b2f: Download complete
b754fddf4523: Download complete
2acd6c61d108: Download complete
379fb05c49a4: Download complete
1e98ca63b498: Download complete
4b3c9cd8abfe: Download complete
$ sudo docker run --rm -t -i vast /bin/bash
Unable to find image 'vast' locally
Pulling repository vast
2014/09/11 04:14:21 HTTP code: 404
$ sudo docker run --rm -t -i mavam/vast /bin/bash
root@6e679baf7d87:/#
```
