### PR TITLE
Delay JSON parsing of incoming parameter data

### DIFF
--- a/libvast/include/vast/http_api.hpp
+++ b/libvast/include/vast/http_api.hpp
@@ -17,7 +17,6 @@
 #include <caf/expected.hpp>
 #include <caf/optional.hpp>
 
-#include <simdjson.h>
 #include <string>
 
 namespace vast {
@@ -152,7 +151,10 @@ public:
   std::string canonical_path;
 
   /// Query parameters, path parameters, x-www-urlencoded body parameters
-  detail::stable_map<std::string, std::string> params;
+  // TODO: Currently this is unused since platform plugin only accepts
+  // json bodies, but it will become necessary once the web plugin
+  // also goes through the node.
+  // detail::stable_map<std::string, std::string> params;
 
   /// The POST JSON body, if it existed.
   std::string json_body;
@@ -162,7 +164,7 @@ public:
     return f.object(e)
       .pretty_name("vast.http_request_description")
       .fields(f.field("canonical_path", e.canonical_path),
-              f.field("params", e.params), f.field("json_body", e.json_body));
+              f.field("json_body", e.json_body));
   }
 };
 
@@ -184,7 +186,7 @@ struct http_parameter_map {
   /// Insert a new key and value.
   auto emplace(std::string&& key, vast::data&& value) -> void;
 
-  /// Unchecked access to the internal data.
+  /// Unchecked access to the internal data. Used by unit tests.
   auto get_unsafe() -> detail::stable_map<std::string, vast::data>&;
 
 private:
@@ -228,10 +230,6 @@ private:
 auto parse_endpoint_parameters(const vast::rest_endpoint& endpoint,
                                const http_parameter_map& params)
   -> caf::expected<vast::record>;
-
-/// Parse from JSON data.
-auto parse_skeleton(simdjson::ondemand::value value, size_t depth = 0)
-  -> vast::data;
 
 } // namespace vast
 

