### PR TITLE
Add /bin to prefix when installing Tenzir via install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -190,7 +190,7 @@ fi
 
 # Test the installation.
 action "Checking version"
-PATH="${prefix}:$PATH"
+PATH="${prefix}/bin:$PATH"
 tenzir -q 'version | select version | write json'
 
 # Inform about next steps.


### PR DESCRIPTION
This change fixes the Tenzir installer adding the wrong prefix to the PATH variable to check for successful Tenzir installations.