### PR TITLE
Yield all IDs for pattern searches from string index

### DIFF
--- a/libvast/src/index/string_index.cpp
+++ b/libvast/src/index/string_index.cpp
@@ -83,6 +83,18 @@ string_index::lookup_impl(relational_operator op, data_view x) const {
     [&](auto x) -> caf::expected<ids> {
       return caf::make_error(ec::type_clash, materialize(x));
     },
+    [&](view<pattern>) -> caf::expected<ids> {
+      switch (op) {
+        default:
+          return caf::make_error(ec::unsupported_operator, op);
+        case relational_operator::equal:
+        case relational_operator::not_equal:
+        case relational_operator::match:
+        case relational_operator::not_match: {
+           return ids{offset(), true};
+        }
+      }
+    },
     [&](view<std::string> str) -> caf::expected<ids> {
       auto str_size = str.size();
       if (str_size > max_length_)


### PR DESCRIPTION
This removes a noisy warning for queries like `http.hostname ~ /.*\.com$/`, which actually do work like expected despite being _really_ slow because we instantiate the regular expression for every individual element instead of doing that only once.

### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [vast.io](https://vast.io), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Tests are yet to be implemented; just wanted to capture a small experiment somewhere.

For reviewing I recommend playing with this locally for now; I'm not sure whether we should merge this before optimizing it to at least not instantiate the regular expression as often.