### PR TITLE
More demo node fixes

### DIFF
--- a/demo-node/entrypoint.bash
+++ b/demo-node/entrypoint.bash
@@ -22,17 +22,17 @@ while ! timeout 100 bash -c "echo > /dev/tcp/127.0.0.1/5160"; do
   sleep 1
 done
 
-suricata_pipe="shell 'bash -c \\\"curl -s -L https://storage.googleapis.com/tenzir-datasets/M57/suricata.tar.zst | tar -x --zstd --to-stdout\\\"' | parse suricata | import"
+suricata_pipe="shell 'bash -c \\\"curl -s -L https://storage.googleapis.com/tenzir-datasets/M57/suricata.tar.zst | tar -x --zstd --to-stdout\\\"' | parse suricata | where #type != \\\"suricata.stats\\\" | import"
 zeek_pipe="shell 'bash -c \\\"curl -s -L https://storage.googleapis.com/tenzir-datasets/M57/zeek.tar.zst | tar -x --zstd; cat Zeek/*.log\\\"' | parse zeek-tsv | import"
 
 curl -X POST \
   -H "Content-Type: application/json" \
-  -d "{\"definition\": \"${suricata_pipe}\", \"start_when_created\": true}" \
+  -d "{\"name\": \"M57 Suricata Import\", \"definition\": \"${suricata_pipe}\", \"start_when_created\": true}" \
   http://127.0.0.1:5160/api/v0/pipeline/create
 
 curl -X POST \
   -H "Content-Type: application/json" \
-  -d "{\"definition\": \"${zeek_pipe}\", \"start_when_created\": true}" \
+  -d "{\"name\": \"M57 Zeek Import\", \"definition\": \"${zeek_pipe}\", \"start_when_created\": true}" \
   http://127.0.0.1:5160/api/v0/pipeline/create
 
 wait "$NODE_PID"

--- a/demo-node/entrypoint.bash
+++ b/demo-node/entrypoint.bash
@@ -3,6 +3,7 @@
 export TENZIR_AUTOMATIC_REBUILD="${TENZIR_AUTOMATIC_REBUILD:-0}"
 export TENZIR_ALLOW_UNSAFE_PIPELINES=true
 
+# Forward signals as SIGTERM to all children.
 trap 'trap " " SIGTERM; kill 0; wait' SIGINT SIGTERM
 
 coproc NODE { exec tenzir-node --print-endpoint --commands="web server --mode=dev"; }
@@ -14,6 +15,12 @@ read -r -u "${NODE[0]}" DUMMY
 export TENZIR_CONSOLE_VERBOSITY="${TENZIR_CLIENT_CONSOLE_VERBOSITY:-"info"}"
 
 tenzir 'remote version | put version | write json'
+
+# Wait until the HTTP endpoint is listening.
+while ! timeout 100 bash -c "echo > /dev/tcp/127.0.0.1/5160"; do
+  echo "Waiting for the HTTP service..."
+  sleep 1
+done
 
 suricata_pipe="shell 'bash -c \\\"curl -s -L https://storage.googleapis.com/tenzir-datasets/M57/suricata.tar.zst | tar -x --zstd --to-stdout\\\"' | parse suricata | import"
 zeek_pipe="shell 'bash -c \\\"curl -s -L https://storage.googleapis.com/tenzir-datasets/M57/zeek.tar.zst | tar -x --zstd; cat Zeek/*.log\\\"' | parse zeek-tsv | import"

--- a/demo-node/entrypoint.bash
+++ b/demo-node/entrypoint.bash
@@ -12,8 +12,10 @@ read -r -u "${NODE[0]}" DUMMY
 # of Tenzir processes.
 export TENZIR_CONSOLE_VERBOSITY="${TENZIR_CLIENT_CONSOLE_VERBOSITY:-"info"}"
 
-suricata_pipe="shell \'bash -c \"curl -s -L https://storage.googleapis.com/tenzir-datasets/M57/suricata.tar.zst | tar -x --zstd --to-stdout\"\' | parse suricata | import"
-zeek_pipe="shell \'bash -c \"curl -s -L https://storage.googleapis.com/tenzir-datasets/M57/suricata.tar.zst | tar -x --zstd; cat Zeek/*.log\"\' | parse zeek | import"
+tenzir 'remote version | put version | write json'
+
+suricata_pipe="shell 'bash -c \\\"curl -s -L https://storage.googleapis.com/tenzir-datasets/M57/suricata.tar.zst | tar -x --zstd --to-stdout\\\"' | parse suricata | import"
+zeek_pipe="shell 'bash -c \\\"curl -s -L https://storage.googleapis.com/tenzir-datasets/M57/zeek.tar.zst | tar -x --zstd; cat Zeek/*.log\\\"' | parse zeek-tsv | import"
 
 curl -X POST \
   -H "Content-Type: application/json" \

--- a/demo-node/entrypoint.bash
+++ b/demo-node/entrypoint.bash
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 export TENZIR_AUTOMATIC_REBUILD="${TENZIR_AUTOMATIC_REBUILD:-0}"
+export TENZIR_ALLOW_UNSAFE_PIPELINES=true
 
 trap 'trap " " SIGTERM; kill 0; wait' SIGINT SIGTERM
 

--- a/demo-node/entrypoint.bash
+++ b/demo-node/entrypoint.bash
@@ -2,6 +2,8 @@
 
 export TENZIR_AUTOMATIC_REBUILD="${TENZIR_AUTOMATIC_REBUILD:-0}"
 
+trap 'trap " " SIGTERM; kill 0; wait' SIGINT SIGTERM
+
 coproc NODE { exec tenzir-node --print-endpoint --commands="web server --mode=dev"; }
 # shellcheck disable=SC2034
 read -r -u "${NODE[0]}" DUMMY


### PR DESCRIPTION
The main fix here is to apply correct quote escaping so that the body is actually valid JSON.

The PR also contains reliability and quality of life improvements:
* Make sure that the HTTP endpoint is listening when the endpoint message is printed
* Enable unsafe pipelines in the demo node
* Make the entrypoint interruptible
* Add names to the demo data pipelines
* Filter out `suricata.stats` events