### PR TITLE
Emit error if `summarize` has `resolution` without `by`

### DIFF
--- a/libtenzir/builtins/operators/summarize.cpp
+++ b/libtenzir/builtins/operators/summarize.cpp
@@ -831,6 +831,13 @@ public:
     }
     config.group_by_extractors = std::move(std::get<1>(parsed_aggregations));
     config.time_resolution = std::move(std::get<2>(parsed_aggregations));
+    if (config.time_resolution and config.group_by_extractors.empty()) {
+      return {
+        std::string_view{f, l},
+        caf::make_error(ec::syntax_error, "found `resolution` specifier "
+                                          "without `by` clause"),
+      };
+    }
     return {
       std::string_view{f, l},
       std::make_unique<summarize_operator>(std::move(config)),

--- a/web/docs/operators/transformations/summarize.md
+++ b/web/docs/operators/transformations/summarize.md
@@ -96,5 +96,5 @@ Create 1-hour groups and produce a summary of network traffic between host
 pairs:
 
 ```
-summarize sum(bytes_in), sum(bytes_out) by src_ip, dest_ip resolution 1 hour
+summarize sum(bytes_in), sum(bytes_out) by ts, src_ip, dest_ip resolution 1 hour
 ```


### PR DESCRIPTION
In this case, the `resolution` specifier has no effect. This PR also fixes an example that misled readers into thinking that it does.
