### PR TITLE
Fix third-party license for digestpp

### DIFF
--- a/LICENSE.3rdparty
+++ b/LICENSE.3rdparty
@@ -35,7 +35,7 @@ License: BSD-2-clause
 
 Files: libvast/src/concept/hashable/sha1.cpp
 Copyright: (none)
-License: public-domain
+License: Unlicense
 Comment: https://github.com/kerukuro/digestpp
 
 Files: libvast/vast/detail/zip_iterator.hpp

--- a/libvast/src/concept/hashable/sha1.cpp
+++ b/libvast/src/concept/hashable/sha1.cpp
@@ -14,7 +14,7 @@
 // - Commit:     92dc9b33a63da76b088ac2471fbb350177d04c2f
 // - Path:       algorithm/detail/sha1_provider.hpp
 // - Author:     kerukuro
-// - License:    Public Domain
+// - License:    The Unlicense
 
 #include "vast/concept/hashable/sha1.hpp"
 


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

While public domain is semantically correct, the actual license of digestpp is [The Unlicense](https://spdx.org/licenses/Unlicense.html).

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Double-check with https://github.com/kerukuro/digestpp/blob/master/LICENSE and that this is correctly entered into our SBOM.