### PR TITLE
Add the missing "pause" pipeline action to the API docs

### DIFF
--- a/web/openapi/openapi.yaml
+++ b/web/openapi/openapi.yaml
@@ -421,6 +421,7 @@ paths:
                   type: string
                   enum:
                     - start
+                    - pause
                     - stop
                   description: The action that will change the pipeline's running state.
                   example: start


### PR DESCRIPTION
This PR is a simple addition to the API docs. Somehow the `pause` action did not make it during the sequential pipeline manager PR.