### PR TITLE
Introduce an experimental `sigma` operator

### DIFF
--- a/.github/workflows/tenzir.yaml
+++ b/.github/workflows/tenzir.yaml
@@ -827,6 +827,9 @@ jobs:
           - name: Platform
             target: platform
             path: contrib/tenzir-plugins/platform
+          - name: Sigma
+            target: sigma
+            path: plugins/sigma
         exclude:
           # Disable the Parquet plugin because trying
           # to use it on the macOS CI runners crashes because of an illegal
@@ -842,6 +845,7 @@ jobs:
           - {setup: {os: macos-latest}, plugin: {name: Matcher}}
           - {setup: {os: macos-latest}, plugin: {name: Netflow}}
           - {setup: {os: macos-latest}, plugin: {name: Pipeline Manager}}
+          - {setup: {os: macos-latest}, plugin: {name: Sigma}}
     env:
       INSTALL_DIR: "${{ github.workspace }}/_install"
       BUILD_DIR: "${{ github.workspace }}/_build"

--- a/changelog/next/features/3138--sigma-operator.md
+++ b/changelog/next/features/3138--sigma-operator.md
@@ -1,0 +1,2 @@
+The new `sigma` operator filters its input with Sigma rules and outputs matching
+events alongside the matched rule.

--- a/libtenzir/src/pattern.cpp
+++ b/libtenzir/src/pattern.cpp
@@ -32,8 +32,9 @@ auto pattern::make(std::string str, pattern_options options) noexcept
   result.options_ = options;
   result.regex_ = std::make_shared<regex_impl>(result.str_, opts);
   if (!result.regex_->ok())
-    return caf::make_error(
-      ec::syntax_error, fmt::format("failed to create regex from '{}'", str));
+    return caf::make_error(ec::syntax_error,
+                           fmt::format("failed to create regex from '{}'",
+                                       result.str_));
   return result;
 }
 

--- a/nix/tenzir/default.nix
+++ b/nix/tenzir/default.nix
@@ -60,6 +60,7 @@
         "plugins/kafka"
         "plugins/nic"
         "plugins/parquet"
+        "plugins/sigma"
         "plugins/web"
       ]
       ++ extraPlugins';

--- a/plugins/sigma/CMakeLists.txt
+++ b/plugins/sigma/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.19...3.24 FATAL_ERROR)
+
+project(
+  sigma
+  DESCRIPTION "Sigma query language plugin for Tenzir"
+  LANGUAGES CXX)
+
+include(CTest)
+
+file(GLOB_RECURSE sigma_sources CONFIGURE_DEPENDS
+     "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp"
+     "${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp")
+
+file(GLOB_RECURSE sigma_tests CONFIGURE_DEPENDS
+     "${CMAKE_CURRENT_SOURCE_DIR}/tests/*.cpp")
+
+find_package(Tenzir REQUIRED)
+TenzirRegisterPlugin(
+  TARGET sigma
+  ENTRYPOINT src/plugin.cpp
+  SOURCES ${sigma_sources}
+  TEST_SOURCES ${sigma_tests}
+  INCLUDE_DIRECTORIES include)

--- a/plugins/sigma/include/sigma/parse.hpp
+++ b/plugins/sigma/include/sigma/parse.hpp
@@ -1,0 +1,30 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "tenzir/fwd.hpp"
+
+#include "tenzir/expression.hpp"
+
+#include <caf/expected.hpp>
+
+/// Utilities to work with [Sigma](https://github.com/Neo23x0/sigma).
+namespace tenzir::plugins::sigma {
+
+/// Parses a *rule* as tenzir expression.
+/// @param yaml The rule contents.
+/// @returns The tenzir expression corresponding to *yaml*.
+caf::expected<expression> parse_rule(const data& yaml);
+
+/// Parses a *search identifier* as tenzir expression.
+/// @param yaml The contents converted from YAML.
+/// @returns The tenzir expression corresponding to *yaml*.
+caf::expected<expression> parse_search_id(const data& yaml);
+
+} // namespace tenzir::plugins::sigma

