### PR TITLE
Improve low-load memory consumption

### DIFF
--- a/changelog/next/changes/3377--reduce-passive-partition-cache-size.md
+++ b/changelog/next/changes/3377--reduce-passive-partition-cache-size.md
@@ -1,0 +1,3 @@
+The default value for `max-resident-partitions` has been reduced from 10 to 1.
+We now rely on the OS Page Cache to provide fast data access to recently loaded
+partitions.

--- a/changelog/next/changes/3377--reduce-rebuild-frequency.md
+++ b/changelog/next/changes/3377--reduce-rebuild-frequency.md
@@ -1,0 +1,2 @@
+The default interval between two automatic rebuilds is now set to 2 hours and
+can be configured with the `rebuild-interval` option.

--- a/libtenzir/builtins/commands/rebuild.cpp
+++ b/libtenzir/builtins/commands/rebuild.cpp
@@ -607,8 +607,8 @@ rebuilder(rebuilder_actor::stateful_pointer<rebuilder_state> self,
     self->system().config(), "tenzir.automatic-rebuild", size_t{1});
   if (self->state.automatic_rebuild > 0) {
     self->state.rebuild_interval
-      = caf::get_or(self->system().config(), "tenzir.active-partition-timeout",
-                    defaults::active_partition_timeout);
+      = caf::get_or(self->system().config(), "tenzir.rebuild-interval",
+                    defaults::rebuild_interval);
     self->state.schedule();
   }
   self->set_exit_handler([self](const caf::exit_msg& msg) {

--- a/libtenzir/include/tenzir/defaults.hpp
+++ b/libtenzir/include/tenzir/defaults.hpp
@@ -221,8 +221,11 @@ inline constexpr size_t max_partition_size = 4'194'304; // 4 Mi
 inline constexpr caf::timespan active_partition_timeout
   = std::chrono::seconds{30};
 
+/// Timeout after which a new automatic rebuild is triggered.
+inline constexpr caf::timespan rebuild_interval = std::chrono::minutes{120};
+
 /// Maximum number of in-memory INDEX partitions.
-inline constexpr size_t max_in_mem_partitions = 10;
+inline constexpr size_t max_in_mem_partitions = 1;
 
 /// Number of immediately scheduled INDEX partitions.
 inline constexpr size_t taste_partitions = 5;

--- a/libtenzir/src/application.cpp
+++ b/libtenzir/src/application.cpp
@@ -106,13 +106,16 @@ void add_root_opts(command& cmd) {
                             "forcibly flushed (default: 30s)");
   cmd.options.add<int64_t>("?tenzir", "max-resident-partitions",
                            "maximum number of in-memory "
-                           "partitions");
+                           "partitions (default: 1)");
   cmd.options.add<int64_t>("?tenzir", "max-taste-partitions",
                            "maximum number of immediately "
                            "scheduled partitions");
   cmd.options.add<int64_t>("?tenzir", "max-queries,q",
                            "maximum number of "
                            "concurrent queries");
+  cmd.options.add<duration>("?tenzir", "rebuild-interval",
+                            "timespan after which an automatic rebuild is "
+                            "triggered (default: 2h)");
 }
 
 auto make_count_command() {

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -108,8 +108,11 @@ tenzir:
   # disable.
   automatic-rebuild: 1
 
+  # Timeout after which an automatic rebuild is triggered.
+  rebuild-interval: 2 hours
+
   # The number of index shards that can be cached in memory.
-  max-resident-partitions: 10
+  max-resident-partitions: 1
 
   # The number of index shards that are considered for the first evaluation
   # round of a query.


### PR DESCRIPTION
This reduces the default frequency in which automatic rebuilds are triggered from 5 Minutes to 2 Hours, and decouples the option from the active partition timeout.

We also demote the number of cached query partitions to 1, to avoid holding multiple copies of the same data in memory.
