### PR TITLE
Adjust Plausible website tracking

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -1,8 +1,8 @@
-# VAST Website
+# Tenzir Website
 
-This directory contains code and content of the official VAST website at
-https://vast.io. We use [Docusaurus](https://docusaurus.io/) as driving
-framework and an [enhanced flavor of
+This directory contains code and content of the official Tenzir documentation
+site at <https://docs.tenzir.com> We use [Docusaurus](https://docusaurus.io/) as
+driving framework and an [enhanced flavor of
 Markdown](https://docusaurus.io/docs/markdown-features) for primary content.
 
 ## Structure
@@ -18,10 +18,8 @@ Key files and directories of the `/web` directory include:
 ## Adding and Editing Content
 
 Please consult the section on [writing
-documentation](https://vast.io/docs/develop/write-documentation) for
-instructions on how to change existing or add new content (which corresponds
-to the local file
-[`/docs/develop/write-documentation.md`](/docs/develop/write-documentation.md)).
+documentation](https://docs.tenzir.com/next/contribute/documentation) for
+instructions on how to change existing or add new content.
 
 ## Build and View Locally
 

--- a/web/blog/from-slack-to-discord/index.md
+++ b/web/blog/from-slack-to-discord/index.md
@@ -25,7 +25,7 @@ that abandons Slack. [Numerous][meilisearch] [open-source][appwrite]
 ![Slack-to-Discord](/img/blog/slack-to-discord.excalidraw.svg)
 
 :::info Discord Invite Link
-You can join our Discord community chat via <https://vast.io/discord>.
+You can join our Discord community chat via <https://discord.tenzir.com>.
 :::
 
 Here are the top four reasons why we are switching:

--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -352,7 +352,7 @@ async function createConfig() {
         src: 'https://plausible.io/js/script.js',
         aysnc: true,
         defer: true,
-        'data-domain': 'vast.io',
+        'data-domain': 'docs.tenzir.com',
       },
     ],
   };

--- a/web/src/pages/privacy-statement.md
+++ b/web/src/pages/privacy-statement.md
@@ -51,7 +51,7 @@ with GDPR, CCPA and PECR**. Plausible is made and hosted in the EU, powered by
 European-owned cloud infrastructure.
 
 For maximum transparency, we share our analytics dashboard publicly at
-<https://plausible.io/vast.io>.
+<https://plausible.io/docs.tenzir.com>.
 
 Please refer to Plausible's [data policy](https://plausible.io/data-policy) for
 a complete list of collected metrics.

--- a/web/src/pages/privacy-statement.md
+++ b/web/src/pages/privacy-statement.md
@@ -31,7 +31,7 @@ how to object to the use of your personal data, please visit the section
 
 We host this website on [GitHub Pages](https://pages.github.com). The web site
 is open source and you can inspect the source code at
-<https://github.com/tenzir/vast>.
+<https://github.com/tenzir/tenzir>.
 
 By visiting this website, Github collects information (e.g., in the form of web
 server log files), including your IP address, your browser type, language


### PR DESCRIPTION
The primary change in this PR is updating the `data-domain` for Plausible, so that we get correct statistics at now <https://plausible.io/docs.tenzir.com>.
