### PR TITLE
Return empty object by default

### DIFF
--- a/libvast/include/vast/http_api.hpp
+++ b/libvast/include/vast/http_api.hpp
@@ -131,7 +131,7 @@ private:
   size_t code_ = 200;
 
   // The response body
-  std::string body_ = {};
+  std::string body_ = "{}";
 
   // Whether this is an error response. We can't just check `code_` because
   // HTTP defines many different "success" values, and we can't just check

--- a/nix/vast/plugins/source.json
+++ b/nix/vast/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "29003ad5f5e540905fe33e6a79203cac16b33897",
+  "rev": "33e96a0d2ba62e74c34d4a4db4ed71dc0763786e",
   "submodules": true,
   "shallow": true
 }


### PR DESCRIPTION
Ensure we have a valid JSON body for a default-constructed rest response by using '{}' as the default body.