### PR TITLE
Remove make_data, address_view and subnet_view

### DIFF
--- a/libvast/src/address.cpp
+++ b/libvast/src/address.cpp
@@ -43,10 +43,6 @@ address::address() {
   bytes_.fill(0);
 }
 
-address::address(const array_type& bytes) : bytes_(bytes) {
-  // nop
-}
-
 address::address(const void* bytes, family fam, byte_order order) {
   auto b = reinterpret_cast<const uint32_t*>(bytes);
   if (fam == ipv4) {

--- a/libvast/src/default_table_slice_builder.cpp
+++ b/libvast/src/default_table_slice_builder.cpp
@@ -41,7 +41,7 @@ bool default_table_slice_builder::append(data x) {
 }
 
 bool default_table_slice_builder::add(data_view x) {
-  return append(make_data(x));
+  return append(materialize(x));
 }
 
 table_slice_ptr default_table_slice_builder::finish() {

--- a/libvast/test/view.cpp
+++ b/libvast/test/view.cpp
@@ -70,7 +70,6 @@ TEST(vector view) {
   auto j = v->begin() + 1;
   CHECK_EQUAL(i - j, xs.size() - 1);
   MESSAGE("check conversion back to data");
-  CHECK(make_data(v) == xs);
   CHECK_EQUAL(xs, materialize(v));
 }
 
@@ -85,7 +84,6 @@ TEST(set view) {
   CHECK_EQUAL(std::next(v->begin(), 3), v->end());
   CHECK_EQUAL(*std::next(v->begin(), 1), make_data_view(42));
   MESSAGE("check conversion back to data");
-  CHECK(make_data(v) == xs);
   CHECK_EQUAL(xs, materialize(v));
 }
 
@@ -107,7 +105,6 @@ TEST(map view) {
   CHECK_EQUAL(key, make_data_view(42));
   CHECK_EQUAL(value, make_data_view(true));
   MESSAGE("check conversion back to data");
-  CHECK(make_data(v) == xs);
   CHECK_EQUAL(xs, materialize(v));
 }
 

--- a/libvast/vast/address.hpp
+++ b/libvast/vast/address.hpp
@@ -55,8 +55,6 @@ public:
   /// Default-constructs an (invalid) address.
   address();
 
-  explicit address(const array_type& bytes);
-
   /// Constructs an address from raw bytes.
   /// @param bytes A pointer to the raw byte representation. This must point
   ///              to 4 bytes if *fam* is `ipv4`, and to 16 bytes if *fam* is

--- a/libvast/vast/view.hpp
+++ b/libvast/vast/view.hpp
@@ -58,6 +58,8 @@ VAST_VIEW_TRAIT(real);
 VAST_VIEW_TRAIT(timespan);
 VAST_VIEW_TRAIT(timestamp);
 VAST_VIEW_TRAIT(port);
+VAST_VIEW_TRAIT(address);
+VAST_VIEW_TRAIT(subnet);
 
 #undef VAST_VIEW_TRAIT
 
@@ -97,59 +99,6 @@ private:
 template <>
 struct view<pattern> {
   using type = pattern_view;
-};
-
-/// @relates view
-class address_view : detail::totally_ordered<address_view> {
-public:
-  address_view(const address& x);
-
-  // See vast::address for documentation.
-  bool is_v4() const;
-  bool is_v6() const;
-  bool is_loopback() const;
-  bool is_broadcast() const;
-  bool is_multicast() const;
-  bool mask(unsigned top_bits_to_keep) const;
-  bool compare(address_view other, size_t k) const;
-  const std::array<uint8_t, 16>& data() const;
-
-  friend bool operator==(address_view x, address_view y) noexcept;
-  friend bool operator<(address_view x, address_view y) noexcept;
-
-private:
-  const std::array<uint8_t, 16>* data_;
-};
-
-//// @relates view
-template <>
-struct view<address> {
-  using type = address_view;
-};
-
-/// @relates view
-class subnet_view : detail::totally_ordered<subnet_view> {
-public:
-  subnet_view(const subnet& x);
-
-  // See vast::subnet for documentation.
-  bool contains(address_view x) const;
-  bool contains(subnet_view x) const;
-  address_view network() const;
-  uint8_t length() const;
-
-  friend bool operator==(subnet_view x, subnet_view y) noexcept;
-  friend bool operator<(subnet_view x, subnet_view y) noexcept;
-
-private:
-  address_view network_;
-  uint8_t length_;
-};
-
-//// @relates view
-template <>
-struct view<subnet> {
-  using type = subnet_view;
 };
 
 
@@ -376,10 +325,6 @@ data_view make_data_view(const T& x) {
   return make_view(x);
 }
 
-/// Creates a data instance from a data_view.
-/// @relates view data
-data make_data(data_view x);
-
 // -- materialization ----------------------------------------------------------
 
 constexpr auto materialize(caf::none_t x) {
@@ -389,10 +334,6 @@ constexpr auto materialize(caf::none_t x) {
 std::string materialize(std::string_view x);
 
 pattern materialize(pattern_view x);
-
-address materialize(address_view x);
-
-subnet materialize(subnet_view x);
 
 vector materialize(vector_view_ptr xs);
 


### PR DESCRIPTION
Table slices generated by `default_table_slice_builder` contain corrupt
data when inserting IP addresses, because `add` calls `make_data`. Since
we already have `materialize` as a more general replacement, the natural
choice is to drop `make_data` and always use `materialize` instead.

On a similar note, `address_view` and `subnet_view` add unnecessary
complexity. They have the size of a `std::string_view`, so there is no
need to not treat them as values in the same way we do for `integer`,
`real`, etc. Storing them as values also does not increase the size of
`data_view`, because vectors and maps already require more storage.