### PR TITLE
Fix timing-related crashes in the `web` plugin

### DIFF
--- a/changelog/next/bug-fixes/3553.md
+++ b/changelog/next/bug-fixes/3553.md
@@ -1,0 +1,1 @@
+The web server will not crash when receiving requests during shutdown anymore.

--- a/plugins/web/src/restinio_response.cpp
+++ b/plugins/web/src/restinio_response.cpp
@@ -33,6 +33,8 @@ restinio_response::restinio_response(request_handle_t&& handle,
     response_(request_->create_response<restinio::user_controlled_output_t>()) {
   response_.append_header(restinio::http_field::content_type,
                           content_type_to_string(endpoint.content_type));
+  response_.header().status_code(
+    restinio::http_status_code_t{restinio::status_code::internal_server_error});
 }
 
 restinio_response::~restinio_response() {
@@ -46,6 +48,8 @@ void restinio_response::append(std::string body) {
 }
 
 void restinio_response::finish(caf::expected<std::string> body) {
+  response_.header().status_code(
+    restinio::http_status_code_t{restinio::status_code::ok});
   auto text = body ? *body : fmt::format("{}", body.error());
   body_size_ += text.size();
   response_.append_body(std::move(text));

--- a/plugins/web/src/server_command.cpp
+++ b/plugins/web/src/server_command.cpp
@@ -463,6 +463,8 @@ auto server_command(const tenzir::invocation& inv, caf::actor_system& system)
       return stop;
     });
   // Shutdown
+  self->send_exit(dispatcher, caf::exit_reason::user_shutdown);
+  self->wait_for(dispatcher);
   std::visit(
     detail::overload{
       [](auto& server) {
@@ -470,7 +472,6 @@ auto server_command(const tenzir::invocation& inv, caf::actor_system& system)
       },
     },
     server);
-  self->send_exit(dispatcher, caf::exit_reason::user_shutdown);
   for (auto& handler : handlers)
     self->send_exit(handler, caf::exit_reason::user_shutdown);
   server_thread.join();


### PR DESCRIPTION
This change fixes an obscure crash when a web server is shutting down while receiving requests at the same time.
