### PR TITLE
Fix the deprecated operator in the Linux node install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -192,7 +192,7 @@ fi
 # Test the installation.
 action "Checking version"
 PATH="${prefix}/bin:$PATH"
-tenzir -q 'version | select version | write json'
+tenzir -q 'show version | write json'
 
 # Inform about next steps.
 action "Providing guidance"


### PR DESCRIPTION
This change is a quick fix for the Linux node install script that still used deprecated operators.