### PR TITLE
Fix connector names in docs for `https` and `ftps`

### DIFF
--- a/web/docs/connectors/ftps.md
+++ b/web/docs/connectors/ftps.md
@@ -1,4 +1,4 @@
-# ftp
+# ftps
 
 Loads bytes via FTPS.
 

--- a/web/docs/connectors/https.md
+++ b/web/docs/connectors/https.md
@@ -1,4 +1,4 @@
-# http
+# https
 
 Loads bytes via HTTPS.
 


### PR DESCRIPTION
This PR fixes a docs glitch.
