### PR TITLE
Use a distinctive marker for the final continuation token

### DIFF
--- a/libtenzir/builtins/operators/serve.cpp
+++ b/libtenzir/builtins/operators/serve.cpp
@@ -262,7 +262,7 @@ struct managed_serve_operator {
     delayed_attempt.dispose();
     requested = 0;
     TENZIR_DEBUG("clearing continuation token");
-    last_continuation_token = std::exchange(continuation_token, {});
+    last_continuation_token = std::exchange(continuation_token, "__DONE__");
     last_results = results;
     // If the pipeline is at its end then we must not assign a new token, but
     // rather end here.

--- a/libtenzir/builtins/operators/serve.cpp
+++ b/libtenzir/builtins/operators/serve.cpp
@@ -74,6 +74,7 @@ namespace tenzir::plugins::serve {
 namespace {
 
 constexpr auto SERVE_ENDPOINT_ID = 0;
+constexpr auto FINAL_CONTINUATION_TOKEN = std::string{"__DONE__"};
 
 constexpr auto SPEC_V0 = R"_(
 /serve:
@@ -262,13 +263,12 @@ struct managed_serve_operator {
     delayed_attempt.dispose();
     requested = 0;
     TENZIR_DEBUG("clearing continuation token");
-    last_continuation_token = std::exchange(continuation_token, "__DONE__");
+    last_continuation_token = std::exchange(continuation_token, {});
     last_results = results;
-    // If the pipeline is at its end then we must not assign a new token, but
-    // rather end here.
     if (stop_rp.pending() and buffer.empty()) {
       TENZIR_ASSERT(not put_rp.pending());
       TENZIR_DEBUG("serve for id {} is done", escape_operator_arg(serve_id));
+      continuation_token = FINAL_CONTINUATION_TOKEN;
       get_rp.deliver(std::make_tuple(std::string{}, std::move(results)));
       stop_rp.deliver();
       return true;
@@ -616,7 +616,7 @@ struct serve_handler_state {
       .oneline = true,
     }};
     auto result
-      = next_continuation_token.empty()
+      = next_continuation_token == FINAL_CONTINUATION_TOKEN
           ? std::string{R"({"next_continuation_token":null,"events":[)"}
           : fmt::format(R"({{"next_continuation_token":"{}","events":[)",
                         next_continuation_token);


### PR DESCRIPTION
When a pipeline is at its end, the `continuation_token` is left as an empty string.

However, that is also the expected value of the continuation token for the initial request to the serve endpoint.

So if a client repeats the initial request (i.e. because the response was dropped by the network) after a pipeline is done but before its state is ultimately removed, the serve manager will assume this is a valid initial request and assign a new continuation token, getting stuck in an endless loop until the state is finally cleaned up.