### PR TITLE
Only print startup message for non-native plugins

### DIFF
--- a/libvast/src/plugin.cpp
+++ b/libvast/src/plugin.cpp
@@ -327,8 +327,9 @@ caf::error initialize(caf::actor_system_config& cfg) {
       continue;
     }
     // Third, initialize the plugin with the merged configuration.
-    VAST_VERBOSE("initializing the {} plugin with options: {}", plugin->name(),
-                 merged_config);
+    if (plugin.type() != plugin_ptr::type::builtin)
+      VAST_VERBOSE("initializing the {} plugin with options: {}",
+                   plugin->name(), merged_config);
     if (auto err = plugin->initialize(merged_config, global_config))
       return caf::make_error(ec::unspecified,
                              fmt::format("failed to initialize "


### PR DESCRIPTION
With over 70 native plugins at the time of writing, this log message has become a source of considerable log spam when starting a Tenzir node in verbose logging mode.