### PR TITLE
Add --append and --real-time to directory saver

### DIFF
--- a/changelog/next/features/3379.md
+++ b/changelog/next/features/3379.md
@@ -1,0 +1,4 @@
+The `directory` saver now supports the two arguments `-a|--append` and
+`-r|--realtime` that have the same semantics as they have for the `file` saver:
+open nefiles in the directory in append mode (instead of overwriting) and
+synchronize the file with every new input.

--- a/libtenzir/builtins/connectors/directory.cpp
+++ b/libtenzir/builtins/connectors/directory.cpp
@@ -19,11 +19,25 @@
 
 namespace tenzir::plugins::directory {
 
+struct saver_args {
+  std::string path;
+  bool appending;
+  bool real_time;
+
+  template <class Inspector>
+  friend auto inspect(Inspector& f, saver_args& x) -> bool {
+    return f.object(x)
+      .pretty_name("saver_args")
+      .fields(f.field("path", x.path), f.field("appending", x.appending),
+              f.field("real_time", x.real_time));
+  }
+};
+
 class directory_saver final : public plugin_saver {
 public:
   directory_saver() = default;
 
-  explicit directory_saver(std::string path) : path_{std::move(path)} {
+  explicit directory_saver(saver_args args) : args_{std::move(args)} {
   }
 
   auto name() const -> std::string override {
@@ -38,7 +52,7 @@ public:
                              "cannot use directory saver outside of `to "
                              "directory write ...`");
     }
-    auto dir_path = std::filesystem::path(path_);
+    auto dir_path = std::filesystem::path(args_.path);
     std::error_code ec{};
     std::filesystem::create_directories(dir_path, ec);
     if (ec) {
@@ -55,10 +69,14 @@ public:
       return caf::make_error(ec::unspecified, "could not find `file` saver");
     }
     auto diag = null_diagnostic_handler{};
+    auto file_pipeline = escape_operator_arg(file_path.string());
+    if (args_.appending)
+      file_pipeline += " --appending";
+    if (args_.real_time)
+      file_pipeline += " --real-time";
     // TODO: We should probably use a better mechanism here than escaping and
     // re-parsing.
-    auto pi = tql::make_parser_interface(
-      escape_operator_arg(file_path.string()), diag);
+    auto pi = tql::make_parser_interface(std::move(file_pipeline), diag);
     auto parsed = std::unique_ptr<plugin_saver>{};
     try {
       parsed = p->parse_saver(*pi);
@@ -92,11 +110,11 @@ public:
   }
 
   friend auto inspect(auto& f, directory_saver& x) -> bool {
-    return f.apply(x.path_);
+    return f.apply(x.args_);
   }
 
 private:
-  std::string path_;
+  saver_args args_;
 };
 
 class plugin : public virtual saver_plugin<directory_saver> {
@@ -105,10 +123,12 @@ public:
     -> std::unique_ptr<plugin_saver> override {
     auto parser = argument_parser{name(), "https://docs.tenzir.com/next/"
                                           "connectors/directory"};
-    auto path = std::string{};
-    parser.add(path, "<path>");
+    auto args = saver_args{};
+    parser.add(args.path, "<path>");
+    parser.add("-a,--appending", args.appending);
+    parser.add("-r,--real-time", args.real_time);
     parser.parse(p);
-    return std::make_unique<directory_saver>(std::move(path));
+    return std::make_unique<directory_saver>(std::move(args));
   }
 };
 

--- a/web/docs/connectors/directory.md
+++ b/web/docs/connectors/directory.md
@@ -5,7 +5,7 @@ Saves bytes to one file per schema into a directory.
 ## Synopsis
 
 ```
-directory <path>
+directory [-a|--append] [-r|--real-time] <path>
 ```
 
 ## Description
@@ -13,6 +13,15 @@ directory <path>
 The `directory` saver writes one file per schema into the provided directory.
 
 The default printer for the `directory` saver is [`json`](../formats/json.md).
+
+### `-a|--append`
+
+Append to files in `path` instead of overwriting them with a new file.
+
+### `-r|--real-time`
+
+Immediately synchronize files in `path` with every chunk of bytes instead of
+buffering bytes to batch filesystem write operations.
 
 ### `<path>`
 


### PR DESCRIPTION
This PR adds two new options (that are already known from the `file` saver) to the `directory` saver: `--append` and `--real-time`.
