### PR TITLE
Fix Suricata TLS SNI field name in concepts

### DIFF
--- a/schema/concepts/suricata.yaml
+++ b/schema/concepts/suricata.yaml
@@ -216,6 +216,7 @@
       - suricata.smb.host
       - suricata.smb.smb.ntlmssp.host
       - suricata.ssh.host
+      - suricata.tls.tls.sni
 - concept:
     name: net.domain
     fields:
@@ -226,7 +227,7 @@
       # The rrname field may also include IP addresses, e.g., for reverse
       # lookups.
       - suricata.dns.dns.rrname
-      - suricata.tls.sni
+      - suricata.tls.tls.sni
       - suricata.http.http.hostname
 - concept:
     name: net.uri

--- a/version.json
+++ b/version.json
@@ -11,7 +11,7 @@
     "under the assumption that the release-preparing PR contains exactly one",
     "commit and is rebased before merging."
   ],
-  "tenzir-version-rev-count": 17842,
+  "tenzir-version-rev-count": 17845,
   "tenzir-partition-version_COMMENT": [
     "The partition version. This number must be bumped alongside the release",
     "version for releases that contain major format changes to the on-disk",


### PR DESCRIPTION
We noticed today that Tenzir ships a `net.domain` concept referencing the EVE JSON field `suricata.tls.sni` which does not exist in the schema. It should be `suricata.tls.tls.sni` according to the schema definition:

```
type suricata.tls = suricata.component.common + record {
  tls: record {
    sni: string,
    session_resumed: bool,
    subject: string,
    issuerdn: string,
    serial: string,
    fingerprint: string,
    ja3: suricata.component.ja3,
    ja3s: suricata.component.ja3,
    notbefore: time,
    notafter: time
  }
}
```
For the sake of completeness we also add it to the `net.hostname` concept, as it serves a similar purpose as `suricata.http.http.hostname`  which is also in that concept.