### PR TITLE
Fix program startup of the static binary

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -21,6 +21,18 @@ in {
           ./google-cloud-cpp/0001-Use-pkg-config-to-find-CURL.patch
         ];
       });
+  aws-c-cal =
+    if !isStatic
+    then prev.aws-c-cal
+    else
+      prev.aws-c-cal.overrideAttrs (orig: {
+        patches = (orig.patches or []) ++ [
+          (prev.fetchpatch {
+            url = "https://github.com/awslabs/aws-c-cal/commit/ee46efc3dd0cf300ff4ec89cc2d79f1b0fe1c8cb.patch";
+            sha256 = "sha256-bFc0Mqt0Ho3i3xGHiQitP35dQgPd9Wthkyb1TT/nRYs=";
+          })
+        ];
+      });
   arrow-cpp =
     if !isStatic
     then prev.arrow-cpp


### PR DESCRIPTION
The recent addition of the s3 connector causes the linker to add symbols from the AWS crypto abstraction layer library. This lib uses the `dlopen` and `dlclose` functions even when built as a static library - which is possible. What's more, the return value of those functions is asserted, causing the tenzir executables to abort during initialization.

The good news is that this can be worked around by disabling the problematic assert. For that we pull a patch that does exactly that from an open upstream pull request.

Fixes https://github.com/tenzir/issues/issues/885.