### PR TITLE
Fixes for building dynamic executables with Nix

### DIFF
--- a/nix/tenzir/default.nix
+++ b/nix/tenzir/default.nix
@@ -187,26 +187,18 @@
               self.override {
                 extraPlugins = map (x: x.src) actualPlugins;
               }
-            else let
-              pluginDir = symlinkJoin {
-                name = "tenzir-plugin-dir";
-                paths = [actualPlugins];
+            else
+              symlinkJoin {
+                name = "tenzir";
+                paths = [self actualPlugins];
               };
-            in
-              runCommand "tenzir-with-plugins"
-              {
-                nativeBuildInputs = [makeWrapper];
-              } ''
-                makeWrapper ${self}/bin/tenzir-ctl $out/bin/tenzir-ctl \
-                  --set TENZIR_PLUGIN_DIRS "${pluginDir}/lib/tenzir/plugins"
-              '';
         };
 
         meta = with lib; {
           description = "Visibility Across Space and Time";
           homepage = "https://www.tenzir.com/";
           # Set mainProgram so that all editions work with `nix run`.
-          mainProgram = "tenzir-ctl";
+          mainProgram = "tenzir";
           license = licenses.bsd3;
           platforms = platforms.unix;
           maintainers = with maintainers; [tobim];

--- a/nix/tenzir/default.nix
+++ b/nix/tenzir/default.nix
@@ -88,8 +88,6 @@
         ];
         propagatedNativeBuildInputs = [pkg-config];
         buildInputs = [
-          boost
-          curl
           fast_float
           libpcap
           libunwind
@@ -101,7 +99,9 @@
         ];
         propagatedBuildInputs = [
           arrow-cpp
+          boost
           caf
+          curl
           flatbuffers
           jemalloc
           robin-map

--- a/nix/tenzir/default.nix
+++ b/nix/tenzir/default.nix
@@ -195,7 +195,7 @@
         };
 
         meta = with lib; {
-          description = "Visibility Across Space and Time";
+          description = "Open Source Security Data Pipelines";
           homepage = "https://www.tenzir.com/";
           # Set mainProgram so that all editions work with `nix run`.
           mainProgram = "tenzir";

--- a/plugins/zmq/CMakeLists.txt
+++ b/plugins/zmq/CMakeLists.txt
@@ -20,6 +20,14 @@ TenzirRegisterPlugin(
 
 find_package(cppzmq QUIET)
 
+if (TARGET libzmq)
+  # libzmq declares its link dependencies as public, but in reality they are all
+  # private. Clearing the link libraries fixes execution when those dependencies
+  # are not installed in a "standard location", such as in a Nix managed build
+  # environment.
+  set_target_properties(libzmq PROPERTIES INTERFACE_LINK_LIBRARIES "")
+endif ()
+
 if (TENZIR_ENABLE_STATIC_EXECUTABLE)
   target_link_libraries(zmq PUBLIC cppzmq-static)
 else ()


### PR DESCRIPTION
`nix run .#tenzir` was broken for multiple reasons. Each commit fixes one of them.