### PR TITLE
Use llvm@12 in macOS CI

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -380,6 +380,7 @@ jobs:
             gnu-sed \
             libpcap \
             libunwind-headers \
+            llvm@12 \
             ninja \
             openssl \
             pandoc \
@@ -400,7 +401,7 @@ jobs:
       - name: Setup Homebrew Clang
         if: matrix.build.compiler == 'Clang'
         run: |
-          llvm_root="$(brew --prefix llvm)"
+          llvm_root="$(brew --prefix llvm@12)"
           echo "${llvm_root}/bin" >> $GITHUB_PATH
           echo "LDFLAGS=-Wl,-rpath,${llvm_root}" >> $GITHUB_ENV
           echo "CPPFLAGS=-isystem ${llvm_root}/include" >> $GITHUB_ENV


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

We need to do this until we can upgrade to Arrow 6.0, because Arrow 5.0 still uses `std::result_of` in its header files, which was first deprecated with C++17 and subsequently removed with C++20. The libc++ shipping with clang 13 is the first version that does not contain it, causing a compile failure in our code.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Watch CI.