--- a/libvast/src/node.cpp
+++ b/libvast/src/node.cpp
@@ -555,7 +555,13 @@ node(node_actor::stateful_pointer<node_state> self, std::string /*name*/,
         // spawn) here.
         return rest_response::make_error(500, "failed to get rest handler",
                                          caf::error{});
-      auto params = parse_endpoint_parameters(endpoint, desc.params);
+      auto unparsed_params = http_parameter_map::from_json(desc.json_body);
+      if (!unparsed_params)
+        return rest_response::make_error(400, "invalid json",
+                                         unparsed_params.error());
+      for (auto&& [key, value] : std::exchange(desc.params, {}))
+        unparsed_params->emplace(std::move(key), vast::data{value});
+      auto params = parse_endpoint_parameters(endpoint, *unparsed_params);
       if (!params)
         return rest_response::make_error(400, "invalid parameters",
                                          params.error());

--- a/libvast/src/node.cpp
+++ b/libvast/src/node.cpp
@@ -559,8 +559,6 @@ node(node_actor::stateful_pointer<node_state> self, std::string /*name*/,
       if (!unparsed_params)
         return rest_response::make_error(400, "invalid json",
                                          unparsed_params.error());
-      for (auto&& [key, value] : std::exchange(desc.params, {}))
-        unparsed_params->emplace(std::move(key), vast::data{value});
       auto params = parse_endpoint_parameters(endpoint, *unparsed_params);
       if (!params)
         return rest_response::make_error(400, "invalid parameters",

--- a/libvast/test/rest_proxy.cpp
+++ b/libvast/test/rest_proxy.cpp
@@ -21,12 +21,37 @@ struct fixture : public fixtures::node {
 
 } // namespace
 
+TEST(parameter parsing) {
+  auto endpoint = vast::rest_endpoint {
+    .method = vast::http_method::post,
+    .path = "/dummy",
+    .params = vast::record_type{
+      {"id", vast::int64_type{}},
+      {"uid", vast::uint64_type{}},
+      {"timeout", vast::duration_type{}},
+      {"value", vast::string_type{}},
+    },
+    .version = vast::api_version::v0,
+    .content_type = vast::http_content_type::json,
+  };
+  auto params = vast::detail::stable_map<std::string, std::string>{
+    {"id", "0"},
+    {"uid", "0"},
+    {"timeout", "1m"},
+    {"value", "1"},
+  };
+  auto result = parse_endpoint_parameters(endpoint, params);
+  REQUIRE_NOERROR(result);
+}
+
 FIXTURE_SCOPE(rest_api_tests, fixture)
 
-TEST(proxy request) {
+TEST(proxy requests) {
+  // /status
   auto desc = vast::http_request_description{
     .canonical_path = "POST /status (v0)",
-    .params = {},
+    .params
+    = {{"verbosity", "detailed"}, {"components", R"_(["catalog", "index"])_"}},
   };
   auto rp = self->request(test_node, caf::infinite, vast::atom::proxy_v, desc);
   run();
@@ -37,11 +62,38 @@ TEST(proxy request) {
       auto parsed = vast::from_json(body);
       CHECK(parsed);
       CHECK(caf::holds_alternative<vast::record>(*parsed));
-      CHECK(caf::get<vast::record>(*parsed).contains("version"));
+      CHECK(caf::get<vast::record>(*parsed).contains("catalog"));
+      CHECK(caf::get<vast::record>(*parsed).contains("index"));
     },
     [](const caf::error& e) {
       FAIL(e);
     });
+
+  // TODO: Enable this test once the node test fixture includes a
+  // "serve-manager".
+  // auto desc2 = vast::http_request_description{
+  //   .canonical_path = "POST /serve (v0)",
+  //   .params = {
+  //     {"serve_id", "foo"},
+  //     {"max_events", "1"},
+  //   },
+  // };
+  // auto rp2 = self->request(test_node, caf::infinite, vast::atom::proxy_v,
+  //                          desc2);
+  // run();
+  // rp2.receive(
+  //   [](vast::rest_response& response) {
+  //     // We expect an "Unknown serve id" error.
+  //     CHECK_EQUAL(response.code(), size_t{400});
+  //     auto body = std::move(response).release();
+  //     auto parsed = vast::from_json(body);
+  //     CHECK(parsed);
+  //     CHECK(caf::holds_alternative<vast::record>(*parsed));
+  //     CHECK(caf::get<vast::record>(*parsed).contains("error"));
+  //   },
+  //   [](const caf::error& e) {
+  //     FAIL(e);
+  //   });
 }
 
 TEST(invalid request) {
@@ -59,22 +111,22 @@ TEST(invalid request) {
     [](const caf::error& e) {
       FAIL(e);
     });
-  // TODO: Enable when the endpoint does strict parameter validation.
-  // MESSAGE("invalid params");
-  // auto desc2 = vast::http_request_description{
-  //  .canonical_path = "POST /status (v0)",
-  //  .params = {{"asdf", "jkl"}},
-  //};
-  // auto rp2
-  //  = self->request(test_node, caf::infinite, vast::atom::proxy_v, desc2);
-  // run();
-  // rp2.receive(
-  //  [](vast::rest_response& response) {
-  //    CHECK(response.is_error());
-  //  },
-  //  [](const caf::error& e) {
-  //    FAIL(e);
-  //  });
+
+  MESSAGE("invalid params");
+  auto desc2 = vast::http_request_description{
+    .canonical_path = "POST /status (v0)",
+    .params = {{"verbosity", "jklo"}},
+  };
+  auto rp2
+    = self->request(test_node, caf::infinite, vast::atom::proxy_v, desc2);
+  run();
+  rp2.receive(
+    [](vast::rest_response& response) {
+      CHECK(response.is_error());
+    },
+    [](const caf::error& e) {
+      FAIL(e);
+    });
 }
 
 FIXTURE_SCOPE_END()

--- a/libvast/test/rest_proxy.cpp
+++ b/libvast/test/rest_proxy.cpp
@@ -30,6 +30,8 @@ TEST(parameter parsing) {
       {"uid", vast::uint64_type{}},
       {"timeout", vast::duration_type{}},
       {"value", vast::string_type{}},
+      {"li", vast::list_type{vast::ip_type{}}},
+      {"ls", vast::list_type{vast::string_type{}}},
     },
     .version = vast::api_version::v0,
     .content_type = vast::http_content_type::json,
@@ -39,6 +41,8 @@ TEST(parameter parsing) {
     {"uid", std::string{"0"}},
     {"timeout", std::string{"1m"}},
     {"value", std::string{"1"}},
+    {"li", vast::list{std::string{"12.34.1.2"}}},
+    {"ls", vast::list{std::string{"1"}, std::string{"2"}}},
   };
   vast::http_parameter_map pmap;
   pmap.get_unsafe() = params;
@@ -52,7 +56,6 @@ TEST(proxy requests) {
   // /status
   auto desc = vast::http_request_description{
     .canonical_path = "POST /status (v0)",
-    .params = {},
     .json_body
     = R"_({"verbosity": "detailed", "components": ["catalog", "index"]})_",
   };
@@ -76,9 +79,7 @@ TEST(proxy requests) {
   // "serve-manager".
   // auto desc2 = vast::http_request_description{
   //   .canonical_path = "POST /serve (v0)",
-  //   .params = {
-  //     {"serve_id", "foo"},
-  //     {"max_events", "1"},
+  //   .json_body = R"_({"serve_id": "foo", "max_events", "1"})_",
   //   },
   // };
   // auto rp2 = self->request(test_node, caf::infinite, vast::atom::proxy_v,
@@ -103,7 +104,6 @@ TEST(invalid request) {
   MESSAGE("invalid path");
   auto desc = vast::http_request_description{
     .canonical_path = "foo",
-    .params = {},
     .json_body = {},
   };
   auto rp = self->request(test_node, caf::infinite, vast::atom::proxy_v, desc);
@@ -119,7 +119,6 @@ TEST(invalid request) {
   MESSAGE("invalid params");
   auto desc2 = vast::http_request_description{
     .canonical_path = "POST /status (v0)",
-    .params = {},
     .json_body = R"_({"verbosity": "jklo"})_",
   };
   auto rp2

--- a/libvast/test/rest_proxy.cpp
+++ b/libvast/test/rest_proxy.cpp
@@ -34,13 +34,15 @@ TEST(parameter parsing) {
     .version = vast::api_version::v0,
     .content_type = vast::http_content_type::json,
   };
-  auto params = vast::detail::stable_map<std::string, std::string>{
-    {"id", "0"},
-    {"uid", "0"},
-    {"timeout", "1m"},
-    {"value", "1"},
+  auto params = vast::detail::stable_map<std::string, vast::data>{
+    {"id", std::string{"+0"}},
+    {"uid", std::string{"0"}},
+    {"timeout", std::string{"1m"}},
+    {"value", std::string{"1"}},
   };
-  auto result = parse_endpoint_parameters(endpoint, params);
+  vast::http_parameter_map pmap;
+  pmap.get_unsafe() = params;
+  auto result = parse_endpoint_parameters(endpoint, pmap);
   REQUIRE_NOERROR(result);
 }
 
@@ -50,8 +52,9 @@ TEST(proxy requests) {
   // /status
   auto desc = vast::http_request_description{
     .canonical_path = "POST /status (v0)",
-    .params
-    = {{"verbosity", "detailed"}, {"components", R"_(["catalog", "index"])_"}},
+    .params = {},
+    .json_body
+    = R"_({"verbosity": "detailed", "components": ["catalog", "index"]})_",
   };
   auto rp = self->request(test_node, caf::infinite, vast::atom::proxy_v, desc);
   run();
@@ -101,6 +104,7 @@ TEST(invalid request) {
   auto desc = vast::http_request_description{
     .canonical_path = "foo",
     .params = {},
+    .json_body = {},
   };
   auto rp = self->request(test_node, caf::infinite, vast::atom::proxy_v, desc);
   run();
@@ -115,7 +119,8 @@ TEST(invalid request) {
   MESSAGE("invalid params");
   auto desc2 = vast::http_request_description{
     .canonical_path = "POST /status (v0)",
-    .params = {{"verbosity", "jklo"}},
+    .params = {},
+    .json_body = R"_({"verbosity": "jklo"})_",
   };
   auto rp2
     = self->request(test_node, caf::infinite, vast::atom::proxy_v, desc2);

--- a/nix/vast/plugins/source.json
+++ b/nix/vast/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "7ed804ec4b935426ae135d639607a722dfbded4d",
+  "rev": "c0f941adc40e4d31e752d2372d10e8ebb0f3d4e2",
   "submodules": true,
   "shallow": true
 }

--- a/plugins/web/src/server_command.cpp
+++ b/plugins/web/src/server_command.cpp
@@ -143,7 +143,6 @@ request_dispatcher_actor::behavior_type request_dispatcher(
         auto content_type
           = header.opt_value_of(restinio::http_field_t::content_type)
               .value_or("application/json");
-        VAST_INFO("content type is '{}'", content_type);
         if (content_type == "application/x-www-form-urlencoded") {
           query_params = parse_query_params(body);
           if (!query_params)

--- a/plugins/web/src/server_command.cpp
+++ b/plugins/web/src/server_command.cpp
@@ -19,6 +19,7 @@
 #include <vast/concept/parseable/to.hpp>
 #include <vast/concept/parseable/vast/data.hpp>
 #include <vast/concept/parseable/vast/expression.hpp>
+#include <vast/detail/flat_map.hpp>
 #include <vast/format/json.hpp>
 #include <vast/logger.hpp>
 #include <vast/node.hpp>
@@ -131,8 +132,7 @@ request_dispatcher_actor::behavior_type request_dispatcher(
       if (!query_params)
         return response->abort(400, "failed to parse query\n",
                                query_params.error());
-      auto parser = simdjson::dom::parser{};
-      auto body_params = std::optional<simdjson::dom::object>{};
+      auto body_params = vast::http_parameter_map{};
       // POST requests can contain request parameters in their body in any
       // format supported by the server. The client indicates the data format
       // they used in the `Content-Type` header. See also
@@ -143,6 +143,7 @@ request_dispatcher_actor::behavior_type request_dispatcher(
         auto content_type
           = header.opt_value_of(restinio::http_field_t::content_type)
               .value_or("application/json");
+        VAST_INFO("content type is '{}'", content_type);
         if (content_type == "application/x-www-form-urlencoded") {
           query_params = parse_query_params(body);
           if (!query_params)
@@ -151,20 +152,12 @@ request_dispatcher_actor::behavior_type request_dispatcher(
               query_params.error());
         } else if (content_type == "application/json") {
           auto const& json_body = !body.empty() ? body : "{}";
-          auto json_params = parser.parse(json_body);
-          if (!json_params.is_object()) {
-            if (json_params.error() != simdjson::SUCCESS) {
-              return response->abort(
-                400, "encountered JSON parsing error\n",
-                caf::make_error(ec::invalid_query,
-                                simdjson::error_message(json_params.error())));
-            }
-            return response->abort(
-              400, "invalid JSON body\n",
-              caf::make_error(ec::invalid_query,
-                              simdjson::to_string(json_params)));
+          auto json_params = http_parameter_map::from_json(json_body);
+          if (!json_params) {
+            return response->abort(400, fmt::format("invalid JSON body\n"),
+                                   std::move(json_params.error()));
           }
-          body_params = json_params.get_object();
+          body_params = std::move(*json_params);
         } else {
           return response->abort(
             400, "unsupported content type\n",
@@ -173,32 +166,27 @@ request_dispatcher_actor::behavior_type request_dispatcher(
         }
       }
       auto const& route_params = response->route_params();
-      auto combined_params = detail::stable_map<std::string, std::string>{};
+      // If we encounter body and query parameters with the same
+      // name, we treat the query parameter with the higher precedence
+      // and override the body parameter.
       if (endpoint.params) {
         for (auto const& leaf : endpoint.params->leaves()) {
           auto name = leaf.field.name;
           // TODO: Warn and/or return an error if the same parameter
           // is passed using multiple methods.
-          auto maybe_param = std::optional<std::string>{};
+          // TODO: Attempt to parse lists in query parameters, as in
+          // `?x=1,2,3&y=[a,b]`
+          auto maybe_param = std::optional<vast::data>{};
           if (auto query_param = query_params->get_param(name))
             maybe_param = std::string{*query_param};
           if (auto route_param = route_params.get_param(name))
             maybe_param = std::string{*route_param};
-          if (body_params.has_value())
-            if (auto maybe_value = body_params->at_key(name);
-                maybe_value.error() != simdjson::NO_SUCH_FIELD) {
-              if (not maybe_value.value().is_null()) {
-                maybe_param = simdjson::minify(maybe_value.value());
-                if (maybe_value.is_string())
-                  maybe_param = detail::json_unescape(*maybe_param);
-              }
-            }
           if (!maybe_param)
             continue;
-          combined_params[name] = *maybe_param;
+          body_params.emplace(std::string{name}, std::move(*maybe_param));
         }
       }
-      auto params = parse_endpoint_parameters(endpoint, combined_params);
+      auto params = parse_endpoint_parameters(endpoint, body_params);
       if (!params)
         return response->abort(
           422, "failed to parse endpoint parameters: ", params.error());


### PR DESCRIPTION
A client forwarding incoming requests to the node will generally
    not be able to parse all request parameters to the correct
    types declared by the endpoint. Therefore, for POST requests
    we now have a way of forwarding the raw JSON body to the node.
    
This also implies the need to split up JSON body parameters and
    other parameters in the http_request_description, since the
    parsing rules for the latter are slightly different.


Also, increase test coverage of our unit tests.