### PR TITLE
Implement '--disable-timestamp-tags' long-form parameter for zeek-tsv printer

### DIFF
--- a/libvast/builtins/formats/zeek_tsv.cpp
+++ b/libvast/builtins/formats/zeek_tsv.cpp
@@ -665,7 +665,7 @@ public:
     std::optional<char> set_sep;
     std::optional<std::string> empty_field;
     std::optional<std::string> unset_field;
-    bool disable_timestamp_tags;
+    bool disable_timestamp_tags = false;
 
     friend auto inspect(auto& f, args& x) -> bool {
       return f.object(x).fields(
@@ -752,6 +752,7 @@ public:
     parser.add("-s,--set-separator", set_separator, "<sep>");
     parser.add("-e,--empty-field", args.empty_field, "<str>");
     parser.add("-u,--unset-field", args.unset_field, "<str>");
+    parser.add("-d,--disable-timestamp-tags", args.disable_timestamp_tags);
     parser.parse(p);
     if (set_separator) {
       auto converted = to_xsv_sep(set_separator->inner);
@@ -769,20 +770,12 @@ public:
       }
       args.set_sep = *converted;
     }
-    args.disable_timestamp_tags = disable_timestamp_tags_;
     return std::make_unique<zeek_tsv_printer>(std::move(args));
   }
 
-  auto initialize(const record&, const record& global_config)
-    -> caf::error override {
-    disable_timestamp_tags_
-      = get_or(global_config, "vast.export.zeek.disable-timestamp-tags",
-               disable_timestamp_tags_);
+  auto initialize(const record&, const record&) -> caf::error override {
     return caf::none;
   }
-
-private:
-  bool disable_timestamp_tags_{false};
 };
 
 } // namespace vast::plugins::zeek_tsv

--- a/vast/integration/vast_integration_suite.yaml
+++ b/vast/integration/vast_integration_suite.yaml
@@ -817,17 +817,17 @@ tests:
         input: data/zeek/merge.log
       - command: exec 'from stdin read zeek-tsv | write json to stdout'
         input: data/zeek/merge_with_whitespace_separation.log
-      - command: exec 'from stdin read zeek-tsv | head 300 | write zeek-tsv to stdout'
+      - command: exec 'from stdin read zeek-tsv | head 300 | write zeek-tsv --disable-timestamp-tags to stdout'
         input: data/zeek/dns.log.gz
       - command: exec 'from stdin read zeek-tsv | head 300 | write csv to stdout'
         input: data/zeek/dns.log.gz
-      - command: exec 'from stdin read zeek-tsv | write zeek-tsv --set-separator ";" --empty-field "empty" --unset-field "NULLVAL" to stdout'
+      - command: exec 'from stdin read zeek-tsv | write zeek-tsv --disable-timestamp-tags --set-separator ";" --empty-field "empty" --unset-field "NULLVAL" to stdout'
         input: data/zeek/whitespace_start.log
-      - command: exec 'from stdin read json | write zeek-tsv to stdout'
+      - command: exec 'from stdin read json | write zeek-tsv --disable-timestamp-tags to stdout'
         input: data/json/snmp.log.json.gz
-      - command: exec 'from stdin read zeek-tsv | write zeek-tsv to stdout'
+      - command: exec 'from stdin read zeek-tsv | write zeek-tsv --disable-timestamp-tags to stdout'
         input: data/zeek/empty.log
-      - command: exec 'from stdin read zeek-tsv | write zeek-tsv to stdout'
+      - command: exec 'from stdin read zeek-tsv | write zeek-tsv --disable-timestamp-tags to stdout'
         input: data/zeek/broken_no_separator_header.log
         expected_result: error
       - command: exec 'from stdin read zeek-tsv | write zeek-tsv to stdout'

--- a/web/docs/formats/zeek-tsv.md
+++ b/web/docs/formats/zeek-tsv.md
@@ -75,6 +75,12 @@ Specifies the separator for unset "null" fields.
 
 Defaults to `-`.
 
+### `-d|--disable-timestamp-tags` (Printer)
+
+Disables the `#open` and `#close` timestamp tags.
+
+Defaults to `false`.
+
 ## Examples
 
 Read a Zeek `conn.log` from a file:


### PR DESCRIPTION
This change adds a new TQL parser argument `--disable-timestamp-tags` to the `zeek-tsv` printer.