### PR TITLE
Add installer shell script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -173,7 +173,6 @@ then
   echo
   echo "  - ${cmd1}"
   echo "  - ${cmd2}"
-  echo
   read -r dummy_
   action "Installing via dpkg"
   eval "${cmd1}"
@@ -185,7 +184,6 @@ then
   echo "Press ${green}ENTER${normal} to continue with the following commands:"
   echo
   echo "  - ${cmd1}"
-  echo
   action "Unpacking tarball"
   eval "${cmd1}"
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -143,37 +143,51 @@ echo "(You can skip these steps, but then only open source features will be"
 echo "available. Visit ${bold}https://tenzir.com/pricing${normal} for a" \
   "feature comparison.)"
 echo
-echo "Press ${green}ENTER${normal} to proceed with the installation."
+echo "Press ${green}ENTER${normal} to continue."
 read -r dummy_
 
 # Check for platform configuration.
+action "Checking for existence of platform configuration"
 if ! [ -f "${config}" ]
 then
+  echo "Could not find config at ${bold}${config}${normal}."
+  action "Using open source feature set"
   open_source=1
-fi
-if [ -n "${open_source}" ]
-then
-  echo "Could not find platform config at ${bold}${config}${normal}."
-  action "Using open source edition"
+else
+  echo "Found config at ${bold}${config}${normal}."
+  action "Using complete feature set"
 fi
 
 # Trigger installation.
+action "Installing package into ${prefix}"
 if ! check sudo
 then
   echo "Could not find ${bold}sudo${normal} in \$PATH."
   exit 1
 fi
-action "Installing package into ${prefix}"
 if [ "${platform}" = "Debian" ]
 then
+  cmd1="sudo dpkg -i \"${tmpdir}/${package}\""
+  cmd2="sudo systemctl status tenzir"
+  echo "Press ${green}ENTER${normal} to continue with the following commands:"
+  echo
+  echo "  - ${cmd1}"
+  echo "  - ${cmd2}"
+  echo
+  read -r dummy_
   action "Installing via dpkg"
-  sudo dpkg -i "${tmpdir}/${package}"
+  eval "${cmd1}"
   action "Checking node status"
-  sudo systemctl status tenzir
+  eval "${cmd2}"
 elif [ "${platform}" = "Linux" ]
 then
+  cmd1="sudo tar xzf \"${tmpdir}/${package}\" -C /"
+  echo "Press ${green}ENTER${normal} to continue with the following commands:"
+  echo
+  echo "  - ${cmd1}"
+  echo
   action "Unpacking tarball"
-  sudo tar xzf "${tmpdir}/${package}" -C /
+  eval "${cmd1}"
 fi
 
 # Test the installation.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -111,13 +111,15 @@ base="https://github.com/tenzir/tenzir/releases/latest/download"
 url="${base}/${package}"
 tmpdir="$(dirname "$(mktemp -u --tmpdir)")"
 action "Downloading ${url}"
-if check wget; then
+if check wget
+then
   wget -q --show-progress -O "${tmpdir}/${package}" "${url}"
-elif check curl; then
+elif check curl
+then
   curl --progress-bar -L -o "${tmpdir}/${package}" "${url}"
 else
   echo "Neither ${bold}wget${normal} nor ${bold}curl${normal}" \
-    "in ${bold}\$PATH${normal}, aborting"
+    "found in \$PATH."
   exit 1
 fi
 echo "Successfully downloaded ${package}"
@@ -152,17 +154,22 @@ then
 fi
 
 # Trigger installation.
+if ! check sudo
+then
+  echo "Could not find ${bold}sudo${normal} in \$PATH."
+  exit 1
+fi
 action "Installing package into ${prefix}"
 if [ "${platform}" = "Debian" ]
 then
   action "Installing via dpkg"
-  dpkg -i "${tmpdir}/${package}"
+  sudo dpkg -i "${tmpdir}/${package}"
   action "Checking node status"
-  systemctl status tenzir
+  sudo systemctl status tenzir
 elif [ "${platform}" = "Linux" ]
 then
   action "Unpacking tarball"
-  tar xzf "${tmpdir}/${package}" -C /
+  sudo tar xzf "${tmpdir}/${package}" -C /
 fi
 
 # Test the installation.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -130,7 +130,7 @@ echo "available. Visit ${bold}https://tenzir.com/pricing${normal} for a" \
   "feature comparison.)"
 echo
 echo "Press ${green}ENTER${normal} to proceed with the installation."
-read -r
+read -r dummy_
 
 # Check for platform configuration.
 if ! [ -f "${config}" ]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,6 +6,9 @@
 # Treat unset variables as an error when substituting.
 set -u
 
