### PR TITLE
Create a new /ping endpoint

### DIFF
--- a/libtenzir/builtins/endpoints/ping.cpp
+++ b/libtenzir/builtins/endpoints/ping.cpp
@@ -3,7 +3,7 @@
 //   | |/ / __ |_\ \  / /          Across
 //   |___/_/ |_/___/ /_/       Space and Time
 //
-// SPDX-FileCopyrightText: (c) 2022 The TENZIR Contributors
+// SPDX-FileCopyrightText: (c) 2023 The Tenzir Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include <tenzir/builtin_rest_endpoints.hpp>
@@ -16,7 +16,7 @@ namespace tenzir::plugins::rest_api::ping {
 
 static auto const* SPEC_V0 = R"_(
 /ping:
-  get:
+  post:
     summary: Returns a success response
     description: Returns a success response to indicate that the node is able to respond to requests. The response body includes the current node version.
     responses:
@@ -81,8 +81,8 @@ class plugin final : public virtual rest_endpoint_plugin {
     -> const std::vector<rest_endpoint>& override {
     static const auto endpoints = std::vector<rest_endpoint>{
       {
-        .endpoint_id = static_cast<uint64_t>(status_endpoints::status),
-        .method = http_method::get,
+        .endpoint_id = static_cast<uint64_t>(0),
+        .method = http_method::post,
         .path = "/ping",
         .params = std::nullopt,
         .version = api_version::v0,

--- a/libtenzir/builtins/endpoints/ping.cpp
+++ b/libtenzir/builtins/endpoints/ping.cpp
@@ -51,9 +51,7 @@ auto ping_handler(ping_handler_actor::stateful_pointer<ping_handler_state> self)
     [self](atom::http_request, uint64_t,
            const tenzir::record&) -> caf::result<rest_response> {
       TENZIR_DEBUG("{} handles /ping request", *self);
-      auto versions = retrieve_versions();
-      TENZIR_ASSERT_CHEAP(versions.contains("Tenzir"));
-      return rest_response{record{{{"version", versions.at("Tenzir")}}}};
+      return rest_response{record{{{"version", tenzir::version::version}}}};
     },
   };
 }
@@ -66,7 +64,7 @@ class plugin final : public virtual rest_endpoint_plugin {
   }
 
   [[nodiscard]] auto name() const -> std::string override {
-    return "api-ping";
+    return "ping";
   };
 
   [[nodiscard]] auto openapi_specification(api_version version) const
@@ -84,7 +82,7 @@ class plugin final : public virtual rest_endpoint_plugin {
     static const auto endpoints = std::vector<rest_endpoint>{
       {
         .endpoint_id = static_cast<uint64_t>(status_endpoints::status),
-        .method = http_method::post,
+        .method = http_method::get,
         .path = "/ping",
         .params = std::nullopt,
         .version = api_version::v0,

--- a/libtenzir/builtins/endpoints/version.cpp
+++ b/libtenzir/builtins/endpoints/version.cpp
@@ -1,0 +1,102 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2022 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <vast/builtin_rest_endpoints.hpp>
+#include <vast/node.hpp>
+#include <vast/plugin.hpp>
+#include <vast/version.hpp>
+
+#include <caf/typed_event_based_actor.hpp>
+
+namespace vast::plugins::rest_api::status {
+
+static auto const* SPEC_V0 = R"_(
+/version:
+  get:
+    summary: Return node version
+    description: Returns the version number of the node
+    responses:
+      200:
+        description: OK.
+        content:
+          application/json:
+            schema:
+              type: object
+            example:
+              version: v2.3.0-rc3-32-g8529a6c43f
+      401:
+        description: Not authenticated.
+    )_";
+
+using status_handler_actor
+  = typed_actor_fwd<>::extend_with<rest_handler_actor>::unwrap;
+
+struct version_handler_state {
+  static constexpr auto name = "version-handler";
+  version_handler_state() = default;
+};
+
+auto version_handler(
+  status_handler_actor::stateful_pointer<version_handler_state> self)
+  -> status_handler_actor::behavior_type {
+  return {
+    [self](atom::http_request, uint64_t,
+           const vast::record&) -> caf::result<rest_response> {
+      VAST_DEBUG("{} handles /version request", *self);
+      auto versions = retrieve_versions();
+      VAST_ASSERT_CHEAP(versions.contains("Tenzir"));
+      return rest_response{record{{{"version", versions.at("Tenzir")}}}};
+    },
+  };
+}
+
+class plugin final : public virtual rest_endpoint_plugin {
+  auto initialize([[maybe_unused]] const record& plugin_config,
+                  [[maybe_unused]] const record& global_config)
+    -> caf::error override {
+    return {};
+  }
+
+  [[nodiscard]] auto name() const -> std::string override {
+    return "api-version";
+  };
+
+  [[nodiscard]] auto openapi_specification(api_version version) const
+    -> data override {
+    if (version != api_version::v0)
+      return vast::record{};
+    auto result = from_yaml(SPEC_V0);
+    VAST_ASSERT(result);
+    return *result;
+  }
+
+  /// List of API endpoints provided by this plugin.
+  [[nodiscard]] auto rest_endpoints() const
+    -> const std::vector<rest_endpoint>& override {
+    static const auto endpoints = std::vector<rest_endpoint>{
+      {
+        .endpoint_id = static_cast<uint64_t>(status_endpoints::status),
+        .method = http_method::post,
+        .path = "/version",
+        .params = std::nullopt,
+        .version = api_version::v0,
+        .content_type = http_content_type::json,
+      },
+    };
+    return endpoints;
+  }
+
+  auto handler(caf::actor_system& system, node_actor node) const
+    -> rest_handler_actor override {
+    return system.spawn(version_handler);
+  }
+};
+
+} // namespace vast::plugins::rest_api::status
+
+VAST_REGISTER_PLUGIN(vast::plugins::rest_api::status::plugin)

--- a/web/openapi/openapi.yaml
+++ b/web/openapi/openapi.yaml
@@ -3,9 +3,9 @@ openapi: 3.0.0
 info:
   title: Tenzir Rest API
   version: "\"0.1\""
-  description: "\nThis API can be used to interact with a Tenzir Node in a RESTful manner.\n\nAll API requests must be authenticated with a valid token, which must be\nsupplied in the `X-Tenzir-Token` request header. The token can be generated\non the command-line using the `vast rest generate-token` command."
+  description: "\nThis API can be used to interact with a Tenzir Node in a RESTful manner.\n\nAll API requests must be authenticated with a valid token, which must be\nsupplied in the `X-Tenzir-Token` request header. The token can be generated\non the command-line using the `tenzir rest generate-token` command."
 servers:
-  - url: https://vast.example.com/api/v0
+  - url: https://tenzir.example.com/api/v0
 security:
   - VastToken:
       []
@@ -118,6 +118,26 @@ components:
       in: header
       name: X-Tenzir-Token
 paths:
+  /ping:
+    get:
+      summary: Returns a success response
+      description: Returns a success response to indicate that the node is able to respond to requests. The response body includes the current node version.
+      responses:
+        200:
+          description: OK.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  version:
+                    type: string
+                    description: The version of the responding node.
+                    example: v2.3.0-rc3-32-g8529a6c43f
+              example:
+                version: v2.3.0-rc3-32-g8529a6c43f
+        401:
+          description: Not authenticated.
   /pipeline/create:
     post:
       summary: Create a new pipeline
@@ -434,6 +454,10 @@ paths:
                     type: string
                     description: A token to access the next pipeline data batch, null if the pipeline is completed.
                     example: 340ce2j
+                  dropped:
+                    type: integer
+                    description: The serve endpoint will drop responses that exceed the configured maximum message size. The number of events dropped this way is returned here. Should be 0 most of the time.
+                    example: 0
                   schemas:
                     type: array
                     items:


### PR DESCRIPTION
In order to implement HTTP health checks, we want an endpoint that always returns instantly and puts no strain on the system. The existing `/status` is not suited for this, since it can take up to 10s to respond if actors are not responsive.

The ping response contains the node version as payload in order to give a low-effort alternative to the `version` operator for developers trying to determine the version of a remote node.