### PR TITLE
Add missing operator name to example in Get Started guide

### DIFF
--- a/web/docs/get-started.md
+++ b/web/docs/get-started.md
@@ -323,7 +323,7 @@ Aside from filtering, you can also perform aggregations with
 
 ```
 export
-| #schema == "suricata.alert"
+| where #schema == "suricata.alert"
 | summarize count=count(src_ip) by severity
 ```
 


### PR DESCRIPTION
This change fixes a typo in the Get Started guide that would currently result in a pipeline syntax error.