### PR TITLE
Switch to YAML flow scalars

### DIFF
--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -503,7 +503,7 @@ caf:
   # User-defined operators.
   operators:
     # The Zeek operator is an example that takes raw bytes in the form of a
-    # PCAP and then parses Zeek's output via the 'zeek-json` format to generate
+    # PCAP and then parses Zeek's output via the `zeek-json` format to generate
     # a stream of events.
     zeek:
       shell "zeek -r - LogAscii::output_to_stdout=T
@@ -511,6 +511,10 @@ caf:
              JSONStreaming::enable_log_rotation=F
              json-streaming-logs"
       | read zeek-json
+    # The Suricata operator is analogous to the above Zeek example, with the
+    # difference that we are using Suricata. The commmand line configures
+    # Suricata such that it reads PCAP on stdin and produces EVE JSON logs on
+    # stdout, which we then parse with the `suricata` format.
     suricata:
      shell "suricata -r /dev/stdin
             --set outputs.1.eve-log.filename=/dev/stdout

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -505,9 +505,14 @@ caf:
     # The Zeek operator is an example that takes raw bytes in the form of a
     # PCAP and then parses Zeek's output via the 'zeek-json` format to generate
     # a stream of events.
-    zeek: >
+    zeek:
       shell "zeek -r - LogAscii::output_to_stdout=T
              JSONStreaming::disable_default_logs=T
              JSONStreaming::enable_log_rotation=F
              json-streaming-logs"
       | read zeek-json
+    suricata:
+     shell "suricata -r /dev/stdin
+            --set outputs.1.eve-log.filename=/dev/stdout
+            --set logging.outputs.0.console.enabled=no"
+     | read suricata

--- a/web/blog/shell-yeah-supercharging-zeek-and-suricata-with-tenzir/index.md
+++ b/web/blog/shell-yeah-supercharging-zeek-and-suricata-with-tenzir/index.md
@@ -2,6 +2,7 @@
 title: Shell Yeah! Supercharging Zeek and Suricata with Tenzir
 authors: mavam
 date: 2023-07-20
+last_updated: 2023-07-22
 tags: [zeek, suricata, logs, shell]
 comments: true
 ---
@@ -84,13 +85,13 @@ shell script:
 ```yaml title="tenzir.yaml"
 tenzir:
   operators:
-    zeek: >
+    zeek:
      shell "zeek -r - LogAscii::output_to_stdout=T
             JSONStreaming::disable_default_logs=T
             JSONStreaming::enable_log_rotation=F
             json-streaming-logs"
      | read zeek-json
-    suricata: >
+    suricata:
      shell "suricata -r /dev/stdin
             --set outputs.1.eve-log.filename=/dev/stdout
             --set logging.outputs.0.console.enabled=no"

--- a/web/docs/operators/transformations/shell.md
+++ b/web/docs/operators/transformations/shell.md
@@ -60,7 +60,7 @@ Using [user-defined operators](../user-defined.md), we can expose this
 ```yaml {0} title="tenzir.yaml"
 tenzir:
   operators:
-    jsonize: >
+    jsonize:
       write json | shell "jq -C" | save stdout
 ```
 
@@ -86,7 +86,7 @@ that:
 ```yaml {0} title="tenzir.yaml"
 tenzir:
   operators:
-    zeek: >
+    zeek:
       shell "zeek -r - LogAscii::output_to_stdout=T
              JSONStreaming::disable_default_logs=T
              JSONStreaming::enable_log_rotation=F

--- a/web/docs/operators/user-defined.md
+++ b/web/docs/operators/user-defined.md
@@ -14,7 +14,7 @@ tenzir:
   operators:
     # Aggregate suricata.flow events with matching source and destination IP
     # addresses.
-    summarize-flows: >
+    summarize-flows:
       where #schema == "suricata.flow"
       | summarize
           pkts_toserver=sum(flow.pkts_toserver),


### PR DESCRIPTION
Otherwise newlines in the `shell` operator may mess with some applications.

Note to the reviewer: I snuck in another UDO definition in the `tenzir.yaml.example`, based on our last blog post.