### PR TITLE
Bump the tenzir-plugins submodule pointer to include the pipeline manager's failure and rendered diagnostics functionality

### DIFF
--- a/changelog/next/features/3479--rendered-diagnostics-and-failed-state.md
+++ b/changelog/next/features/3479--rendered-diagnostics-and-failed-state.md
@@ -1,0 +1,5 @@
+The `rendered` field in the pipeline manager diagnostics delivers a displayable
+version of the diagnostic's error message.
+
+Pipelines that encounter an error during execution are now in a new `failed`
+rather than `stopped` state.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "8ec3679444264030606acf08827eb681dfd0f13b",
+  "rev": "f6ddd86fab90f357db4a8a1d9bc57bb1c5c16936",
   "submodules": true,
   "shallow": true
 }

--- a/plugins/web/src/specification_command.cpp
+++ b/plugins/web/src/specification_command.cpp
@@ -113,6 +113,9 @@ Diagnostic:
       type: array
       items:
         $ref: '#/components/schemas/Note'
+    rendered:
+      type: string
+      example: "\u001b[1m\u001b[31merror\u001b[39m: unknown option `--frobnify`\u001b[0m\n"
 Annotation:
   type: object
   properties:
@@ -162,6 +165,7 @@ PipelineInfo:
         - created
         - running
         - paused
+        - failed
         - stopped
     error:
       type: string

--- a/web/openapi/openapi.yaml
+++ b/web/openapi/openapi.yaml
@@ -105,6 +105,9 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Note"
+        rendered:
+          type: string
+          example: "\u001b[1m\u001b[31merror\u001b[39m: unknown option `--frobnify`\u001b[0m\n"
     Annotation:
       type: object
       properties:
@@ -158,6 +161,7 @@ components:
             - created
             - running
             - paused
+            - failed
             - stopped
         error:
           type: string


### PR DESCRIPTION
Another submodule pointer bump.