### PR TITLE
Do not warn when packet parsing fails

### DIFF
--- a/vast/integration/reference/pcap-format/step_01.ref
+++ b/vast/integration/reference/pcap-format/step_01.ref
@@ -3,5 +3,3 @@
 {"vlan": {"outer": 104}}
 {"vlan": {"outer": 32}}
 {"vlan": {"outer": 32}}
-warning: failed to parse layer-3 packet
- = note: EtherType: IPX


### PR DESCRIPTION
Packet parsing is not a worth emitting a warning. Our `decapsulate` operator is support to work on a best-effort basis: it parses what it can and yields the layers it understands. Otherwise we'd have an incredibly noisy warning stream because there are so many packets we will never be able to parse at the various layers.
