### PR TITLE
Implement a `cast` operator

### DIFF
--- a/libvast/builtins/operators/cast.cpp
+++ b/libvast/builtins/operators/cast.cpp
@@ -1,0 +1,105 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2023 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "vast/pipeline.hpp"
+
+#include <vast/cast.hpp>
+#include <vast/concept/parseable/string/char_class.hpp>
+#include <vast/concept/parseable/vast/pipeline.hpp>
+#include <vast/error.hpp>
+#include <vast/logger.hpp>
+#include <vast/plugin.hpp>
+
+#include <arrow/type.h>
+
+namespace vast::plugins::cast {
+
+namespace {
+
+class cast_operator final : public schematic_operator<cast_operator, type> {
+public:
+  explicit cast_operator(std::string schema_name)
+    : schema_name_{std::move(schema_name)} {
+  }
+
+  auto initialize(const type& input_schema, operator_control_plane& ctrl) const
+    -> caf::expected<state_type> override {
+    auto output_schema = std::find_if(
+      ctrl.schemas().begin(), ctrl.schemas().end(), [this](const auto& schema) {
+        return schema.name() == schema_name_;
+      });
+    if (output_schema == ctrl.schemas().end()) {
+      return caf::make_error(
+        ec::invalid_argument,
+        fmt::format("cast operator failed to find schema '{}'", schema_name_));
+    }
+    auto castable = can_cast(input_schema, *output_schema);
+    if (not castable) {
+      return caf::make_error(
+        ec::invalid_argument,
+        fmt::format("cast operator cannot cast from '{}' to '{}': {}",
+                    input_schema, schema_name_, castable.error()));
+    }
+    return *output_schema;
+  }
+
+  auto process(table_slice slice, state_type& output_schema) const
+    -> table_slice override {
+    return vast::cast(slice, output_schema);
+  }
+
+  auto to_string() const -> std::string override {
+    return fmt::format("cast {}", schema_name_);
+  }
+
+private:
+  std::string schema_name_ = {};
+};
+
+class plugin final : public virtual operator_plugin {
+public:
+  // plugin API
+  auto initialize([[maybe_unused]] const record& plugin_config,
+                  [[maybe_unused]] const record& global_config)
+    -> caf::error override {
+    return {};
+  }
+
+  auto name() const -> std::string override {
+    return "cast";
+  };
+
+  auto make_operator(std::string_view pipeline) const
+    -> std::pair<std::string_view, caf::expected<operator_ptr>> override {
+    using parsers::optional_ws_or_comment, parsers::end_of_pipeline_operator,
+      parsers::identifier;
+    const auto* f = pipeline.begin();
+    const auto* const l = pipeline.end();
+    const auto p = optional_ws_or_comment >> identifier
+                   >> optional_ws_or_comment >> end_of_pipeline_operator;
+    auto schema_name = std::string{};
+    if (!p(f, l, schema_name)) {
+      return {
+        std::string_view{f, l},
+        caf::make_error(ec::syntax_error, fmt::format("failed to parse "
+                                                      "cast operator: '{}'",
+                                                      pipeline)),
+      };
+    }
+    return {
+      std::string_view{f, l},
+      std::make_unique<cast_operator>(std::move(schema_name)),
+    };
+  }
+};
+
+} // namespace
+
+} // namespace vast::plugins::cast
+
+VAST_REGISTER_PLUGIN(vast::plugins::cast::plugin)

--- a/vast/integration/vast_integration_suite.yaml
+++ b/vast/integration/vast_integration_suite.yaml
@@ -502,8 +502,24 @@ tests:
       - command: version
         transformation: sleep 4
       - command: count '#type == /zeek.*/'
+  Cast:
+    tags: [server, client, import-export, pipeline]
+    fixture: ServerTester
+    steps:
+      - command: import -b zeek
+        input: data/zeek/conn.log.gz
+      - command: |
+          export json 'where #type == "zeek.conn"
+            | head 1
+            | extend schema_before=#type'
+      - command: |
+          export json 'where #type == "zeek.conn"
+            | head 1
+            | extend schema_before=#type
+            | cast zeek.sip
+            | extend schema_after=#type'
   Export pipeline operator parsing everything but summarize:
-    tags: [server, client, import-export, transforms]
+    tags: [server, client, import-export, pipeline]
     fixture: ServerTester
     steps:
       - command: import -b suricata
@@ -552,7 +568,7 @@ tests:
                                | rename source_ip=src_ip
                                | where #type ==\"suricata.alert\" || #type == \"suricata.fileinfo\"'"
   Import pipeline operator parsing everything but summarize:
-    tags: [server, client, import-export, transforms]
+    tags: [server, client, import-export, pipeline]
     fixture: ServerTester
     steps:
       - command: |
@@ -572,7 +588,7 @@ tests:
         input: data/suricata/eve.json
       - command: export json
   Export pipeline operator parsing only summarize:
