### PR TITLE
Allow list builder to change type

### DIFF
--- a/libtenzir/include/tenzir/cast.hpp
+++ b/libtenzir/include/tenzir/cast.hpp
@@ -439,6 +439,7 @@ struct cast_helper<record_type, record_type> {
         auto input_at_path = descend(std::addressof(in), key);
         if (not input_at_path)
           return std::move(input_at_path.error());
+        TENZIR_ASSERT(*input_at_path);
         if (**input_at_path == caf::none) {
           ret[to_field.name] = caf::none;
           continue;

--- a/libtenzir/include/tenzir/cast.hpp
+++ b/libtenzir/include/tenzir/cast.hpp
@@ -842,11 +842,13 @@ struct cast_helper<enumeration_type, enumeration_type> {
     return std::move(can.error());
   }
 
-  static auto cast(const enumeration_type&,
-                   std::shared_ptr<type_to_arrow_array_t<enumeration_type>>,
-                   const enumeration_type&) noexcept
+  static auto
+  cast(const enumeration_type& from,
+       std::shared_ptr<type_to_arrow_array_t<enumeration_type>> array,
+       const enumeration_type& to) noexcept
     -> std::shared_ptr<type_to_arrow_array_t<enumeration_type>> {
-    die("enumeration to enumeration cast unimplemented");
+    TENZIR_ASSERT(can_cast(from, to));
+    return array;
   }
 };
 

--- a/libtenzir/include/tenzir/cast.hpp
+++ b/libtenzir/include/tenzir/cast.hpp
@@ -300,6 +300,7 @@ struct cast_helper<list_type, list_type> {
     if (from_type == to_type)
       return value;
     auto output = to_type.construct();
+    output.reserve(value.size());
     for (const auto& val : value) {
       auto cast_val = cast_helper<type, type>::cast_value(
         from_type.value_type(), val, to_type.value_type());

--- a/libtenzir/include/tenzir/detail/adaptive_table_slice_builder_guards.hpp
+++ b/libtenzir/include/tenzir/detail/adaptive_table_slice_builder_guards.hpp
@@ -143,18 +143,8 @@ private:
         [view, this](const auto& t) {
           auto cast_val = cast_value(Type{}, view, t);
           if (cast_val) {
-            // "this" is sometimes not used due to the if constexpr below.
-            // It prevents compilation warning treated as an error.
-            (void)this;
-            // We don't handle caf::expected<void> here because the cast api
-            // only returns caf::expected<void> if the operation is not
-            // supported. The caf::expected<void> will fall into common_type
-            // casting case.
-            if constexpr (not std::is_same_v<caf::expected<void>,
-                                             decltype(cast_val)>) {
-              append_value_to_builder(t, *cast_val);
-              return caf::error{};
-            }
+            append_value_to_builder(t, *cast_val);
+            return caf::error{};
           }
           auto new_type = get_root_list_builder().change_type(
             type{t}, type{Type{}}, data{materialize(view)});

--- a/libtenzir/include/tenzir/detail/adaptive_table_slice_builder_guards.hpp
+++ b/libtenzir/include/tenzir/detail/adaptive_table_slice_builder_guards.hpp
@@ -25,6 +25,9 @@ struct type_from_data
 template <class T>
 using type_from_data_t = typename type_from_data<T>::type;
 
+using parent_record_builder_provider
+  = std::function<concrete_series_builder<record_type>*()>;
+
 class field_guard;
 
 /// @brief A view of a list column created within adaptive_table_slice_builder.
@@ -181,8 +184,11 @@ private:
 class record_guard {
 public:
   record_guard(builder_provider builder_provider,
+               parent_record_builder_provider parent_record_builder_provider,
                arrow_length_type starting_fields_length)
     : builder_provider_{std::move(builder_provider)},
+      parent_record_builder_provider_{
+        std::move(parent_record_builder_provider)},
       starting_fields_length_{starting_fields_length} {
   }
 
@@ -193,6 +199,7 @@ public:
 
 private:
   builder_provider builder_provider_;
+  parent_record_builder_provider parent_record_builder_provider_;
   arrow_length_type starting_fields_length_ = 0u;
 };
 
@@ -201,8 +208,11 @@ private:
 class field_guard {
 public:
   field_guard(builder_provider builder_provider,
+              parent_record_builder_provider parent_record_builder_provider,
               arrow_length_type starting_fields_length)
     : builder_provider_{std::move(builder_provider)},
+      parent_record_builder_provider_{
+        std::move(parent_record_builder_provider)},
       starting_fields_length_{starting_fields_length} {
   }
 
@@ -242,6 +252,7 @@ public:
 
 private:
   builder_provider builder_provider_;
+  parent_record_builder_provider parent_record_builder_provider_;
   arrow_length_type starting_fields_length_ = 0u;
 };
 

--- a/libtenzir/include/tenzir/detail/adaptive_table_slice_builder_guards.hpp
+++ b/libtenzir/include/tenzir/detail/adaptive_table_slice_builder_guards.hpp
@@ -25,6 +25,12 @@ struct type_from_data
 template <class T>
 using type_from_data_t = typename type_from_data<T>::type;
 
+/// @brief returns a valid pointer to the parent record_type builder when the
+/// parent builder is constructed and it is allowed to change fields (it is not
+/// a fixed_fields_record_builder) The parent builder will be constructed for:
+/// 1) The fields from the input schema
+/// 2) Inferred fields that had a value added to them (the type was inferred
+/// from the input -> adequate builder was created)
 using parent_record_builder_provider
   = std::function<concrete_series_builder<record_type>*()>;
 

--- a/libtenzir/include/tenzir/detail/series_builders.hpp
+++ b/libtenzir/include/tenzir/detail/series_builders.hpp
@@ -388,15 +388,11 @@ private:
                    concrete_series_builder<duration_type>& builder, auto view) {
     auto unit = builder.type().attribute("unit").value_or("s");
     auto result = cast_value(view_type, view, duration_type{}, unit);
-    if constexpr (std::is_same_v<decltype(result), caf::expected<void>>) {
-      return std::move(result.error());
-    } else {
-      if (result) {
-        builder.add(*result);
-        return caf::error{};
-      }
+    if (not result) {
       return std::move(result.error());
     }
+    builder.add(*result);
+    return caf::error{};
   }
 
   auto
@@ -425,10 +421,7 @@ private:
       auto maybe_new_value = cast_value(ViewType{}, view, BuilderType{});
       if (not maybe_new_value)
         return std::move(maybe_new_value.error());
-      if constexpr (not std::is_same_v<decltype(maybe_new_value),
-                                       caf::expected<void>>) {
-        builder.add(*maybe_new_value);
-      }
+      builder.add(*maybe_new_value);
       return caf::error{};
     }
   }

--- a/libtenzir/include/tenzir/detail/series_builders.hpp
+++ b/libtenzir/include/tenzir/detail/series_builders.hpp
@@ -365,7 +365,7 @@ private:
       if constexpr (std::is_same_v<Type, NewType>) {
         auto cast_builder = cast_to_builder(
           curr_type,
-          std::static_pointer_cast<type_to_arrow_array_t<CurrentType>>(array),
+          static_cast<const type_to_arrow_array_t<CurrentType>&>(*array),
           new_value_type);
         if (not cast_builder)
           return failure;
@@ -379,7 +379,7 @@ private:
           return failure;
         auto cast_builder = cast_to_builder(
           curr_type,
-          std::static_pointer_cast<type_to_arrow_array_t<CurrentType>>(array),
+          static_cast<const type_to_arrow_array_t<CurrentType>&>(*array),
           common_type);
         if (not cast_builder)
           return failure;

--- a/libtenzir/include/tenzir/detail/type_list.hpp
+++ b/libtenzir/include/tenzir/detail/type_list.hpp
@@ -24,6 +24,7 @@ using caf::detail::tl_apply_all;
 using caf::detail::tl_at;
 using caf::detail::tl_back;
 using caf::detail::tl_concat;
+using caf::detail::tl_contains;
 using caf::detail::tl_count;
 using caf::detail::tl_count_not;
 using caf::detail::tl_distinct;
@@ -73,6 +74,9 @@ using tl_unzip_t = typename tl_unzip<List>::type;
 
 template <class List>
 using tl_reverse_t = typename tl_reverse<List>::type;
+
+template <class List, class T>
+constexpr auto tl_contains_v = tl_contains<List, T>::value;
 
 template <class ListA, class ListB>
 using tl_concat_t = typename tl_concat<ListA, ListB>::type;
@@ -143,7 +147,7 @@ struct common_types_helper<L1, type_list<>> {
 template <class L1, class L2>
 struct common_types_helper<L1, L2> {
   using type = std::conditional_t<
-    caf::detail::tl_contains<L1, caf::detail::tl_head_t<L2>>::value,
+    tl_contains_v<L1, caf::detail::tl_head_t<L2>>,
     tl_prepend_t<
       typename common_types_helper<L1, caf::detail::tl_tail_t<L2>>::type,
       caf::detail::tl_head_t<L2>>,

--- a/libtenzir/include/tenzir/type.hpp
+++ b/libtenzir/include/tenzir/type.hpp
@@ -1865,25 +1865,25 @@ struct sum_type_access<arrow::ArrayBuilder> final {
     return nullptr;
   }
 
-  template <class Result, class Visitor, class... Args, class Builder>
-    requires(std::same_as<std::remove_cv_t<Builder>, arrow::ArrayBuilder>)
-  static auto apply(Builder& x, Visitor&& v, Args&&... xs) -> Result {
+  template <class Result, class Visitor, class... Args>
+  static auto apply(const arrow::ArrayBuilder& x, Visitor&& v, Args&&... xs)
+    -> Result {
     TENZIR_ASSERT(x.type());
     // A dispatch table that maps variant type index to dispatch function for
     // the concrete type.
-    static constexpr auto table =
-      []<class... Ts, int... Indices>(
-        detail::type_list<Ts...>,
-        std::integer_sequence<int, Indices...>) noexcept {
-        return std::array{+[](Builder& x, Visitor&& v, Args&&... xs) -> Result {
+    static constexpr auto table = []<class... Ts, int... Indices>(
+      detail::type_list<Ts...>,
+      std::integer_sequence<int, Indices...>) noexcept {
+      return std::array{
+        +[](const arrow::ArrayBuilder& x, Visitor&& v, Args&&... xs) -> Result {
           auto xs_as_tuple = std::forward_as_tuple(xs...);
           auto indices = detail::get_indices(xs_as_tuple);
           return detail::apply_args_suffxied(
             std::forward<decltype(v)>(v), std::move(indices), xs_as_tuple,
             get(x, sum_type_token<Ts, Indices>{}));
         }...};
-      }(types{},
-        std::make_integer_sequence<int, detail::tl_size<types>::value>());
+    }
+    (types{}, std::make_integer_sequence<int, detail::tl_size<types>::value>());
     const auto dispatch
       = table[sum_type_access<arrow::DataType>::index_from_type(*x.type())];
     TENZIR_ASSERT(dispatch);

--- a/libtenzir/include/tenzir/view.hpp
+++ b/libtenzir/include/tenzir/view.hpp
@@ -515,6 +515,12 @@ data_view to_canonical(const type& t, const data_view& x);
 /// @return A data view on the internal representation of the value.
 data_view to_internal(const type& t, const data_view& x);
 
+/// Tries to find the entry with the dot-sperated `path`. If one of the parents
+/// is not a record, but it does exist, an error is returned. Also returns
+/// an error if the path does not resolve.
+/// @pre `!path.empty()`
+auto descend(view<record> r, std::string_view path) -> caf::expected<data_view>;
+
 } // namespace tenzir
 
 namespace std {

--- a/libtenzir/src/detail/series_builders.cpp
+++ b/libtenzir/src/detail/series_builders.cpp
@@ -8,7 +8,259 @@
 
 #include "tenzir/detail/series_builders.hpp"
 
+#include "caf/detail/scope_guard.hpp"
+
 namespace tenzir::detail {
+
+namespace {
+template <class T>
+constexpr auto is_caf_expected = false;
+
+template <class T>
+constexpr auto is_caf_expected<caf::expected<T>> = true;
+
+template <class T>
+concept allowed_common_type
+  = concrete_type<T>
+    and not tl_contains_v<type_list<map_type, list_type, record_type>, T>;
+
+template <concrete_type T1, concrete_type T2>
+consteval auto get_common_type_list() {
+  // Remove T1 as casting from T1 to T1 makes no sense in this context. We'd
+  // never try a common type cast in such case. Remove enumeration_type as it
+  // has no field informations to be cast into.
+  using common_types = caf::detail::tl_filter_not_type_t<
+    caf::detail::tl_filter_not_type_t<
+      detail::tl_common_types_t<typename supported_casts<T1>::types,
+                                typename supported_casts<T2>::types>,
+      T1>,
+    enumeration_type>;
+  return common_types{};
+}
+
+template <concrete_type InputType, class... CommonTypes>
+auto get_common_types_impl(const InputType& input_type, const data& new_input,
+                           type_list<CommonTypes...>)
+  -> std::vector<std::pair<type, data>> {
+  auto ret = std::vector<std::pair<type, data>>{};
+  auto push_type = [&](const auto& current_common_type) {
+    const auto& actual_data = caf::get<type_to_data_t<InputType>>(new_input);
+    auto cast_val = cast_value(input_type, actual_data, current_common_type);
+    if constexpr (not is_caf_expected<decltype(cast_val)>) {
+      ret.push_back({type{current_common_type}, std::move(cast_val)});
+    } else if constexpr (not std::is_same_v<caf::expected<void>,
+                                            decltype(cast_val)>) {
+      if (cast_val) {
+        ret.push_back({type{current_common_type}, std::move(*cast_val)});
+      }
+    }
+  };
+  (push_type(CommonTypes{}), ...);
+  return ret;
+}
+
+auto get_common_types(const data& new_input, const type& new_input_type,
+                      const type& current_builder_type)
+  -> std::vector<std::pair<type, data>> {
+  return caf::visit(
+    detail::overload{
+      [](const auto&, const auto&) -> std::vector<std::pair<type, data>> {
+        return {};
+      },
+      []<class T>(const T&, const T&) -> std::vector<std::pair<type, data>> {
+        return {};
+      },
+      [&new_input]<allowed_common_type InputType, allowed_common_type CurrType>(
+        const InputType& input_type,
+        const CurrType&) -> std::vector<std::pair<type, data>> {
+        return get_common_types_impl(
+          input_type, new_input, get_common_type_list<CurrType, InputType>());
+      },
+    },
+    new_input_type, current_builder_type);
+}
+
+auto append_no_null_values(
+  const data& data, arrow::ArrayBuilder& builder, const type& type,
+  concrete_series_builder<record_type>& cast_field_parent_record) -> bool {
+  return caf::visit(
+    detail::overload{
+      []<class FieldType>(const FieldType& field_type,
+                          type_to_arrow_builder_t<FieldType>& builder,
+                          const type_to_data_t<FieldType>& data) -> bool {
+        auto status = append_builder(field_type, builder, make_view(data));
+        TENZIR_ASSERT(status.ok());
+        return true;
+      },
+      [&cast_field_parent_record](
+        const list_type& type, type_to_arrow_builder_t<list_type>& builder,
+        const type_to_data_t<list_type>& list) -> bool {
+        auto status = builder.Append();
+        TENZIR_ASSERT(status.ok());
+        auto should_append_builder = true;
+        for (const auto& v : list) {
+          if (v == caf::none) {
+            continue;
+          }
+          auto should_append
+            = append_no_null_values(v, *builder.value_builder(),
+                                    type.value_type(),
+                                    cast_field_parent_record);
+          should_append_builder = should_append ? should_append_builder : false;
+        }
+        return should_append_builder;
+      },
+      [&cast_field_parent_record](
+        const record_type& type, type_to_arrow_builder_t<record_type>& builder,
+        const type_to_data_t<record_type>& record) -> bool {
+        auto should_append_builder
+          = std::addressof(builder)
+            != cast_field_parent_record.get_arrow_builder().get();
+        for (auto field_no = 0u; const auto& field : type.fields()) {
+          const auto& data = record.at(field.name);
+          // Only field of a record that started common type casting should have
+          // null here. We ignore them as we had to add them in order to finish
+          // the struct array.
+          if (data == caf::none) {
+            ++field_no;
+            continue;
+          }
+          auto should_append
+            = append_no_null_values(data, *builder.field_builder(field_no),
+                                    field.type, cast_field_parent_record);
+          should_append_builder = should_append ? should_append_builder : false;
+          ++field_no;
+        }
+        if (should_append_builder) {
+          auto status = builder.Append();
+          TENZIR_ASSERT(status.ok());
+        }
+        return should_append_builder;
+      },
+      [](auto&&...) -> bool {
+        TENZIR_WARN("unexpected data/builder/type");
+        return true;
+      },
+    },
+    type, builder, data);
+}
+
+auto add_new_value(const data& data, const type& type_of_new_data,
+                   series_builder& cast_builder) -> caf::error {
+  return caf::visit(
+    detail::overload{
+      [&data,
+       &cast_builder]<allowed_common_type CommonType>(const CommonType&) {
+        auto new_val = caf::get_if<type_to_data_t<CommonType>>(&data);
+        TENZIR_ASSERT(new_val);
+        return cast_builder.add<CommonType>(*new_val);
+      },
+      [](const auto&) {
+        return caf::make_error(ec::convert_error, "invalid common type chosen");
+      },
+    },
+    type_of_new_data);
+}
+
+auto change_child_builder(std::vector<std::pair<type, data>> possible_new_types,
+                          series_builder& builder_that_needs_type_change)
+  -> bool {
+  auto array = builder_that_needs_type_change.finish();
+  for (auto& [type, data] : possible_new_types) {
+    if (auto err = builder_that_needs_type_change.change_type(type, *array)) {
+      continue;
+    }
+    auto err = add_new_value(data, type, builder_that_needs_type_change);
+    return not err;
+  }
+  return false;
+}
+
+type get_list_type_with_new_non_list_value_type(const type& list_type,
+                                                const type& new_value_type) {
+  return caf::visit(detail::overload{
+                      [&new_value_type](const tenzir::list_type& type) {
+                        return tenzir::type{tenzir::list_type{
+                          get_list_type_with_new_non_list_value_type(
+                            type.value_type(), new_value_type)}};
+                      },
+                      [&new_value_type](const auto&) {
+                        return new_value_type;
+                      },
+                    },
+                    list_type);
+}
+
+type get_first_non_list_type(const type& type) {
+  return caf::visit(detail::overload{
+                      [](const list_type& type) {
+                        return get_first_non_list_type(type.value_type());
+                      },
+                      [](const auto& t) {
+                        return tenzir::type{t};
+                      },
+                    },
+                    type);
+}
+
+const record* get_last_record(const data& data) {
+  return caf::visit(detail::overload{
+                      [](const list& list) {
+                        const record* last_record = nullptr;
+                        for (auto it = list.rbegin(); it != list.rend(); ++it) {
+                          if (auto last = get_last_record(*it)) {
+                            return last;
+                          }
+                        }
+                        return last_record;
+                      },
+                      [&](const record& rec) {
+                        return std::addressof(rec);
+                      },
+                      [](const auto&) -> const record* {
+                        return nullptr;
+                      },
+                    },
+                    data);
+}
+
+// Copies all the data to the new list builder but the last record.
+// The last record must be copied without null values as they were appended just
+// so that the child struct array could have been finished.
+auto add_last_cast_list_data(
+  const record* last_record,
+  concrete_series_builder<record_type>& cast_field_parent_record,
+  const data& last_data, arrow::ArrayBuilder& root_builder) -> void {
+  caf::visit(
+    detail::overload{
+      [last_record, &cast_field_parent_record](
+        const list& list, type_to_arrow_builder_t<list_type>& builder) {
+        auto status = builder.Append();
+        TENZIR_ASSERT(status.ok());
+        for (const auto& v : list) {
+          add_last_cast_list_data(last_record, cast_field_parent_record, v,
+                                  *builder.value_builder());
+        }
+      },
+      [last_record, &cast_field_parent_record](
+        const record& rec, type_to_arrow_builder_t<record_type>& builder) {
+        auto type = type::from_arrow(*builder.type());
+        if (last_record == std::addressof(rec)) {
+          append_no_null_values(rec, builder, type, cast_field_parent_record);
+          return;
+        }
+        auto status = append_builder(caf::get<record_type>(type), builder,
+                                     make_view(rec));
+        TENZIR_ASSERT(status.ok());
+      },
+      [](auto&&...) {
+        // nop
+      },
+    },
+    last_data, root_builder);
+}
+
+} // namespace
 
 auto builder_provider::provide() -> series_builder& {
   return std::visit(
@@ -43,7 +295,7 @@ concrete_series_builder<record_type>::concrete_series_builder(
   const record_type& type) {
   for (auto view : type.fields()) {
     field_builders_[std::string{view.name}]
-      = std::make_unique<series_builder>(std::move(view.type));
+      = std::make_unique<series_builder>(std::move(view.type), this);
   }
 }
 
@@ -53,10 +305,12 @@ auto concrete_series_builder<record_type>::get_field_builder_provider(
   if (auto it = field_builders_.find(std::string{field});
       it != field_builders_.end())
     return {std::ref(*(it->second))};
-  return {[field, starting_fields_length,
-           &builders = field_builders_]() -> series_builder& {
-    auto& new_builder = *(
-      builders.emplace(field, std::make_unique<series_builder>()).first->second);
+  return {[field, starting_fields_length, &builders = field_builders_,
+           this]() -> series_builder& {
+    auto& new_builder = *(builders
+                            .emplace(field, std::make_unique<series_builder>(
+                                              unknown_type_builder{}, this))
+                            .first->second);
     new_builder.add_up_to_n_nulls(starting_fields_length);
     return new_builder;
   }};
@@ -121,6 +375,201 @@ auto concrete_series_builder<record_type>::type() const -> tenzir::type {
   return tenzir::type{record_type{std::move(fields)}};
 }
 
+auto concrete_series_builder<record_type>::is_part_of_a_list() const -> bool {
+  return std::visit(detail::overload{
+                      [](std::monostate) {
+                        return false;
+                      },
+                      [](concrete_series_builder<record_type>* obs) {
+                        return obs ? obs->is_part_of_a_list() : false;
+                      },
+                      [](concrete_series_builder<list_type>* obs) {
+                        return static_cast<bool>(obs);
+                      },
+                    },
+                    type_change_observer_);
+}
+
+auto concrete_series_builder<record_type>::on_field_type_change(
+  series_builder& builder_that_needs_type_change,
+  const tenzir::type& type_of_new_input, const data& new_input) -> caf::error {
+  auto possible_new_field_types = get_common_types(
+    new_input, type_of_new_input, builder_that_needs_type_change.type());
+  if (possible_new_field_types.empty()) {
+    return caf::make_error(
+      ec::convert_error,
+      "cannot add value {} : unable to find a common type between {} and {}",
+      new_input, builder_that_needs_type_change.type(), type_of_new_input);
+  }
+  if (not is_part_of_a_list()) {
+    if (change_child_builder(possible_new_field_types,
+                             builder_that_needs_type_change)) {
+      return {};
+    }
+    return caf::make_error(
+      ec::convert_error,
+      "cannot add value {} : unable to find a common type between {} and {}",
+      new_input, builder_that_needs_type_change.type(), type_of_new_input);
+  }
+  changing_builder_ = std::addressof(builder_that_needs_type_change);
+  auto changing_builder_clearer = caf::detail::make_scope_guard([this] {
+    changing_builder_ = nullptr;
+  });
+  auto cast_infos = get_cast_infos(possible_new_field_types);
+  // At least one of the field must have value added so that we can finish the
+  // struct array. We add a null here so that we don't need to check if any
+  // value was added to this record before a common type cast was started.
+  auto status = changing_builder_->get_arrow_builder()->AppendNull();
+  TENZIR_ASSERT(status.ok());
+  if (auto err = propagate_type_change_to_observer(cast_infos))
+    return err;
+  auto new_common_type = builder_that_needs_type_change.type();
+  auto common_type_cast_info
+    = std::find_if(cast_infos.begin(), cast_infos.end(),
+                   [&new_common_type](const auto& cast_info) {
+                     return cast_info.type_of_value_to_add_after_cast
+                            == new_common_type;
+                   });
+  TENZIR_ASSERT(common_type_cast_info != cast_infos.end());
+  return add_new_value(common_type_cast_info->value_to_add_after_cast,
+                       new_common_type, builder_that_needs_type_change);
+}
+
+auto concrete_series_builder<record_type>::on_child_record_type_change(
+  concrete_series_builder<record_type>& child,
+  std::vector<common_type_cast_info> child_cast_infos) -> caf::error {
+  auto child_builder_it = std::find_if(
+    field_builders_.begin(), field_builders_.end(),
+    [&child](const auto& field_name_and_builder) {
+      auto& builder = field_name_and_builder.second;
+      auto maybe_rec_builder
+        = std::get_if<concrete_series_builder<record_type>>(builder.get());
+      return maybe_rec_builder == std::addressof(child);
+    });
+  if (child_builder_it == field_builders_.end()) {
+    return caf::make_error(ec::convert_error,
+                           "unable to change a type of a field in the list "
+                           "of nested records: child builder not found");
+  }
+  auto cast_infos_for_current_record
+    = get_cast_infos(std::move(child_cast_infos), *child_builder_it->second);
+  return propagate_type_change_to_observer(
+    std::move(cast_infos_for_current_record));
+}
+
+auto concrete_series_builder<record_type>::get_cast_infos(
+  std::vector<std::pair<tenzir::type, data>> possible_new_field_types)
+  -> std::vector<common_type_cast_info> {
+  auto ret = std::vector<common_type_cast_info>{};
+  for (auto& [type, val] : possible_new_field_types) {
+    std::vector<record_type::field_view> fields;
+    fields.reserve(field_builders_.size());
+    for (const auto& [name, builder] : field_builders_) {
+      if (builder.get() == changing_builder_)
+        fields.emplace_back(name, type);
+      else if (auto type = builder->type())
+        fields.emplace_back(name, std::move(type));
+    }
+    ret.push_back(
+      {tenzir::type{record_type{std::move(fields)}}, val, type, this});
+  }
+  return ret;
+}
+
+auto concrete_series_builder<record_type>::propagate_type_change_to_observer(
+  const std::vector<common_type_cast_info>& cast_infos) -> caf::error {
+  return std::visit(
+    detail::overload{
+      [](std::monostate) {
+        return caf::make_error(ec::convert_error,
+                               "unexpected monostate when trying to cast to a "
+                               "common type");
+      },
+      [this, &cast_infos](concrete_series_builder<record_type>* obs) {
+        TENZIR_ASSERT(obs);
+        return obs->on_child_record_type_change(*this, cast_infos);
+      },
+      [this, &cast_infos](concrete_series_builder<list_type>* obs) {
+        TENZIR_ASSERT(obs);
+        fill_nulls();
+        append();
+        return obs->on_record_type_change(cast_infos);
+      },
+    },
+    type_change_observer_);
+}
+
+auto concrete_series_builder<record_type>::get_cast_infos(
+  std::vector<common_type_cast_info> child_cast_infos,
+  const series_builder& child_builder) -> std::vector<common_type_cast_info> {
+  std::vector<common_type_cast_info> ret;
+  ret.reserve(child_cast_infos.size());
+  for (auto& info : child_cast_infos) {
+    std::vector<record_type::field_view> fields;
+    fields.reserve(field_builders_.size());
+    for (const auto& [field_name, builder] : field_builders_) {
+      if (builder.get() == std::addressof(child_builder)) {
+        fields.emplace_back(field_name, std::move(info.new_type_candidate));
+      } else {
+        fields.emplace_back(field_name, builder->type());
+      }
+    }
+    ret.push_back({tenzir::type{record_type{std::move(fields)}},
+                   std::move(info.value_to_add_after_cast),
+                   std::move(info.type_of_value_to_add_after_cast),
+                   info.cast_field_parent_record});
+  }
+  return ret;
+}
+
+auto concrete_series_builder<record_type>::on_child_list_change(
+  concrete_series_builder<list_type>* child,
+  std::vector<common_type_cast_info> child_cast_infos) -> caf::error {
+  auto child_builder_it = std::find_if(
+    field_builders_.begin(), field_builders_.end(),
+    [child](const auto& field_name_and_builder) {
+      auto& builder = field_name_and_builder.second;
+      auto maybe_list_builder
+        = std::get_if<concrete_series_builder<list_type>>(builder.get());
+      return maybe_list_builder == child;
+    });
+  TENZIR_ASSERT(child_builder_it != field_builders_.end());
+  auto cast_infos_for_current_record
+    = get_cast_infos(std::move(child_cast_infos), *child_builder_it->second);
+  return propagate_type_change_to_observer(
+    std::move(cast_infos_for_current_record));
+}
+
+auto concrete_series_builder<record_type>::reset(
+  tenzir::type chosen_type_of_changing_field,
+  const tenzir::type& new_builder_type) -> void {
+  TENZIR_ASSERT(caf::holds_alternative<record_type>(new_builder_type));
+  auto& new_record_type = caf::get<record_type>(new_builder_type);
+  for (auto field_index = 0u; auto& [field_name, builder] : field_builders_) {
+    if (auto record_builder
+        = std::get_if<concrete_series_builder<record_type>>(builder.get())) {
+      record_builder->reset(chosen_type_of_changing_field,
+                            new_record_type.field(field_index).type);
+    } else if (auto list_builder
+               = std::get_if<concrete_series_builder<list_type>>(
+                 builder.get())) {
+      list_builder->reset(chosen_type_of_changing_field,
+                          new_record_type.field(field_index).type);
+    }
+    ++field_index;
+  }
+  if (changing_builder_) {
+    *changing_builder_ = series_builder{chosen_type_of_changing_field, this};
+  }
+  if (arrow_builder_)
+    arrow_builder_.reset();
+}
+
+auto concrete_series_builder<record_type>::set_type_change_observer(
+  type_change_observer obs) -> void {
+  type_change_observer_ = std::move(obs);
+}
+
 auto record_series_builder_base::append() -> void {
   TENZIR_ASSERT(arrow_builder_);
   for (auto& [_, builder] : field_builders_) {
@@ -175,9 +624,7 @@ auto concrete_series_builder<list_type>::type() const -> const tenzir::type& {
 }
 
 auto concrete_series_builder<list_type>::length() const -> arrow_length_type {
-  if (not builder_)
-    return 0u;
-  return builder_->length();
+  return builder_ ? builder_->length() : 0u;
 }
 
 auto concrete_series_builder<list_type>::create_builder(
@@ -203,7 +650,9 @@ auto concrete_series_builder<list_type>::get_record_builder()
   -> series_builder& {
   if (not record_builder_) [[unlikely]] {
     record_builder_ = std::make_unique<series_builder>(
-      concrete_series_builder<record_type>{});
+      concrete_series_builder<record_type>{}, nullptr);
+    std::get<concrete_series_builder<record_type>>(*record_builder_)
+      .set_type_change_observer(this);
   }
   return *record_builder_;
 }
@@ -226,8 +675,8 @@ fixed_fields_record_builder::fixed_fields_record_builder(record_type type)
   : type_{std::move(type)} {
   constexpr auto fixed_fields = true;
   for (auto view : caf::get<record_type>(type_).fields()) {
-    field_builders_[std::string{view.name}]
-      = std::make_unique<series_builder>(std::move(view.type), fixed_fields);
+    field_builders_[std::string{view.name}] = std::make_unique<series_builder>(
+      std::move(view.type), nullptr, fixed_fields);
   }
 }
 
@@ -255,22 +704,27 @@ auto fixed_fields_record_builder::get_arrow_builder()
   return record_series_builder_base::get_arrow_builder(type_);
 }
 
-series_builder::series_builder(const tenzir::type& type,
-                               bool are_fields_fixed) {
+series_builder::series_builder(
+  const tenzir::type& type, concrete_series_builder<record_type>* parent_record,
+  bool are_fields_fixed) {
   caf::visit(
     detail::overload{
-      [this, &type]<class Type>(const Type&) {
-        *this = concrete_series_builder<Type>{type};
+      [this, &type, parent_record]<class Type>(const Type&) {
+        *this = {concrete_series_builder<Type>{type}, parent_record};
       },
-      [this, are_fields_fixed](const record_type& t) {
+      [this, are_fields_fixed, parent_record](const record_type& t) {
         if (are_fields_fixed) {
-          *this = fixed_fields_record_builder{t};
+          *this = {fixed_fields_record_builder{t}, parent_record};
         } else {
-          *this = concrete_series_builder<record_type>{t};
+          auto builder = concrete_series_builder<record_type>{t};
+          builder.set_type_change_observer(parent_record);
+          *this = {std::move(builder), parent_record};
         }
       },
-      [this, are_fields_fixed](const list_type& t) {
-        *this = concrete_series_builder<list_type>{t, are_fields_fixed};
+      [this, are_fields_fixed, parent_record](const list_type& t) {
+        auto builder = concrete_series_builder<list_type>{t, are_fields_fixed};
+        builder.set_record_type_change_observer(parent_record);
+        *this = {std::move(builder), parent_record};
       },
       [](const map_type&) {
         die("unsupported map_type in construction of series builder");
@@ -278,7 +732,6 @@ series_builder::series_builder(const tenzir::type& type,
       },
     },
     type);
-  can_change_builder_type_ = not are_fields_fixed;
 }
 
 arrow_length_type series_builder::length() const {
@@ -331,14 +784,43 @@ auto series_builder::remove_last_row() -> void {
     [this](auto& actual) {
       if constexpr (std::is_same_v<bool, decltype(actual.remove_last_row())>) {
         if (auto all_values_are_null = actual.remove_last_row();
-            all_values_are_null and can_change_builder_type_) {
-          *this = unknown_type_builder(actual.length());
+            all_values_are_null and field_type_change_handler_) {
+          *this = {unknown_type_builder(actual.length()),
+                   field_type_change_handler_};
         }
       } else {
         actual.remove_last_row();
       }
     },
     *this);
+}
+
+auto series_builder::change_type(const tenzir::type& new_type,
+                                 const arrow::Array& array) -> caf::error {
+  return caf::visit(
+    detail::overload{
+      [](const auto& current_type, const auto& concrete_new_type) {
+        return caf::make_error(ec::convert_error,
+                               fmt::format("unsupported common type: {} for a "
+                                           "field of type: {}",
+                                           concrete_new_type, current_type));
+      },
+      [this, &array,
+       &new_type]<allowed_common_type CurrentType, allowed_common_type NewType>(
+        const CurrentType& current_type, const NewType& concrete_new_type) {
+        auto cast_builder = cast_to_builder(
+          current_type,
+          static_cast<const type_to_arrow_array_t<CurrentType>&>(array),
+          concrete_new_type);
+        if (not cast_builder)
+          return std::move(cast_builder.error());
+        auto new_builder = concrete_series_builder<NewType>(
+          new_type, std::move(*cast_builder));
+        *this = {std::move(new_builder), field_type_change_handler_};
+        return caf::error{};
+      },
+    },
+    type(), new_type);
 }
 
 std::shared_ptr<arrow::Array> record_series_builder_base::finish() {
@@ -355,6 +837,96 @@ std::shared_ptr<arrow::Array> record_series_builder_base::finish() {
   if (arrays.empty())
     return nullptr;
   return arrow::StructArray::Make(arrays, field_names).ValueOrDie();
+}
+
+auto concrete_series_builder<list_type>::on_record_type_change(
+  std::vector<common_type_cast_info> cast_infos) -> caf::error {
+  if (record_type_change_observer_
+      and record_type_change_observer_->is_part_of_a_list()) {
+    auto new_cast_infos = std::vector<common_type_cast_info>{};
+    for (auto& info : cast_infos) {
+      new_cast_infos.push_back({get_list_type_with_new_non_list_value_type(
+                                  type_, std::move(info.new_type_candidate)),
+                                std::move(info.value_to_add_after_cast),
+                                std::move(info.type_of_value_to_add_after_cast),
+                                info.cast_field_parent_record});
+    }
+    return record_type_change_observer_->on_child_list_change(
+      this, std::move(new_cast_infos));
+  }
+  auto arr = finish();
+  auto new_list_builder
+    = std::shared_ptr<type_to_arrow_builder_t<list_type>>{nullptr};
+  auto new_list_builder_type = tenzir::type{};
+  const common_type_cast_info* successful_cast_info = nullptr;
+  for (const auto& cast_info : cast_infos) {
+    auto new_type = get_list_type_with_new_non_list_value_type(
+      type_, cast_info.new_type_candidate);
+    auto cast = cast_to_builder(
+      caf::get<list_type>(type_),
+      static_cast<const type_to_arrow_array_t<list_type>&>(*arr),
+      caf::get<list_type>(new_type));
+    if (cast) {
+      new_list_builder = std::move(*cast);
+      successful_cast_info = std::addressof(cast_info);
+      new_list_builder_type = std::move(new_type);
+      break;
+    }
+  }
+  if (not new_list_builder) {
+    return caf::make_error(ec::convert_error, "unable to find appropriate list "
+                                              "type for common type cast");
+  }
+  const auto& [new_record_type, new_data, new_data_type,
+               cast_field_parent_record]
+    = *successful_cast_info;
+  reset(new_data_type, new_list_builder_type);
+  // The idea here is to copy every single data from the cast_builder to the new
+  // builder, but the last record. The last record is inflated with a manually
+  // appened nulls that should be skipped. They were appended just so that the
+  // finished list array didn't have invalid length.
+  auto new_list_arr = new_list_builder->Finish().ValueOrDie();
+  std::vector<data_view> current_builder_data;
+  for (auto v : values(new_list_builder_type, *new_list_arr)) {
+    current_builder_data.push_back(v);
+  }
+  auto last_data = materialize(current_builder_data.back());
+  current_builder_data.pop_back();
+  auto& new_list_type = caf::get<list_type>(new_list_builder_type);
+  for (auto& d : current_builder_data) {
+    if (caf::holds_alternative<view<caf::none_t>>(d)) {
+      const auto status = builder_->AppendNull();
+      TENZIR_ASSERT(status.ok());
+      continue;
+    }
+    TENZIR_ASSERT(caf::holds_alternative<view<list>>(d));
+    const auto status
+      = append_builder(new_list_type, *builder_, caf::get<view<list>>(d));
+    TENZIR_ASSERT(status.ok());
+  }
+  auto last_record = get_last_record(last_data);
+  add_last_cast_list_data(last_record, *cast_field_parent_record, last_data,
+                          *builder_);
+  return {};
+}
+
+auto concrete_series_builder<list_type>::set_record_type_change_observer(
+  concrete_series_builder<record_type>* obs) -> void {
+  record_type_change_observer_ = obs;
+}
+
+auto concrete_series_builder<list_type>::reset(
+  tenzir::type chosen_type_of_changing_field,
+  const tenzir::type& new_builder_type) -> void {
+  if (record_builder_) {
+    auto rec = std::get_if<concrete_series_builder<record_type>>(
+      record_builder_.get());
+    TENZIR_ASSERT(rec);
+    rec->reset(chosen_type_of_changing_field,
+               get_first_non_list_type(new_builder_type));
+  }
+  child_builders_.clear();
+  create_builder(caf::get<list_type>(new_builder_type).value_type());
 }
 
 auto concrete_series_builder<list_type>::create_builder_impl(
@@ -379,10 +951,12 @@ auto concrete_series_builder<list_type>::create_builder_impl(
         if (not record_builder_) {
           if (are_fields_fixed_) {
             record_builder_ = std::make_unique<series_builder>(
-              fixed_fields_record_builder{type});
+              fixed_fields_record_builder{type}, nullptr);
           } else {
             record_builder_ = std::make_unique<series_builder>(
-              concrete_series_builder<record_type>{type});
+              concrete_series_builder<record_type>{type}, nullptr);
+            std::get<concrete_series_builder<record_type>>(*record_builder_)
+              .set_type_change_observer(this);
           }
         }
         auto ret = record_builder_->get_arrow_builder();
@@ -391,6 +965,94 @@ auto concrete_series_builder<list_type>::create_builder_impl(
       },
     },
     t);
+}
+
+auto concrete_series_builder<list_type>::change_type(
+  tenzir::type list_value_type, tenzir::type new_value_type, data value_to_add)
+  -> caf::expected<tenzir::type> {
+  if (are_fields_fixed_) {
+    return caf::make_error(ec::parse_error,
+                           fmt::format("unable to add {} to the list: casting "
+                                       "required but "
+                                       "type inference is disabled",
+                                       value_to_add));
+  }
+  auto common_types_candidates
+    = get_common_types(value_to_add, new_value_type, list_value_type);
+  if (record_type_change_observer_
+      and record_type_change_observer_->is_part_of_a_list()) {
+    return change_type_with_nested_list_parent(common_types_candidates);
+  }
+  auto arr = finish();
+  for (auto [common_type, new_val_to_add] : common_types_candidates) {
+    auto new_type
+      = get_list_type_with_new_non_list_value_type(type_, common_type);
+    auto cast = cast_to_builder(
+      caf::get<list_type>(type_),
+      static_cast<const type_to_arrow_array_t<list_type>&>(*arr),
+      caf::get<list_type>(new_type));
+    if (not cast) {
+      continue;
+    }
+    builder_ = std::move(*cast);
+    // The builder_ has a new type. The type_ and child_builders_ must be
+    // adjusted to the new builder_.
+    type_ = new_type;
+    child_builders_.clear();
+    auto update_builders = detail::overload{
+      [this](auto&& recursive_update,
+             type_to_arrow_builder_t<list_type>& builder) {
+        child_builders_[type::from_arrow(*builder.type())]
+          = std::addressof(builder);
+        recursive_update(recursive_update, *builder.value_builder());
+      },
+      [this](auto&&, auto& builder) {
+        child_builders_[type::from_arrow(*builder.type())]
+          = std::addressof(builder);
+      },
+    };
+    auto update_builders_visit
+      = [&update_builders](auto&& update, arrow::ArrayBuilder& b) {
+          caf::visit(update_builders, detail::passthrough(update), b);
+        };
+    update_builders_visit(update_builders_visit, *builder_->value_builder());
+    auto status = append_builder(common_type, *child_builders_[common_type],
+                                 make_view(new_val_to_add));
+    TENZIR_ASSERT(status.ok());
+    return common_type;
+  }
+  return caf::make_error(ec::parse_error,
+                         fmt::format("unable to add {} to the list: common "
+                                     "type not found",
+                                     value_to_add));
+}
+
+auto concrete_series_builder<list_type>::change_type_with_nested_list_parent(
+  const std::vector<std::pair<tenzir::type, data>>& common_type_candidates)
+  -> caf::expected<tenzir::type> {
+  auto cast_infos = std::vector<common_type_cast_info>{};
+  cast_infos.reserve(common_type_candidates.size());
+  for (auto& [new_type, data] : common_type_candidates) {
+    cast_infos.push_back(
+      {get_list_type_with_new_non_list_value_type(type_, new_type), data,
+       new_type, record_type_change_observer_});
+  }
+  auto err = record_type_change_observer_->on_child_list_change(
+    this, std::move(cast_infos));
+  if (err) {
+    return err;
+  }
+  auto new_value_type = get_first_non_list_type(type_);
+  for (const auto& [type, data] : common_type_candidates) {
+    if (new_value_type == type) {
+      auto status = append_builder(
+        new_value_type, *child_builders_[new_value_type], make_view(data));
+      TENZIR_ASSERT(status.ok());
+      return new_value_type;
+    }
+  }
+  return caf::make_error(ec::parse_error, fmt::format("nested list common "
+                                                      "type casting failed"));
 }
 
 } // namespace tenzir::detail

--- a/libtenzir/src/detail/series_builders.cpp
+++ b/libtenzir/src/detail/series_builders.cpp
@@ -45,14 +45,9 @@ auto get_common_types_impl(const InputType& input_type, const data& new_input,
   auto ret = std::vector<std::pair<type, data>>{};
   auto push_type = [&](const auto& current_common_type) {
     const auto& actual_data = caf::get<type_to_data_t<InputType>>(new_input);
-    auto cast_val = cast_value(input_type, actual_data, current_common_type);
-    if constexpr (not is_caf_expected<decltype(cast_val)>) {
-      ret.push_back({type{current_common_type}, std::move(cast_val)});
-    } else if constexpr (not std::is_same_v<caf::expected<void>,
-                                            decltype(cast_val)>) {
-      if (cast_val) {
-        ret.push_back({type{current_common_type}, std::move(*cast_val)});
-      }
+    if (auto cast_val
+        = cast_value(input_type, actual_data, current_common_type)) {
+      ret.push_back({type{current_common_type}, std::move(*cast_val)});
     }
   };
   (push_type(CommonTypes{}), ...);

--- a/libtenzir/test/adaptive_table_slice_builder.cpp
+++ b/libtenzir/test/adaptive_table_slice_builder.cpp
@@ -1197,3 +1197,449 @@ TEST(cast the whole column to a double type when input double is not 0.0
   const auto expected_schema = tenzir::type{schema.make_fingerprint(), schema};
   CHECK_EQUAL(expected_schema, out.schema());
 }
+
+TEST(common type casting of a nested record field) {
+  adaptive_table_slice_builder sut;
+  {
+    auto row = sut.push_row();
+    auto f = row.push_field("a");
+    auto rec = f.push_record();
+    auto nested = rec.push_field("nested");
+    REQUIRE(not nested.add(true));
+  }
+  {
+    auto row = sut.push_row();
+    auto f = row.push_field("a");
+    auto rec = f.push_record();
+    auto nested = rec.push_field("nested");
+    REQUIRE(not nested.add("str"));
+  }
+  auto out = sut.finish();
+  REQUIRE_EQUAL(out.rows(), 2u);
+  REQUIRE_EQUAL(out.columns(), 1u);
+  CHECK_EQUAL((materialize(out.at(0u, 0u))), "true");
+  CHECK_EQUAL((materialize(out.at(1u, 0u))), "str");
+  const auto schema
+    = type{record_type{{"a", record_type{{"nested", string_type{}}}}}};
+  const auto expected_schema = type{schema.make_fingerprint(), schema};
+  CHECK_EQUAL(expected_schema, out.schema());
+}
+
+TEST(common type casting of a nested record list field) {
+  adaptive_table_slice_builder sut;
+  {
+    auto row = sut.push_row();
+    auto f = row.push_field("list");
+    auto list = f.push_list();
+
+    {
+      auto rec = list.push_record();
+      auto nested = rec.push_field("nested");
+      REQUIRE(not nested.add(true));
+    }
+    {
+      auto rec = list.push_record();
+      auto nested = rec.push_field("nested");
+      REQUIRE(not nested.add(false));
+    }
+  }
+  {
+    auto row = sut.push_row();
+    auto f = row.push_field("list");
+    auto list = f.push_list();
+    {
+      auto rec = list.push_record();
+      auto nested = rec.push_field("nested");
+      REQUIRE(not nested.add(false));
+    }
+    {
+      auto rec = list.push_record();
+      auto nested = rec.push_field("nested");
+      REQUIRE(not nested.add("str"));
+    }
+  }
+  auto out = sut.finish();
+  REQUIRE_EQUAL(out.rows(), 2u);
+  REQUIRE_EQUAL(out.columns(), 1u);
+  CHECK_EQUAL((materialize(out.at(0u, 0u))),
+              (list{record{{"nested", "true"}}, record{
+                                                  {{"nested", "false"}},
+                                                }}));
+  CHECK_EQUAL((materialize(out.at(1u, 0u))),
+              (list{record{{"nested", "false"}}, record{{"nested", "str"}}}));
+  const auto schema = type{
+    record_type{{"list", list_type{record_type{{"nested", string_type{}}}}}}};
+  const auto expected_schema = type{schema.make_fingerprint(), schema};
+  CHECK_EQUAL(expected_schema, out.schema());
+}
+
+TEST(common type casting of a list<record<record>> field with additional fields
+       in both records) {
+  adaptive_table_slice_builder sut;
+  {
+    auto row = sut.push_row();
+    auto f = row.push_field("list");
+    auto list = f.push_list();
+    {
+      auto rec = list.push_record();
+      auto int_field = rec.push_field("int");
+      REQUIRE(not int_field.add(int64_t{5}));
+      {
+        auto nested = rec.push_field("nested rec");
+        auto nested_rec = nested.push_record();
+        auto nested_int_field = nested_rec.push_field("nested int");
+        REQUIRE(not nested_int_field.add(int64_t{50}));
+        auto cast_field = nested_rec.push_field("cast");
+        REQUIRE(not cast_field.add(int64_t{500}));
+        auto nested_str_field = nested_rec.push_field("nested str");
+        REQUIRE(not nested_str_field.add("nested_str1"));
+      }
+      auto str_field = rec.push_field("str");
+      REQUIRE(not str_field.add("str1"));
+    }
+    {
+      auto rec = list.push_record();
+      auto int_field = rec.push_field("int");
+      REQUIRE(not int_field.add(int64_t{2}));
+      {
+        auto nested = rec.push_field("nested rec");
+        auto nested_rec = nested.push_record();
+        auto nested_int_field = nested_rec.push_field("nested int");
+        REQUIRE(not nested_int_field.add(int64_t{20}));
+        auto cast_field = nested_rec.push_field("cast");
+        REQUIRE(not cast_field.add(int64_t{200}));
+        auto nested_str_field = nested_rec.push_field("nested str");
+        REQUIRE(not nested_str_field.add("nested_str2"));
+      }
+      auto str_field = rec.push_field("str");
+      REQUIRE(not str_field.add("str2"));
+    }
+  }
+  {
+    auto row = sut.push_row();
+    auto f = row.push_field("list");
+    auto list = f.push_list();
+    {
+      auto rec = list.push_record();
+      auto int_field = rec.push_field("int");
+      REQUIRE(not int_field.add(int64_t{3}));
+      {
+        auto nested = rec.push_field("nested rec");
+        auto nested_rec = nested.push_record();
+        auto nested_int_field = nested_rec.push_field("nested int");
+        REQUIRE(not nested_int_field.add(int64_t{30}));
+        auto cast_field = nested_rec.push_field("cast");
+        REQUIRE(not cast_field.add("cast_str"));
+        auto nested_str_field = nested_rec.push_field("nested str");
+        REQUIRE(not nested_str_field.add("nested_str3"));
+      }
+      auto str_field = rec.push_field("str");
+      REQUIRE(not str_field.add("str3"));
+    }
+    {
+      auto rec = list.push_record();
+      auto int_field = rec.push_field("int");
+      REQUIRE(not int_field.add(int64_t{4}));
+      {
+        auto nested = rec.push_field("nested rec");
+        auto nested_rec = nested.push_record();
+        auto nested_int_field = nested_rec.push_field("nested int");
+        REQUIRE(not nested_int_field.add(int64_t{40}));
+        auto cast_field = nested_rec.push_field("cast");
+        // int type should be casted to a new string_type.
+        REQUIRE(not cast_field.add(int64_t{400}));
+        auto nested_str_field = nested_rec.push_field("nested str");
+        REQUIRE(not nested_str_field.add("nested_str4"));
+      }
+      auto str_field = rec.push_field("str");
+      REQUIRE(not str_field.add("str4"));
+    }
+  }
+  auto out = sut.finish();
+  REQUIRE_EQUAL(out.rows(), 2u);
+  REQUIRE_EQUAL(out.columns(), 1u);
+  CHECK_EQUAL((materialize(out.at(0u, 0u))),
+              (list{record{
+                      {"int", int64_t{5}},
+                      {"nested rec",
+                       record{
+                         {"nested int", int64_t{50}},
+                         {"cast", "+500"},
+                         {"nested str", "nested_str1"},
+                       }},
+                      {"str", "str1"},
+                    },
+                    record{
+                      {"int", int64_t{2}},
+                      {"nested rec",
+                       record{
+                         {"nested int", int64_t{20}},
+                         {"cast", "+200"},
+                         {"nested str", "nested_str2"},
+                       }},
+                      {"str", "str2"},
+                    }}));
+  CHECK_EQUAL((materialize(out.at(1u, 0u))),
+              (list{record{
+                      {"int", int64_t{3}},
+                      {"nested rec",
+                       record{
+                         {"nested int", int64_t{30}},
+                         {"cast", "cast_str"},
+                         {"nested str", "nested_str3"},
+                       }},
+                      {"str", "str3"},
+                    },
+                    record{
+                      {"int", int64_t{4}},
+                      {"nested rec",
+                       record{
+                         {"nested int", int64_t{40}},
+                         {"cast", "+400"},
+                         {"nested str", "nested_str4"},
+                       }},
+                      {"str", "str4"},
+                    }}));
+  const auto schema
+    = type{record_type{{"list", list_type{record_type{
+                                  {"int", int64_type{}},
+                                  {"nested rec",
+                                   record_type{
+                                     {"nested int", int64_type{}},
+                                     {"cast", string_type{}},
+                                     {"nested str", string_type{}},
+                                   }},
+                                  {"str", string_type{}},
+
+                                }}}}};
+  const auto expected_schema = type{schema.make_fingerprint(), schema};
+  CHECK_EQUAL(expected_schema, out.schema());
+}
+
+TEST(field changes in the deepest record in list<record<list<record>>>and
+       another field changes in the first record) {
+  adaptive_table_slice_builder sut;
+  {
+    auto row = sut.push_row();
+    auto f = row.push_field("list");
+    auto list = f.push_list();
+    {
+      auto rec = list.push_record();
+      {
+        auto nested_list_field = rec.push_field("nested list");
+        auto nested_list = nested_list_field.push_list();
+        auto nested_record = nested_list.push_record();
+        auto cast_field1 = nested_record.push_field("cast_field1");
+        REQUIRE(not cast_field1.add(true));
+      }
+      auto cast_field2 = rec.push_field("cast_field2");
+      REQUIRE(not cast_field2.add(true));
+    }
+  }
+  {
+    auto row = sut.push_row();
+    auto f = row.push_field("list");
+    auto list = f.push_list();
+    {
+      auto rec = list.push_record();
+      {
+        auto nested_list_field = rec.push_field("nested list");
+        auto nested_list = nested_list_field.push_list();
+        auto nested_record = nested_list.push_record();
+        auto cast_field1 = nested_record.push_field("cast_field1");
+        REQUIRE(not cast_field1.add("cast_field1_str"));
+      }
+      auto cast_field2 = rec.push_field("cast_field2");
+      REQUIRE(not cast_field2.add(10.0));
+    }
+  }
+  auto out = sut.finish();
+  REQUIRE_EQUAL(out.rows(), 2u);
+  REQUIRE_EQUAL(out.columns(), 1u);
+  CHECK_EQUAL((materialize(out.at(0u, 0u))),
+              (list{{
+                record{
+                  {"nested list", list{{record{
+                                    {"cast_field1", "true"},
+                                  }}}},
+                  {"cast_field2", 1.0},
+                },
+              }}));
+  CHECK_EQUAL((materialize(out.at(1u, 0u))),
+              (list{{
+                record{
+                  {"nested list", list{{record{
+                                    {"cast_field1", "cast_field1_str"},
+                                  }}}},
+                  {"cast_field2", 10.0},
+                },
+              }}));
+
+  const auto schema = type{
+    record_type{{"list", list_type{record_type{
+                           {"nested list", list_type{record_type{
+                                             {"cast_field1", string_type{}},
+                                           }}},
+                           {"cast_field2", double_type{}},
+
+                         }}}}};
+  const auto expected_schema = type{schema.make_fingerprint(), schema};
+  CHECK_EQUAL(expected_schema, out.schema());
+}
+
+TEST(cast a list<ip> into list<string> when the list field is not a child of
+       another list type) {
+  adaptive_table_slice_builder sut;
+  {
+    auto row = sut.push_row();
+    auto f = row.push_field("list");
+    auto list = f.push_list();
+    REQUIRE(not list.add(ip::v4(0xFF)));
+    REQUIRE(not list.add(ip::v4(0xFF << 1)));
+    REQUIRE(not list.add("str"));
+  }
+  auto out = sut.finish();
+  REQUIRE_EQUAL(out.rows(), 1u);
+  REQUIRE_EQUAL(out.columns(), 1u);
+  CHECK_EQUAL((materialize(out.at(0u, 0u))),
+              (list{"0.0.0.255", "0.0.1.254", "str"}));
+  const auto schema = type{record_type{{"list", list_type{string_type{}}}}};
+  const auto expected_schema = type{schema.make_fingerprint(), schema};
+  CHECK_EQUAL(expected_schema, out.schema());
+}
+
+TEST(list field changes in list<record<list<..>>> with some fields common type
+       casting before the list common type cast) {
+  adaptive_table_slice_builder sut;
+  {
+    auto row = sut.push_row();
+    auto f = row.push_field("list");
+    auto list = f.push_list();
+    {
+      auto rec_f = list.push_record();
+      {
+        auto a = rec_f.push_field("a");
+        REQUIRE(not a.add(true));
+        auto b = rec_f.push_field("b");
+        auto b_list = b.push_list();
+        REQUIRE(not b_list.add(false));
+        auto c = rec_f.push_field("c");
+        REQUIRE(not c.add(false));
+      }
+    }
+  }
+  {
+    auto row = sut.push_row();
+    auto f = row.push_field("list");
+    auto list = f.push_list();
+    {
+      auto rec_f = list.push_record();
+      {
+        auto a = rec_f.push_field("a");
+        REQUIRE(not a.add("a cast"));
+        auto b = rec_f.push_field("b");
+        auto b_list = b.push_list();
+        REQUIRE(not b_list.add(true));
+        auto c = rec_f.push_field("c");
+        REQUIRE(not c.add(true));
+      }
+    }
+    {
+      auto rec_f = list.push_record();
+      auto a = rec_f.push_field("a");
+      REQUIRE(not a.add(false));
+      auto b = rec_f.push_field("b");
+      auto b_list = b.push_list();
+      REQUIRE(not b_list.add(true));
+      REQUIRE(not b_list.add("list cast"));
+      REQUIRE(not b_list.add(false));
+      auto c = rec_f.push_field("c");
+      REQUIRE(not c.add("c cast"));
+    }
+  }
+
+  auto out = sut.finish();
+  REQUIRE_EQUAL(out.rows(), 2u);
+  REQUIRE_EQUAL(out.columns(), 1u);
+  CHECK_EQUAL((materialize(out.at(0u, 0u))), (list{{
+                                               record{
+                                                 {"a", "true"},
+                                                 {"b", list{{"false"}}},
+                                                 {"c", "false"},
+                                               },
+                                             }}));
+  CHECK_EQUAL((materialize(out.at(1u, 0u))), (list{
+                                               record{
+                                                 {"a", "a cast"},
+                                                 {"b", list{{"true"}}},
+                                                 {"c", "true"},
+                                               },
+                                               record{
+                                                 {"a", "false"},
+                                                 {"b",
+                                                  list{
+                                                    "true",
+                                                    "list cast",
+                                                    "false",
+                                                  }},
+                                                 {"c", "c cast"},
+                                               },
+                                             }));
+  const auto schema = type{record_type{{"list", list_type{record_type{
+                                                  {
+                                                    "a",
+                                                    string_type{},
+                                                  },
+                                                  {
+                                                    "b",
+                                                    list_type{string_type{}},
+                                                  },
+                                                  {
+                                                    "c",
+                                                    string_type{},
+                                                  },
+                                                }}}}};
+  const auto expected_schema = type{schema.make_fingerprint(), schema};
+  CHECK_EQUAL(expected_schema, out.schema());
+}
+
+TEST(fixed fields builder will return an error when trying to add a value
+       that requires common type cast to the record field) {
+  const auto schema = tenzir::type{
+    "a nice name",
+    record_type{{"a", bool_type{}}},
+  };
+  auto sut = adaptive_table_slice_builder{schema};
+  auto row = sut.push_row();
+  {
+    auto field = row.push_field("a");
+    REQUIRE(not field.add(true));
+    REQUIRE(field.add("str"));
+  }
+  auto out = sut.finish(schema.name());
+  REQUIRE_EQUAL(schema, out.schema());
+  REQUIRE_EQUAL(out.rows(), 1u);
+  REQUIRE_EQUAL(out.columns(), 1u);
+  CHECK_EQUAL(materialize(out.at(0u, 0u)), true);
+}
+
+TEST(fixed fields builder will return an error when trying to add a value
+       that requires common type cast to the list) {
+  const auto schema
+    = tenzir::type{"a nice name", record_type{
+                                    {"list", list_type{bool_type{}}},
+                                  }};
+  auto sut = adaptive_table_slice_builder{schema};
+  auto row = sut.push_row();
+  {
+    auto list_field = row.push_field("list");
+    auto list = list_field.push_list();
+    REQUIRE(not list.add(true));
+    REQUIRE(list.add("str"));
+  }
+  auto out = sut.finish(schema.name());
+  REQUIRE_EQUAL(schema, out.schema());
+  REQUIRE_EQUAL(out.rows(), 1u);
+  REQUIRE_EQUAL(out.columns(), 1u);
+  CHECK_EQUAL(materialize(out.at(0u, 0u)), (list{{true}}));
+}

--- a/libtenzir/test/cast.cpp
+++ b/libtenzir/test/cast.cpp
@@ -610,6 +610,77 @@ TEST(positive double to duration) {
   CHECK_EQUAL(*out, std::chrono::seconds{120});
 }
 
+TEST(cast value type erased) {
+  auto type = tenzir::type{tenzir::int64_type{}};
+  auto out
+    = tenzir::cast_value(type, tenzir::data{int64_t{2}}, tenzir::string_type{});
+  REQUIRE(out);
+  CHECK_EQUAL(*out, "+2");
+}
+
+TEST(cast value type erased 2) {
+  auto type = tenzir::type{tenzir::ip_type{}};
+  auto out
+    = tenzir::cast_value(type,
+                         tenzir::data{tenzir::ip::v4(uint32_t{0x01'02'03'04})},
+                         tenzir::string_type{});
+  REQUIRE(out);
+  CHECK_EQUAL(*out, "1.2.3.4");
+}
+
+TEST(cast value type erased 3) {
+  auto type = tenzir::type{tenzir::ip_type{}};
+  auto out
+    = tenzir::cast_value(type,
+                         tenzir::data{tenzir::ip::v4(uint32_t{0x01'02'03'04})},
+                         tenzir::type{tenzir::string_type{}});
+  REQUIRE(out);
+  CHECK_EQUAL(*out, "1.2.3.4");
+}
+
+TEST(cast lists) {
+  auto in_type = tenzir::list_type{tenzir::ip_type{}};
+  auto out_type = tenzir::list_type{tenzir::string_type{}};
+  auto in_list = tenzir::list{tenzir::ip::v4(uint32_t{0x01'02'03'04}),
+                              tenzir::ip::v4(uint32_t{0x01'02'03'05})};
+  auto out = tenzir::cast_value(in_type, in_list, out_type);
+  REQUIRE(out);
+  CHECK_EQUAL(*out, (tenzir::list{"1.2.3.4", "1.2.3.5"}));
+}
+
+TEST(cast record success) {
+  auto in_type = tenzir::record_type{{"a", tenzir::ip_type{}}};
+  auto out_type = tenzir::record_type{{"a", tenzir::string_type{}}};
+  auto in_val = tenzir::record{{"a", tenzir::ip::v4(uint32_t{0x01'02'03'04})}};
+  auto out = tenzir::cast_value(in_type, in_val, out_type);
+  REQUIRE(out);
+  CHECK_EQUAL(*out, (tenzir::record{{"a", "1.2.3.4"}}));
+}
+
+TEST(cast record inserts nulls for fields that dont exist in the input) {
+  auto in_type = tenzir::record_type{{"a", tenzir::int64_type{}}};
+  auto out_type = tenzir::record_type{{"a", tenzir::string_type{}},
+                                      {"b", tenzir::int64_type{}}};
+  auto in_val = tenzir::record{{"a", int64_t{-10}}};
+  auto out = tenzir::cast_value(in_type, in_val, out_type);
+  REQUIRE(out);
+  CHECK_EQUAL(*out, (tenzir::record{{"a", "-10"}, {"b", caf::none}}));
+}
+
+TEST(cast lists of records) {
+  auto in_type
+    = tenzir::list_type{tenzir::record_type{{"a", tenzir::ip_type{}}}};
+  auto out_type
+    = tenzir::list_type{tenzir::record_type{{"a", tenzir::string_type{}}}};
+  auto in_list = tenzir::list{
+    tenzir::record{{"a", tenzir::ip::v4(uint32_t{0x01'02'03'04})}},
+    tenzir::record{{"a", tenzir::ip::v4(uint32_t{0x01'02'03'05})}}};
+  auto out = tenzir::cast_value(in_type, in_list, out_type);
+  REQUIRE(out);
+  CHECK_EQUAL(*out, (tenzir::list{tenzir::record{{"a", "1.2.3.4"}},
+                                  tenzir::record{{"a", "1.2.3.5"}}}));
+}
+
 FIXTURE_SCOPE_END()
 
 TEST(cast int64_t array to a string builder) {

--- a/libtenzir/test/cast.cpp
+++ b/libtenzir/test/cast.cpp
@@ -693,7 +693,7 @@ TEST(cast int64_t array to a string builder) {
   auto array
     = std::static_pointer_cast<tenzir::type_to_arrow_array_t<tenzir::int64_type>>(
       int_builder->Finish().ValueOrDie());
-  auto out = tenzir::cast_to_builder(tenzir::int64_type{}, array,
+  auto out = tenzir::cast_to_builder(tenzir::int64_type{}, *array,
                                      tenzir::string_type{});
   REQUIRE(out);
   auto arr = (*out)->Finish().ValueOrDie();
@@ -715,7 +715,7 @@ TEST(casting builder with no compatible types results in an error) {
   auto array
     = std::static_pointer_cast<tenzir::type_to_arrow_array_t<tenzir::int64_type>>(
       int_builder->Finish().ValueOrDie());
-  auto out = tenzir::cast_to_builder(tenzir::int64_type{}, array,
+  auto out = tenzir::cast_to_builder(tenzir::int64_type{}, *array,
                                      tenzir::list_type{tenzir::string_type{}});
   CHECK(not out);
 }
@@ -730,7 +730,7 @@ TEST(
   auto array
     = std::static_pointer_cast<tenzir::type_to_arrow_array_t<tenzir::int64_type>>(
       int_builder->Finish().ValueOrDie());
-  auto out = tenzir::cast_to_builder(tenzir::int64_type{}, array,
+  auto out = tenzir::cast_to_builder(tenzir::int64_type{}, *array,
                                      tenzir::uint64_type{});
   REQUIRE(out);
   auto arr = (*out)->Finish().ValueOrDie();
@@ -751,7 +751,7 @@ TEST(casting int64_t array to uint64_t builder fails due to negative value) {
   auto array
     = std::static_pointer_cast<tenzir::type_to_arrow_array_t<tenzir::int64_type>>(
       int_builder->Finish().ValueOrDie());
-  auto out = tenzir::cast_to_builder(tenzir::int64_type{}, array,
+  auto out = tenzir::cast_to_builder(tenzir::int64_type{}, *array,
                                      tenzir::uint64_type{});
   CHECK(not out);
 }

--- a/libtenzir/test/cast.cpp
+++ b/libtenzir/test/cast.cpp
@@ -374,7 +374,7 @@ TEST(time to string) {
 }
 
 TEST(string to string) {
-  constexpr auto in = "amazing_string!@#%Q@&*@";
+  constexpr auto in = std::string_view{"amazing_string!@#%Q@&*@"};
   auto out
     = tenzir::cast_value(tenzir::string_type{}, in, tenzir::string_type{});
   REQUIRE(out);


### PR DESCRIPTION
In this PR we allow the some form of a common type casting inside a records and lists.

Previously changing a field inside a nested record was considered as a casting of a `record_type` so it was not implemented.
Same with the lists. A `list<int>` changing to `list<string>` is a list casting, which was not planned to be implemented yet.

It seems that the live data has a lot of `ip` -> `string` conversions that must be supported. These conversions occurr inside the lists and inside the nested record so this type of casting should be supported.

In this PR we allow:
- changing of a list_type when the added value requires the common type casting. E.g when we have a `list<ip>` we may add a "www.tenzir.com". This is inferred as a string type and the whole list must be cast to a `list<string>` in order to be compatible with the new string input.
- In case of `list<record<...>>` the field inside a record can also require the common type casting. E.g `list<record<ip_field: ip>>` can be converted to `list<record<ip_field: string>>` when we try to add some not castable data to the `ip_field`