### PR TITLE
Improve error message for operator type clashes

### DIFF
--- a/libtenzir/builtins/operators/from_load_read.cpp
+++ b/libtenzir/builtins/operators/from_load_read.cpp
@@ -57,7 +57,7 @@ protected:
     // TODO: Fuse this check with crtp_operator::instantiate()
     return caf::make_error(ec::type_clash,
                            fmt::format("'{}' does not accept {} as input",
-                                       to_string(), operator_type_name(input)));
+                                       name(), operator_type_name(input)));
   }
 
 private:
@@ -99,7 +99,7 @@ protected:
     // TODO: Fuse this check with crtp_operator::instantiate()
     return caf::make_error(ec::type_clash,
                            fmt::format("'{}' does not accept {} as input",
-                                       to_string(), operator_type_name(input)));
+                                       name(), operator_type_name(input)));
   }
 
 private:

--- a/libtenzir/builtins/operators/to_write_save.cpp
+++ b/libtenzir/builtins/operators/to_write_save.cpp
@@ -133,7 +133,7 @@ protected:
     // TODO: Fuse this check with crtp_operator::instantiate()
     return caf::make_error(ec::type_clash,
                            fmt::format("'{}' does not accept {} as input",
-                                       to_string(), operator_type_name(input)));
+                                       name(), operator_type_name(input)));
   }
 
 private:
@@ -213,7 +213,7 @@ protected:
     // TODO: Fuse this check with crtp_operator::instantiate()
     return caf::make_error(ec::type_clash,
                            fmt::format("'{}' does not accept {} as input",
-                                       to_string(), operator_type_name(input)));
+                                       name(), operator_type_name(input)));
   }
 
 private:
@@ -305,7 +305,7 @@ protected:
     // TODO: Fuse this check with crtp_operator::instantiate()
     return caf::make_error(ec::type_clash,
                            fmt::format("'{}' does not accept {} as input",
-                                       to_string(), operator_type_name(input)));
+                                       name(), operator_type_name(input)));
   }
 
 private:

--- a/libtenzir/include/tenzir/pipeline.hpp
+++ b/libtenzir/include/tenzir/pipeline.hpp
@@ -463,10 +463,9 @@ public:
         } else if constexpr (gen_ctrl) {
           return convert_output(self()(std::move(input), ctrl));
         } else {
-          return caf::make_error(ec::type_clash,
-                                 fmt::format("'{}' does not accept {} as input",
-                                             to_string(),
-                                             operator_type_name<Input>()));
+          return caf::make_error(
+            ec::type_clash, fmt::format("'{}' does not accept {} as input",
+                                        name(), operator_type_name<Input>()));
         }
       },
     };


### PR DESCRIPTION
Instead of showing the full internals of operators for type clashes, it makes a lot more sense to just show the name to keep the error message legible.