### PR TITLE
Add `from <uri>` and `load <uri>`

### DIFF
--- a/libtenzir/builtins/connectors/file.cpp
+++ b/libtenzir/builtins/connectors/file.cpp
@@ -338,7 +338,7 @@ public:
   }
 
   auto to_string() const -> std::string override {
-    auto result = std::string{"file"};
+    auto result = std::string{"file "};
     result += escape_operator_arg(args_.path.inner);
     if (args_.follow) {
       result += " --follow";


### PR DESCRIPTION
This PR makes it so that we resolve `from <scheme>://<path>` to `from <scheme> <path>`, which will enable `from https://example.org/...`, for example.

- [X] Implement `from <uri> [options...] [read <parser>]`
- [ ] Implement `from <path>` for `from file <path>`
- [ ] Consider some loader restrictions + remapping (e.g., for `gcs`)
- [ ] Same for `load`
- [ ] Cleanup