### PR TITLE
Support parsing of concatenated PCAPs

### DIFF
--- a/changelog/next/changes/3513.md
+++ b/changelog/next/changes/3513.md
@@ -1,0 +1,3 @@
+The long option name `--emit-file-header` of the `pcap` parser is now called
+`--emit-file-headers` (plural) to streamline it with the `nic` loader and the
+new capability to process concatenated PCAP files.

--- a/changelog/next/features/3513.md
+++ b/changelog/next/features/3513.md
@@ -1,0 +1,8 @@
+The `pcap` parser can now process a stream of concatenated PCAP files. On the
+command line, you can now parse traces with `cat *.pcap | tenzir 'read pcap'`.
+When providing `--emit-file-headers`, each intermediate file header yields a
+separate event.
+
+The `nic` loader has a new option `--emit-file-headers` that prepends a PCAP
+file header for every batch of bytes that the loader produces, yielding a
+stream of concatenated PCAP files.

--- a/libtenzir/builtins/formats/pcap.cpp
+++ b/libtenzir/builtins/formats/pcap.cpp
@@ -169,7 +169,7 @@ public:
         co_return;
       }
       if (*need_swap) {
-        TENZIR_VERBOSE("detected different byte order in file and host");
+        TENZIR_DEBUG("detected different byte order in file and host");
         input_file_header = byteswap(input_file_header);
       } else {
         TENZIR_DEBUG("detected identical byte order in file and host");
@@ -245,10 +245,16 @@ public:
             need_swap = need_byte_swap(input_file_header.magic_number);
             TENZIR_ASSERT(need_swap); // checked in is_file_header
             if (*need_swap) {
-              TENZIR_VERBOSE("detected different byte order in file and host");
+              TENZIR_DEBUG("detected different byte order in file and host");
               input_file_header = byteswap(input_file_header);
             } else {
               TENZIR_DEBUG("detected identical byte order in file and host");
+            }
+            // Before emitting the new file header, flush all buffered packets
+            // from the previous trace.
+            if (builder.rows() > 0) {
+              last_finish = now;
+              co_yield builder.finish();
             }
             if (emit_file_header)
               co_yield make_file_header_table_slice(input_file_header);

--- a/libtenzir/builtins/formats/pcap.cpp
+++ b/libtenzir/builtins/formats/pcap.cpp
@@ -307,9 +307,7 @@ public:
   }
 
   static auto pack(const file_header& header) -> chunk_ptr {
-    const auto* ptr = reinterpret_cast<const std::byte*>(&header);
-    auto bytes = std::span<const std::byte>{ptr, sizeof(file_header)};
-    return chunk::copy(bytes);
+    return chunk::copy(as_bytes(header));
   }
 
   static auto make_file_header(const table_slice& slice)

