### PR TITLE
Add `events` field to output of `show partitions`

### DIFF
--- a/changelog/next/features/3580--show-partitions-events.md
+++ b/changelog/next/features/3580--show-partitions-events.md
@@ -1,0 +1,4 @@
+The output of `show partitions` includes a new `events` field that shows the
+number of events kept in that partition. E.g., the pipeline `show partitions |
+summarize events=sum(events) by schema` shows the number of events per schema
+stored at the node.

--- a/libtenzir/builtins/aspects/partitions.cpp
+++ b/libtenzir/builtins/aspects/partitions.cpp
@@ -7,34 +7,19 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include <tenzir/actors.hpp>
-#include <tenzir/adaptive_table_slice_builder.hpp>
 #include <tenzir/argument_parser.hpp>
 #include <tenzir/catalog.hpp>
 #include <tenzir/node_control.hpp>
 #include <tenzir/partition_synopsis.hpp>
 #include <tenzir/plugin.hpp>
+#include <tenzir/series_builder.hpp>
+#include <tenzir/si_literals.hpp>
 
 #include <caf/scoped_actor.hpp>
 
 namespace tenzir::plugins::partitions {
 
 namespace {
-
-/// A type that represents a partition.
-auto partition_type() -> type {
-  return type{
-    "tenzir.partition",
-    record_type{
-      {"uuid", string_type{}},
-      {"memory_usage", uint64_type{}},
-      {"min_import_time", time_type{}},
-      {"max_import_time", time_type{}},
-      {"version", uint64_type{}},
-      {"schema", string_type{}},
-      {"schema_id", string_type{}},
-    },
-  };
-}
 
 class plugin final : public virtual aspect_plugin {
 public:
@@ -76,29 +61,32 @@ public:
       ctrl.abort(std::move(error));
       co_return;
     }
-    auto builder = table_slice_builder{partition_type()};
+    auto builder = series_builder{};
     using namespace tenzir::si_literals;
     constexpr auto max_rows = size_t{8_Ki};
     for (auto i = 0u; i < synopses.size(); ++i) {
       auto& synopsis = synopses[i];
-      if (not(builder.add(fmt::to_string(synopsis.uuid))
-              && builder.add(uint64_t{synopsis.synopsis->memusage()})
-              && builder.add(synopsis.synopsis->min_import_time)
-              && builder.add(synopsis.synopsis->max_import_time)
-              && builder.add(synopsis.synopsis->version)
-              && builder.add(synopsis.synopsis->schema.name())
-              && builder.add(synopsis.synopsis->schema.make_fingerprint()))) {
-        diagnostic::error("failed to add partition entry")
-          .emit(ctrl.diagnostics());
-        co_return;
-      }
+      auto event = builder.record();
+      event.field("uuid").data(fmt::to_string(synopsis.uuid));
+      event.field("memusage").data(synopsis.synopsis->memusage());
+      event.field("events").data(synopsis.synopsis->events);
+      event.field("min_import_time").data(synopsis.synopsis->min_import_time);
+      event.field("max_import_time").data(synopsis.synopsis->max_import_time);
+      event.field("version").data(synopsis.synopsis->version);
+      event.field("schema").data(synopsis.synopsis->schema.name());
+      event.field("schema_id")
+        .data(synopsis.synopsis->schema.make_fingerprint());
       if ((i + 1) % max_rows == 0) {
-        co_yield builder.finish();
-        builder = std::exchange(builder, table_slice_builder{partition_type()});
+        for (auto result : builder.finish_as_table_slice("tenzir.partition")) {
+          co_yield std::move(result);
+        }
       }
     }
-    if (synopses.size() % max_rows != 0) // no empty slices
-      co_yield builder.finish();
+    if (synopses.size() % max_rows != 0) { // no empty slices
+      for (auto result : builder.finish_as_table_slice("tenzir.partition")) {
+        co_yield std::move(result);
+      }
+    }
   }
 };
 

--- a/libtenzir/builtins/aspects/partitions.cpp
+++ b/libtenzir/builtins/aspects/partitions.cpp
@@ -77,7 +77,7 @@ public:
       event.field("schema_id")
         .data(synopsis.synopsis->schema.make_fingerprint());
       if ((i + 1) % max_rows == 0) {
-        for (auto result : builder.finish_as_table_slice("tenzir.partition")) {
+        for (auto&& result : builder.finish_as_table_slice("tenzir.partition")) {
           co_yield std::move(result);
         }
       }


### PR DESCRIPTION
One simple use case for this is wanting to see how many events are stored at the node per schema.

```
show partitions
| summarize events=sum(events) by schema
| sort events desc
```