### PR TITLE
Bump submodule pointer to include the /pipeline/update endpoint fixes

### DIFF
--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "15b3c31c9c6121af7d89a6dcea8f083e68cf6c88",
+  "rev": "9596f97779401d7548c271ecb22c88ec13f3aa40",
   "submodules": true,
   "shallow": true
 }


### PR DESCRIPTION
This change bumps the submodule pointer to include an important fix for the 4.0.0-rc9 release.