### PR TITLE
Remove incorrect convert overload for address

### DIFF
--- a/libvast/src/address.cpp
+++ b/libvast/src/address.cpp
@@ -152,9 +152,4 @@ bool operator<(const address& x, const address& y) {
   return x.bytes_ < y.bytes_;
 }
 
-bool convert(const address& a, data& d) {
-  d = to_string(a);
-  return true;
-}
-
 } // namespace vast

--- a/libvast/vast/address.hpp
+++ b/libvast/vast/address.hpp
@@ -129,8 +129,6 @@ public:
     return f(a.bytes_);
   }
 
-  friend bool convert(const address& a, vast::data& d);
-
 private:
   std::array<uint8_t, 16> bytes_;
 };

--- a/libvast/vast/concept/printable/vast/json.hpp
+++ b/libvast/vast/concept/printable/vast/json.hpp
@@ -56,6 +56,11 @@ struct json_printer
       return printers::str.print(out_, std::to_string(x.value));
     }
 
+    bool operator()(const address& x) {
+      static auto p = '"' << make_printer<address>{} << '"';
+      return p.print(out_, x);
+    }
+
     bool operator()(const data& x) {
       return caf::visit(*this, x);
     }


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

This convert overload did no harm (yet), but it definitely shouldn't've existed. I've instead changed the JSON printer to make use of the correct printer instead.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.