### PR TITLE
Fix noisy unflatten warning

### DIFF
--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -1258,9 +1258,9 @@ auto unflatten_struct_array(std::shared_ptr<arrow::StructArray> slice_array,
       = unflatten_field{field_name, slice_array->GetFieldByName(field_name)};
     if (field_name.starts_with(nested_field_separator)
         or field_name.ends_with(nested_field_separator)) {
-      VAST_WARN("retaining original field {} during unflattening: encountered "
-                "name with separator at beginning/end",
-                field_name);
+      VAST_DEBUG("retaining original field {} during unflattening: encountered "
+                 "name with separator at beginning/end",
+                 field_name);
       continue;
     }
     auto separator_count
@@ -1297,10 +1297,10 @@ auto unflatten_struct_array(std::shared_ptr<arrow::StructArray> slice_array,
             field, slice_array->GetFieldByName(std::string{field})};
           original_field_name_to_new_field_map[field]
             = std::addressof(unflattened_field_map[field]);
-          VAST_WARN("retaining original field {} during unflattening: "
-                    "encountered potential value collision with already "
-                    "unflattened field {}",
-                    field, prefix);
+          VAST_DEBUG("retaining original field {} during unflattening: "
+                     "encountered potential value collision with already "
+                     "unflattened field {}",
+                     field, prefix);
           continue;
         }
       }


### PR DESCRIPTION
Queries such as `from file vast/integration/data/zeek/zeek.json read zeek-json`previously spammed the console with unflattening warnings. This PR demotes the warnings to debug messages.