### PR TITLE
Fix a rare crash in table slice builders

### DIFF
--- a/libvast/src/module.cpp
+++ b/libvast/src/module.cpp
@@ -146,12 +146,17 @@ get_module_dirs(const caf::actor_system_config& cfg) {
   }
   if (!bare_mode) {
     result.insert(detail::install_configdir() / "schema");
-    if (auto xdg_config_home = detail::getenv("XDG_CONFIG_HOME"))
+    if (auto xdg_config_home = detail::getenv("XDG_CONFIG_HOME")) {
+      result.insert(std::filesystem::path{*xdg_config_home} / "tenzir"
+                    / "schema");
       result.insert(std::filesystem::path{*xdg_config_home} / "vast"
                     / "schema");
-    else if (auto home = detail::getenv("HOME"))
+    } else if (auto home = detail::getenv("HOME")) {
+      result.insert(std::filesystem::path{*home} / ".config" / "tenzir"
+                    / "schema");
       result.insert(std::filesystem::path{*home} / ".config" / "vast"
                     / "schema");
+    }
   }
   if (auto dirs = detail::unpack_config_list_to_vector<std::string>( //
         cfg, "tenzir.schema-dirs"))

--- a/libvast/src/table_slice_builder.cpp
+++ b/libvast/src/table_slice_builder.cpp
@@ -269,7 +269,11 @@ bool table_slice_builder::add(data_view x) {
   for (size_t i = 0; i < index.size() - 1; ++i) {
     nested_builder = &caf::get<type_to_arrow_builder_t<record_type>>(
       *nested_builder->field_builder(detail::narrow_cast<int>(index[i])));
-    if (index.back() == 0) {
+    const auto following_indices_are_zero
+      = std::all_of(index.begin() + i + 1, index.end(), [](size_t j) {
+          return j == 0;
+        });
+    if (following_indices_are_zero) {
       if (auto status = nested_builder->Append(); !status.ok()) {
         VAST_ERROR("failed to add nested record to builder with schema {}: "
                    "{}",

--- a/libvast/test/feather.cpp
+++ b/libvast/test/feather.cpp
@@ -288,8 +288,9 @@ TEST(active feather store fetchall query) {
   run();
   auto results = query(builder, vast::ids{});
   run();
-  CHECK_EQUAL(results.size(), 3ull);
-  compare_table_slices(slice, results[2]);
+  REQUIRE_EQUAL(results.size(), 1ull);
+  CHECK_EQUAL(results[0].rows(), rows(slices));
+  compare_table_slices(results[0], concatenate(slices));
 }
 
 TEST(passive feather store fetchall query) {


### PR DESCRIPTION
This is two changes in one PR for the sake of CI throughput:

First, this fixes the detection of schemas in `$XDG_CONFIG_HOME/tenzir/schemas`.

Second, this fixes a rare crash in table slice builders for schemas like this one:

```go
type test = record {
  foo: record {
    bar: record {
      baz: string, // anything but a record
      qux: record {
        quux: string,
      }
    }
  }
}
```

A logic bug in the builder caused two entries to be added for `foo.bar`: Once when adding `foo.bar.baz`, and once when adding `foo.bar.qux.quux`.