--- a/plugins/sigma/src/parse.cpp
+++ b/plugins/sigma/src/parse.cpp
@@ -1,0 +1,491 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "sigma/parse.hpp"
+
+#include <tenzir/concept/parseable/core.hpp>
+#include <tenzir/concept/parseable/string.hpp>
+#include <tenzir/concept/printable/tenzir/data.hpp>
+#include <tenzir/concept/printable/to_string.hpp>
+#include <tenzir/detail/base64.hpp>
+#include <tenzir/detail/string.hpp>
+#include <tenzir/error.hpp>
+#include <tenzir/expression_visitors.hpp>
+
+#include <array>
+#include <map>
+#include <regex>
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace tenzir::plugins::sigma {
+
+// TODO: A lot of code in here is directly copied from
+// src/concept/parseable/expression.cpp. We should factor the implementation in
+// the future.
+
+namespace {
+
+using expression_map = std::map<std::string, expression>;
+
+/// A symbol-table-like parser for Sigma search identifers. In addition to the
+/// exact match as in a symbol table, this parser also performs the additional
+/// syntax "1/all of X" where X can be "them", a search identifier, or a
+/// wildcard pattern. This parsers is effective a predicate operand in the
+/// "condition" field of the "detection" attribute.
+struct search_id_symbol_table : parser_base<search_id_symbol_table> {
+  using attribute = expression;
+
+  enum class quantifier { all, any };
+
+  /// Constructs a search ID symbol table from an expression map.
+  explicit search_id_symbol_table(const expression_map& exprs) {
+    id.symbols.reserve(exprs.size());
+    for (auto& [key, value] : exprs)
+      id.symbols.emplace(key, value);
+  }
+
+  /// Joins a set of sub-expressions into a conjunction or disjunction.
+  template <class Connective>
+  static expression join(std::vector<expression> xs) {
+    Connective result;
+    result.reserve(xs.size());
+    std::move(xs.begin(), xs.end(), std::back_insert_iterator(result));
+    return hoist(expression{std::move(result)});
+  }
+
+  // Forces a conjunction or disjunction on a given expression.
+  template <class Connective>
+  static expression force(expression x) {
+    auto transform = [](auto&& connective) {
+      auto xs = static_cast<std::vector<expression>&>(connective);
+      return expression{Connective{std::move(xs)}};
+    };
+    if constexpr (std::is_same_v<Connective, conjunction>)
+      if (auto xs = caf::get_if<disjunction>(&x))
+        return transform(std::move(*xs));
+    if constexpr (std::is_same_v<Connective, disjunction>)
+      if (auto xs = caf::get_if<conjunction>(&x))
+        return transform(std::move(*xs));
+    return x;
+  }
+
+  /// Performs *-wildcard search on all search identifiers.
+  [[nodiscard]] std::vector<expression> search(std::string str) const {
+    auto rx_str = std::regex_replace(str, std::regex("\\*"), ".*");
+    auto rx = std::regex{rx_str};
+    std::vector<expression> result;
+    for (auto& [sym, expr] : id.symbols)
+      if (std::regex_search(sym.begin(), sym.end(), rx))
+        result.push_back(expr);
+    return result;
+  }
+
+  template <class Iterator, class Attribute>
+  bool parse(Iterator& f, const Iterator& l, Attribute& result) const {
+    using namespace parser_literals;
+    // clang-format off
+    auto ws = ignore(*parsers::space);
+    auto pattern = +(parsers::any - parsers::space);
+    auto selection
+      = "them"_p ->* [this] { return search("*"); }
+      | pattern ->* [this](std::string str) { return search(str); }
+      ;
+    auto expr
+      = "all of"_p >> ws >> id ->* force<conjunction>
+      | "1 of"_p >> ws >> id ->* force<disjunction>
+      | "all of"_p >> ws >> selection ->* join<conjunction>
+      | "1 of"_p >> ws >> selection ->* join<disjunction>
+      | id
+      | selection ->* join<conjunction>
+      ;
+    // clang-format on
+    return expr(f, l, result);
+  }
+
+  symbol_table<expression> id;
+};
+
+/// Parses the "detection" attribute from a Sigma rule. See the Sigma wiki for
+/// details: https://github.com/Neo23x0/sigma/wiki/Specification#detection
+struct detection_parser : parser_base<detection_parser> {
+  using attribute = expression;
+
+  explicit detection_parser(const expression_map& exprs) : search_id{exprs} {
+  }
+
+  static expression to_expr(
+    std::tuple<expression, std::vector<std::tuple<bool_operator, expression>>>
+      expr) {
+    auto& [x, xs] = expr;
+    if (xs.empty())
+      return x;
+    // We split the expression chain at each OR node in order to take care of
+    // operator precedance: AND binds stronger than OR.
+    disjunction dis;
+    auto con = conjunction{x};
+    for (auto& [op, expr] : xs)
+      if (op == bool_operator::logical_and) {
+        con.emplace_back(std::move(expr));
+      } else if (op == bool_operator::logical_or) {
+        TENZIR_ASSERT(!con.empty());
+        if (con.size() == 1)
+          dis.emplace_back(std::move(con[0]));
+        else
+          dis.emplace_back(std::move(con));
+        con = conjunction{std::move(expr)};
+      } else {
+        TENZIR_ASSERT(!"negations must not exist here");
+      }
+    if (con.size() == 1)
+      dis.emplace_back(std::move(con[0]));
+    else
+      dis.emplace_back(std::move(con));
+    return dis.size() == 1 ? std::move(dis[0]) : expression{dis};
+  };
+
+  template <class Iterator>
+  bool parse(Iterator& f, const Iterator& l, expression& result) const {
+    using namespace parser_literals;
+    auto ws = ignore(*parsers::space);
+    auto negate = [](expression x) {
+      return negation{std::move(x)};
+    };
+    rule<Iterator, expression> expr;
+    rule<Iterator, expression> group;
+    // clang-format off
+    group
+      = '(' >> ws >> ref(expr) >> ws >> ')'
+      | "not"_p >> ws >> '(' >> ws >> (ref(expr) ->* negate) >> ws >> ')'
+      | "not"_p >> ws >> search_id ->* negate
+      | search_id
+      ;
+    auto and_or
+      = "or"_p  ->* [] { return bool_operator::logical_or; }
+      | "and"_p  ->* [] { return bool_operator::logical_and; }
+      ;
+    expr
+      = (group >> *(ws >> and_or >> ws >> ref(group)) >> ws) ->* to_expr
+      ;
+    // clang-format on
+    auto p = expr >> parsers::eoi;
+    return p(f, l, result);
+  }
+
+  search_id_symbol_table search_id;
+};
+
+/// Transforms a string that may contain Sigma glob wildcards into a pattern
+/// with respective regular expression metacharacters. Sigma patterns are always
+/// case-insensitive.
+caf::expected<pattern> transform_sigma_string(std::string_view str) {
+  // The following invariants apply according to the Sigma spec:
+  // - All values are treated as case-insensitive strings
+  // - You can use wildcard characters '*' and '?' in strings
+  // - Wildcards can be escaped with \, e.g. \*. If some wildcard after a
+  //   backslash should be searched, the backslash has to be escaped: \\*.
+  // - Regular expressions are case-sensitive by default
+  // - You don't have to escape characters except the string quotation
+  //   marks '
+  auto f = str.begin();
+  auto l = str.end();
+  std::string rx;
+  // FIXME: this is a pretty hand-wavy approach to transforming a glob string
+  // to a valid regex. We need to revisit this once we have actual pattern
+  // support in the query language.
+  while (f != l) {
+    auto c = *f++;
+    if (c == '\\') {
+      if (f == l) {
+        rx += '\\'; // A single backslash at the end is a literal backslash.
+        break;
+      }
+      auto w = *f++;
+      if (w == '*') {
+        // Escaped wildcard
+        rx += '*';
+      } else if (w == '?') {
+        // Escaped wildcard
+        rx += '?';
+      } else {
+        // Do nothing by default;
+        rx += '\\';
+        rx += w;
+      }
+    } else if (c == '*') {
+      rx += ".*";
+    } else if (c == '?') {
+      rx += ".";
+    } else {
+      rx += c;
+    }
+  };
+  return pattern::make(std::move(rx), {.case_insensitive = true});
+}
+
+} // namespace
+
+caf::expected<expression> parse_search_id(const data& yaml) {
+  if (auto xs = caf::get_if<record>(&yaml)) {
+    conjunction result;
+    for (auto& [key, rhs] : *xs) {
+      auto keys = detail::split(key, "|");
+      auto extractor = field_extractor{std::string{keys[0]}};
+      auto op = relational_operator::equal;
+      auto all = false;
+      // Value transformation; identity (= no modifiers) by default.
+      std::vector<std::function<caf::expected<data>(const data&)>> transforms;
+      // Parse modifiers.
+      for (auto i = keys.begin() + 1; i != keys.end(); ++i) {
+        if (*i == "all") {
+          all = true;
+        } else if (*i == "lt") {
+          op = relational_operator::less;
+        } else if (*i == "lte") {
+          op = relational_operator::less_equal;
+        } else if (*i == "gt") {
+          op = relational_operator::greater;
+        } else if (*i == "gte") {
+          op = relational_operator::greater_equal;
+        } else if (*i == "contains") {
+          auto to_re = [](const data& d) -> caf::expected<data> {
+            auto f = detail::overload{[](const auto& x) -> caf::expected<data> {
+              auto str = detail::control_char_escape(to_string(x));
+              auto result = transform_sigma_string(fmt::format("*{}*", str));
+              if (!result)
+                return std::move(result.error());
+              return std::move(*result);
+            }};
+            return caf::visit(f, d);
+          };
+          transforms.emplace_back(to_re);
+        } else if (*i == "base64") {
+          auto encode = [](const data& x) -> caf::expected<data> {
+            if (const auto* str = caf::get_if<std::string>(&x))
+              return detail::base64::encode(*str);
+            return caf::make_error(ec::type_clash, //
+                                   "base64 only works with strings");
+          };
+          transforms.emplace_back(encode);
+        } else if (*i == "base64offset") {
+          auto encode = [](const data& x) -> caf::expected<data> {
+            const auto* str = caf::get_if<std::string>(&x);
+            if (!str)
+              return caf::make_error(ec::type_clash, //
+                                     "base64offset only works with strings");
+            static constexpr std::array<size_t, 3> start = {{0, 2, 3}};
+            static constexpr std::array<size_t, 3> end = {{0, 3, 2}};
+            std::vector<std::string> xs(3);
+            for (size_t i = 0; i < 3; ++i) {
+              auto padded = std::string(i, ' ') + *str;
+              auto b64 = detail::base64::encode(padded);
+              auto len = b64.size() - end[(str->size() + i) % 3];
+              xs[i] = b64.substr(start[i], len - start[i]);
+            }
+            return list{xs[0], xs[1], xs[2]};
+          };
+          transforms.emplace_back(encode);
+        } else if (*i == "utf16le" || *i == "wide") {
+          return caf::make_error(ec::unimplemented, //
+                                 "utf16le/wide not yet implemented");
+          // FIXME: the attempt below doesn't work yet, but gives an idea on
+          // what needs to be done algorithmically.
+          auto convert = [](const data& x) -> caf::expected<data> {
+            const auto* str = caf::get_if<std::string>(&x);
+            if (!str)
+              return caf::make_error(ec::type_clash, //
+                                     "utf16le/wide only works with strings");
+            // Hand-roll conversion.
+            std::string result;
+            result.reserve(str->size() * 2);
+            for (auto c : *str) {
+              result.push_back(c);
+              result.push_back(0x00);
+            }
+            return result;
+          };
+          transforms.emplace_back(convert);
+        } else if (*i == "utf16be") {
+          return caf::make_error(ec::unimplemented, //
+                                 "utf16be not yet implemented");
+        } else if (*i == "utf16") {
+          return caf::make_error(ec::unimplemented, //
+                                 "utf16 not yet implemented");
+        } else if (*i == "startswith") {
+          auto to_re = [](const data& d) -> caf::expected<data> {
+            auto f = detail::overload{[](const auto& x) -> caf::expected<data> {
+              auto str = detail::control_char_escape(to_string(x));
+              auto result = transform_sigma_string(fmt::format("^{}*", str));
+              if (!result)
+                return std::move(result.error());
+              return std::move(*result);
+            }};
+            return caf::visit(f, d);
+          };
+          transforms.emplace_back(to_re);
+        } else if (*i == "endswith") {
+          op = relational_operator::equal;
+          auto to_re = [](const data& d) -> caf::expected<data> {
+            auto f = detail::overload{[](const auto& x) -> caf::expected<data> {
+              auto str = detail::control_char_escape(to_string(x));
+              auto result = transform_sigma_string(fmt::format("*{}$", str));
+              if (!result)
+                return std::move(result.error());
+              return std::move(*result);
+            }};
+            return caf::visit(f, d);
+          };
+          transforms.emplace_back(to_re);
+        } else if (*i == "re") {
+          op = relational_operator::equal;
+          auto to_re = [](const data& d) -> caf::expected<data> {
+            auto f = detail::overload{
+              [](const auto& x) -> caf::expected<data> {
+                auto str = to_string(x);
+                auto result = transform_sigma_string(str);
+                if (!result)
+                  return std::move(result.error());
+                if (str == result->string()) {
+                  return str;
+                }
+                return std::move(*result);
+              },
+              [](const std::string& x) -> caf::expected<data> {
+                auto result = pattern::make(x);
+                if (!result)
+                  return std::move(result.error());
+                return std::move(*result);
+              },
+              [](pattern x) -> caf::expected<data> {
+                return x;
+              },
+            };
+            return caf::visit(f, d);
+          };
+          transforms.emplace_back(to_re);
+        } else if (*i == "cidr") {
+          // This modifier only requires adjusting the operator because tenzir
+          // already parses strings as typed values.
+          op = relational_operator::in;
+        } else if (*i == "expand") {
+          // TODO
+          return caf::make_error(ec::unimplemented, "expand modifier not yet "
+                                                    "implemented");
+        }
+      }
+      // Helper to apply all modifiers over a value.
+      auto modify = [&](const data& x) -> caf::expected<data> {
+        auto result = x;
+        for (const auto& f : transforms)
+          if (auto x = f(result))
+            result = std::move(*x);
+          else
+            return x.error();
+        return result;
+      };
+      // Helper to create an expression from a (transformed) value.
+      auto make_predicate_expr = [&](const data& value) -> expression {
+        // Convert strings to case-insensitive patterns.
+        if (auto str = caf::get_if<std::string>(&value))
+          if (auto pat = transform_sigma_string(*str))
+            return predicate{extractor, op, data{std::move(*pat)}};
+        // The modifier 'base64offset' is unique in that it creates
+        // multiple values represented as list. If followed by 'contains', then
+        // we have substring search on each value; otherwise we can use equality
+        // comparison.
+        if (auto xs = caf::get_if<list>(&value)) {
+          // Only 'base64offset' creates a list value. Lists are otherwise not
+          // allowed as values.
+          TENZIR_ASSERT(xs->size() == 3);
+          disjunction result;
+          for (const auto& x : *xs)
+            result.emplace_back(predicate{extractor, op, x});
+          return result;
+        }
+        // By default, we take the (potentially modified) operator.
+        return predicate{extractor, op, value};
+      };
+      // Parse RHS.
+      if (caf::holds_alternative<record>(rhs))
+        return caf::make_error(ec::type_clash, "nested records not allowed");
+      if (auto values = caf::get_if<list>(&rhs)) {
+        std::vector<expression> connective;
+        for (const auto& value : *values) {
+          if (caf::holds_alternative<list>(value))
+            return caf::make_error(ec::type_clash, "nested lists disallowed");
+          if (caf::holds_alternative<record>(value))
+            return caf::make_error(ec::type_clash, "nested records disallowed");
+          if (auto x = modify(value))
+            connective.emplace_back(make_predicate_expr(*x));
+          else
+            return x.error();
+        }
+        auto expr = all ? expression{conjunction(std::move(connective))}
+                        : expression{disjunction(std::move(connective))};
+        result.emplace_back(hoist(std::move(expr)));
+      } else {
+        if (auto x = modify(rhs))
+          result.emplace_back(make_predicate_expr(*x));
+        else
+          return x.error();
+      }
+    }
+    return result.size() == 1 ? result[0] : result;
+  } else if (auto xs = caf::get_if<list>(&yaml)) {
+    disjunction result;
+    for (auto& search_id : *xs)
+      if (auto expr = parse_search_id(search_id))
+        result.push_back(std::move(*expr));
+      else
+        return expr.error();
+    return result.size() == 1 ? result[0] : result;
+  } else {
+    return caf::make_error(ec::type_clash, "search id not a list or record");
+  }
+}
+
+caf::expected<expression> parse_rule(const data& yaml) {
+  auto xs = caf::get_if<record>(&yaml);
+  if (!xs)
+    return caf::make_error(ec::type_clash, "rule must be a record");
+  // Extract detection attribute.
+  const record* detection;
+  if (auto i = xs->find("detection"); i == xs->end())
+    return caf::make_error(ec::invalid_query, "no detection attribute");
+  else
+    detection = caf::get_if<record>(&i->second);
+  if (!detection)
+    return caf::make_error(ec::type_clash, "detection not a record");
+  // Resolve all named sub-expression except for "condition".
+  expression_map exprs;
+  for (auto& [key, value] : *detection) {
+    if (key == "condition")
+      continue;
+    if (auto expr = parse_search_id(value))
+      exprs[key] = std::move(*expr);
+    else
+      return expr.error();
+  }
+  // Extract condition.
+  const std::string* condition;
+  if (auto i = detection->find("condition"); i == detection->end())
+    return caf::make_error(ec::invalid_query, "no condition key");
+  else
+    condition = caf::get_if<std::string>(&i->second);
+  if (!condition)
+    return caf::make_error(ec::type_clash, "condition not a string");
+  // Parse condition.
+  expression result;
+  detection_parser p{exprs};
+  if (!p(*condition, result))
+    return caf::make_error(ec::parse_error, "invalid condition syntax");
+  return result;
+}
+
+} // namespace tenzir::plugins::sigma

