### PR TITLE
Remove newline in serve operator docs

### DIFF
--- a/web/docs/operators/sinks/serve.md
+++ b/web/docs/operators/sinks/serve.md
@@ -1,7 +1,6 @@
 # serve
 
-Make events available under the [`/serve` REST API
-endpoint](/api#/paths/~1serve/post).
+Make events available under the [`/serve` REST API endpoint](/api#/paths/~1serve/post).
 
 ## Synopsis
 


### PR DESCRIPTION
For the codemirror-lang-tql docs to tooltips processor script to work without lots of edge-case handling, the short description of an operator should be written in one single line.
