### PR TITLE
Add an optional content type to chunk

### DIFF
--- a/libtenzir/include/tenzir/detail/legacy_deserialize.hpp
+++ b/libtenzir/include/tenzir/detail/legacy_deserialize.hpp
@@ -311,6 +311,24 @@ public:
     return true;
   }
 
+  template <class T>
+  result_type apply(std::optional<T>& x) {
+    bool is_set = false;
+    if (!apply(is_set)) {
+      x = {};
+      return false;
+    }
+    if (!is_set) {
+      x = {};
+      return true;
+    }
+    T v;
+    if (!apply(v))
+      return false;
+    x = v;
+    return true;
+  }
+
   result_type apply(caf::config_value& x) {
     uint8_t type_tag = 0;
     if (!apply(type_tag))


### PR DESCRIPTION
This addition allows for transferring metadata about chunks in-stream. Specifically, this adds a metadata field for the content type, which is the missing piece for tenzir/tenzir#3539.

The alternative to this approach is to forbid `write <format> | save <connector>` in favor of always requiring the combined `to <connector> write <format>`. However, the latter does not compose as freely as transferring the content type in-stream.

What's left is to make use of the content type, but I will leave that to the linked PR adding HTTP(S) savers.