### PR TITLE
Add pipeline label support to the main repository

### DIFF
--- a/changelog/next/features/3541.md
+++ b/changelog/next/features/3541.md
@@ -1,0 +1,1 @@
+The pipeline manager now supports user-provided labels for pipelines.

--- a/libtenzir/src/version.cpp
+++ b/libtenzir/src/version.cpp
@@ -79,7 +79,9 @@ auto tenzir_features() -> std::vector<std::string> {
   // launch_endpoint - The pipeline manager plugin has a new `/pipeline/launch`
   //                   endpoint and can thus unify the workflows of running &
   //                   deploying pipelines.
-  return {"large_responses", "launch_endpoint"};
+  // pipeline_labels - The pipeline manager plugin supports pipeline labels that
+  //                   can be modified using the `/pipeline/update` endpoint.
+  return {"large_responses", "launch_endpoint", "pipeline_labels"};
 }
 
 } // namespace tenzir

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "86efa8fa6d1e567011a2d10b9d547ac7c1669384",
+  "rev": "faf3531ca0f5645696350da388226053a81326f4",
   "submodules": true,
   "shallow": true
 }

--- a/plugins/web/src/specification_command.cpp
+++ b/plugins/web/src/specification_command.cpp
@@ -203,6 +203,11 @@ Location:
     end:
       type: number
       example: 48
+PipelineLabels:
+  type: array
+  description: The user-provided labels for this pipeline.
+  items:
+    $ref: "#/components/schemas/PipelineLabel"
 PipelineInfo:
   type: object
   properties:
@@ -248,6 +253,8 @@ PipelineInfo:
       $ref: '#/components/schemas/Diagnostics'
     metrics:
       $ref: '#/components/schemas/Metrics'
+    labels:
+      $ref: "#/components/schemas/PipelineLabels"
   )_");
   TENZIR_ASSERT_CHEAP(schemas);
   // clang-format off

--- a/web/openapi/openapi.yaml
+++ b/web/openapi/openapi.yaml
@@ -199,6 +199,22 @@ components:
         end:
           type: number
           example: 48
+    PipelineLabel:
+      type: object
+      properties:
+        text:
+          type: string
+          description: The pipeline label text.
+          example: zeek
+        name:
+          type: string
+          description: The pipeline label color.
+          example: 3F1A24
+    PipelineLabels:
+      type: array
+      description: The user-provided labels for this pipeline.
+      items:
+        $ref: "#/components/schemas/PipelineLabel"
     PipelineInfo:
       type: object
       properties:
@@ -244,6 +260,8 @@ components:
           $ref: "#/components/schemas/Diagnostics"
         metrics:
           $ref: "#/components/schemas/Metrics"
+        labels:
+          $ref: "#/components/schemas/PipelineLabels"
   securitySchemes:
     TenzirToken:
       type: apiKey
@@ -465,6 +483,8 @@ paths:
                 restart_with_node:
                   type: boolean
                   description: Flag that specifies whether the pipeline should be restarted when the Tenzir Node is restarted.
+                labels:
+                  $ref: "#/components/schemas/PipelineLabels"
       responses:
         200:
           description: Success.


### PR DESCRIPTION
This PR is a submodule pointer bump + `http_api` support for pipeline labels in HTTP requests.