### PR TITLE
Don't use AppendArraySlice in remove_last_row

### DIFF
--- a/libtenzir/src/adaptive_table_slice_builder.cpp
+++ b/libtenzir/src/adaptive_table_slice_builder.cpp
@@ -90,6 +90,7 @@ auto adaptive_table_slice_builder::row_guard::cancel() -> void {
   if (auto row_added = current_rows > starting_rows_count_; row_added) {
     std::visit(
       [](auto& b) {
+        b.fill_nulls();
         b.remove_last_row();
       },
       builder_.root_builder_);

--- a/libtenzir/src/detail/series_builders.cpp
+++ b/libtenzir/src/detail/series_builders.cpp
@@ -214,9 +214,11 @@ auto concrete_series_builder<list_type>::remove_last_row() -> bool {
 
   auto array = builder_->Finish().ValueOrDie();
   auto new_array = array->Slice(0, array->length() - 1);
-  const auto status
-    = builder_->AppendArraySlice(*new_array->data(), 0u, new_array->length());
-  TENZIR_ASSERT(status.ok());
+  for (auto view : values(type_, *new_array)) {
+    auto status = append_builder(
+      type_, static_cast<arrow::ArrayBuilder&>(*builder_), view);
+    TENZIR_ASSERT(status.ok());
+  }
   if (are_fields_fixed_)
     return false;
   return builder_->null_count() == builder_->length();

--- a/libtenzir/test/adaptive_table_slice_builder.cpp
+++ b/libtenzir/test/adaptive_table_slice_builder.cpp
@@ -1112,6 +1112,21 @@ TEST(Fixed fields builder remove record type row) {
               }));
 }
 
+TEST(Remove row when not all of the schema fields got value added) {
+  const auto schema
+    = tenzir::type{"a nice name", record_type{{"int", int64_type{}},
+                                              {"str", string_type{}},
+                                              {"duration", duration_type{}}}};
+  auto sut = adaptive_table_slice_builder{schema};
+  {
+    auto row = sut.push_row();
+    REQUIRE(not row.push_field("int").add(int64_t{5}));
+    row.cancel();
+  }
+  auto out = sut.finish();
+  CHECK_EQUAL(out.rows(), 0u);
+}
+
 TEST(Field type changes when it was first discovered with a different one but
        the value got removed and a different type value was added) {
   auto sut = adaptive_table_slice_builder{};


### PR DESCRIPTION
The AppendArraySlice API shouldn't be used with the extension types.
In this change we no longer use it.

The row_guard::cancel_row() is also calling fill_nulls() now. All the fields that were not added to the row would have different length.
The code expects fill_nulls() to be called after each row is inserted. This logic is implemented in row_guard DTOR, which will only be run after the cancel_row() call.