### PR TITLE
Remove a confusing exit message for `docker compose up`

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -40,12 +40,12 @@ services:
     image: tenzir/tenzir:main
     build:
       target: tenzir
+    profiles:
+      - donotstart
     depends_on:
       - tenzir-node
     environment:
       - TENZIR_ENDPOINT=tenzir-node:5158
-    command:
-      - version | put version | write json
 
 volumes:
   tenzir-node:


### PR DESCRIPTION
Running `docker compose up` had a mysterious "exited with code 0" at the end. This is confusing: users may think that the node exited again immediately.

```
$ docker compose up
[+] Building 0.0s (0/0)
[+] Running 3/3
Attaching to main-tenzir-1, main-tenzir-api-1, main-tenzir-node-1
main-tenzir-node-1  |
main-tenzir-node-1  |      _____ _____ _   _ ________ ____
main-tenzir-node-1  |     |_   _| ____| \ | |__  /_ _|  _ \
main-tenzir-node-1  |       | | |  _| |  \| | / / | || |_) |
main-tenzir-node-1  |       | | | |___| |\  |/ /_ | ||  _ <
main-tenzir-node-1  |       |_| |_____|_| \_/____|___|_| \_\
main-tenzir-node-1  |
main-tenzir-node-1  | Visit https://app.tenzir.com to get started.
main-tenzir-node-1  |
main-tenzir-node-1  | [12:09:33.971] node (v4.0.0-rc5) is listening on tenzir-node:5158
main-tenzir-node-1  | [12:09:33.977] index-11 finished initializing and is ready to accept queries
main-tenzir-api-1   | [12:09:34.272] client connects to tenzir-node:5158 (172.22.0.2)
main-tenzir-api-1   | [12:09:34.273] client connected to VAST node at tenzir-node:5158
main-tenzir-1       | {"version": "v4.0.0-rc5"}
main-tenzir-api-1   | [12:09:34.281] server listening on on http://0.0.0.0:5160
main-tenzir-1 exited with code 0
```

However, this was just because we have a separate `tenzir` service for use with `docker compose run` to enable ad-hoc pipelines. That was configured to run a pipeline that showed the version on startup.

Since we now print the version in the banner on startup of the node, we no longer need this at all, and can change the `tenzir` service to just not start automatically. This also removes the confusing log message.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made in the pull request description in a way that
   is consumable by everyone, not just developers who know the context of the
   change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://docs.tenzir.com/next/contribute/changelog
3. Provide instructions for the reviewer.
4. Remove this comment so it doesn't show up in the merge commit.
-->
