### PR TITLE
Add `ctrl.has_terminal()` and use it for `shell`

### DIFF
--- a/libtenzir/builtins/commands/exec.cpp
+++ b/libtenzir/builtins/commands/exec.cpp
@@ -124,7 +124,7 @@ auto exec_pipeline(pipeline pipe, caf::actor_system& sys,
       });
       self->state.executor = self->spawn<caf::monitored>(
         pipeline_executor, std::move(pipe),
-        caf::actor_cast<receiver_actor<diagnostic>>(self), node_actor{});
+        caf::actor_cast<receiver_actor<diagnostic>>(self), node_actor{}, true);
       self->request(self->state.executor, caf::infinite, atom::start_v)
         .then(
           []() {

--- a/libtenzir/include/tenzir/execution_node.hpp
+++ b/libtenzir/include/tenzir/execution_node.hpp
@@ -43,13 +43,16 @@ namespace tenzir {
 /// @param node The node actor to expose in the control plane. Must be set if
 /// the operator runs at a remote node.
 /// @param diagnostics_handler The handler asked to spawn diagnostics.
+/// @param has_terminal True if the operator shall have access to the terminal.
+///
 /// @returns The execution node actor and its output type, or an error.
 /// @pre op != nullptr
 /// @pre node != nullptr or not (op->location() == operator_location::remote)
 /// @pre diagnostics_handler != nullptr
 auto spawn_exec_node(caf::scheduled_actor* self, operator_ptr op,
                      operator_type input_type, node_actor node,
-                     receiver_actor<diagnostic> diagnostics_handler)
+                     receiver_actor<diagnostic> diagnostics_handler,
+                     bool has_terminal)
   -> caf::expected<std::pair<exec_node_actor, operator_type>>;
 
 } // namespace tenzir

--- a/libtenzir/include/tenzir/operator_control_plane.hpp
+++ b/libtenzir/include/tenzir/operator_control_plane.hpp
@@ -58,6 +58,9 @@ struct operator_control_plane {
 
   /// Returns whether the pipeline may do potentially unsafe things.
   virtual auto allow_unsafe_pipelines() const noexcept -> bool = 0;
+
+  /// Returns true if the operator is hosted by process that has a terminal.
+  virtual auto has_terminal() const noexcept -> bool = 0;
 };
 
 } // namespace tenzir

--- a/libtenzir/include/tenzir/pipeline_executor.hpp
+++ b/libtenzir/include/tenzir/pipeline_executor.hpp
@@ -31,6 +31,9 @@ struct pipeline_executor_state {
   /// Flag for allowing unsafe pipelines.
   bool allow_unsafe_pipelines = {};
 
+  /// True if the locally-run nodes shall have access to the terminal.
+  bool has_terminal = {};
+
   auto start() -> caf::result<void>;
 
   void start_nodes_if_all_spawned();
@@ -46,7 +49,7 @@ struct pipeline_executor_state {
 /// Start a pipeline executor for a given pipeline.
 auto pipeline_executor(
   pipeline_executor_actor::stateful_pointer<pipeline_executor_state> self,
-  pipeline pipe, receiver_actor<diagnostic> diagnostics, node_actor node)
-  -> pipeline_executor_actor::behavior_type;
+  pipeline pipe, receiver_actor<diagnostic> diagnostics, node_actor node,
+  bool has_terminal) -> pipeline_executor_actor::behavior_type;
 
 } // namespace tenzir

--- a/libtenzir/src/node.cpp
+++ b/libtenzir/src/node.cpp
@@ -688,9 +688,9 @@ node(node_actor::stateful_pointer<node_state> self, std::string /*name*/,
                                            *self, op));
       }
       auto description = op->to_string();
-      auto spawn_result
-        = spawn_exec_node(self, std::move(op), input_type,
-                          static_cast<node_actor>(self), diagnostic_handler);
+      auto spawn_result = spawn_exec_node(self, std::move(op), input_type,
+                                          static_cast<node_actor>(self),
+                                          diagnostic_handler, false);
       if (not spawn_result) {
         return caf::make_error(ec::logic_error,
                                fmt::format("{} failed to spawn execution node "

--- a/libtenzir/src/pipeline.cpp
+++ b/libtenzir/src/pipeline.cpp
@@ -77,6 +77,10 @@ public:
     return false;
   }
 
+  auto has_terminal() const noexcept -> bool override {
+    return false;
+  }
+
 private:
   caf::error error_{};
 };

--- a/libtenzir/test/json_parser.cpp
+++ b/libtenzir/test/json_parser.cpp
@@ -67,6 +67,10 @@ public:
     return false;
   }
 
+  auto has_terminal() const noexcept -> bool override {
+    return false;
+  }
+
 private:
   OnWarnCallable on_warn_;
   std::vector<type> schemas_;

--- a/libtenzir/test/loader_plugin.cpp
+++ b/libtenzir/test/loader_plugin.cpp
@@ -69,6 +69,10 @@ struct fixture {
     auto allow_unsafe_pipelines() const noexcept -> bool override {
       return false;
     }
+
+    auto has_terminal() const noexcept -> bool override {
+      return false;
+    }
   };
 
   auto make_loader(std::string_view name, std::string args)

--- a/libtenzir/test/pipeline.cpp
+++ b/libtenzir/test/pipeline.cpp
@@ -152,7 +152,7 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
     auto self = caf::scoped_actor{sys};
     auto executor = self->spawn<caf::monitored>(
       pipeline_executor, std::move(p),
-      caf::actor_cast<receiver_actor<diagnostic>>(self), node_actor{});
+      caf::actor_cast<receiver_actor<diagnostic>>(self), node_actor{}, false);
     self->send(executor, atom::start_v);
     auto start_result = std::optional<caf::error>{};
     auto down_result = std::optional<caf::error>{};

--- a/libtenzir/test/pipeline.cpp
+++ b/libtenzir/test/pipeline.cpp
@@ -76,6 +76,10 @@ public:
     return false;
   }
 
+  auto has_terminal() const noexcept -> bool override {
+    return false;
+  }
+
 private:
   caf::error error_{};
 };

--- a/libtenzir/test/printer_plugin.cpp
+++ b/libtenzir/test/printer_plugin.cpp
@@ -84,6 +84,10 @@ struct fixture : fixtures::events {
     auto allow_unsafe_pipelines() const noexcept -> bool override {
       return false;
     }
+
+    auto has_terminal() const noexcept -> bool override {
+      return false;
+    }
   };
 
   fixture() {

--- a/libtenzir/test/saver_plugin.cpp
+++ b/libtenzir/test/saver_plugin.cpp
@@ -64,6 +64,10 @@ struct fixture {
     auto allow_unsafe_pipelines() const noexcept -> bool override {
       return false;
     }
+
+    auto has_terminal() const noexcept -> bool override {
+      return false;
+    }
   };
 
   fixture() {

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,8 +2,7 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "501b9fe75c0e700482f19049fb7c2515dcbcddce",
+  "rev": "c2bec488e34810a37475b62c6681cc87b213e2b2",
   "submodules": true,
-  "shallow": true,
-  "allRefs": true
+  "shallow": true
 }

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "207d161b813c8131b2f2c7acd0e21705fd63b3fd",
+  "rev": "501b9fe75c0e700482f19049fb7c2515dcbcddce",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
This PR solves the issue discussed in https://github.com/tenzir/tenzir/pull/3350#discussion_r1261408423.