### PR TITLE
Enable transparent decompression for single file inputs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,7 @@ RUN apt-get update && \
     apt-get -y --no-install-recommends install \
       ca-certificates \
       gnupg2 \
+      libarchive13 \
       libasan6 \
       libc++1 \
       libc++abi1 \

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -349,6 +349,12 @@ else ()
 endif ()
 target_link_libraries(libvast PRIVATE FastFloat::fast_float)
 
+# Link against LibArchive.
+find_package(LibArchive REQUIRED)
+#string(APPEND VAST_FIND_DEPENDENCY_LIST "\nfind_package(LibArchive REQUIRED)")
+target_link_libraries(libvast PUBLIC LibArchive::LibArchive)
+dependency_summary("libarchive" LibArchive::LibArchive "Dependencies")
+
 # Link against a backtrace library.
 option(VAST_ENABLE_BACKTRACE "Print a backtrace on unexpected termination" ON)
 add_feature_info("VAST_ENABLE_BACKTRACE" VAST_ENABLE_BACKTRACE

--- a/nix/vast/default.nix
+++ b/nix/vast/default.nix
@@ -23,6 +23,7 @@
     simdjson,
     robin-map,
     jemalloc,
+    libarchive,
     libunwind,
     xxHash,
     re2,
@@ -108,6 +109,7 @@
           boost
           fast_float
           libpcap
+          libarchive
           libunwind
           libyamlcpp
           re2

--- a/scripts/debian/install-dev-dependencies.sh
+++ b/scripts/debian/install-dev-dependencies.sh
@@ -16,6 +16,7 @@ apt-get -y --no-install-recommends install \
     git-core \
     gnupg2 gnupg-agent\
     jq \
+    libarchive-dev \
     libboost1.81-dev \
     libflatbuffers-dev \
     libfmt-dev \

--- a/scripts/macOS/install-dev-dependencies.sh
+++ b/scripts/macOS/install-dev-dependencies.sh
@@ -11,6 +11,7 @@ brew install \
     fmt \
     gnu-sed \
     http-parser \
+    libarchive \
     libpcap \
     libunwind-headers \
     llvm \


### PR DESCRIPTION
This PR replaces the IO path in the `file` loader with API functions provided by libarchive. This allows command line invocations like
```
vast -q exec 'from - read json | write json to stdout' < vast/integration/data/json/conn.log.json.gz
```
The other file loading variations work accordingly.

This currently comes at the expense of the `timeout` and `following` options, which need to be brought back in a libarchive specific way.
Doing so may be possible with a custom implementation for `archive_read_set_read_callback`, but that needs to be verified.