### PR TITLE
Add further performance logs to the execution node

### DIFF
--- a/libvast/builtins/commands/exec.cpp
+++ b/libvast/builtins/commands/exec.cpp
@@ -49,33 +49,41 @@ auto exec_pipeline(pipeline pipe, caf::actor_system& sys,
     pipe.append(std::move(*op));
   }
   auto self = caf::scoped_actor{sys};
-  auto executor = self->spawn<caf::monitored>(
-    pipeline_executor, std::move(pipe),
-    caf::actor_cast<receiver_actor<diagnostic>>(self), node_actor{});
   auto result = caf::expected<void>{};
   // TODO: This command should probably implement signal handling, and check
   // whether a signal was raised in every iteration over the executor. This
   // will likely be easier to implement once we switch to the actor-based
   // asynchronous executor, so we may as well wait until then.
-  self->send(executor, atom::start_v);
-  auto running = true;
-  self->receive_while(running)(
-    []() {
-      VAST_DEBUG("pipeline was succcesfully started");
-    },
-    [&](diagnostic& d) {
-      diag->emit(std::move(d));
-    },
-    [&](caf::error& err) {
-      VAST_DEBUG("failed to start pipeline: {}", err);
-      result = err;
-      running = false;
-    },
-    [&](caf::down_msg& msg) {
-      VAST_DEBUG("pipeline execution finished: {}", msg.reason);
-      running = false;
-      result = msg.reason;
-    });
+  auto handler
+    = self->spawn([&](caf::event_based_actor* self) -> caf::behavior {
+        self->set_down_handler([&, self](const caf::down_msg& msg) {
+          VAST_DEBUG("command received down: {}", msg.reason);
+          if (msg.reason) {
+            result = msg.reason;
+          }
+          self->quit();
+        });
+        auto executor = self->spawn<caf::monitored>(
+          pipeline_executor, std::move(pipe),
+          caf::actor_cast<receiver_actor<diagnostic>>(self), node_actor{});
+        self->request(executor, caf::infinite, atom::start_v)
+          .then(
+            []() {
+              VAST_DEBUG("started pipeline successfully");
+            },
+            [&, self](caf::error& err) {
+              VAST_WARN("failed to start pipeline: {}", err);
+              result = std::move(err);
+              self->quit();
+            });
+        return {
+          [&](diagnostic& d) {
+            diag->emit(std::move(d));
+          },
+        };
+      });
+  self->wait_for(handler);
+  VAST_DEBUG("command is done");
   return result;
 }
 

--- a/libvast/src/execution_node.cpp
+++ b/libvast/src/execution_node.cpp
@@ -433,8 +433,8 @@ struct exec_node_state : inbound_state_mixin<Input>,
       auto time_scheduled_guard = make_timer_guard(time_scheduled);
       this->signaled_demand = false;
       schedule_run();
-      if (error == caf::sec::request_receiver_down
-          or error == caf::sec::broken_promise) {
+      if (error == caf::sec::request_receiver_down) {
+        this->previous = nullptr;
         return;
       }
       // We failed to get results from the previous; let's emit a diagnostic
@@ -693,7 +693,7 @@ struct exec_node_state : inbound_state_mixin<Input>,
         VAST_ASSERT(not this->current_demand);
         VAST_ASSERT(this->outbound_buffer_size == 0);
       }
-      VAST_DEBUG("{} is done", op);
+      VAST_VERBOSE("{} is done", op);
       print_metrics();
       self->quit();
       return;

--- a/libvast/src/execution_node.cpp
+++ b/libvast/src/execution_node.cpp
@@ -624,11 +624,11 @@ struct exec_node_state : inbound_state_mixin<Input>,
                  .count()
              * 100.0;
     };
-    VAST_VERBOSE("{} was scheduled for {:.2f}% of total runtime", op->name(),
+    VAST_VERBOSE("{} was scheduled for {:.2g}% of total runtime", op->name(),
                  percentage(time_scheduled, elapsed));
-    VAST_VERBOSE("{} spent {:.2f}% of scheduled time starting", op->name(),
+    VAST_VERBOSE("{} spent {:.2g}% of scheduled time starting", op->name(),
                  percentage(time_starting, time_scheduled));
-    VAST_VERBOSE("{} spent {:.2f}% of scheduled time running", op->name(),
+    VAST_VERBOSE("{} spent {:.2g}% of scheduled time running", op->name(),
                  percentage(time_running, time_scheduled));
     if constexpr (not std::is_same_v<Input, std::monostate>) {
       constexpr auto inbound_unit
@@ -637,7 +637,7 @@ struct exec_node_state : inbound_state_mixin<Input>,
         = std::is_same_v<Input, chunk_ptr> ? 1'048'576.0 : 1.0;
       const auto total = static_cast<double>(inbound_total) / ratio;
       VAST_VERBOSE(
-        "{} inbound {:.2f} {} in {} rate = {:.2f} {}/s avg batch size = {:.2f} "
+        "{} inbound {:.0f} {} in {} rate = {:.2g} {}/s avg batch size = {:.2f} "
         "{}",
         op->name(), total, inbound_unit, data{elapsed},
         total
@@ -655,7 +655,7 @@ struct exec_node_state : inbound_state_mixin<Input>,
         = std::is_same_v<Output, chunk_ptr> ? 1'048'576.0 : 1.0;
       const auto total = static_cast<double>(outbound_total) / ratio;
       VAST_VERBOSE(
-        "{} outbound {:.2f} {} in {} rate = {:.2f} {}/s avg batch size = "
+        "{} outbound {:.0f} {} in {} rate = {:.2g} {}/s avg batch size = "
         "{:.2f} {}",
         op->name(), total, outbound_unit, data{elapsed},
         total

--- a/libvast/src/pipeline_executor.cpp
+++ b/libvast/src/pipeline_executor.cpp
@@ -234,6 +234,11 @@ auto pipeline_executor(
     }
     for (auto it = self->state.exec_nodes.begin(); it != exec_node; ++it) {
       self->demonitor(*it);
+      // The exit reason `kill` is the only exit reason that takes effect
+      // immediately, and has even higher priority than other high priority
+      // messages. We must use it here to avoid the exit being delayed by an
+      // await, which we may never receive a reply for because of this bug in
+      // CAF: https://github.com/actor-framework/actor-framework/issues/1466
       self->send_exit(*it, caf::exit_reason::kill);
     }
     self->state.exec_nodes.erase(self->state.exec_nodes.begin(), exec_node + 1);


### PR DESCRIPTION
This makes it so we track the total time an execution node is scheduled for, which is a good indicator for performance when compared against (1) the total time spent in `advance_generator()` and (2) the total time since the execution node was started.