### PR TITLE
Disable `failed to tailor` warning

### DIFF
--- a/libvast/builtins/operators/where.cpp
+++ b/libvast/builtins/operators/where.cpp
@@ -65,15 +65,16 @@ public:
 #endif // VAST_ENABLE_ASSERTIONS
   }
 
-  auto initialize(const type& schema, operator_control_plane& ctrl) const
+  auto initialize(const type& schema, operator_control_plane&) const
     -> caf::expected<state_type> override {
     auto tailored_expr = tailor(expr_.inner, schema);
-    // Failing to tailor in this context is not an error, it just means that we
-    // cannot do anything with the result.
+    // We ideally want to warn when extractors can not be resolved. However,
+    // this is tricky for e.g. `where #schema == "foo" && bar == 42` and
+    // changing the behavior for this is tricky with the current expressions.
     if (not tailored_expr) {
-      diagnostic::warning("{}", tailored_expr.error())
-        .primary(expr_.source)
-        .emit(ctrl.diagnostics());
+      // diagnostic::warning("{}", tailored_expr.error())
+      //   .primary(expr_.source)
+      //   .emit(ctrl.diagnostics());
       return std::nullopt;
     }
     return std::move(*tailored_expr);

--- a/vast/integration/reference/export-in-pipeline/step_10.ref
+++ b/vast/integration/reference/export-in-pipeline/step_10.ref
@@ -1,7 +1,1 @@
 {"cef_version": 0, "device_vendor": "Check Point", "device_product": "VPN-1 & FireWall-1", "device_version": "Check Point", "signature_id": "Log", "name": "https", "severity": "Unknown", "extension": {"act": "Accept", "destinationTranslatedAddress": "0.0.0.0", "destinationTranslatedPort": 0, "deviceDirection": 0, "rt": 1543270652000, "sourceTranslatedAddress": "192.168.103.254", "sourceTranslatedPort": 35398, "spt": 49363, "dpt": 443, "cs2Label": "Rule Name", "layer_name": "Network", "layer_uuid": "b406b732-2437-4848-9741-6eae1f5bf112", "match_id": 4, "parent_rule": 0, "rule_action": "Accept", "rule_uid": "9e5e6e74-aa9a-4693-b9fe-53712dd27bea", "ifname": "eth0", "logid": 0, "loguid": "{0x5bfc70fc,0x1,0xfe65a8c0,0xc0000001}", "origin": "192.168.101.254", "originsicname": "CN=R80,O=R80_M..6u6bdo", "sequencenum": 1, "version": 5, "dst": "52.173.84.157", "inzone": "Internal", "nat_addtnl_rulenum": 1, "nat_rulenum": 4, "outzone": "External", "product": "VPN-1 & FireWall-1", "proto": 6, "service_id": "https", "src": "192.168.101.100", "cs5Label": "Matched Category", "cs5": "Business / Economy", "deviceCustomDate2": 1508150533713, "deviceCustomDate2Label": "This field is made up"}}
-warning: !! unspecified: failed to tailor expression :ip == 192.168.101.100 for schema cef.event
- --> <input>:1:63
-  |
-1 | export | where device_product == "VPN-1 & FireWall-1" | where 192.168.101.100 | to stdout
-  |                                                               ~~~~~~~~~~~~~~~~ 
-  |

--- a/vast/integration/reference/export-in-pipeline/step_11.ref
+++ b/vast/integration/reference/export-in-pipeline/step_11.ref
@@ -1,7 +1,1 @@
 {"cef_version": 0, "device_vendor": "Check Point", "device_product": "VPN-1 & FireWall-1", "device_version": "Check Point", "signature_id": "Log", "name": "https", "severity": "Unknown", "extension": {"act": "Accept", "destinationTranslatedAddress": "0.0.0.0", "destinationTranslatedPort": 0, "deviceDirection": 0, "rt": 1543270652000, "sourceTranslatedAddress": "192.168.103.254", "sourceTranslatedPort": 35398, "spt": 49363, "dpt": 443, "cs2Label": "Rule Name", "layer_name": "Network", "layer_uuid": "b406b732-2437-4848-9741-6eae1f5bf112", "match_id": 4, "parent_rule": 0, "rule_action": "Accept", "rule_uid": "9e5e6e74-aa9a-4693-b9fe-53712dd27bea", "ifname": "eth0", "logid": 0, "loguid": "{0x5bfc70fc,0x1,0xfe65a8c0,0xc0000001}", "origin": "192.168.101.254", "originsicname": "CN=R80,O=R80_M..6u6bdo", "sequencenum": 1, "version": 5, "dst": "52.173.84.157", "inzone": "Internal", "nat_addtnl_rulenum": 1, "nat_rulenum": 4, "outzone": "External", "product": "VPN-1 & FireWall-1", "proto": 6, "service_id": "https", "src": "192.168.101.100", "cs5Label": "Matched Category", "cs5": "Business / Economy", "deviceCustomDate2": 1508150533713, "deviceCustomDate2Label": "This field is made up"}}
-warning: !! unspecified: failed to tailor expression (device_product == "VPN-1 & FireWall-1" && :ip == 192.168.101.100) for schema cef.event
- --> <input>:1:16
-  |
-1 | export | where device_product == "VPN-1 & FireWall-1" && 192.168.101.100 | to stdout
-  |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
-  |


### PR DESCRIPTION
We will probably re-enable this warning in the future, but want to make it more reliable first.