### PR TITLE
Add a 'collect()' utility function

### DIFF
--- a/libvast/include/vast/detail/collect.hpp
+++ b/libvast/include/vast/detail/collect.hpp
@@ -24,8 +24,8 @@ Container collect(vast::detail::generator<T> g, size_t size_hint = 0) {
   Container result = {};
   if (size_hint)
     result.reserve(size_hint);
-  for (auto& x : g)
-    result.emplace(result.end(), x);
+  for (auto&& x : g)
+    result.emplace(result.end(), std::move(x));
   return result;
 }
 

--- a/libvast/src/expression_visitors.cpp
+++ b/libvast/src/expression_visitors.cpp
@@ -449,7 +449,7 @@ type_resolver::operator()(const field_extractor& ex, const data& d) {
   std::vector<expression> connective;
   // First, interpret the field as a suffix of a record field name.
   auto suffixes = layout_.resolve_key_suffix(ex.field, layout_name_);
-  for (auto& offset : suffixes) {
+  for (auto&& offset : suffixes) {
     const auto f = layout_.field(offset);
     if (!compatible(f.type, op_, d))
       continue;


### PR DESCRIPTION
Mostly reduces the amount of typing required, but occasionally crucial for print statements where depending on the context it can be non-obvious to figure out the correct element type of the vector.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
