### PR TITLE
Fix pipeline executor output check

### DIFF
--- a/libtenzir/src/pipeline_executor.cpp
+++ b/libtenzir/src/pipeline_executor.cpp
@@ -206,6 +206,7 @@ auto pipeline_executor_state::start() -> caf::result<void> {
       diagnostic::error("expected pipeline to end with a sink{}", suffix)
         .docs("https://docs.tenzir.com/next/operators/sinks")
         .done());
+    return start_rp;
   }
   if (not node) {
     for (const auto& op : pipe.operators()) {


### PR DESCRIPTION
The pipeline executor has a check that aborts startup if a pipeline is started with a non-void output type (e.g. `version`). However, there was a `return` missing after this check, such that the execution continued. This could sometimes lead to signaling a successful pipeline start, even though we already emitted an error.