### PR TITLE
Add fixed route to SBOM

### DIFF
--- a/web/src/pages/sbom.tsx
+++ b/web/src/pages/sbom.tsx
@@ -1,0 +1,12 @@
+import ExternalLink from "@site/src/components/ExternalLink";
+import React from "react";
+
+const Element = () => {
+  return (
+    <ExternalLink
+      url={"https://github.com/tenzir/tenzir/releases/latest/download/Tenzir.spdx"}
+    />
+  );
+};
+
+export default Element;


### PR DESCRIPTION
This PR creates a static route to our SBOM so that we can link it reliably.