+# Abort on error.
+set -e
+
 #
 # Helper utilities
 #
@@ -147,7 +150,7 @@ then
   action "Installing via dpkg"
   dpkg -i "${package}"
   action "Checking node status"
-  systemctl status tenzir || exit 1
+  systemctl status tenzir
 elif [ "${platform}" = "Linux" ]
 then
   action "Unpacking tarball"
@@ -157,7 +160,7 @@ fi
 # Test the installation.
 action "Checking version"
 PATH="${prefix}:$PATH"
-tenzir -q 'version | select version | write json' || exit 1
+tenzir -q 'version | select version | write json'
 
 # Inform about next steps.
 action "Providing guidance"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -109,7 +109,7 @@ echo "Using ${package}"
 # Download package.
 base="https://github.com/tenzir/tenzir/releases/latest/download"
 url="${base}/${package}"
-tmpdir="$(mktemp -u)"
+tmpdir="$(dirname "$(mktemp -u)")"
 action "Downloading ${url}"
 if check wget
 then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -42,12 +42,6 @@ action() {
 # Execution
 #
 
-if [ -z "${BASH_VERSION:-}" ]
-then
-  echo "Bash is required to interpret this script."
-  exit 1
-fi
-
 # Print welcome banner.
 echo "${blue}"
 echo "                _____ _____ _   _ ________ ____  "

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -80,6 +80,17 @@ then
 elif [ "${PLATFORM}" = "Linux" ]
 then
   PACKAGE="tenzir-linux-static.tar.gz"
+elif [ "${PLATFORM}" = "NixOS" ]
+then
+  echo "Try Tenzir with our ${bold}flake.nix${normal}:"
+  echo
+  echo "    ${bold}nix run github:tenzir/tenzir/stable${normal}"
+  echo
+  echo "Install Tenzir by adding" \
+    "${bold}github:tenzir/tenzir/stable${normal} to your"
+  echo "flake inputs, or use your preferred method to include third-party"
+  echo "modules on classic NixOS."
+  exit 0
 else
   echo "We do not offer pre-built packages for ${bold}${PLATFORM}${normal}." \
        "Your options:"
@@ -87,7 +98,7 @@ else
   echo "1. Use Docker"
   echo "2. Build from source"
   echo
-  echo "See https://docs.tenzir.com for further information."
+  echo "See ${bold}https://docs.tenzir.com${normal} for further information."
   exit 1
 fi
 echo "Using ${PACKAGE}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -53,35 +53,35 @@ echo
 
 # Detect OS.
 action "Identifying platform"
-PLATFORM=
-OS=$(uname -s)
-if [ "${OS}" = "Linux" ]
+platform=
+os=$(uname -s)
+if [ "${os}" = "Linux" ]
 then
     if [ -f "/etc/debian_version" ]
     then
-        PLATFORM=Debian
+        platform=Debian
     elif [ -f "/etc/NIXOS" ]
     then
-        PLATFORM=NixOS
+        platform=NixOS
     else
-        PLATFORM=Linux
+        platform=Linux
     fi
-elif [ "${OS}" = "Darwin" ]
+elif [ "${os}" = "Darwin" ]
 then
-  PLATFORM=macOS
+  platform=macOS
 fi
-echo "Found ${PLATFORM}."
+echo "Found ${platform}."
 
 # Select appropriate package.
 action "Identifying package"
-PACKAGE=
-if [ "${PLATFORM}" = "Debian" ]
+package=
+if [ "${platform}" = "Debian" ]
 then
-  PACKAGE="tenzir-linux-static.deb"
-elif [ "${PLATFORM}" = "Linux" ]
+  package="tenzir-linux-static.deb"
+elif [ "${platform}" = "Linux" ]
 then
-  PACKAGE="tenzir-linux-static.tar.gz"
-elif [ "${PLATFORM}" = "NixOS" ]
+  package="tenzir-linux-static.tar.gz"
+elif [ "${platform}" = "NixOS" ]
 then
   echo "Try Tenzir with our ${bold}flake.nix${normal}:"
   echo
@@ -93,7 +93,7 @@ then
   echo "modules on classic NixOS."
   exit 0
 else
-  echo "We do not offer pre-built packages for ${PLATFORM}." \
+  echo "We do not offer pre-built packages for ${platform}." \
        "Your options:"
   echo
   echo "  1. Use Docker"
@@ -102,25 +102,25 @@ else
   echo "Visit ${bold}https://docs.tenzir.com${normal} for further instructions."
   exit 1
 fi
-echo "Using ${PACKAGE}"
+echo "Using ${package}"
 
 # Download package.
-BASE="https://github.com/tenzir/tenzir/releases/latest/download"
-URL="${BASE}/${PACKAGE}"
-action "Downloading ${URL}"
-curl --progress-bar -L "${URL}" -o "${PACKAGE}" || exit 1
-echo "Successfully downloaded ${PACKAGE}"
+base="https://github.com/tenzir/tenzir/releases/latest/download"
+url="${base}/${package}"
+action "Downloading ${url}"
+curl --progress-bar -L "${url}" -o "${package}" || exit 1
+echo "Successfully downloaded ${package}"
 
 # Get platform config.
-PREFIX=/opt/tenzir
-CONFIG="${PREFIX}/etc/tenzir/plugin/platform.yaml"
+prefix=/opt/tenzir
+config="${prefix}/etc/tenzir/plugin/platform.yaml"
 echo
 echo "Unlock the full potential of your Tenzir node as follows:"
 echo
 echo "  1. Go to ${bold}https://app.tenzir.com${normal}"
 echo "  2. Sign up for a free account"
 echo "  3. Configure a node and download a ${bold}platform.yaml${normal} config"
-echo "  4. Move the config to ${bold}${CONFIG}${normal}"
+echo "  4. Move the config to ${bold}${config}${normal}"
 echo
 echo "(You can skip these steps, but then only open source features will be"
 echo "available. Visit ${bold}https://tenzir.com/pricing${normal} for a" \
@@ -130,33 +130,33 @@ echo "Press ${green}ENTER${normal} to proceed with the installation."
 read -r
 
 # Check for platform configuration.
-if ! [ -f "${CONFIG}" ]
+if ! [ -f "${config}" ]
 then
-  OPEN_SOURCE=1
+  open_source=1
 fi
-if [ -n "${OPEN_SOURCE}" ]
+if [ -n "${open_source}" ]
 then
-  echo "Could not find platform config at ${bold}${CONFIG}${normal}."
+  echo "Could not find platform config at ${bold}${config}${normal}."
   action "Using open source edition"
 fi
 
 # Trigger installation.
-action "Installing package into ${PREFIX}"
-if [ "${PLATFORM}" = "Debian" ]
+action "Installing package into ${prefix}"
+if [ "${platform}" = "Debian" ]
 then
   action "Installing via dpkg"
-  dpkg -i "${PACKAGE}"
+  dpkg -i "${package}"
   action "Checking node status"
   systemctl status tenzir || exit 1
-elif [ "${PLATFORM}" = "Linux" ]
+elif [ "${platform}" = "Linux" ]
 then
   action "Unpacking tarball"
-  tar xzf "${PACKAGE}" -C /
+  tar xzf "${package}" -C /
 fi
 
 # Test the installation.
 action "Checking version"
-PATH="${PREFIX}:$PATH"
+PATH="${prefix}:$PATH"
 tenzir -q 'version | select version | write json' || exit 1
 
 # Inform about next steps.
@@ -164,11 +164,11 @@ action "Providing guidance"
 echo "You're all set! Next steps:"
 echo
 echo "  - Run a pipeline via ${green}tenzir <pipeline>${normal}"
-if [ "${PLATFORM}" = "Linux" ]
+if [ "${platform}" = "Linux" ]
 then
   echo "  - Spawn a node via ${green}tenzir-node${normal}"
 fi
-if [ -z "${OPEN_SOURCE}" ]
+if [ -z "${open_source}" ]
 then
   echo "  - Explore your node and manage pipelines at" \
     "${bold}https://app.tenzir.com${normal}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -102,14 +102,15 @@ else
   echo "  2. Build from source"
   echo
   echo "Visit ${bold}https://docs.tenzir.com${normal} for further instructions."
-  exit 1
+  #exit 1
+  package="vast-linux-static.tar.gz"
 fi
 echo "Using ${package}"
 
 # Download package.
 base="https://github.com/tenzir/tenzir/releases/latest/download"
 url="${base}/${package}"
-tmpdir="$(dirname "$(mktemp -u --tmpdir)")"
+tmpdir="$(mktemp -u)"
 action "Downloading ${url}"
 if check wget
 then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+#
+# This script installs the latest release of Tenzir.
+#
+
+# Treat unset variables as an error when substituting.
+set -u
+
+#
+# Helper utilities
+#
+
+# Only use colors when we have a TTY.
+if [ -t 1 ]
+then
+  escape() { printf "\033[%sm" "$1"; }
+else
+  escape() { :; }
+fi
+make_bold() { escape "1;$1"; }
+blue="$(make_bold 34)"
+bold="$(make_bold 39)"
+normal="$(escape 0)"
+
+# Prints an "action", i.e., something the script is doing.
+# Use this to transparently inform the user about the key
+# steps this script takes.
+action() {
+  printf "${blue}==>${bold} %s${normal}\n" "$@"
+}
+
+# Gets a single character from stdin.
+getc() {
+  local save_state
+  save_state="$(/bin/stty -g)"
+  /bin/stty raw -echo
+  IFS='' read -r -n 1 -d '' "$@"
+  /bin/stty "${save_state}"
+}
+
+#
+# Execution
+#
+
+if [ -z "${BASH_VERSION:-}" ]
+then
+  echo "Bash is required to interpret this script."
+  exit 1
+fi
+
+# Print welcome banner.
+echo "${bold}${blue}"
+echo "                _____ _____ _   _ ________ ____  "
+echo "               |_   _| ____| \ | |__  /_ _|  _ \ "
+echo "                 | | |  _| |  \| | / / | || |_) |"
+echo "                 | | | |___| |\  |/ /_ | ||  _ < "
+echo "                 |_| |_____|_| \_/____|___|_| \\_\\"
+echo "${normal}"
+echo "                            INSTALLER"
+echo
+
+# Detect OS.
+action "Identifying platform"
+PLATFORM=
+OS=$(uname -s)
+if [ "${OS}" = "Linux" ]
+then
+    if [ -f "/etc/debian_version" ]
+    then
+        PLATFORM=Debian
+    elif [ -f "/etc/NIXOS" ]
+    then
+        PLATFORM=NixOS
+    else
+        PLATFORM=Linux
+    fi
+elif [ "${OS}" = "Darwin" ]
+then
+  PLATFORM=macOS
+fi
+echo "Found ${PLATFORM}"
+
+# Select appropriate package.
+action "Identifying package"
+PACKAGE=
+if [ "${PLATFORM}" = "Debian" ]
+then
+  PACKAGE="tenzir-linux-static.deb"
+elif [ "${PLATFORM}" = "Linux" ]
+then
+  PACKAGE="tenzir-linux-static.tar.gz"
+else
+  echo "We do not offer pre-built packages for ${bold}${PLATFORM}${normal}." \
+       "Your options:"
+  echo
+  echo "1. Use Docker"
+  echo "2. Build from source"
+  echo
+  echo "See https://docs.tenzir.com for further information."
+  exit 1
+fi
+echo "Using ${PACKAGE}"
+
+# Download package.
+BASE="https://github.com/tenzir/tenzir/releases/latest/download"
+URL="${BASE}/${PACKAGE}"
+action "Downloading ${URL}"
+curl --progress-bar -L "${URL}" -o "${PACKAGE}" || exit 1
+echo "Successfully downloaded ${PACKAGE}"
+
+# Trigger installation.
+PREFIX=/opt/tenzir
+action "Installing package into ${PREFIX}"
+echo "Press any key to continue..."
+getc dummy
+if [ "${PLATFORM}" = "Debian" ]
+then
+  echo "Installing via dpkg"
+  dpkg -i "${PACKAGE}"
+elif [ "${PLATFORM}" = "Linux" ]
+then
+  echo "Unpacking tarball"
+  tar xzf "${PACKAGE}" -C /
+fi
+
+# Test the installation.
+action "Verifying installation"
+PATH="${PREFIX}:$PATH"
+tenzir version || exit 1
+
+# Inform about next steps.
+echo
+echo "You're all set! Next steps:"
+echo "  - Run a pipeline via ${blue}tenzir <pipeline>${normal}"
+echo "  - Spawn a node via ${blue}tenzir-node${normal}"
+echo "  - Follow the guides at https://docs.tenzir.com/next/user-guides"
+echo "  - Swing by our friendly Discord at https://docs.tenzir.com/discord"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -71,6 +71,10 @@ then
 elif [ "${os}" = "Darwin" ]
 then
   platform=macOS
+elif [ -z "${os}" ]
+then
+  echo "Could not identify platform."
+  exit 1
 fi
 echo "Found ${platform}."
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # This script installs the latest release of Tenzir.
 #
@@ -27,15 +27,6 @@ normal="$(escape 0)"
 # steps this script takes.
 action() {
   printf "${blue}==>${bold} %s${normal}\n" "$@"
-}
-
-# Gets a single character from stdin.
-getc() {
-  local save_state
-  save_state="$(/bin/stty -g)"
-  /bin/stty raw -echo
-  IFS='' read -r -n 1 -d '' "$@"
-  /bin/stty "${save_state}"
 }
 
 #
@@ -111,8 +102,8 @@ echo "Successfully downloaded ${PACKAGE}"
 # Trigger installation.
 PREFIX=/opt/tenzir
 action "Installing package into ${PREFIX}"
-echo "Press any key to continue..."
-getc dummy
+echo "Press ${bold}ENTER${normal} to continue..."
+read -r
 if [ "${PLATFORM}" = "Debian" ]
 then
   echo "Installing via dpkg"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -113,7 +113,7 @@ echo "Successfully downloaded ${PACKAGE}"
 
 # Get platform config.
 PREFIX=/opt/tenzir
-CONFIG="${PREFIX}/etc/tenzir/plugins/platform.yaml"
+CONFIG="${PREFIX}/etc/tenzir/plugin/platform.yaml"
 echo
 echo "Unlock the full potential of your Tenzir node as follows:"
 echo

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -102,8 +102,7 @@ else
   echo "  2. Build from source"
   echo
   echo "Visit ${bold}https://docs.tenzir.com${normal} for further instructions."
-  #exit 1
-  package="vast-linux-static.tar.gz"
+  exit 1
 fi
 echo "Using ${package}"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -181,6 +181,7 @@ tenzir -q 'version | select version | write json'
 action "Providing guidance"
 echo "You're all set! Next steps:"
 echo
+echo "  - Ensure that ${bold}${prefix}/bin${normal} is in your \$PATH"
 echo "  - Run a pipeline via ${green}tenzir <pipeline>${normal}"
 if [ "${platform}" = "Linux" ]
 then

--- a/web/docs/get-started.md
+++ b/web/docs/get-started.md
@@ -24,7 +24,7 @@ import TabItem from '@theme/TabItem';
 Let our installer take care of getting started:
 
 ```bash
-curl https://get.tenzir.com/ | sh
+curl -L get.tenzir.app | sh
 ```
 
 </TabItem>

--- a/web/docs/get-started.md
+++ b/web/docs/get-started.md
@@ -15,46 +15,50 @@ command line examples.
 
 Select your platform to download and install Tenzir.
 
+[tenzir-debian-package]: https://github.com/tenzir/tenzir/releases/latest/download/tenzir-linux-static.deb
+[tenzir-tarball]: https://github.com/tenzir/tenzir/releases/latest/download/tenzir-linux-static.tar.gz
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <Tabs>
 <TabItem value="universal" label="All Platforms" default>
 
-Let our installer take care of getting started:
+Use our installer to perform a platform-specific installation:
 
 ```bash
 curl -L get.tenzir.app | sh
 ```
 
+The shell script asks you once to confirm the installation.
+
 </TabItem>
 <TabItem value="debian" label="Debian">
 
-Download the latest [Debian
-package](https://github.com/tenzir/tenzir/releases/latest/download/tenzir-linux-static.deb)
-and install it via `dpdk`:
+Download the latest [Debian package][tenzir-debian-package] and install it via
+`dpkg`:
 
 ```bash
-dpdk -i tenzir-linux-static.deb
+dpkg -i tenzir-linux-static.deb
 ```
 
 </TabItem>
 <TabItem value="nix" label="Nix">
 
-We provide a `flake.nix` so that you can use
-`tenzir = "github:tenzir/tenzir/stable"` as an input in your own flake, or just
-try it out with:
+Try Tenzir with our `flake.nix`:
 
 ```bash
 nix run github:tenzir/tenzir/stable
 ```
 
+Install Tenzir by adding `github:tenzir/tenzir/stable` to your flake inputs, or
+use your preferred method to include third-party modules on classic NixOS.
+
 </TabItem>
 <TabItem value="linux" label="Linux">
 
-Download a tarball with our [static
-binary](https://github.com/tenzir/tenzir/releases/latest/download/tenzir-linux-static.tar.gz)
-for all Linux distributions and unpack it into `/opt/tenzir`:
+Download a tarball with our [static binary][tenzir-tarball] for all Linux
+distributions and unpack it into `/opt/tenzir`:
 
 ```bash
 tar xzf tenzir-linux-static.tar.gz -C /
@@ -78,7 +82,7 @@ until we offer a native package.
 </TabItem>
 <TabItem value="docker" label="Docker">
 
-Pull the open source image:
+Pull the image:
 
 ```bash
 docker pull tenzir/tenzir


### PR DESCRIPTION
This PR adds an installer shell script so that installing Tenzir will be as simple as:

```bash
curl -L get.tenzir.app | sh
```

This supersedes #2476, a more complex attempt that was Homebrew-inspired.