### PR TITLE
Flush `shell` operator's child process stdout

### DIFF
--- a/libtenzir/builtins/operators/shell.cpp
+++ b/libtenzir/builtins/operators/shell.cpp
@@ -108,12 +108,15 @@ public:
     return caf::none;
   }
 
-  void close_stdin() {
+  void close_stdinout() {
     // See https://github.com/boostorg/process/issues/125 for why we
     // seemingly double-close the pipe.
     TENZIR_DEBUG("sending EOF to child's stdin");
     stdin_.close();
     stdin_.pipe().close();
+    TENZIR_DEBUG("sending EOF to child's stdout");
+    stdout_.close();
+    stdout_.pipe().close();
   }
 
   auto wait() -> caf::error {
@@ -207,7 +210,7 @@ public:
     {
       // Coroutines require RAII-style exit handling.
       auto at_exit = caf::detail::make_scope_guard([&] {
-        child->close_stdin();
+        child->close_stdinout();
         TENZIR_DEBUG("joining thread");
         thread.join();
       });


### PR DESCRIPTION
This fixes a race condition in the shutdown of the `shell` operator. For example, `tenzir 'shell "echo hi"'` when run repeatedly sometimes printed nothing before this change. The fix is simple: always explicitly flush the child process' stdout on shutdown of the operator.