### PR TITLE
Fix JSON parser --no-infer option

### DIFF
--- a/libvast/builtins/connectors/directory.cpp
+++ b/libvast/builtins/connectors/directory.cpp
@@ -104,7 +104,7 @@ class plugin : public virtual saver_plugin<directory_saver> {
 public:
   auto parse_saver(parser_interface& p) const
     -> std::unique_ptr<plugin_saver> override {
-    auto parser = argument_parser{name(), "https://vast.io/docs/next/"
+    auto parser = argument_parser{name(), "https://docs.tenzir.com/next/"
                                           "connectors/directory"};
     auto path = std::string{};
     parser.add(path, "<path>");

--- a/libvast/builtins/connectors/file.cpp
+++ b/libvast/builtins/connectors/file.cpp
@@ -475,7 +475,7 @@ public:
   auto parse_loader(parser_interface& p) const
     -> std::unique_ptr<plugin_loader> override {
     auto args = loader_args{};
-    auto parser = argument_parser{"file", "https://vast.io/docs/next/"
+    auto parser = argument_parser{"file", "https://docs.tenzir.com/next/"
                                           "connectors/file"};
     parser.add(args.path, "<path>");
     parser.add("-f,--follow", args.follow);
@@ -511,7 +511,7 @@ public:
   auto parse_saver(parser_interface& p) const
     -> std::unique_ptr<plugin_saver> override {
     auto args = saver_args{};
-    auto parser = argument_parser{"file", "https://vast.io/docs/next/"
+    auto parser = argument_parser{"file", "https://docs.tenzir.com/next/"
                                           "connectors/file"};
     parser.add(args.path, "<path>");
     parser.add("-a,--appending", args.appending);
@@ -553,7 +553,7 @@ public:
     -> std::unique_ptr<plugin_loader> override {
     auto args = file::loader_args{};
     args.path.inner = "-";
-    auto parser = argument_parser{"stdin", "https://vast.io/docs/next/"
+    auto parser = argument_parser{"stdin", "https://docs.tenzir.com/next/"
                                            "connectors/stdin"};
     parser.add("-t,--timeout", args.timeout, "<duration>");
     parser.parse(p);
@@ -573,7 +573,7 @@ public:
     -> std::unique_ptr<plugin_saver> override {
     auto args = file::saver_args{};
     args.path.inner = "-";
-    auto parser = argument_parser{name(), "https://vast.io/docs/next/"
+    auto parser = argument_parser{name(), "https://docs.tenzir.com/next/"
                                           "connectors/stdout"};
     parser.parse(p);
     return std::make_unique<file::file_saver>(std::move(args));

--- a/libvast/builtins/formats/cef.cpp
+++ b/libvast/builtins/formats/cef.cpp
@@ -417,7 +417,7 @@ class plugin final : public virtual reader_plugin,
 
   auto parse_parser(parser_interface& p) const
     -> std::unique_ptr<plugin_parser> override {
-    argument_parser{"cef", "https://vast.io/docs/next/formats/cef"}.parse(p);
+    argument_parser{"cef", "https://docs.tenzir.com/next/formats/cef"}.parse(p);
     return std::make_unique<cef_parser>();
   }
 };

--- a/libvast/builtins/formats/json.cpp
+++ b/libvast/builtins/formats/json.cpp
@@ -516,6 +516,11 @@ struct config {
   }
 };
 
+auto add_common_options_to_parser(argument_parser& parser, config& cfg)
+  -> void {
+  parser.add("--no-infer", cfg.no_infer);
+}
+
 class json_parser final : public plugin_parser {
 public:
   json_parser() = default;
@@ -611,7 +616,7 @@ public:
                                           "formats/json"};
     parser.add("--selector", selector, "<selector>");
     parser.add("--unnest-separator", cfg.unnest_separator, "<separator>");
-    parser.add("--no-infer", cfg.no_infer);
+    add_common_options_to_parser(parser, cfg);
     parser.parse(p);
     if (selector) {
       cfg.selector = parse_selector(selector->inner, selector->source);
@@ -640,8 +645,13 @@ public:
 
   auto parse_parser(parser_interface& p) const
     -> std::unique_ptr<plugin_parser> override {
-    argument_parser{name()}.parse(p);
+    auto parser
+      = argument_parser{name(), fmt::format("https://vast.io/docs/next/"
+                                            "formats/{}",
+                                            name())};
     auto cfg = config{};
+    add_common_options_to_parser(parser, cfg);
+    parser.parse(p);
     cfg.selector = parse_selector(Selector.str(), location::unknown);
     cfg.unnest_separator = Separator.str();
     return std::make_unique<json_parser>(std::move(cfg));

--- a/libvast/builtins/formats/json.cpp
+++ b/libvast/builtins/formats/json.cpp
@@ -612,8 +612,8 @@ public:
     -> std::unique_ptr<plugin_parser> override {
     auto cfg = config{};
     auto selector = std::optional<located<std::string>>{};
-    auto parser = argument_parser{"json", "https://vast.io/docs/next/"
-                                          "formats/json"};
+    auto parser
+      = argument_parser{"json", "https://docs.tenzir.com/next/formats/json"};
     parser.add("--selector", selector, "<selector>");
     parser.add("--unnest-separator", cfg.unnest_separator, "<separator>");
     add_common_options_to_parser(parser, cfg);
@@ -627,8 +627,8 @@ public:
   auto parse_printer(parser_interface& p) const
     -> std::unique_ptr<plugin_printer> override {
     auto pretty = false;
-    auto parser = argument_parser{"json", "https://vast.io/docs/next/"
-                                          "formats/json"};
+    auto parser
+      = argument_parser{"json", "https://docs.tenzir.com/next/formats/json"};
     parser.add("--pretty", pretty);
     parser.parse(p);
     return std::make_unique<json_printer>(pretty);
@@ -645,10 +645,8 @@ public:
 
   auto parse_parser(parser_interface& p) const
     -> std::unique_ptr<plugin_parser> override {
-    auto parser
-      = argument_parser{name(), fmt::format("https://vast.io/docs/next/"
-                                            "formats/{}",
-                                            name())};
+    auto parser = argument_parser{
+      name(), fmt::format("https://docs.tenzir.com/next/formats/{}", name())};
     auto cfg = config{};
     add_common_options_to_parser(parser, cfg);
     parser.parse(p);

--- a/libvast/builtins/formats/xsv.cpp
+++ b/libvast/builtins/formats/xsv.cpp
@@ -349,7 +349,7 @@ public:
   auto parse_parser(parser_interface& p) const
     -> std::unique_ptr<plugin_parser> override {
     auto sep_str = located<std::string>{};
-    auto parser = argument_parser{"xsv", "https://vast.io/docs/next/"
+    auto parser = argument_parser{"xsv", "https://docs.tenzir.com/next/"
                                          "formats/xsv"};
     parser.add(sep_str, "<sep>");
     parser.parse(p);
@@ -367,7 +367,7 @@ public:
     auto list_sep_str = located<std::string>{};
     auto null_value = located<std::string>{};
     auto parser
-      = argument_parser{"xsv", "https://vast.io/docs/next/formats/xsv"};
+      = argument_parser{"xsv", "https://docs.tenzir.com/next/formats/xsv"};
     parser.add(field_sep_str, "<field-sep>");
     parser.add(list_sep_str, "<list-sep>");
     parser.add(null_value, "<null-value>");

--- a/libvast/builtins/formats/zeek_tsv.cpp
+++ b/libvast/builtins/formats/zeek_tsv.cpp
@@ -738,7 +738,7 @@ public:
 
   auto parse_parser(parser_interface& p) const
     -> std::unique_ptr<plugin_parser> override {
-    argument_parser{"zeek-tsv", "https://vast.io/docs/next/formats/zeek-tsv"}
+    argument_parser{"zeek-tsv", "https://docs.tenzir.com/next/formats/zeek-tsv"}
       .parse(p);
     return std::make_unique<zeek_tsv_parser>();
   }
@@ -747,7 +747,7 @@ public:
     -> std::unique_ptr<plugin_printer> override {
     auto args = zeek_tsv_printer::args{};
     auto set_separator = std::optional<located<std::string>>{};
-    auto parser = argument_parser{"zeek-tsv", "https://vast.io/docs/next/"
+    auto parser = argument_parser{"zeek-tsv", "https://docs.tenzir.com/next/"
                                               "formats/zeek-tsv"};
     parser.add("-s,--set-separator", set_separator, "<sep>");
     parser.add("-e,--empty-field", args.empty_field, "<str>");

--- a/libvast/builtins/operators/from_read_load_parse.cpp
+++ b/libvast/builtins/operators/from_read_load_parse.cpp
@@ -118,7 +118,7 @@ auto parse_default_parser(std::string definition)
   diagnostic::error("loader `{}` could not be found", x.inner)
     .primary(x.source)
     .hint("must be one of {}", fmt::join(available, ", "))
-    .docs("https://vast.io/docs/next/connectors")
+    .docs("https://docs.tenzir.com/next/connectors")
     .throw_();
 }
 
@@ -130,7 +130,7 @@ auto parse_default_parser(std::string definition)
   diagnostic::error("parser `{}` could not be found", x.inner)
     .primary(x.source)
     .hint("must be one of {}", fmt::join(available, ", "))
-    .docs("https://vast.io/docs/next/formats")
+    .docs("https://docs.tenzir.com/next/formats")
     .throw_();
 }
 
@@ -142,7 +142,7 @@ public:
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
     auto usage = "from <loader> <args>... [read <parser> <args>...]";
-    auto docs = "https://vast.io/docs/next/operators/sources/from";
+    auto docs = "https://docs.tenzir.com/next/operators/sources/from";
     auto l_name = p.accept_shell_arg();
     if (!l_name) {
       diagnostic::error("expected loader name")
@@ -205,7 +205,7 @@ public:
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
     auto usage = "read <parser> <args>... [from <loader> <args>...]";
-    auto docs = "https://vast.io/docs/next/operators/sources/read";
+    auto docs = "https://docs.tenzir.com/next/operators/sources/read";
     auto p_name = p.accept_shell_arg();
     if (!p_name) {
       diagnostic::error("expected parser name")
@@ -254,7 +254,7 @@ class load_plugin final : virtual public operator_plugin<load_operator> {
 public:
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
     auto usage = "load <loader> <args>...";
-    auto docs = "https://vast.io/docs/next/operators/sources/load";
+    auto docs = "https://docs.tenzir.com/next/operators/sources/load";
     auto name = p.accept_shell_arg();
     if (!name) {
       diagnostic::error("expected loader name", p.current_span())
@@ -277,7 +277,7 @@ class parse_plugin final : virtual public operator_plugin<parse_operator> {
 public:
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
     auto usage = "parse <parser> <args>...";
-    auto docs = "https://vast.io/docs/next/operators/transformations/parse";
+    auto docs = "https://docs.tenzir.com/next/operators/transformations/parse";
     auto name = p.accept_shell_arg();
     if (!name) {
       diagnostic::error("expected parser name")

--- a/libvast/builtins/operators/head.cpp
+++ b/libvast/builtins/operators/head.cpp
@@ -64,7 +64,7 @@ private:
 class plugin final : public virtual operator_plugin<head_operator> {
 public:
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
-    auto parser = argument_parser{"head", "https://vast.io/docs/next/"
+    auto parser = argument_parser{"head", "https://docs.tenzir.com/next/"
                                           "operators/transformations/head"};
     auto count = std::optional<uint64_t>{};
     parser.add(count, "<limit>");

--- a/libvast/builtins/operators/version.cpp
+++ b/libvast/builtins/operators/version.cpp
@@ -231,7 +231,7 @@ private:
 class plugin final : public virtual operator_plugin<version_operator> {
 public:
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
-    auto parser = argument_parser{"version", "https://vast.io/docs/next/"
+    auto parser = argument_parser{"version", "https://docs.tenzir.com/next/"
                                              "operators/sources/version"};
     auto dev = false;
     parser.add("--dev", dev);

--- a/libvast/builtins/operators/where.cpp
+++ b/libvast/builtins/operators/where.cpp
@@ -119,7 +119,7 @@ private:
 class plugin final : public virtual operator_plugin<where_operator> {
 public:
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
-    auto parser = argument_parser{"where", "https://vast.io/docs/next/"
+    auto parser = argument_parser{"where", "https://docs.tenzir.com/next/"
                                            "operators/transformations/where"};
     auto expr = located<vast::expression>{};
     parser.add(expr, "<expr>");

--- a/libvast/builtins/operators/write_to_print_save.cpp
+++ b/libvast/builtins/operators/write_to_print_save.cpp
@@ -38,7 +38,7 @@ namespace {
   diagnostic::error("printer `{}` could not be found", x.inner)
     .primary(x.source)
     .hint("must be one of {}", fmt::join(available, ", "))
-    .docs("https://vast.io/docs/next/formats")
+    .docs("https://docs.tenzir.com/next/formats")
     .throw_();
 }
 
@@ -50,7 +50,7 @@ namespace {
   diagnostic::error("saver `{}` could not be found", x.inner)
     .primary(x.source)
     .hint("must be one of {}", fmt::join(available, ", "))
-    .docs("https://vast.io/docs/next/connectors")
+    .docs("https://docs.tenzir.com/next/connectors")
     .throw_();
 }
 
@@ -138,7 +138,7 @@ class print_plugin final : public virtual operator_plugin<print_operator> {
 public:
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
     auto usage = "print <printer> <args>...";
-    auto docs = "https://vast.io/docs/next/operators/transformations/print";
+    auto docs = "https://docs.tenzir.com/next/operators/transformations/print";
     auto name = p.accept_shell_arg();
     if (!name) {
       diagnostic::error("expected printer name")
@@ -206,7 +206,7 @@ class save_plugin final : public virtual operator_plugin<save_operator> {
 public:
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
     auto usage = "save <saver> <args>...";
-    auto docs = "https://vast.io/docs/next/operators/sinks/save";
+    auto docs = "https://docs.tenzir.com/next/operators/sinks/save";
     auto name = p.accept_shell_arg();
     if (!name) {
       diagnostic::error("expected saver name", p.current_span())
@@ -301,7 +301,7 @@ public:
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
     auto usage = "write <printer> <args>... [to <saver> <args>...]";
-    auto docs = "https://vast.io/docs/next/operators/sinks/write";
+    auto docs = "https://docs.tenzir.com/next/operators/sinks/write";
     auto l_name = p.accept_shell_arg();
     if (!l_name) {
       diagnostic::error("expected printer name")
@@ -381,7 +381,7 @@ public:
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
     auto usage = "to <saver> <args>... [write <printer> <args>...]";
-    auto docs = "https://vast.io/docs/next/operators/sinks/to";
+    auto docs = "https://docs.tenzir.com/next/operators/sinks/to";
     auto l_name = p.accept_shell_arg();
     if (!l_name) {
       diagnostic::error("expected saver name")

--- a/libvast/src/detail/series_builders.cpp
+++ b/libvast/src/detail/series_builders.cpp
@@ -255,8 +255,7 @@ auto fixed_fields_record_builder::get_arrow_builder()
   return record_series_builder_base::get_arrow_builder(type_);
 }
 
-series_builder::series_builder(const vast::type& type, bool are_fields_fixed)
-  : can_change_builder_type_{not are_fields_fixed} {
+series_builder::series_builder(const vast::type& type, bool are_fields_fixed) {
   caf::visit(
     detail::overload{
       [this, &type]<class Type>(const Type&) {
@@ -278,6 +277,7 @@ series_builder::series_builder(const vast::type& type, bool are_fields_fixed)
       },
     },
     type);
+  can_change_builder_type_ = not are_fields_fixed;
 }
 
 arrow_length_type series_builder::length() const {
@@ -330,7 +330,7 @@ auto series_builder::remove_last_row() -> void {
     [this](auto& actual) {
       if constexpr (std::is_same_v<bool, decltype(actual.remove_last_row())>) {
         if (auto all_values_are_null = actual.remove_last_row();
-            all_values_are_null) {
+            all_values_are_null and can_change_builder_type_) {
           *this = unknown_type_builder(actual.length());
         }
       } else {

--- a/libvast/src/tql/parser.cpp
+++ b/libvast/src/tql/parser.cpp
@@ -353,7 +353,7 @@ private:
     if (!plugin) {
       diagnostic::error("no such operator: `{}`", ident.name)
         .primary(ident.source)
-        .docs("https://vast.io/docs/next/operators")
+        .docs("https://docs.tenzir.com/next/operators")
         .throw_();
     }
     try {

--- a/vast/integration/data/suricata/dns-with-no-schema-column.json
+++ b/vast/integration/data/suricata/dns-with-no-schema-column.json
@@ -1,0 +1,1 @@
+{"custom_field" : "CUSTOM_FIELD", "timestamp":"2011-08-12T14:55:22.154618+0200","flow_id":2247896271051770,"pcap_cnt":775,"event_type":"dns","src_ip":"147.32.84.165","src_port":1141,"dest_ip":"147.32.80.9","dest_port":53,"proto":"UDP","dns":{"type":"query","id":553,"rrname":"irc.freenode.net","rrtype":"A","tx_id":0}}

--- a/vast/integration/reference/parse-operators/step_02.ref
+++ b/vast/integration/reference/parse-operators/step_02.ref
@@ -5,7 +5,7 @@ error: unknown option `--tev`
   |         ^^^^^ 
   |
   = usage: version [--dev]
-  = docs: https://vast.io/docs/next/operators/sources/version
+  = docs: https://docs.tenzir.com/next/operators/sources/version
 ---
 [1m[31merror[39m: unknown option `--tev`[0m
  [1m[34m-->[0m <input>:1:9
@@ -14,7 +14,7 @@ error: unknown option `--tev`
   [1m[34m| [31m        ^^^^^ [0m
   [1m[34m|[0m
   [1m[34m=[39m usage:[0m version [--dev]
-  [1m[34m=[39m docs:[0m https://vast.io/docs/next/operators/sources/version
+  [1m[34m=[39m docs:[0m https://docs.tenzir.com/next/operators/sources/version
 ---
 {
   "@type": "vast::diagnostic",
@@ -37,7 +37,7 @@ error: unknown option `--tev`
     },
     {
       "kind": "docs",
-      "message": "https://vast.io/docs/next/operators/sources/version"
+      "message": "https://docs.tenzir.com/next/operators/sources/version"
     }
   ]
 }

--- a/vast/integration/reference/parse-operators/step_03.ref
+++ b/vast/integration/reference/parse-operators/step_03.ref
@@ -5,7 +5,7 @@ error: unexpected positional argument
   |         ^^ 
   |
   = usage: version [--dev]
-  = docs: https://vast.io/docs/next/operators/sources/version
+  = docs: https://docs.tenzir.com/next/operators/sources/version
 ---
 [1m[31merror[39m: unexpected positional argument[0m
  [1m[34m-->[0m <input>:1:9
@@ -14,7 +14,7 @@ error: unexpected positional argument
   [1m[34m| [31m        ^^ [0m
   [1m[34m|[0m
   [1m[34m=[39m usage:[0m version [--dev]
-  [1m[34m=[39m docs:[0m https://vast.io/docs/next/operators/sources/version
+  [1m[34m=[39m docs:[0m https://docs.tenzir.com/next/operators/sources/version
 ---
 {
   "@type": "vast::diagnostic",
@@ -37,7 +37,7 @@ error: unexpected positional argument
     },
     {
       "kind": "docs",
-      "message": "https://vast.io/docs/next/operators/sources/version"
+      "message": "https://docs.tenzir.com/next/operators/sources/version"
     }
   ]
 }

--- a/vast/integration/reference/parse-operators/step_04.ref
+++ b/vast/integration/reference/parse-operators/step_04.ref
@@ -5,7 +5,7 @@ error: loader `a/b/c.json` could not be found
   |      ^^^^^^^^^^ 
   |
   = hint: must be one of -, file, stdin
-  = docs: https://vast.io/docs/next/connectors
+  = docs: https://docs.tenzir.com/next/connectors
 ---
 [1m[31merror[39m: loader `a/b/c.json` could not be found[0m
  [1m[34m-->[0m <input>:1:6
@@ -14,7 +14,7 @@ error: loader `a/b/c.json` could not be found
   [1m[34m| [31m     ^^^^^^^^^^ [0m
   [1m[34m|[0m
   [1m[34m=[39m hint:[0m must be one of -, file, stdin
-  [1m[34m=[39m docs:[0m https://vast.io/docs/next/connectors
+  [1m[34m=[39m docs:[0m https://docs.tenzir.com/next/connectors
 ---
 {
   "@type": "vast::diagnostic",
@@ -37,7 +37,7 @@ error: loader `a/b/c.json` could not be found
     },
     {
       "kind": "docs",
-      "message": "https://vast.io/docs/next/connectors"
+      "message": "https://docs.tenzir.com/next/connectors"
     }
   ]
 }

--- a/vast/integration/vast_integration_suite.yaml
+++ b/vast/integration/vast_integration_suite.yaml
@@ -733,6 +733,11 @@ tests:
     steps:
       - command: exec 'from file @./data/suricata/eve.json read suricata | write json to stdout'
 
+  Skip columns that are not in the schema for suricata input with no-infer option:
+    tags: [pipelines]
+    steps:
+      - command: exec 'from file @./data/suricata/dns-with-no-schema-column.json read suricata --no-infer | select custom_field | write json to stdout'
+
   Read from zeek json file:
     tags: [pipelines]
     steps:


### PR DESCRIPTION
It seems that --no-infer doesn't work with suricata/zeek-json parsers after pipeline parsing refactor.
This PR fixes this issue + fixes a bug in the series_builder which allowed fields to be cast into a common_type when --no-infer was enabled.