### PR TITLE
Build against latest arrow version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -142,7 +142,7 @@ RUN apt-get update && \
     apt-get -y --no-install-recommends install \
       ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
     apt-get update && \
-    apt-get -y --no-install-recommends install libarrow500 && \
+    apt-get -y --no-install-recommends install libarrow600 && \
     rm -rf /var/lib/apt/lists/*
 
 USER vast:vast


### PR DESCRIPTION
<!-- Describe the change you've made in this section. -->

The recent release of Arrow 6 caused a discrepancy between the versions of arrow used in the `vast-dev` image and the images used by the CI for our internal plugins.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
