### PR TITLE
Disable the inventory plugin

### DIFF
--- a/.github/workflows/tenzir.yaml
+++ b/.github/workflows/tenzir.yaml
@@ -809,9 +809,9 @@ jobs:
           - name: Compaction
             target: compaction
             path: contrib/tenzir-plugins/compaction
-          - name: Inventory
-            target: inventory
-            path: contrib/tenzir-plugins/inventory
+          # - name: Inventory
+          #   target: inventory
+          #   path: contrib/tenzir-plugins/inventory
           - name: Matcher
             target: matcher
             path: contrib/tenzir-plugins/matcher

--- a/Dockerfile
+++ b/Dockerfile
@@ -145,13 +145,13 @@ RUN cmake -S contrib/tenzir-plugins/compaction -B build-compaction -G Ninja \
       DESTDIR=/plugin/compaction cmake --install build-compaction --strip --component Runtime && \
       rm -rf build-compaction
 
-FROM plugins-source AS inventory-plugin
-
-RUN cmake -S contrib/tenzir-plugins/inventory -B build-inventory -G Ninja \
-      -D CMAKE_INSTALL_PREFIX:STRING="$PREFIX" && \
-      cmake --build build-inventory --parallel && \
-      DESTDIR=/plugin/inventory cmake --install build-inventory --strip --component Runtime && \
-      rm -rf build-inventory
+# FROM plugins-source AS inventory-plugin
+#
+# RUN cmake -S contrib/tenzir-plugins/inventory -B build-inventory -G Ninja \
+#       -D CMAKE_INSTALL_PREFIX:STRING="$PREFIX" && \
+#       cmake --build build-inventory --parallel && \
+#       DESTDIR=/plugin/inventory cmake --install build-inventory --strip --component Runtime && \
+#       rm -rf build-inventory
 
 FROM plugins-source AS matcher-plugin
 

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,8 +2,7 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "dd3724153ccb48f90dd61e0a23286c7986adadfd",
+  "rev": "f8a8ec67bb2d6fd0a82060114176b520c250c462",
   "submodules": true,
-  "shallow": true,
-  "allRefs": true
+  "shallow": true
 }

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "589c8385aed28cad2ce0a184dfd2bc10f969201a",
+  "rev": "dd3724153ccb48f90dd61e0a23286c7986adadfd",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/web/docs/user-guides/run-a-pipeline/README.md
+++ b/web/docs/user-guides/run-a-pipeline/README.md
@@ -58,10 +58,6 @@ a single event rendered as JSON:
       "version": "bundled"
     },
     {
-      "name": "inventory",
-      "version": "bundled"
-    },
-    {
       "name": "kafka",
       "version": "bundled"
     },


### PR DESCRIPTION
The plugin isn't working all too well currently, and has basically been in maintenance mode for a while now. This disables it until we have time to bring it back properly. Note that the plugin had already been disabled for quite some time for all publicly available builds, so this change only affects developers.