-    tags: [server, client, import-export, transforms]
+    tags: [server, client, import-export, pipeline]
     fixture: ServerTester
     steps:
       - command: import -b -t sysmon.NetworkConnection json
@@ -581,14 +597,14 @@ tests:
       - command: export json 'summarize any(Initiated) by SourceIp, SourcePort, DestinationPoint, UtcTime resolution 1 minute'
       - command: export json 'summarize usercount=count(User), initiated=all(Initiated) by ProcessId'
   Import pipeline operator parsing only summarize:
-    tags: [server, client, import-export, transforms]
+    tags: [server, client, import-export, pipeline]
     fixture: ServerTester
     steps:
       - command: "import -b -t sysmon.NetworkConnection json 'summarize distinct(SourcePort) by SourceIp'"
         input: data/json/sysmon.json
       - command: export json
   Export pipeline operator parsing after expression:
-    tags: [server, client, import-export, transforms]
+    tags: [server, client, import-export, pipeline]
     fixture: ServerTester
     steps:
       - command: import -b suricata
@@ -654,7 +670,7 @@ tests:
                                | rename source_ip=src_ip
                                | where #type ==\"suricata.alert\" || #type == \"suricata.fileinfo\"'"
   Import pipeline operator parsing after expression:
-    tags: [server, client, import-export, transforms]
+    tags: [server, client, import-export, pipeline]
     fixture: ServerTester
     steps:
       - command: "import -b suricata 'src_ip==147.32.84.165 && (src_port==1181 || src_port == 138)
@@ -669,7 +685,7 @@ tests:
         input: data/suricata/eve.json
       - command: export json
   Export pipeline operator summarize after expression:
-    tags: [server, client, import-export, transforms]
+    tags: [server, client, import-export, pipeline]
     fixture: ServerTester
     steps:
       - command: import -b -t sysmon.NetworkConnection json
@@ -677,7 +693,7 @@ tests:
       - command: "export json 'where SourcePort==56162 || SourcePort == 37156
                                | summarize distinct(SourceIp) by SourcePort'"
   Import pipeline operator summarize after expression:
-    tags: [server, client, import-export, transforms]
+    tags: [server, client, import-export, pipeline]
     fixture: ServerTester
     steps:
       - command: "import -b -t sysmon.NetworkConnection json 'SourcePort==56162 || SourcePort == 37156
@@ -685,7 +701,7 @@ tests:
         input: data/json/sysmon.json
       - command: export json
   Spawn source with pipeline operators:
-    tags: [import-export, spawn-source, transforms, zeek]
+    tags: [import-export, spawn-source, pipeline, zeek]
     fixture: ServerTester
     steps:
       - command: "spawn source -r @./data/suricata/eve.json suricata
@@ -699,7 +715,7 @@ tests:
                                | where #type ==\"suricata.alert\" || #type == \"suricata.fileinfo\"'"
       - command: export json
   Spawn source with expression and pipeline operators:
-    tags: [import-export, spawn-source, transforms, zeek]
+    tags: [import-export, spawn-source, pipeline, zeek]
     fixture: ServerTester
     steps:
       - command: "spawn source -r @./data/suricata/eve.json suricata
@@ -831,7 +847,7 @@ tests:
 
   Comments:
     fixture: ServerTester
-    tags: [pipelines, comments]
+    tags: [pipeline, comments]
     steps:
       - command: import --blocking suricata
         input: data/suricata/eve.json
@@ -842,7 +858,7 @@ tests:
         expected_result: error
 
   Local Pipeline Execution:
-    tags: [pipelines]
+    tags: [pipeline]
     steps:
       # - is an alternative form of stdin and stdout
       - command: exec 'from stdin read json | write json to stdout'

--- a/web/docs/understand/operators/transformations/cast.md
+++ b/web/docs/understand/operators/transformations/cast.md
@@ -1,0 +1,27 @@
+# cast
+
+Casts the input to the given schema.
+
+:::warning Expert Operator
+The `cast` operator is a lower-level building block of other operators and is a
+more powerful, but also less flexible way of reshaping events compared to the
+[`put`](put.md) operator.
+:::
+
+## Synopsis
+
+```
+cast <schema>
+```
+
+## Description
+
+The `cast` operator casts input events to a known schema.
+
+## Examples
+
+Cast the input to `zeek.conn` as best possible:
+
+```
+cast zeek.conn
+```


### PR DESCRIPTION
The semantics of this are rather straightforward: The `cast <schema>` operator takes the name of a known schema, and parses input events to it iff possible.

I developed this primarily because I needed it to be able to test casting to understand how we want to improve upon the adaptive builder, and figured that it'd make for a pretty good operator on its own.

NOTE: This is not ready to be merged; I primarily opened this as a draft PR because I didn't want the work to be lost. There are quite a few missing conversions in casting, so while the operator itself is unlikely to change it is pretty much useless right now because the underlying `cast` function needs more of our attention.