### PR TITLE
Implement `type::to_definition()` for the null type

### DIFF
--- a/libtenzir/src/type.cpp
+++ b/libtenzir/src/type.cpp
@@ -817,7 +817,6 @@ data type::construct() const noexcept {
 }
 
 data type::to_definition(bool expand) const noexcept {
-  TENZIR_ASSERT(*this);
   // Utility function for adding the attributes to a type definition, if
   // required.
   auto attributes_enriched_definition
@@ -852,6 +851,9 @@ data type::to_definition(bool expand) const noexcept {
   // type may still have attributes.
   TENZIR_ASSERT(name().empty());
   auto make_type_definition = detail::overload{
+    [](const null_type&) noexcept -> data {
+      return {};
+    },
     [](const basic_type auto& self) noexcept -> data {
       return fmt::to_string(self);
     },

--- a/libtenzir/test/type.cpp
+++ b/libtenzir/test/type.cpp
@@ -42,6 +42,8 @@ TEST(null_type) {
   CHECK_EQUAL(*lt.to_arrow_type(), *arrow::list(arrow::null()));
   CHECK_EQUAL(*ln.to_arrow_type(), *arrow::list(arrow::null()));
   CHECK_EQUAL(*ltn.to_arrow_type(), *arrow::list(arrow::null()));
+  const auto expected_definition = data{};
+  CHECK_EQUAL(tn.to_definition(), expected_definition);
 }
 
 TEST(bool_type) {


### PR DESCRIPTION
Fixes tenzir/issues#910