### PR TITLE
Adopt latest C++20 function wording

### DIFF
--- a/libvast/src/value_index_factory.cpp
+++ b/libvast/src/value_index_factory.cpp
@@ -74,13 +74,13 @@ value_index_ptr make(legacy_type x, caf::settings opts) {
                     __func__);
           return std::make_unique<hash_index<8>>(std::move(x));
         }
-        if (!detail::ispow2(*cardinality))
+        if (!detail::has_single_bit(*cardinality))
           VAST_WARN("{} cardinality not a power of 2", __func__);
         // For 2^n unique values, we expect collisions after sqrt(2^n).
         // Thus, we use 2n bits as digest size.
-        size_t digest_bits = detail::ispow2(*cardinality)
-                               ? (detail::log2p1(*cardinality) - 1) * 2
-                               : detail::log2p1(*cardinality) * 2;
+        size_t digest_bits = detail::has_single_bit(*cardinality)
+                               ? (detail::bit_width(*cardinality) - 1) * 2
+                               : detail::bit_width(*cardinality) * 2;
         auto digest_bytes = digest_bits / 8;
         if (digest_bits % 8 > 0)
           ++digest_bytes;

--- a/libvast/vast/detail/bit.hpp
+++ b/libvast/vast/detail/bit.hpp
@@ -47,12 +47,12 @@ constexpr int countl_zero(T x) noexcept {
 }
 
 template <class T>
-constexpr bool ispow2(T x) noexcept {
+constexpr bool has_single_bit(T x) noexcept {
   return x && ((x & (x - 1)) == 0);
 }
 
 template <class T>
-constexpr T ceil2(T x) noexcept {
+constexpr T bit_ceil(T x) noexcept {
   constexpr auto d = std::numeric_limits<T>::digits;
   if (x == 0 || x == 1)
     return 1;
@@ -66,7 +66,7 @@ constexpr T ceil2(T x) noexcept {
 }
 
 template <class T>
-constexpr T floor2(T x) noexcept {
+constexpr T bit_floor(T x) noexcept {
   constexpr auto digits = std::numeric_limits<T>::digits;
   if (x == 0)
     return 0;
@@ -74,7 +74,7 @@ constexpr T floor2(T x) noexcept {
 }
 
 template <class T>
-constexpr T log2p1(T x) noexcept {
+constexpr T bit_width(T x) noexcept {
   return std::numeric_limits<T>::digits - countl_zero(x);
 }
 


### PR DESCRIPTION
Small PR that aligns our hand-rolled version of `<bit>` with the latest wording in the standard.

### :dart: Review Instructions

Look at the diff in one shot and consult https://en.cppreference.com/w/cpp/header/bit.
