### PR TITLE
Disable 0mq socket lingering

### DIFF
--- a/changelog/changes/3536.md
+++ b/changelog/changes/3536.md
@@ -1,0 +1,4 @@
+We made it easier to reuse the default `zmq` socket endpoint by disabling
+*socket lingering*, and thereby immediately relinquishing resources when
+terminating a ZeroMQ pipeline. Changing the linger period from infinite to 0 no
+longer buffers pending messages in memory after closing a ZeroMQ socket.

--- a/plugins/zmq/src/plugin.cpp
+++ b/plugins/zmq/src/plugin.cpp
@@ -283,6 +283,14 @@ private:
 
   explicit engine(::zmq::socket_type socket_type)
     : socket_{ctx_, socket_type}, monitor_{ctx_, socket_} {
+    // The linger period determines how long pending messages which have yet
+    // to be sent to a peer shall linger in memory after a socket is closed
+    // with zmq_close(3), and further affects the termination of the socket's
+    // context with zmq_term(3).
+    //
+    // The value of 0 specifies no linger period. Pending messages shall be
+    // discarded immediately when the socket is closed with zmq_close().
+    socket_.set(::zmq::sockopt::linger, 0);
   }
 
   void bind(const std::string& endpoint) {


### PR DESCRIPTION
This PR disables 0mq socket lingering to enable instant freeing of resources.
