### PR TITLE
Replace the wrong "generate-token" commands in the documentation with the correct versions

### DIFF
--- a/plugins/web/README.md
+++ b/plugins/web/README.md
@@ -14,12 +14,12 @@ subdirectory.
 To run the REST API as dedicated process, use the `web server` command:
 
 ```bash
-tenzir web server --certfile=/path/to/server.certificate --keyfile=/path/to/private.key
+tenzir-ctl web server --certfile=/path/to/server.certificate --keyfile=/path/to/private.key
 ```
 To run the server within the main Tenzir process, use a `start` command:
 
 ```bash
-tenzir start --commands="web server [...]"
+tenzir-node --commands="web server [...]"
 ```
 
 All requests must be authenticated by a valid authentication token, which is a
@@ -28,11 +28,11 @@ short string that must be sent in the `X-Tenzir-Token` request header.
 You can generate a valid token on the command line as follows:
 
 ```bash
-tenzir web generate-token
+tenzir-ctl web generate-token
 ```
 
 Use the "developer mode" to bypass encryption and token validation:
 
 ```bash
-tenzir web server --mode=dev
+tenzir-ctl web server --mode=dev
 ```

--- a/plugins/web/src/specification_command.cpp
+++ b/plugins/web/src/specification_command.cpp
@@ -178,7 +178,7 @@ This API can be used to interact with a Tenzir Node in a RESTful manner.
 
 All API requests must be authenticated with a valid token, which must be
 supplied in the `X-Tenzir-Token` request header. The token can be generated
-on the command-line using the `tenzir rest generate-token` command.)_"},
+on the command-line using the `tenzir-ctl web generate-token` command.)_"},
      }},
     {"servers", list{{
       record{{"url", "https://tenzir.example.com/api/v0"}},

--- a/web/openapi/openapi.yaml
+++ b/web/openapi/openapi.yaml
@@ -3,7 +3,7 @@ openapi: 3.0.0
 info:
   title: Tenzir Rest API
   version: "\"0.1\""
-  description: "\nThis API can be used to interact with a Tenzir Node in a RESTful manner.\n\nAll API requests must be authenticated with a valid token, which must be\nsupplied in the `X-Tenzir-Token` request header. The token can be generated\non the command-line using the `tenzir rest generate-token` command."
+  description: "\nThis API can be used to interact with a Tenzir Node in a RESTful manner.\n\nAll API requests must be authenticated with a valid token, which must be\nsupplied in the `X-Tenzir-Token` request header. The token can be generated\non the command-line using the `tenzir-ctl web generate-token` command."
 servers:
   - url: https://tenzir.example.com/api/v0
 security:


### PR DESCRIPTION
This change fixes a mishap as a result of the VAST->Tenzir renaming.