### PR TITLE
Sort and dedup CMake dependency summary

### DIFF
--- a/cmake/VASTUtilities.cmake
+++ b/cmake/VASTUtilities.cmake
@@ -88,6 +88,8 @@ macro (dependency_summary name what category)
     set(location "Not found")
   endif ()
   list(APPEND VAST_DEPENDENCY_SUMMARY " * ${name}: ${location}")
+  list(SORT VAST_DEPENDENCY_SUMMARY)
+  list(REMOVE_DUPLICATES VAST_DEPENDENCY_SUMMARY)
   set_property(GLOBAL PROPERTY "VAST_DEPENDENCY_SUMMARY_${category}_PROPERTY"
                                "${VAST_DEPENDENCY_SUMMARY}")
 endmacro ()


### PR DESCRIPTION
The list contained FlatBuffers twice if plugins used the `VASTCompileFlatbuffers` function, so this deduplicates the list of dependencies to avoid that.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t