### PR TITLE
Add scheme omission to s3 and gcs loaders

### DIFF
--- a/libtenzir/builtins/connectors/s3.cpp
+++ b/libtenzir/builtins/connectors/s3.cpp
@@ -265,6 +265,9 @@ public:
     parser.add("--anonymous", args.anonymous);
     parser.add(args.uri, "<uri>");
     parser.parse(p);
+    // TODO: URI parser.
+    if (not args.uri.inner.starts_with("s3://"))
+      args.uri.inner = fmt::format("s3://{}", args.uri.inner);
     return std::make_unique<s3_loader>(std::move(args));
   }
 
@@ -277,6 +280,7 @@ public:
     parser.add("--anonymous", args.anonymous);
     parser.add(args.uri, "<uri>");
     parser.parse(p);
+    // TODO: URI parser.
     if (not args.uri.inner.starts_with("s3://"))
       args.uri.inner = fmt::format("s3://{}", args.uri.inner);
     return std::make_unique<s3_saver>(std::move(args));

--- a/plugins/gcs/src/plugin.cpp
+++ b/plugins/gcs/src/plugin.cpp
@@ -254,6 +254,9 @@ public:
     parser.add("--anonymous", args.anonymous);
     parser.add(args.uri, "<uri>");
     parser.parse(p);
+    // TODO: URI parser.
+    if (not args.uri.inner.starts_with("gs://"))
+      args.uri.inner = fmt::format("gs://{}", args.uri.inner);
     return std::make_unique<gcs_loader>(std::move(args));
   }
 
@@ -266,6 +269,7 @@ public:
     parser.add("--anonymous", args.anonymous);
     parser.add(args.uri, "<uri>");
     parser.parse(p);
+    // TODO: URI parser.
     if (not args.uri.inner.starts_with("gs://"))
       args.uri.inner = fmt::format("gs://{}", args.uri.inner);
     return std::make_unique<gcs_saver>(std::move(args));


### PR DESCRIPTION
This PR adds missing scheme omission to the `s3` and `gcs` loaders.