### PR TITLE
Use `load -` and `read json` as implicit sources

### DIFF
--- a/changelog/next/features/3329--implicit-sink.md
+++ b/changelog/next/features/3329--implicit-sink.md
@@ -1,0 +1,3 @@
+Pipelines executed locally with `tenzir` now use `load -` and `read json` as
+implicit sources. This complements `save -` and `write json --pretty` as
+implicit sinks.


### PR DESCRIPTION
This is the dual to the already existing feature of the `tenzir` binary that added implicit `save -` or `write json --pretty` to the pipeline if the pipeline ended in bytes or events, respectively: now we also add a source as needed.