### PR TITLE
Fix an assertion failure in the `decompress` operator

### DIFF
--- a/libtenzir/builtins/operators/compress_decompress.cpp
+++ b/libtenzir/builtins/operators/compress_decompress.cpp
@@ -313,7 +313,7 @@ public:
         }
         if (result->bytes_written > 0) {
           TENZIR_ASSERT(result->bytes_written
-                        < detail::narrow_cast<int64_t>(out_buffer.size()));
+                        <= detail::narrow_cast<int64_t>(out_buffer.size()));
           co_yield chunk::copy(
             as_bytes(out_buffer).subspan(0, result->bytes_written));
         } else {


### PR DESCRIPTION
This was an issue only in Debug mode, so it's not really worth a changelog entry. The decompressed buffer is not guaranteed to be larger than the compressed buffer, as they can also be the same size. This usually happens for very small chunk sizes.