### PR TITLE
Set 'open_source' variable to empty value at beginning of install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -129,6 +129,7 @@ fi
 echo "Successfully downloaded ${package}"
 
 # Get platform config.
+open_source=
 prefix=/opt/tenzir
 config="${prefix}/etc/tenzir/plugin/platform.yaml"
 echo


### PR DESCRIPTION
This change avoids the install script cancelling with an `unbound variable` error at the very end of the installation process.