### PR TITLE
Remove API to dynamically disable plugins

### DIFF
--- a/libvast/include/vast/fwd.hpp
+++ b/libvast/include/vast/fwd.hpp
@@ -382,6 +382,8 @@ using writer_ptr = std::unique_ptr<writer>;
 
 } // namespace vast
 
+namespace tenzir = vast;
+
 // -- type announcements -------------------------------------------------------
 
 constexpr inline caf::type_id_t first_vast_type_id = 800;

--- a/libvast/include/vast/plugin.hpp
+++ b/libvast/include/vast/plugin.hpp
@@ -114,13 +114,6 @@ public:
   plugin(plugin&&) noexcept = default;
   plugin& operator=(plugin&&) noexcept = default;
 
-  /// Allow the plugin to have its own logic for when it should be loaded.
-  /// The plugin will no be initialized if `enabled()` returns false.
-  /// The default implementation looks for a key named 'enabled' in the
-  /// plugin config, and defaults to `true` if that does not exist.
-  [[nodiscard]] virtual bool
-  enabled(const record& plugin_config, const record& global_config) const;
-
   /// Initializes a plugin with its respective entries from the YAML config
   /// file, i.e., `plugin.<NAME>`.
   /// @param plugin_config The relevant subsection of the configuration.

--- a/libvast/src/node.cpp
+++ b/libvast/src/node.cpp
@@ -581,10 +581,9 @@ node(node_actor::stateful_pointer<node_state> self, std::string /*name*/,
       for (const auto& component : plugins::get<component_plugin>()) {
         auto handle = component->make_component(self);
         if (!handle)
-          return caf::make_error( //
-            ec::unspecified,
-            fmt::format("{} failed to spawn component {} from plugin {}", *self,
-                        component->component_name(), component->name()));
+          // The spawn function can provide a better log message so we don't
+          // print one here.
+          continue;
         if (auto err
             = register_component(self, caf::actor_cast<caf::actor>(handle),
                                  component->component_name()))

--- a/libvast_test/src/main.cpp
+++ b/libvast_test/src/main.cpp
@@ -123,12 +123,10 @@ int main(int argc, char** argv) {
   // and allow the unit tests to specify a list of required
   // plugins and their config.
   for (auto& plugin : vast::plugins::get_mutable()) {
-    if (plugin->enabled({}, {})) {
-      if (auto err = plugin->initialize({}, {})) {
-        fmt::print(stderr, "failed to initialize plugin {}: {}", plugin->name(),
-                   err);
-        return EXIT_FAILURE;
-      }
+    if (auto err = plugin->initialize({}, {})) {
+      fmt::print(stderr, "failed to initialize plugin {}: {}", plugin->name(),
+                 err);
+      return EXIT_FAILURE;
     }
   }
   caf::settings log_settings;

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "3474e4363f23416ba11501f7a1e9a6def3210670",
+  "rev": "1648ec5ef47f663ed4b29cfb0b7aafa3a81c590a",
   "submodules": true,
   "shallow": true
 }


### PR DESCRIPTION
A plugin being enabled or disabled based on the runtime config is not useful except for component plugins.
Removing that bit of state from the generic plugin level rids us form a couple of corner cases, e.g., missing plugins from the `version` operator, or a warning that gets displayed `tenzir` connects to a `tenzir-node` with mismatching plugins.