### PR TITLE
Use pinned nixpkgs for nushell script deps

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -109,7 +109,7 @@ jobs:
           RCLONE_GCS_SERVICE_ACCOUNT_CREDENTIALS: ${{ secrets.GCS_SERVICE_ACCOUNT_CREDENTIALS }}
           RCLONE_GCS_BUCKET_POLICY_ONLY: True
         run: |
-          nix shell \
+          nix shell --inputs-from ./. \
             nixpkgs#git \
             nixpkgs#nushell \
             nixpkgs#rclone \


### PR DESCRIPTION
Without adding `--inputs-from` we always get the latest versions of the dependencies that are currently available in `nixpkgs`. Explicitly using the revision from the flake is an easy way to pin and avoid unexpected breakage.