### PR TITLE
Introduce ndjson mode for json parser

### DIFF
--- a/libvast/builtins/formats/json.cpp
+++ b/libvast/builtins/formats/json.cpp
@@ -32,6 +32,56 @@ namespace vast::plugins::json {
 
 namespace {
 
+/// A variant of *to_lines* that returns a string view with additional padding
+/// bytes that are safe to read.
+inline auto to_padded_lines(generator<chunk_ptr> input)
+  -> generator<std::optional<simdjson::padded_string_view>> {
+  auto buffer = std::string{};
+  bool ended_on_linefeed = false;
+  for (auto&& chunk : input) {
+    if (!chunk || chunk->size() == 0) {
+      co_yield std::nullopt;
+      continue;
+    }
+    const auto* begin = reinterpret_cast<const char*>(chunk->data());
+    const auto* const end = begin + chunk->size();
+    if (ended_on_linefeed && *begin == '\n') {
+      ++begin;
+    };
+    ended_on_linefeed = false;
+    for (const auto* current = begin; current != end; ++current) {
+      if (*current != '\n' && *current != '\r') {
+        continue;
+      }
+      const auto capacity = static_cast<size_t>(end - begin);
+      const auto size = static_cast<size_t>(current - begin);
+      if (buffer.empty() and capacity >= size + simdjson::SIMDJSON_PADDING) {
+        co_yield simdjson::padded_string_view{begin, size, capacity};
+      } else {
+        buffer.append(begin, current);
+        buffer.reserve(buffer.size() + simdjson::SIMDJSON_PADDING);
+        co_yield simdjson::padded_string_view{buffer};
+        buffer.clear();
+      }
+      if (*current == '\r') {
+        auto next = current + 1;
+        if (next == end) {
+          ended_on_linefeed = true;
+        } else if (*next == '\n') {
+          ++current;
+        }
+      }
+      begin = current + 1;
+    }
+    buffer.append(begin, end);
+    co_yield std::nullopt;
+  }
+  if (!buffer.empty()) {
+    buffer.reserve(buffer.size() + simdjson::SIMDJSON_PADDING);
+    co_yield simdjson::padded_string_view{buffer};
+  }
+}
+
 enum class parser_action {
   skip = 0,
   yield = 1,

--- a/libvast/include/vast/to_lines.hpp
+++ b/libvast/include/vast/to_lines.hpp
@@ -11,6 +11,9 @@
 #include "vast/chunk.hpp"
 #include "vast/generator.hpp"
 
+#include <simdjson/padded_string.h>
+#include <simdjson/padded_string_view.h>
+
 namespace vast {
 
 /// Transforms a sequence of bytes into a sequence of lines. The returned
@@ -56,7 +59,57 @@ inline auto to_lines(generator<chunk_ptr> input)
     co_yield std::nullopt;
   }
   if (!buffer.empty()) {
-    co_yield std::move(buffer);
+    co_yield buffer;
+  }
+}
+
+/// A variant of *to_lines* that returns a string viewn with additional padding
+/// bytes that are safe to read.
+inline auto to_padded_lines(generator<chunk_ptr> input)
+  -> generator<std::optional<simdjson::padded_string_view>> {
+  auto buffer = std::string{};
+  bool ended_on_linefeed = false;
+  for (auto&& chunk : input) {
+    if (!chunk || chunk->size() == 0) {
+      co_yield std::nullopt;
+      continue;
+    }
+    const auto* begin = reinterpret_cast<const char*>(chunk->data());
+    const auto* const end = begin + chunk->size();
+    if (ended_on_linefeed && *begin == '\n') {
+      ++begin;
+    };
+    ended_on_linefeed = false;
+    for (const auto* current = begin; current != end; ++current) {
+      if (*current != '\n' && *current != '\r') {
+        continue;
+      }
+      const auto capacity = static_cast<size_t>(end - begin);
+      const auto size = static_cast<size_t>(current - begin);
+      if (buffer.empty() and capacity >= size + simdjson::SIMDJSON_PADDING) {
+        co_yield simdjson::padded_string_view{begin, size, capacity};
+      } else {
+        buffer.append(begin, current);
+        buffer.reserve(buffer.size() + simdjson::SIMDJSON_PADDING);
+        co_yield simdjson::padded_string_view{buffer};
+        buffer.clear();
+      }
+      if (*current == '\r') {
+        auto next = current + 1;
+        if (next == end) {
+          ended_on_linefeed = true;
+        } else if (*next == '\n') {
+          ++current;
+        }
+      }
+      begin = current + 1;
+    }
+    buffer.append(begin, end);
+    co_yield std::nullopt;
+  }
+  if (!buffer.empty()) {
+    buffer.reserve(buffer.size() + simdjson::SIMDJSON_PADDING);
+    co_yield simdjson::padded_string_view{buffer};
   }
 }
 

--- a/libvast/include/vast/to_lines.hpp
+++ b/libvast/include/vast/to_lines.hpp
@@ -11,9 +11,6 @@
 #include "vast/chunk.hpp"
 #include "vast/generator.hpp"
 
-#include <simdjson/padded_string.h>
-#include <simdjson/padded_string_view.h>
-
 namespace vast {
 
 /// Transforms a sequence of bytes into a sequence of lines. The returned
@@ -60,56 +57,6 @@ inline auto to_lines(generator<chunk_ptr> input)
   }
   if (!buffer.empty()) {
     co_yield buffer;
-  }
-}
-
-/// A variant of *to_lines* that returns a string viewn with additional padding
-/// bytes that are safe to read.
-inline auto to_padded_lines(generator<chunk_ptr> input)
-  -> generator<std::optional<simdjson::padded_string_view>> {
-  auto buffer = std::string{};
-  bool ended_on_linefeed = false;
-  for (auto&& chunk : input) {
-    if (!chunk || chunk->size() == 0) {
-      co_yield std::nullopt;
-      continue;
-    }
-    const auto* begin = reinterpret_cast<const char*>(chunk->data());
-    const auto* const end = begin + chunk->size();
-    if (ended_on_linefeed && *begin == '\n') {
-      ++begin;
-    };
-    ended_on_linefeed = false;
-    for (const auto* current = begin; current != end; ++current) {
-      if (*current != '\n' && *current != '\r') {
-        continue;
-      }
-      const auto capacity = static_cast<size_t>(end - begin);
-      const auto size = static_cast<size_t>(current - begin);
-      if (buffer.empty() and capacity >= size + simdjson::SIMDJSON_PADDING) {
-        co_yield simdjson::padded_string_view{begin, size, capacity};
-      } else {
-        buffer.append(begin, current);
-        buffer.reserve(buffer.size() + simdjson::SIMDJSON_PADDING);
-        co_yield simdjson::padded_string_view{buffer};
-        buffer.clear();
-      }
-      if (*current == '\r') {
-        auto next = current + 1;
-        if (next == end) {
-          ended_on_linefeed = true;
-        } else if (*next == '\n') {
-          ++current;
-        }
-      }
-      begin = current + 1;
-    }
-    buffer.append(begin, end);
-    co_yield std::nullopt;
-  }
-  if (!buffer.empty()) {
-    buffer.reserve(buffer.size() + simdjson::SIMDJSON_PADDING);
-    co_yield simdjson::padded_string_view{buffer};
   }
 }
 

--- a/vast/integration/reference/parse-operators/step_05.ref
+++ b/vast/integration/reference/parse-operators/step_05.ref
@@ -1,3 +1,3 @@
-load "file", loader_args(located("a/b/c.json", location(10, 20)), null, null, null) | parse "json", config(null, "", false)
+load "file", loader_args(located("a/b/c.json", location(10, 20)), null, null, null) | parse "json", config(null, "", false, false)
 -----
-located([[["load", "file", loader_args(located("a/b/c.json", location(10, 20)), null, null, null)]], [["parse", "json", config(null, "", false)]]], location(0, 20))
+located([[["load", "file", loader_args(located("a/b/c.json", location(10, 20)), null, null, null)]], [["parse", "json", config(null, "", false, false)]]], location(0, 20))

--- a/web/docs/formats/suricata.md
+++ b/web/docs/formats/suricata.md
@@ -1,7 +1,11 @@
 # suricata
 
 Reads [Suricata][suricata]'s [EVE JSON][eve-json] output. The parser is an alias
-for [`json`](json.md) with the option `--selector=event_type:suricata`.
+for [`json`](json.md) with the arguments:
+- `--selector=event_type:suricata`
+- `--ndjson"`
+
+All other options from [`json`](json.md) are also supported.
 
 ## Synopsis
 

--- a/web/docs/formats/zeek-json.md
+++ b/web/docs/formats/zeek-json.md
@@ -3,3 +3,6 @@
 The `zeek-json` format is an alias for [`json`](json.md) with the arguments:
 - `--selector=_path:zeek`
 - `--unnest-separator="."`
+- `--ndjson"`
+
+All other options from [`json`](json.md) are also supported.


### PR DESCRIPTION
Blocked by: https://github.com/tenzir/tenzir/pull/3252

If the input is NDJSON then we can handle malformed JSON errors in a more sophisticated way.
Given JSON
`
{"a}.?>
{"b" : "d"}
`

We would get an simdjson_error from iterate_many. The parser would give us no information about how many bytes are malformed. From it's PoV the whole input is bad as it expects the well formed JSON documents on the input. We can't always assume that end of a line is a separator of a documents. 

Parsing the first line as JSON we can discard it as it is malformed one.
Handling the second line as a separate JSON document allows us to parse this event properly.

Zeek-json and suricata parsers use --ndjson option by default.

I didn't give a much thought about optimizing the memory allocation when parsing line by line. Currently i just reuse additional padded_buffer for it. I think it could be sufficent, but maybe someone has an idea how to improve it if this is critical