### PR TITLE
Tweak the execution node behavior

### DIFF
--- a/changelog/next/bug-fixes/3470--exec-node-tweak.md
+++ b/changelog/next/bug-fixes/3470--exec-node-tweak.md
@@ -1,0 +1,6 @@
+Pipeline operators that create output independent of their input now emit their
+output instantly instead of waiting for receiving further input. This makes the
+`shell` operator more reliable.
+
+The `show <aspect>` operator wrongfully required unsafe pipelines to be allowed
+for some aspects. This is now fixed.

--- a/libtenzir/builtins/aspects/build.cpp
+++ b/libtenzir/builtins/aspects/build.cpp
@@ -21,7 +21,7 @@ public:
   }
 
   auto location() const -> operator_location override {
-    return operator_location::local;
+    return operator_location::anywhere;
   }
 
   auto show(operator_control_plane&) const -> generator<table_slice> override {

--- a/libtenzir/builtins/aspects/connectors.cpp
+++ b/libtenzir/builtins/aspects/connectors.cpp
@@ -36,7 +36,7 @@ public:
   }
 
   auto location() const -> operator_location override {
-    return operator_location::local;
+    return operator_location::anywhere;
   }
 
   auto show(operator_control_plane& ctrl) const

--- a/libtenzir/builtins/aspects/dependencies.cpp
+++ b/libtenzir/builtins/aspects/dependencies.cpp
@@ -35,7 +35,7 @@ public:
   }
 
   auto location() const -> operator_location override {
-    return operator_location::local;
+    return operator_location::anywhere;
   }
 
   auto show(operator_control_plane&) const -> generator<table_slice> override {

--- a/libtenzir/builtins/aspects/formats.cpp
+++ b/libtenzir/builtins/aspects/formats.cpp
@@ -36,7 +36,7 @@ public:
   }
 
   auto location() const -> operator_location override {
-    return operator_location::local;
+    return operator_location::anywhere;
   }
 
   auto show(operator_control_plane& ctrl) const

--- a/libtenzir/builtins/aspects/operators.cpp
+++ b/libtenzir/builtins/aspects/operators.cpp
@@ -34,7 +34,7 @@ public:
   }
 
   auto location() const -> operator_location override {
-    return operator_location::local;
+    return operator_location::anywhere;
   }
 
   auto show(operator_control_plane& ctrl) const

--- a/libtenzir/builtins/aspects/plugins.cpp
+++ b/libtenzir/builtins/aspects/plugins.cpp
@@ -21,7 +21,7 @@ public:
   }
 
   auto location() const -> operator_location override {
-    return operator_location::local;
+    return operator_location::anywhere;
   }
 
   auto show(operator_control_plane&) const -> generator<table_slice> override {

--- a/libtenzir/builtins/aspects/version.cpp
+++ b/libtenzir/builtins/aspects/version.cpp
@@ -31,7 +31,7 @@ public:
   }
 
   auto location() const -> operator_location override {
-    return operator_location::local;
+    return operator_location::anywhere;
   }
 
   auto show(operator_control_plane&) const -> generator<table_slice> override {

--- a/libtenzir/builtins/commands/exec.cpp
+++ b/libtenzir/builtins/commands/exec.cpp
@@ -109,6 +109,12 @@ auto format_metric(const metric& metric) {
                      data{metric.time_processing},
                      100.0 * static_cast<double>(metric.time_processing.count())
                        / static_cast<double>(metric.time_total.count()));
+  it = fmt::format_to(
+    it, "{}runs: {} ({:.2f}% processing / {:.2f}% input / {:.2f}% output)\n",
+    indent, metric.num_runs,
+    100.0 * metric.num_runs_processing / metric.num_runs,
+    100.0 * metric.num_runs_processing_input / metric.num_runs,
+    100.0 * metric.num_runs_processing_output / metric.num_runs);
   if (metric.inbound_measurement.unit != "void") {
     it = fmt::format_to(it, "{}inbound:\n", indent);
     it = fmt::format_to(

--- a/libtenzir/include/tenzir/pipeline.hpp
+++ b/libtenzir/include/tenzir/pipeline.hpp
@@ -195,6 +195,10 @@ struct [[nodiscard]] metric {
   duration time_processing = {};
   duration time_scheduled = {};
   duration time_total = {};
+  uint64_t num_runs = {};
+  uint64_t num_runs_processing = {};
+  uint64_t num_runs_processing_input = {};
+  uint64_t num_runs_processing_output = {};
 
   template <class Inspector>
   friend auto inspect(Inspector& f, metric& x) -> bool {
@@ -206,7 +210,11 @@ struct [[nodiscard]] metric {
       f.field("time_scheduled", x.time_scheduled),
       f.field("time_total", x.time_total),
       f.field("inbound_measurement", x.inbound_measurement),
-      f.field("outbound_measurement", x.outbound_measurement));
+      f.field("outbound_measurement", x.outbound_measurement),
+      f.field("num_runs", x.num_runs),
+      f.field("num_runs_processing", x.num_runs_processing),
+      f.field("num_runs_processing_input", x.num_runs_processing_input),
+      f.field("num_runs_processing_output", x.num_runs_processing_output));
   }
 };
 


### PR DESCRIPTION
This makes the following changes to execution nodes:
- Reduce batch timeout from 250ms to 10ms with exponential backoff to 2s. Execution nodes are now always scheduled after the timeout hits, assuming that the previous operator does not block indefinitely.
- Remove the never correctly implemented logic to advance generators multiple times per scheduled run of an execution node.

Additionally, this fixes the operator location of some aspects. 