### PR TITLE
Check for duplicate field names in zeek_tsv_parser

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,3 +11,4 @@ compile_commands.json
 nix/
 !README.md
 !VERSIONING.md
+cmake-build-*/

--- a/changelog/next/bug-fixes/3578.md
+++ b/changelog/next/bug-fixes/3578.md
@@ -1,0 +1,2 @@
+Having duplicate field names in `zeek-tsv` data no longer causes a crash,
+but rather errors out gracefully.

--- a/libtenzir/builtins/formats/zeek_tsv.cpp
+++ b/libtenzir/builtins/formats/zeek_tsv.cpp
@@ -571,6 +571,19 @@ auto parser_impl(generator<std::optional<std::string_view>> lines,
           .note("line {}", line_nr)
           .emit(ctrl.diagnostics());
       }
+      // Verify that the field names are unique
+      {
+        auto sorted_fields = document.fields;
+        std::ranges::sort(sorted_fields);
+        if (auto it = std::ranges::adjacent_find(sorted_fields);
+            it != sorted_fields.end()) {
+          diagnostic::error(
+            "failed to parse Zeek document: duplicate #field name `{}`", *it)
+            .note("line {}", line_nr)
+            .emit(ctrl.diagnostics());
+          co_return;
+        }
+      }
       continue;
     }
     // If we don't have a builder yet, then we create one lazily.

--- a/tenzir/functional-test/data/zeek/duplicate_field_name.log
+++ b/tenzir/functional-test/data/zeek/duplicate_field_name.log
@@ -1,0 +1,10 @@
+#separator \x09
+#set_separator	,
+#empty_field	(empty)
+#unset_field	-
+#path	tenzir.json
+#open	2023-10-10-12-48-16.056854
+#fields	a.b	a.b
+#types	int	int
+42	43
+#close	2023-10-10-12-48-16.057063

--- a/tenzir/integration/reference/zeek-tsv-pipeline-format/step_16.ref
+++ b/tenzir/integration/reference/zeek-tsv-pipeline-format/step_16.ref
@@ -1,0 +1,2 @@
+error: failed to parse Zeek document: duplicate #field name `a.b`
+ = note: line 7

--- a/tenzir/integration/tests.yaml
+++ b/tenzir/integration/tests.yaml
@@ -833,6 +833,9 @@ tests:
       - command: exec 'from stdin read zeek-tsv | write zeek-tsv --disable-timestamp-tags'
         input: data/zeek/broken_data_after_close_tag.log
         expected_result: error
+      - command: exec 'from stdin read zeek-tsv | write zeek-tsv --disable-timestamp-tags'
+        input: data/zeek/duplicate_field_name.log
+        expected_result: error
 
   Zeek TSV with Remote Import:
     fixture: ServerTester


### PR DESCRIPTION
Fixes https://github.com/tenzir/issues/issues/933

We don't expect valid Zeek TSV data to ever contain duplicate field names, so if we encounter some, we can error with good conscience. Without this fix, there's a crash later on.