--- a/plugins/sigma/src/plugin.cpp
+++ b/plugins/sigma/src/plugin.cpp
@@ -1,0 +1,211 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2022 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "sigma/parse.hpp"
+
+#include <tenzir/argument_parser.hpp>
+#include <tenzir/arrow_table_slice.hpp>
+#include <tenzir/bitmap.hpp>
+#include <tenzir/concept/convertible/data.hpp>
+#include <tenzir/concept/convertible/to.hpp>
+#include <tenzir/concept/parseable/string/char_class.hpp>
+#include <tenzir/concept/parseable/tenzir/pipeline.hpp>
+#include <tenzir/concept/parseable/to.hpp>
+#include <tenzir/data.hpp>
+#include <tenzir/error.hpp>
+#include <tenzir/io/read.hpp>
+#include <tenzir/pipeline.hpp>
+#include <tenzir/plugin.hpp>
+#include <tenzir/table_slice_builder.hpp>
+
+#include <arrow/record_batch.h>
+#include <caf/error.hpp>
+#include <caf/expected.hpp>
+#include <caf/typed_event_based_actor.hpp>
+#include <fmt/format.h>
+
+#include <thread>
+
+namespace tenzir::plugins::sigma {
+
+class sigma_operator final : public crtp_operator<sigma_operator> {
+public:
+  sigma_operator() = default;
+
+  explicit sigma_operator(duration refresh_interval, std::string path)
+    : refresh_interval_{refresh_interval}, path_{std::move(path)} {
+  }
+
+  struct monitor_state {
+    [[nodiscard]] auto update(const std::filesystem::path& path)
+      -> caf::expected<void> {
+      if (std::filesystem::is_directory(path)) {
+        for (const auto& entry : std::filesystem::directory_iterator(path)) {
+          auto status = update(entry.path());
+          if (not status)
+            return status;
+        }
+        return {};
+      }
+      if (path.extension() != ".yml" && path.extension() != ".yaml") {
+        // We silently ignore non-yaml files.
+        return {};
+      }
+      auto query = tenzir::io::read(path);
+      if (not query) {
+        return std::move(query.error());
+      }
+      auto query_str = std::string_view{
+        reinterpret_cast<const char*>(query->data()),
+        reinterpret_cast<const char*>(query->data() + query->size())}; // NOLINT
+      auto yaml = from_yaml(query_str);
+      if (not yaml) {
+        return std::move(yaml.error());
+      }
+      auto rule = parse_rule(*yaml);
+      if (not rule) {
+        return std::move(rule.error());
+      }
+      rules[path.string()] = {std::move(*yaml), std::move(*rule)};
+      return {};
+    }
+
+    std::filesystem::path path;
+    std::unordered_map<std::string, std::pair<data, expression>> rules = {};
+  };
+
+  auto
+  operator()(generator<table_slice> input, operator_control_plane& ctrl) const
+    -> generator<table_slice> {
+    auto state = monitor_state{};
+    state.path = path_;
+    if (auto ok = state.update(state.path); not ok) {
+      diagnostic::error("failed to load sigma rules: {}", ok.error())
+        .emit(ctrl.diagnostics());
+    }
+    auto last_update = std::chrono::steady_clock::now();
+    co_yield {}; // signal that we're done initializing
+    for (auto&& slice : input) {
+      if (slice.rows() == 0) {
+        co_yield {};
+        continue;
+      }
+      if (last_update + refresh_interval_ < std::chrono::steady_clock::now()) {
+        if (auto ok = state.update(state.path); not ok) {
+          diagnostic::warning("failed to update sigma rules: {}", ok.error())
+            .emit(ctrl.diagnostics());
+        }
+        last_update = std::chrono::steady_clock::now();
+      }
+      for (const auto& [path, entry] : state.rules) {
+        const auto& [yaml, rule] = entry;
+        auto expr = tailor(rule, slice.schema());
+        if (not expr) {
+          continue;
+        }
+        if (auto event = filter(slice, *expr)) {
+          const auto rule_schema = caf::get<record_type>(type::infer(yaml));
+          const auto result_schema = type{
+            "tenzir.sigma",
+            record_type{
+              {"event", event->schema()},
+              {"rule", rule_schema},
+            },
+          };
+          auto result_builder
+            = result_schema.make_arrow_builder(arrow::default_memory_pool());
+          auto array = to_record_batch(*event)->ToStructArray().ValueOrDie();
+          for (const auto& row :
+               values(caf::get<record_type>(slice.schema()), *array)) {
+            const auto append_row_result
+              = caf::get<arrow::StructBuilder>(*result_builder).Append();
+            TENZIR_ASSERT(append_row_result.ok());
+            const auto append_event_result = append_builder(
+              caf::get<record_type>(event->schema()),
+              caf::get<arrow::StructBuilder>(
+                *caf::get<arrow::StructBuilder>(*result_builder)
+                   .field_builder(0)),
+              *row);
+            TENZIR_ASSERT(append_event_result.ok());
+            const auto append_rule_result = append_builder(
+              rule_schema,
+              caf::get<arrow::StructBuilder>(
+                *caf::get<arrow::StructBuilder>(*result_builder)
+                   .field_builder(1)),
+              caf::get<view<record>>(make_view(yaml)));
+            TENZIR_ASSERT(append_rule_result.ok());
+          }
+          auto result = result_builder->Finish().ValueOrDie();
+          auto rb = arrow::RecordBatch::Make(
+            result_schema.to_arrow_schema(), event->rows(),
+            caf::get<arrow::StructArray>(*result).fields());
+          co_yield table_slice{rb, result_schema};
+        }
+      }
+    }
+  }
+
+  auto name() const -> std::string override {
+    return "sigma";
+  }
+
+  auto location() const -> operator_location override {
+    // The operator is referring to files, and the user likely assumes that to
+    // be relative to the current process, so we default to local here.
+    return operator_location::local;
+  }
+
+  auto optimize(expression const& filter, event_order order) const
+    -> optimize_result override {
+    (void)order;
+    (void)filter;
+    return do_not_optimize(*this);
+  }
+
+  friend auto inspect(auto& f, sigma_operator& x) -> bool {
+    return f.object(x)
+      .pretty_name("sigma_operator")
+      .fields(f.field("refresh_interval", x.refresh_interval_),
+              f.field("path", x.path_));
+  }
+
+private:
+  duration refresh_interval_ = {};
+  std::string path_ = {};
+};
+
+class plugin final : public virtual operator_plugin<sigma_operator> {
+  auto signature() const -> operator_signature override {
+    return {.transformation = true};
+  }
+
+  auto parse_operator(parser_interface& p) const -> operator_ptr override {
+    auto parser = argument_parser{"sigma", "https://docs.tenzir.com/next/"
+                                           "operators/transformations/batch"};
+    auto refresh_interval = duration{std::chrono::seconds{5}};
+    auto refresh_interval_arg = std::optional<located<std::string>>{};
+    auto path = std::string{};
+    parser.add("--refresh-interval", refresh_interval_arg,
+               "<refresh-interval>");
+    parser.add(path, "<rule-or-directory>");
+    parser.parse(p);
+    if (refresh_interval_arg) {
+      if (not parsers::duration(refresh_interval_arg->inner,
+                                refresh_interval)) {
+        diagnostic::error("refresh interval is not a valid duration")
+          .primary(refresh_interval_arg->source)
+          .throw_();
+      }
+    }
+    return std::make_unique<sigma_operator>(refresh_interval, std::move(path));
+  }
+};
+
+} // namespace tenzir::plugins::sigma
+
+TENZIR_REGISTER_PLUGIN(tenzir::plugins::sigma::plugin)

