### PR TITLE
Add the `/pipeline/launch` endpoint to the `tenzir_features()`

### DIFF
--- a/libtenzir/src/version.cpp
+++ b/libtenzir/src/version.cpp
@@ -76,7 +76,10 @@ auto tenzir_features() -> std::vector<std::string> {
   // large_responses - The platform plugin understands the
   //                   `alternate_payload_destination` field and can send
   //                   out-of-band responses.
-  return {"large_responses"};
+  // launch_endpoint - The pipeline manager plugin has a new `/pipeline/launch`
+  //                   endpoint and can thus unify the workflows of running &
+  //                   deploying pipelines.
+  return {"large_responses", "launch_endpoint"};
 }
 
 } // namespace tenzir


### PR DESCRIPTION
This change adds the `/pipeline/launch` endpoint to the `tenzir_features()` to help the app discern whether unifying the "run & deploy" workflow in the app is possible.
