### PR TITLE
Add developer documentation for label syncing

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -37,13 +37,19 @@
 - name: docs
   color: 0366d6
   description: Documentation and blog
-- name: infra
+- name: ci
   color: 0366d6
   description: Continuous integration and delivery
 - name: rfc
   color: 0366d6
   description: A Request For Comments (RFC)
 # Functionality
+- name: app
+  color: d93f0b
+  description: Our app at app.tenzir.com
+- name: platform
+  color: d93f0b
+  description: The infra behind app.tenzir.com
 - name: engine
   color: d93f0b
   description: Core pipeline and storage engine
@@ -59,3 +65,6 @@
 - name: language
   color: d93f0b
   description: Tenzir Query Language (TQL)
+- name: integration
+  color: d93f0b
+  description: Integration with third-party tools

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,61 @@
+# This file contains the configuration for GitHub Label Sync.
+#
+# Usage:
+#
+#    github-label-sync --access-token TOKEN --labels labels.yaml REPO
+#
+# Where TOKEN is a GitHub Access Token and REPO the repository name to apply
+# this configuration file to, e.g., tenzir/tenzir.
+#
+# For details, see:
+# https://github.com/Financial-Times/github-label-sync
+
+# Status
+- name: blocked
+  color: dddddd
+  description: Blocked by an (external) issue
+# Type of work
+- name: bug
+  color: fbca04
+  description: Incorrect behavior
+- name: feature
+  color: fbca04
+  description: New functionality
+- name: maintenance
+  color: fbca04
+  description: Tasks for keeping up the infrastructure
+- name: performance
+  color: fbca04
+  description: Improvements or regressions of performance
+- name: refactoring
+  color: fbca04
+  description: Restructuring of existing code
+# Code base part
+- name: dependencies
+  color: 0366d6
+  description: Update of dependent software
+- name: docs
+  color: 0366d6
+  description: Documentation and blog
+- name: infra
+  color: 0366d6
+  description: Continuous integration and delivery
+- name: rfc
+  color: 0366d6
+  description: A Request For Comments (RFC)
+# Functionality
+- name: engine
+  color: d93f0b
+  description: Core pipeline and storage engine
+- name: connector
+  color: d93f0b
+  description: Loader and saver
+- name: format
+  color: d93f0b
+  description: Parser and printer
+- name: operator
+  color: d93f0b
+  description: Source, transformation, and sink
+- name: language
+  color: d93f0b
+  description: Tenzir Query Language (TQL)

--- a/web/docs/contribute/github.md
+++ b/web/docs/contribute/github.md
@@ -1,0 +1,26 @@
+# GitHub
+
+This page documents workflows concerning developer-facing GitHub infrastructure.
+
+## Synchronize issue labels
+
+To ensure that [issue and pull request
+labels](https://github.com/tenzir/tenzir/labels) are consistent within and
+across several of our repositories, we use [GitHub Label
+Sync](https://github.com/Financial-Times/github-label-sync). 
+
+To synchronize the labels, run:
+
+```bash
+github-label-sync --access-token TOKEN --labels labels.yml REPO
+```
+
+`TOKEN` is a personal GitHub Access Token and `REPO` the GitHub repository,
+e.g., `tenzir/tenzir`. The labels configuration
+[`labels.yml`](https://github.com/tenzir/tenzir/blob/main/.github/labels.yml) is
+part of this repository and has the following contents:
+
+import CodeBlock from '@theme/CodeBlock';
+import Configuration from '!!raw-loader!@site/../.github/labels.yml';
+
+<CodeBlock language="yaml">{Configuration}</CodeBlock>

--- a/web/docs/contribute/github.md
+++ b/web/docs/contribute/github.md
@@ -7,7 +7,7 @@ This page documents workflows concerning developer-facing GitHub infrastructure.
 To ensure that [issue and pull request
 labels](https://github.com/tenzir/tenzir/labels) are consistent within and
 across several of our repositories, we use [GitHub Label
-Sync](https://github.com/Financial-Times/github-label-sync). 
+Sync](https://github.com/Financial-Times/github-label-sync).
 
 To synchronize the labels, run:
 


### PR DESCRIPTION
This PR adds dev-facing docs with instructions on how to sync repo labels.