--- a/plugins/sigma/tests/tests.cpp
+++ b/plugins/sigma/tests/tests.cpp
@@ -54,10 +54,10 @@ TEST(wildcard unescaping) {
   check_pattern_equality("x: 'f?'", "x == /f./");
   check_pattern_equality("x: 'f*bar'", "x == /f.*bar/");
   check_pattern_equality("x: 'f?bar'", "x == /f.bar/");
-  check_pattern_equality("x: 'f\\*bar'", "x == /f*bar/");
-  check_pattern_equality("x: 'f\\?bar'", "x == /f?bar/");
-  check_pattern_equality("x: 'f\\\\*bar'", "x == /f\\.*bar/");
-  check_pattern_equality("x: 'f\\\\?bar'", "x == /f\\.bar/");
+  check_pattern_equality("x: 'f\\*bar'", "x == /f\\*bar/");
+  check_pattern_equality("x: 'f\\?bar'", "x == /f\\?bar/");
+  check_pattern_equality("x: 'f\\\\*bar'", "x == /f\\\\.*bar/");
+  check_pattern_equality("x: 'f\\\\?bar'", "x == /f\\\\.bar/");
 }
 
 TEST(maps - single value) {
@@ -195,10 +195,10 @@ TEST(modifier - startswith - proper backslash escaping) {
     foo|startswith: "C:\rundll32"
   )__";
   auto search_id = to_search_id(yaml);
-  auto expected = to_expr(R"(foo == /^C:\rundll32.*/i)");
+  auto expected = to_expr(R"(foo == /^C:\\rundll32.*/i)");
   CHECK_EQUAL(search_id, expected);
   auto str = to_string(expected);
-  CHECK_EQUAL(str, R"(foo == /^C:\rundll32.*/i)");
+  CHECK_EQUAL(str, R"(foo == /^C:\\rundll32.*/i)");
 }
 
 TEST(modifier - startswith - wildcards) {
@@ -224,10 +224,10 @@ TEST(modifier - endswith - proper backslash escaping) {
     foo|endswith: "\rundll32.exe"
   )__";
   auto search_id = to_search_id(yaml);
-  auto expected = to_expr(R"(foo == /.*\rundll32.exe$/i)");
+  auto expected = to_expr(R"(foo == /.*\\rundll32\.exe$/i)");
   CHECK_EQUAL(search_id, expected);
   auto str = to_string(expected);
-  CHECK_EQUAL(str, R"(foo == /.*\rundll32.exe$/i)");
+  CHECK_EQUAL(str, R"(foo == /.*\\rundll32\.exe$/i)");
 }
 
 TEST(modifier - endswith - wildcards) {
@@ -517,12 +517,12 @@ level: critical
 TEST(real example) {
   auto expr = to_rule(unc2452);
   // clang-format off
-  auto selection1 = R"__(CommandLine == /7z.exe a -v500m -mx9 -r0 -p/i)__"s;
-  auto selection2a = R"__(ParentCommandLine == /wscript.exe/i && ParentCommandLine == /.vbs/i)__"s;
-  auto selection2b = R"__(CommandLine == /rundll32.exe/i && CommandLine == /C:\Windows/i && CommandLine == /.dll,Tk_/i)__"s;
-  auto selection3 = R"__(ParentImage == /.*\rundll32.exe$/i && ParentCommandLine == /C:\Windows/i && CommandLine == /cmd.exe \/C /i)__"s;
-  auto selection4 = R"__(CommandLine == /rundll32 c:\windows\\/i && CommandLine == /.dll /i)__"s;
-  auto specific1 = R"__(ParentImage == /.*\rundll32.exe$/i && Image == /.*\dllhost.exe$/i)__"s;
+  auto selection1 = R"__(CommandLine == /.*7z\.exe a -v500m -mx9 -r0 -p.*/i)__"s;
+  auto selection2a = R"__(ParentCommandLine == /.*wscript\.exe.*/i && ParentCommandLine == /.*\.vbs.*/i)__"s;
+  auto selection2b = R"__(CommandLine == /.*rundll32\.exe.*/i && CommandLine == /.*C:\\Windows.*/i && CommandLine == /.*\.dll,Tk_.*/i)__"s;
+  auto selection3 = R"__(ParentImage == /.*\\rundll32\.exe$/i && ParentCommandLine == /.*C:\\Windows.*/i && CommandLine == /.*cmd\.exe \/C .*/i)__"s;
+  auto selection4 = R"__(CommandLine == /.*rundll32 c:\\windows\\.*/i && CommandLine == /.*\.dll .*/i)__"s;
+  auto specific1 = R"__(ParentImage == /.*\\rundll32\.exe$/i && Image == /.*\\dllhost\.exe$/i)__"s;
   auto filter1 = R"__(CommandLine == / /i || CommandLine == //i)__"s;
   // clang-format on
   conjunction selection2;

--- a/plugins/sigma/tests/tests.cpp
+++ b/plugins/sigma/tests/tests.cpp
@@ -1,0 +1,582 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2022 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "sigma/parse.hpp"
+
+#include <tenzir/concept/parseable/tenzir/expression.hpp>
+#include <tenzir/concept/parseable/to.hpp>
+#include <tenzir/concept/printable/stream.hpp>
+#include <tenzir/concept/printable/tenzir/expression.hpp>
+#include <tenzir/concept/printable/to_string.hpp>
+#include <tenzir/detail/base64.hpp>
+#include <tenzir/expression.hpp>
+#include <tenzir/test/test.hpp>
+
+#include <caf/test/dsl.hpp>
+
+using namespace std::string_literals;
+using namespace std::string_view_literals;
+using namespace tenzir;
+using namespace tenzir::detail;
+
+namespace {
+
+expression to_search_id(std::string_view yaml) {
+  return unbox(plugins::sigma::parse_search_id(unbox(from_yaml(yaml))));
+}
+
+expression to_rule(std::string_view yaml) {
+  return unbox(plugins::sigma::parse_rule(unbox(from_yaml(yaml))));
+}
+
+expression to_expr(std::string_view expr) {
+  return unbox(to<expression>(expr));
+}
+
+} // namespace
+
+TEST(wildcard unescaping) {
+  auto check_pattern_equality
+    = [](std::string_view sigma, std::string_view pattern) {
+        // Patterns generated from Sigma glob strings are case-insensitive.
+        auto case_insensitive_pattern = fmt::format("{}i", pattern);
+        CHECK_EQUAL(to_search_id(sigma), to_expr(case_insensitive_pattern));
+        CHECK_NOT_EQUAL(to_search_id(sigma), to_expr(pattern));
+      };
+  check_pattern_equality("x: '*'", "x == /.*/");
+  check_pattern_equality("x: '?'", "x == /./");
+  check_pattern_equality("x: 'f*'", "x == /f.*/");
+  check_pattern_equality("x: 'f?'", "x == /f./");
+  check_pattern_equality("x: 'f*bar'", "x == /f.*bar/");
+  check_pattern_equality("x: 'f?bar'", "x == /f.bar/");
+  check_pattern_equality("x: 'f\\*bar'", "x == /f*bar/");
+  check_pattern_equality("x: 'f\\?bar'", "x == /f?bar/");
+  check_pattern_equality("x: 'f\\\\*bar'", "x == /f\\.*bar/");
+  check_pattern_equality("x: 'f\\\\?bar'", "x == /f\\.bar/");
+}
+
+TEST(maps - single value) {
+  auto yaml = "foo: 42";
+  auto search_id = to_search_id(yaml);
+  auto expected = to_expr("foo == 42");
+  CHECK_EQUAL(search_id, expected);
+}
+
+TEST(maps - empty value) {
+  auto yaml = "foo: ''";
+  auto search_id = to_search_id(yaml);
+  auto expected = to_expr("foo == //i");
+  CHECK_EQUAL(search_id, expected);
+}
+
+TEST(maps - null value) {
+  auto yaml = "foo: null";
+  auto search_id = to_search_id(yaml);
+  auto expected = to_expr("foo == null");
+  CHECK_EQUAL(search_id, expected);
+}
+
+TEST(maps - multiple values) {
+  auto yaml = R"__(
+    foo: 42
+    bar: 43
+  )__";
+  auto search_id = to_search_id(yaml);
+  auto expected = to_expr("foo == 42 && bar == 43");
+  CHECK_EQUAL(search_id, expected);
+}
+
+TEST(list - single value) {
+  auto yaml = R"__(
+    foo:
+      - 42
+  )__";
+  auto search_id = to_search_id(yaml);
+  auto expected = to_expr("foo == 42");
+  CHECK_EQUAL(search_id, expected);
+}
+
+TEST(lists - multiple values) {
+  auto yaml = R"__(
+    foo:
+      - 42
+      - 43
+  )__";
+  auto search_id = to_search_id(yaml);
+  auto expected = to_expr("foo == 42 || foo == 43");
+  CHECK_EQUAL(search_id, expected);
+}
+
+TEST(list of maps) {
+  auto yaml = R"__(
+    - foo: 42
+    - bar: 43
+  )__";
+  auto search_id = to_search_id(yaml);
+  auto expected = to_expr("foo == 42 || bar == 43");
+  CHECK_EQUAL(search_id, expected);
+}
+
+TEST(modifier - all) {
+  auto yaml = R"__(
+    foo|all:
+      - 42
+      - 43
+  )__";
+  auto search_id = to_search_id(yaml);
+  auto expected = to_expr("foo == 42 && foo == 43");
+  CHECK_EQUAL(search_id, expected);
+}
+
+TEST(modifier - sequenced all) {
+  auto yaml = R"__(
+    foo|all:
+      - 42
+      - 43
+    bar: 42
+  )__";
+  auto search_id = to_search_id(yaml);
+  auto expected = to_expr("(foo == 42 && foo == 43) && bar == 42");
+  CHECK_EQUAL(search_id, expected);
+}
+
+TEST(modifier - contains) {
+  auto yaml = R"__(
+    foo|contains: "10.0.0.0/8"
+  )__";
+  auto search_id = to_search_id(yaml);
+  auto expected = to_expr("foo ni 10.0.0.0/8");
+  CHECK_EQUAL(search_id, expected);
+}
+
+TEST(modifier - re) {
+  auto yaml = R"__(
+    foo|re: "^.*$"
+  )__";
+  auto search_id = to_search_id(yaml);
+  auto expected = to_expr("foo == /^.*$/");
+  CHECK_EQUAL(search_id, expected);
+}
+
+TEST(modifier - re 2) {
+  auto yaml = R"__(
+    foo|re: '.*foobar.*'
+  )__";
+  auto search_id = to_search_id(yaml);
+  auto expected = to_expr("foo == /.*foobar.*/");
+  CHECK_EQUAL(search_id, expected);
+}
+
+TEST(modifier - re - no wildcards) {
+  auto yaml = R"__(
+    foo|re: 'foobar'
+  )__";
+  auto search_id = to_search_id(yaml);
+  auto expected = to_expr("foo == /foobar/");
+  CHECK_EQUAL(search_id, expected);
+}
+
+TEST(modifier - startswith) {
+  auto yaml = R"__(
+    foo|startswith: "x"
+  )__";
+  auto search_id = to_search_id(yaml);
+  auto expected = to_expr("foo == /^x.*/i");
+  CHECK_EQUAL(search_id, expected);
+}
+
+TEST(modifier - startswith - proper backslash escaping) {
+  auto yaml = R"__(
+    foo|startswith: "C:\rundll32"
+  )__";
+  auto search_id = to_search_id(yaml);
+  auto expected = to_expr(R"(foo == /^C:\rundll32.*/i)");
+  CHECK_EQUAL(search_id, expected);
+  auto str = to_string(expected);
+  CHECK_EQUAL(str, R"(foo == /^C:\rundll32.*/i)");
+}
+
+TEST(modifier - startswith - wildcards) {
+  auto yaml = R"__(
+    foo|startswith: "f*b?r"
+  )__";
+  auto search_id = to_search_id(yaml);
+  auto expected = to_expr("foo == /^f.*b.r.*/i");
+  CHECK_EQUAL(search_id, expected);
+}
+
+TEST(modifier - endswith) {
+  auto yaml = R"__(
+    foo|endswith: "x"
+  )__";
+  auto search_id = to_search_id(yaml);
+  auto expected = to_expr("foo == /.*x$/i");
+  CHECK_EQUAL(search_id, expected);
+}
+
+TEST(modifier - endswith - proper backslash escaping) {
+  auto yaml = R"__(
+    foo|endswith: "\rundll32.exe"
+  )__";
+  auto search_id = to_search_id(yaml);
+  auto expected = to_expr(R"(foo == /.*\rundll32.exe$/i)");
+  CHECK_EQUAL(search_id, expected);
+  auto str = to_string(expected);
+  CHECK_EQUAL(str, R"(foo == /.*\rundll32.exe$/i)");
+}
+
+TEST(modifier - endswith - wildcards) {
+  auto yaml = R"__(
+    foo|endswith: "f*b?r"
+  )__";
+  auto search_id = to_search_id(yaml);
+  auto expected = to_expr("foo == /.*f.*b.r$/i");
+  CHECK_EQUAL(search_id, expected);
+}
+
+TEST(modifier - lt) {
+  auto yaml = R"__(
+    foo|lt: 42
+  )__";
+  auto search_id = to_search_id(yaml);
+  auto expected = to_expr("foo < 42");
+  CHECK_EQUAL(search_id, expected);
+}
+
+TEST(modifier - lte) {
+  auto yaml = R"__(
+    foo|lte: 42
+  )__";
+  auto search_id = to_search_id(yaml);
+  auto expected = to_expr("foo <= 42");
+  CHECK_EQUAL(search_id, expected);
+}
+
+TEST(modifier - gt) {
+  auto yaml = R"__(
+    foo|gt: 42
+  )__";
+  auto search_id = to_search_id(yaml);
+  auto expected = to_expr("foo > 42");
+  CHECK_EQUAL(search_id, expected);
+}
+
+TEST(modifier - gte) {
+  auto yaml = R"__(
+    foo|gte: 42
+  )__";
+  auto search_id = to_search_id(yaml);
+  auto expected = to_expr("foo >= 42");
+  CHECK_EQUAL(search_id, expected);
+}
+
+TEST(modifier - base64) {
+  auto yaml = R"__(
+    foo|base64: value
+  )__";
+  auto search_id = to_search_id(yaml);
+  auto base64_value = detail::base64::encode("value"sv);
+  REQUIRE_EQUAL(base64_value, "dmFsdWU="); // echo -n value | base64
+  auto expected = to_expr(fmt::format("foo == /{}/i", base64_value));
+  CHECK_EQUAL(search_id, expected);
+}
+
+TEST(modifier - double base64) {
+  auto yaml = R"__(
+    foo|base64|base64: value
+  )__";
+  auto search_id = to_search_id(yaml);
+  auto base64_value = detail::base64::encode("value"sv);
+  base64_value = detail::base64::encode(base64_value);
+  REQUIRE_EQUAL(base64_value, "ZG1Gc2RXVT0="); // echo -n dmFsdWU= | base64
+  auto expected = to_expr(fmt::format("foo == /{}/i", base64_value));
+  CHECK_EQUAL(search_id, expected);
+}
+
+// The ground truth is in the sigma repo. We use the rule
+// tests/test-modifiers.yml and invoke it as follows:
+//
+//   tools/sigmac -t es-qs -c winlogbeat tests/test-modifiers.yml
+//
+// This yields:
+//
+// (winlog.channel:"Security" AND field.keyword:/.*foobar.*/ AND
+// encoded:"VABoAGkAcwAgAHMAdAByAGkAbgBnACAAaQBzACAAQgBhAHMAZQA2ADQAIABlAG4AYwBvAGQAZQBkAA\=\="
+// AND obfuscated.keyword:(*aHR0cDovL* OR *h0dHA6Ly* OR *odHRwOi8v* OR
+// *aHR0cHM6Ly* OR *h0dHBzOi8v* OR *odHRwczovL*) AND allmatch.keyword:*foo* AND
+// allmatch.keyword:*bar* AND allmatch.keyword:*bla* AND end.keyword:*test AND
+// start.keyword:test*)
+//
+// Note the following sub-expression: *aHR0cDovL* OR *h0dHA6Ly* OR *odHRwOi8v*.
+// This is a combination of 'base64offset' and 'contains'. Without the contains
+// modifier, it would look like this: aHR0cDovL OR h0dHA6Ly OR odHRwOi8v.
+TEST(modifier - base64offset) {
+  auto yaml = R"__(
+    foo|base64offset: "http://"
+  )__";
+  auto search_id = to_search_id(yaml);
+  auto expr
+    = R"__(foo == "aHR0cDovL" || foo == "h0dHA6Ly" || foo == "odHRwOi8v")__"s;
+  CHECK_EQUAL(search_id, to_expr(expr));
+}
+
+TEST(modifier - base64offset and contains) {
+  auto yaml = R"__(
+    foo|base64offset|contains: "http://"
+  )__";
+  auto search_id = to_search_id(yaml);
+  auto expr
+    = R"__(foo ni "aHR0cDovL" || foo ni "h0dHA6Ly" || foo ni "odHRwOi8v")__"s;
+  CHECK_EQUAL(search_id, to_expr(expr));
+}
+
+TEST(modifier - cidr) {
+  auto yaml = R"__(
+    foo|cidr: 192.168.0.0/24
+  )__";
+  auto search_id = to_search_id(yaml);
+  auto expected = to_expr("foo in 192.168.0.0/24"s);
+  CHECK_EQUAL(search_id, expected);
+}
+
+// FIXME: The expression parser doesn't handle escaped strings properly, so we
+// can't include NUL bytes in a query string yet. Once this is possible.
+TEST_DISABLED(modifier - wide) {
+  auto yaml = R"__(
+    foo|wide: abc
+  )__";
+  auto search_id = to_search_id(yaml);
+  auto expected = to_expr(R"__(foo == "a\x00b\x00c\x00")__"s);
+  CHECK_EQUAL(search_id, expected);
+}
+
+TEST(search id selection - exact match) {
+  auto yaml = R"__(
+    detection:
+      test:
+        foo: 42
+        bar: 42
+      condition: test
+  )__";
+  auto rule = to_rule(yaml);
+  auto expected = to_expr("foo == 42 && bar == 42");
+  CHECK_EQUAL(rule, expected);
+}
+
+TEST(search id selection - boolean algebra 1) {
+  auto yaml = R"__(
+    detection:
+      a:
+        foo: 42
+      b:
+        bar: 42
+      c:
+        baz: 42
+      condition: a and not (b or c)
+  )__";
+  auto rule = to_rule(yaml);
+  auto expected = to_expr("foo == 42 && ! (bar == 42 || baz == 42)");
+  CHECK_EQUAL(rule, expected);
+}
+
+TEST(search id selection - boolean algebra - nested) {
+  auto yaml = R"__(
+    detection:
+      a:
+        foo: 42
+      b:
+        bar:
+          - 42
+          - 43
+        baz:
+          - 42
+      condition: a or b
+  )__";
+  auto rule = to_rule(yaml);
+  auto expected
+    = to_expr("foo == 42 || ((bar == 42 || bar == 43) && baz == 42)");
+  CHECK_EQUAL(rule, expected);
+}
+
+TEST(search id selection - 1 of them) {
+  auto yaml = R"__(
+    detection:
+      selection1:
+        foo: 42
+      selection2:
+        bar: 42
+      condition: 1 of them
+  )__";
+  auto rule = to_rule(yaml);
+  auto expected = to_expr("foo == 42 || bar == 42");
+  CHECK_EQUAL(rule, expected);
+}
+
+TEST(search id selection - 1 of pattern) {
+  auto yaml = R"__(
+    detection:
+      selection1:
+        foo: 42
+      selection2:
+        bar: 42
+      not_considered:
+        evil: 6.6.6.6
+      condition: 1 of sele*
+  )__";
+  auto rule = to_rule(yaml);
+  auto expected = to_expr("foo == 42 || bar == 42");
+  CHECK_EQUAL(rule, expected);
+}
+
+TEST(search id selection - all of pattern) {
+  auto yaml = R"__(
+    detection:
+      selection1:
+        foo: 42
+      selection2:
+        bar: 42
+      not_considered:
+        evil: 6.6.6.6
+      condition: all of sele*
+  )__";
+  auto rule = to_rule(yaml);
+  auto expected = to_expr("foo == 42 && bar == 42");
+  CHECK_EQUAL(rule, expected);
+}
+
+TEST(search id selection - flip to AND) {
+  auto yaml = R"__(
+    detection:
+      test:
+        - foo: 42
+        - bar: 42
+      condition: all of test
+  )__";
+  auto rule = to_rule(yaml);
+  auto expected = to_expr("foo == 42 && bar == 42");
+  CHECK_EQUAL(rule, expected);
+}
+
+// Source:
+// https://github.com/Neo23x0/sigma/commit/b62c705bf02e2b9089d21567e34ac05037f56338
+auto unc2452 = R"__(
+title: UNC2452 Process Creation Patterns
+id: 9be34ad0-b6a7-4fbd-91cf-fc7ec1047f5f
+description: Detects a specific process creation patterns as seen used by UNC2452 and provided by Microsoft as Microsoft Defender ATP queries
+status: experimental
+references:
+    - https://www.microsoft.com/security/blog/2021/01/20/deep-dive-into-the-solorigate-second-stage-activation-from-sunburst-to-teardrop-and-raindrop/
+tags:
+    - attack.execution
+    - attack.t1059.001
+    - sunburst
+    - unc2452
+author: Florian Roth
+date: 2021/01/22
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection1:
+        CommandLine|contains:
+            - '7z.exe a -v500m -mx9 -r0 -p'
+    selection2:
+        ParentCommandLine|contains|all:
+            - 'wscript.exe'
+            - '.vbs'
+        CommandLine|contains|all:
+            - 'rundll32.exe'
+            - 'C:\Windows'
+            - '.dll,Tk_'
+    selection3:
+        ParentImage|endswith: '\rundll32.exe'
+        ParentCommandLine|contains: 'C:\Windows'
+        CommandLine|contains: 'cmd.exe /C '
+    selection4:
+        CommandLine|contains|all:
+            - 'rundll32 c:\windows\\'
+            - '.dll '
+    specific1:
+        ParentImage|endswith: '\rundll32.exe'
+        Image|endswith: '\dllhost.exe'
+    filter1:
+        CommandLine:
+            - ' '
+            - ''
+    condition: selection1 or selection2 or selection3 or selection4 or ( specific1 and not filter1 )
+falsepositives:
+    - Unknown
+level: critical
+)__";
+
+TEST(real example) {
+  auto expr = to_rule(unc2452);
+  // clang-format off
+  auto selection1 = R"__(CommandLine == /7z.exe a -v500m -mx9 -r0 -p/i)__"s;
+  auto selection2a = R"__(ParentCommandLine == /wscript.exe/i && ParentCommandLine == /.vbs/i)__"s;
+  auto selection2b = R"__(CommandLine == /rundll32.exe/i && CommandLine == /C:\Windows/i && CommandLine == /.dll,Tk_/i)__"s;
+  auto selection3 = R"__(ParentImage == /.*\rundll32.exe$/i && ParentCommandLine == /C:\Windows/i && CommandLine == /cmd.exe \/C /i)__"s;
+  auto selection4 = R"__(CommandLine == /rundll32 c:\windows\\/i && CommandLine == /.dll /i)__"s;
+  auto specific1 = R"__(ParentImage == /.*\rundll32.exe$/i && Image == /.*\dllhost.exe$/i)__"s;
+  auto filter1 = R"__(CommandLine == / /i || CommandLine == //i)__"s;
+  // clang-format on
+  conjunction selection2;
+  selection2.emplace_back(to_expr(selection2a));
+  selection2.emplace_back(to_expr(selection2b));
+  conjunction tail;
+  tail.emplace_back(to_expr(specific1));
+  tail.emplace_back(negation{to_expr(filter1)});
+  disjunction expected;
+  expected.emplace_back(to_expr(selection1));
+  expected.emplace_back(selection2);
+  expected.emplace_back(to_expr(selection3));
+  expected.emplace_back(to_expr(selection4));
+  expected.emplace_back(tail);
+  CHECK_EQUAL(expr, expression{expected});
+}
+
+auto modifier_test = R"__(
+ title: Modifier test rule
+ logsource:
+     product: windows
+     service: security
+ detection:
+     selection:
+         field|re: '.*foobar.*'
+         encoded|wide|base64: 'This string is Base64 encoded'
+         obfuscated|base64offset|contains:
+             - 'http://'
+             - 'https://'
+         allmatch|contains|all:
+             - foo
+             - bar
+             - bla
+         end|endswith: test
+         start|startswith: test
+     condition: selection
+)__";
+
+// TODO: For this to run through we need to implement the utf* modifiers.
+TEST_DISABLED(modifier test rule) {
+  auto expr = to_rule(modifier_test);
+  auto field = R"__(field|re: '.*foobar.*')__"s;
+  auto encoded = R"__(encoded|wide|base64: 'This string is Base64 encoded')__"s;
+  auto obfuscated
+    = R"__(obfuscated|base64offset|contains: ['http://', 'https://'])__"s;
+  auto allmatch = R"__(allmatch|contains|all: [foo, bar, bla])__"s;
+  auto end = R"__(end|endswith: test)__"s;
+  auto start = R"__(start|startswith: test)__"s;
+  conjunction expected;
+  expected.emplace_back(to_expr(field));
+  expected.emplace_back(to_expr(encoded));
+  expected.emplace_back(to_expr(obfuscated));
+  expected.emplace_back(to_expr(allmatch));
+  expected.emplace_back(to_expr(end));
+  expected.emplace_back(to_expr(start));
+  CHECK_EQUAL(expr, expression{expected});
+}