--- a/libtenzir/builtins/formats/pcap.cpp
+++ b/libtenzir/builtins/formats/pcap.cpp
@@ -264,7 +264,7 @@ public:
         // Read the packet.
         while (true) {
           TENZIR_DEBUG("reading packet data of size {}",
-                       packet.header.captured_packet_length);
+                       uint32_t{packet.header.captured_packet_length});
           auto length = packet.header.captured_packet_length;
           auto bytes = read_n(length);
           if (!bytes) {

--- a/libtenzir/include/tenzir/pcap.hpp
+++ b/libtenzir/include/tenzir/pcap.hpp
@@ -41,7 +41,11 @@ struct file_header {
 // The file header length is 24 octets.
 static_assert(sizeof(file_header) == 24);
 
-auto as_bytes(const file_header& x) -> std::span<const std::byte>;
+auto as_bytes(const file_header& x)
+  -> std::span<const std::byte, sizeof(file_header)>;
+
+auto as_writeable_bytes(file_header& x)
+  -> std::span<std::byte, sizeof(file_header)>;
 
 /// The packet header.
 struct packet_header {
@@ -54,7 +58,11 @@ struct packet_header {
 // The packet header length is 16 octets.
 static_assert(sizeof(packet_header) == 16);
 
-auto as_bytes(const packet_header& x) -> std::span<const std::byte>;
+auto as_bytes(const packet_header& x)
+  -> std::span<const std::byte, sizeof(packet_header)>;
+
+auto as_writeable_bytes(packet_header& x)
+  -> std::span<std::byte, sizeof(packet_header)>;
 
 // Checks whether a packet header is actually a packet header. This is a
 // heuristic based on the binary shape of the header, not a standard-compliant

--- a/libtenzir/include/tenzir/pcap.hpp
+++ b/libtenzir/include/tenzir/pcap.hpp
@@ -41,6 +41,8 @@ struct file_header {
 // The file header length is 24 octets.
 static_assert(sizeof(file_header) == 24);
 
+auto as_bytes(const file_header& x) -> std::span<const std::byte>;
+
 /// The packet header.
 struct packet_header {
   uint32_t timestamp;
@@ -51,6 +53,8 @@ struct packet_header {
 
 // The packet header length is 16 octets.
 static_assert(sizeof(packet_header) == 16);
+
+auto as_bytes(const packet_header& x) -> std::span<const std::byte>;
 
 // PCAP files are written out with the system endianness, so we may have to
 // swap bytes whenever the local endianness differs from the trace file. The

--- a/libtenzir/include/tenzir/pcap.hpp
+++ b/libtenzir/include/tenzir/pcap.hpp
@@ -56,6 +56,11 @@ static_assert(sizeof(packet_header) == 16);
 
 auto as_bytes(const packet_header& x) -> std::span<const std::byte>;
 
+// Checks whether a packet header is actually a packet header. This is a
+// heuristic based on the binary shape of the header, not a standard-compliant
+// check. However, it works robustly in practice.
+auto is_file_header(const packet_header& header) -> bool;
+
 // PCAP files are written out with the system endianness, so we may have to
 // swap bytes whenever the local endianness differs from the trace file. The
 // magic number in the file helps identifying the endianness.

--- a/libtenzir/src/execution_node.cpp
+++ b/libtenzir/src/execution_node.cpp
@@ -809,7 +809,7 @@ struct exec_node_state : inbound_state_mixin<Input>,
     // consider this the case when neither the input nor the output have
     // stalled, i.e., when there is more input to be consumed and room for
     // output to be produced or further output desired.
-    if (not input_stalled and not output_stalled) {
+    if (not input_stalled or not output_stalled) {
       schedule_run();
     }
     // Adjust performance counters for this run.

--- a/libtenzir/src/pcap.cpp
+++ b/libtenzir/src/pcap.cpp
@@ -72,9 +72,9 @@ auto is_file_header(const packet_header& header) -> bool {
   // base rate is too low for this.
   return true;
   // What could go wrong if we didn't do the next checks? The literal magic
-  // values would be UNIX timestamps equivalent to of Dec 19, 2055. At this
-  // point AGI will have killed us all. If we got (real or simulated) packets
-  // from that very second in the future, we deem it next to impossible that the
+  // values would be UNIX timestamps equivalent to Dec 19, 2055. At this point
+  // AGI will have killed us all. If we got (real or simulated) packets from
+  // that very second in the future, we deem it next to impossible that the
   // fractional timestamp accidentally matched the PCAP version.
   auto major_version = header.timestamp_fraction >> 16;
   auto minor_version = header.timestamp_fraction & 0xffff;

--- a/libtenzir/src/pcap.cpp
+++ b/libtenzir/src/pcap.cpp
@@ -12,6 +12,16 @@
 
 namespace tenzir::pcap {
 
+auto as_bytes(const file_header& header) -> std::span<const std::byte> {
+  const auto* ptr = reinterpret_cast<const std::byte*>(&header);
+  return std::span<const std::byte>{ptr, sizeof(file_header)};
+}
+
+auto as_bytes(const packet_header& header) -> std::span<const std::byte> {
+  const auto* ptr = reinterpret_cast<const std::byte*>(&header);
+  return std::span<const std::byte>{ptr, sizeof(packet_header)};
+}
+
 auto byteswap(file_header hdr) -> file_header {
   auto result = file_header{};
   result.magic_number = detail::byteswap(hdr.magic_number);

--- a/libtenzir/src/pcap.cpp
+++ b/libtenzir/src/pcap.cpp
@@ -12,14 +12,31 @@
 
 namespace tenzir::pcap {
 
-auto as_bytes(const file_header& header) -> std::span<const std::byte> {
+auto as_bytes(const file_header& header)
+  -> std::span<const std::byte, sizeof(file_header)> {
   const auto* ptr = reinterpret_cast<const std::byte*>(&header);
-  return std::span<const std::byte>{ptr, sizeof(file_header)};
+  return std::span<const std::byte, sizeof(file_header)>{ptr,
+                                                         sizeof(file_header)};
 }
 
-auto as_bytes(const packet_header& header) -> std::span<const std::byte> {
+auto as_writeable_bytes(file_header& header)
+  -> std::span<std::byte, sizeof(file_header)> {
+  auto* ptr = reinterpret_cast<std::byte*>(&header);
+  return std::span<std::byte, sizeof(file_header)>{ptr, sizeof(file_header)};
+}
+
+auto as_bytes(const packet_header& header)
+  -> std::span<const std::byte, sizeof(packet_header)> {
   const auto* ptr = reinterpret_cast<const std::byte*>(&header);
-  return std::span<const std::byte>{ptr, sizeof(packet_header)};
+  return std::span<const std::byte, sizeof(packet_header)>{
+    ptr, sizeof(packet_header)};
+}
+
+auto as_writeable_bytes(packet_header& header)
+  -> std::span<std::byte, sizeof(packet_header)> {
+  auto* ptr = reinterpret_cast<std::byte*>(&header);
+  return std::span<std::byte, sizeof(packet_header)>{ptr,
+                                                     sizeof(packet_header)};
 }
 
 auto is_file_header(const packet_header& header) -> bool {

--- a/libtenzir/src/pcap.cpp
+++ b/libtenzir/src/pcap.cpp
@@ -22,6 +22,52 @@ auto as_bytes(const packet_header& header) -> std::span<const std::byte> {
   return std::span<const std::byte>{ptr, sizeof(packet_header)};
 }
 
+auto is_file_header(const packet_header& header) -> bool {
+  // Here they are two headers side by side:
+  //
+  //                FILE HEADER                      PACKET HEADER
+  //
+  //     ┌───────────────────────────────┐  ┌───────────────────────────────┐
+  //     │         MAGIC NUMBER          │  │           TIMESTAMP           │
+  //     ├───────────────┬───────────────┤  ├───────────────────────────────┤
+  //     │ MAJOR VERSION │ MINOR VERSION │  │       TIMESTAMP FRACTION      │
+  //     ├───────────────┴───────────────┤  ├───────────────────────────────┤
+  //     │           RESERVED            │  │     CAPTURED PACKET LENGTH    │
+  //     ├───────────────────────────────┤  ├───────────────────────────────┤
+  //     │           RESERVED            │  │     ORIGINAL PACKET LENGTH    │
+  //     ├───────────────────────────────┤  └───────────────────────────────┘
+  //                  SNAPLEN
+  //     ├ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┤
+  //                 LINKTYPE
+  //     └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘
+  //
+  auto is_reserved
+    = header.captured_packet_length == 0 && header.original_packet_length == 0;
+  if (not is_reserved)
+    return false;
+  // In theory, checking for zeroed out reserved fields should be sufficient.
+  // But we don't all PCAP generating tools, so do a few extra checks.
+  auto is_magic = header.timestamp == pcap::magic_number_1
+                  || header.timestamp == pcap::magic_number_2;
+  if (not is_magic)
+    return false;
+  // We're actually stopping here for now, even though we could go deeper. The
+  // base rate is too low for this.
+  return true;
+  // What could go wrong if we didn't do the next checks? The literal magic
+  // values would be UNIX timestamps equivalent to of Dec 19, 2055. At this
+  // point AGI will have killed us all. If we got (real or simulated) packets
+  // from that very second in the future, we deem it next to impossible that the
+  // fractional timestamp accidentally matched the PCAP version.
+  auto major_version = header.timestamp_fraction >> 16;
+  auto minor_version = header.timestamp_fraction & 0xffff;
+  if (need_byte_swap(header.timestamp)) {
+    major_version = detail::byteswap(major_version);
+    minor_version = detail::byteswap(minor_version);
+  }
+  return major_version == 4 && minor_version == 2;
+}
+
 auto byteswap(file_header hdr) -> file_header {
   auto result = file_header{};
   result.magic_number = detail::byteswap(hdr.magic_number);

--- a/plugins/nic/src/plugin.cpp
+++ b/plugins/nic/src/plugin.cpp
@@ -41,11 +41,11 @@ struct loader_args {
 
 auto make_file_header(int snaplen, int linktype) -> pcap::file_header {
   return {
-#ifdef PCAP_TSTAMP_PRECISION_NANO
-    .magic_number = pcap::magic_number_2,
-#else
+    // Timestamps have microsecond resolution when using pcap_open_live(). If we
+    // want nanosecond resolution, we must stop using pcap_open_live() and
+    // replace it with pcap_create() and pcap_activate(). See
+    // https://stackoverflow.com/q/28310922/1170277 for details.
     .magic_number = pcap::magic_number_1,
-#endif
     .major_version = 2,
     .minor_version = 4,
     .reserved1 = 0,

--- a/plugins/nic/src/plugin.cpp
+++ b/plugins/nic/src/plugin.cpp
@@ -28,13 +28,31 @@ namespace {
 struct loader_args {
   located<std::string> iface;
   std::optional<located<uint32_t>> snaplen;
+  std::optional<location> emit_file_headers;
 
   template <class Inspector>
   friend auto inspect(Inspector& f, loader_args& x) -> bool {
     return f.object(x)
       .pretty_name("loader_args")
-      .fields(f.field("iface", x.iface), f.field("snaplen", x.snaplen));
+      .fields(f.field("iface", x.iface), f.field("snaplen", x.snaplen),
+              f.field("emit_file_headers", x.emit_file_headers));
   }
+};
+
+auto make_file_header(int snaplen, int linktype) -> pcap::file_header {
+  return {
+#ifdef PCAP_TSTAMP_PRECISION_NANO
+    .magic_number = pcap::magic_number_2,
+#else
+    .magic_number = pcap::magic_number_1,
+#endif
+    .major_version = 2,
+    .minor_version = 4,
+    .reserved1 = 0,
+    .reserved2 = 0,
+    .snaplen = detail::narrow_cast<uint32_t>(snaplen),
+    .linktype = detail::narrow_cast<uint32_t>(linktype),
+  };
 };
 
 class nic_loader final : public plugin_loader {
@@ -50,8 +68,8 @@ public:
     auto snaplen = args_.snaplen ? args_.snaplen->inner : 262'144;
     TENZIR_DEBUG("capturing from {} with snaplen of {}", args_.iface.inner,
                  snaplen);
-    auto make = [](auto& ctrl, auto iface,
-                   auto snaplen) mutable -> generator<chunk_ptr> {
+    auto make = [](auto& ctrl, auto iface, auto snaplen,
+                   bool emit_file_headers) mutable -> generator<chunk_ptr> {
       auto put_iface_in_promiscuous_mode = 1;
       // The packet buffer timeout functions much like a read timeout: It
       // describes the number of milliseconds to wait at most until returning
@@ -75,6 +93,8 @@ public:
       auto pcap = std::shared_ptr<pcap_t>{ptr, [](pcap_t* p) {
                                             pcap_close(p);
                                           }};
+      auto linktype = pcap_datalink(pcap.get());
+      TENZIR_ASSERT(linktype != PCAP_ERROR_NOT_ACTIVATED);
       // We yield once initially to signal that the operator successfully
       // started.
       co_yield {};
@@ -118,28 +138,21 @@ public:
             .emit(ctrl.diagnostics());
           break;
         }
-        // Emit a PCAP file header before the first packet. This results in a
-        // packet stream that looks like a standard PCAP file downstream,
-        // allowing users to use the `pcap` format to parse the byte stream.
-        if (num_packets == 0) {
+        // Emit a PCAP file header, either with every chunk or once initially as
+        // separate chunk. This results in a packet stream that looks like a
+        // standard PCAP file downstream, allowing users to use the `pcap`
+        // format to parse the byte stream.
+        if (emit_file_headers) {
+          if (buffer.empty()) {
+            auto header = make_file_header(snaplen, linktype);
+            auto bytes = as_bytes(header);
+            buffer.insert(buffer.end(), bytes.begin(), bytes.end());
+          }
+        } else if (num_packets == 0) {
           auto linktype = pcap_datalink(pcap.get());
           TENZIR_ASSERT(linktype != PCAP_ERROR_NOT_ACTIVATED);
-          auto header = pcap::file_header{
-#ifdef PCAP_TSTAMP_PRECISION_NANO
-            .magic_number = pcap::magic_number_2,
-#else
-            .magic_number = pcap::magic_number_1,
-#endif
-            .major_version = 2,
-            .minor_version = 4,
-            .reserved1 = 0,
-            .reserved2 = 0,
-            .snaplen = snaplen,
-            .linktype = detail::narrow_cast<uint32_t>(linktype),
-          };
-          const auto* ptr = reinterpret_cast<const std::byte*>(&header);
-          auto bytes = std::span<const std::byte>{ptr, sizeof(header)};
-          co_yield chunk::copy(bytes);
+          auto header = make_file_header(snaplen, linktype);
+          co_yield chunk::copy(as_bytes(header));
         }
         auto header = pcap::packet_header{
           .timestamp = detail::narrow_cast<uint32_t>(pkt_hdr->ts.tv_sec),
@@ -160,7 +173,7 @@ public:
         ++num_packets;
       }
     };
-    return make(ctrl, args_.iface.inner, snaplen);
+    return make(ctrl, args_.iface.inner, snaplen, !!args_.emit_file_headers);
   }
 
   auto to_string() const -> std::string override {
@@ -202,10 +215,11 @@ public:
     -> std::unique_ptr<plugin_loader> override {
     auto parser = argument_parser{
       name(),
-      fmt::format("https://docs.tenzir.com/docs/next/connectors/{}", name())};
+      fmt::format("https://docs.tenzir.com/docs/connectors/{}", name())};
     auto args = loader_args{};
     parser.add(args.iface, "<iface>");
     parser.add("-s,--snaplen", args.snaplen, "<count>");
+    parser.add("-e,--emit-file-headers", args.emit_file_headers);
     parser.parse(p);
     return std::make_unique<nic_loader>(std::move(args));
   }

--- a/tenzir/integration/reference/pcap-format/step_04.ref
+++ b/tenzir/integration/reference/pcap-format/step_04.ref
@@ -1,0 +1,13 @@
+{"schema": "pcap.file_header"}
+{"schema": "pcap.packet"}
+{"schema": "pcap.packet"}
+{"schema": "pcap.packet"}
+{"schema": "pcap.packet"}
+{"schema": "pcap.packet"}
+{"schema": "pcap.packet"}
+{"schema": "pcap.file_header"}
+{"schema": "pcap.packet"}
+{"schema": "pcap.packet"}
+{"schema": "pcap.packet"}
+{"schema": "pcap.packet"}
+{"schema": "pcap.packet"}

--- a/tenzir/integration/reference/pcap-format/step_05.ref
+++ b/tenzir/integration/reference/pcap-format/step_05.ref
@@ -1,0 +1,3 @@
+warning: ignoring external PCAP file header
+ = note: cannot re-emit file header after having emitted packets
+ = note: from `pcap`

--- a/tenzir/integration/tests.yaml
+++ b/tenzir/integration/tests.yaml
@@ -1061,6 +1061,10 @@ tests:
       - command: exec 'read pcap -e | write pcap'
         input: data/pcap/example.pcap.gz
         transformation: md5sum | cut -f 1 -d ' '
+      # Concatenate PCAPs and process them. The test ensures that we have the
+      # right sequencing of file header and packet header events.
+      - command: exec 'shell "cat @./data/pcap/vlan-*.pcap" | read pcap -e | put schema=#schema | write json -c'
+      - command: exec 'shell "cat @./data/pcap/vlan-*.pcap" | read pcap -e | write pcap | discard'
 
   Compression:
     tags: [pipelines, compression]

--- a/web/blog/tenzir-v4.2/index.md
+++ b/web/blog/tenzir-v4.2/index.md
@@ -140,3 +140,33 @@ as follows:
 ```
 from file /tmp/test.txt read lines --skip-empty
 ```
+
+## Concatenating PCAP files
+
+The [`pcap`](/formats/pcap) parser can now read concatenated PCAP files,
+allowing you to easily process large amounts of trace files. This comes
+especially handy on the command line:
+
+```bash
+cat *.pcap | tenzir 'read pcap'
+```
+
+The [`nic`](/connectors/nic) loader has a new flag `--emit-file-headers` that
+prepends a PCAP file header for every batch of bytes that it produces, yielding
+a stream of concatenated PCAP files. This gives rise to creative use cases
+involving packet shipping. For example, to ship blocks of packets as "micro
+traces" via 0mq, you could do:
+
+```
+load nic eth0
+| save zmq
+```
+
+This creates 0mq PUB socket where subscribes can come and go. Each 0mq message
+is a self-contained PCAP trace, which avoids painful resynchronization logic.
+You can consume this feed with a remote subscriber:
+
+```
+load zmq
+| read pcap
+```

--- a/web/docs/connectors/nic.md
+++ b/web/docs/connectors/nic.md
@@ -7,7 +7,7 @@ Reads bytes from a network interface card (NIC).
 ## Synopsis
 
 ```
-nic <iface> [-s|--snaplen <count>]
+nic <iface> [-s|--snaplen <count>] [-e|--emit-file-headers]
 ```
 
 ## Description
@@ -28,6 +28,18 @@ This value is an upper bound on the packet size. Packets larger than this size
 get truncated to `<count>` bytes.
 
 Defaults to `262144`.
+
+### `-e|--emit-file-headers`
+
+Creates PCAP file headers for every flushed batch.
+
+The `nic` connector emits chunk of bytes that represent a stream of packets.
+When setting `--emit-file-headers` every chunk gets its own PCAP file header, as
+opposed to just the very first. This yields a continuous stream of concatenated
+PCAP files.
+
+The [`pcap`](../formats/pcap.md) parser can handle such concatenated traces, and
+optionally re-emit thes file headers as separate events.
 
 ## Examples
 

--- a/web/docs/formats/pcap.md
+++ b/web/docs/formats/pcap.md
@@ -45,13 +45,17 @@ pcap.packet:
 
 ### `-e|--emit-file-header` (Parser)
 
-Emit a `pcap.file_header` event that represents the the PCAP file header. If present,
-the parser injects this additional event before the subsequent stream of
-packets.
+Emit a `pcap.file_header` event that represents the PCAP file header. If
+present, the parser injects this additional event before the subsequent stream
+of packets.
 
 Emitting this extra event makes it possible to seed the `pcap` printer with a
 file header from the input. This allows for controlling the timestamp formatting
 (microseconds vs. nanosecond granularity) and byte order in the packet headers.
+
+When the PCAP parser processes a concatenated stream of PCAP files, specifying
+`--emit-file-header` will also re-emit every intermediate file header as
+separate event.
 
 Use this option when you would like to reproduce the identical trace file layout
 of the PCAP input.
@@ -75,4 +79,10 @@ file:
 
 ```
 read pcap | decapsulate
+```
+
+On the command line, merge PCAP files and process parse them:
+
+```bash
+cat *.pcap | tenzir 'read pcap'
 ```

--- a/web/docs/formats/pcap.md
+++ b/web/docs/formats/pcap.md
@@ -9,7 +9,7 @@ Reads and writes raw network packets in [PCAP][pcap-rfc] file format.
 Parser:
 
 ```
-pcap [-e|--emit-file-header]
+pcap [-e|--emit-file-headers]
 ```
 
 Printer:
@@ -43,7 +43,7 @@ pcap.packet:
     - data: string
 ```
 
-### `-e|--emit-file-header` (Parser)
+### `-e|--emit-file-headers` (Parser)
 
 Emit a `pcap.file_header` event that represents the PCAP file header. If
 present, the parser injects this additional event before the subsequent stream
@@ -54,7 +54,7 @@ file header from the input. This allows for controlling the timestamp formatting
 (microseconds vs. nanosecond granularity) and byte order in the packet headers.
 
 When the PCAP parser processes a concatenated stream of PCAP files, specifying
-`--emit-file-header` will also re-emit every intermediate file header as
+`--emit-file-headers` will also re-emit every intermediate file header as
 separate event.
 
 Use this option when you would like to reproduce the identical trace file layout


### PR DESCRIPTION
This PR equips the `pcap` parser with the capability to parse a stream of *concatenated* PCAPS.

This means that you can now do the following:

```bash
cat *.pcap | tenzir 'read pcap'
```