--- a/web/docs/operators/transformations/sigma.md
+++ b/web/docs/operators/transformations/sigma.md
@@ -4,17 +4,22 @@ Filter the input with [Sigma rules][sigma] and output matching events.
 
 [sigma]: https://github.com/SigmaHQ/sigma
 
+:::caution Experimental
+This operator is experimental and subject to change without notice, even in
+minor or patch releases.
+:::
+
 ## Synopsis
 
 ```
-sigma <rule.yaml>
-sigma <directory>
+sigma <rule> [--refresh-interval <refresh-interval>]
+sigma <directory> [--refresh-interval <refresh-interval>]
 ```
 
 ## Description
 
 The `sigma` operator executes [Sigma rules](https://github.com/SigmaHQ/sigma) on
-its input. If a rule matches, the operator emits a `tenzir.sighting` event that
+its input. If a rule matches, the operator emits a `tenzir.sigma` event that
 wraps the input record into a new record along with the matching rule. The
 operator discards all events that do not match the provided rules.
 
@@ -100,6 +105,13 @@ The directory to watch.
 This invocation watches a directory and attempts to parse each contained file as
 a Sigma rule. The `sigma` operator matches if *any* of the contained rules
 match, effectively creating a disjunction of all rules inside the directory.
+
+### `--refresh-interval <refresh-interval>`
+
+How often the Sigma operator looks at the specified rule or directory of rules
+to update its internal state.
+
+Defaults to 5 seconds.
 
 ## Examples
 


### PR DESCRIPTION
The `sigma` operator takes a path to a directory or a single *.yaml or *.yml file, takes all input events, and applies the sigma rule. The resulting events contain matches for the Sigma rule and the rule itself.