### PR TITLE
Fix predicate pushdown for `export | where …`

### DIFF
--- a/libtenzir/builtins/operators/export.cpp
+++ b/libtenzir/builtins/operators/export.cpp
@@ -56,6 +56,10 @@ public:
     auto current_slice = std::optional<table_slice>{};
     auto query_context
       = tenzir::query_context::make_extract("export", blocking_self, expr_);
+    query_context.id = uuid::random();
+    TENZIR_DEBUG("export operator starts catalog lookup with id {} and "
+                 "expression {}",
+                 query_context.id, expr_);
     auto current_result = catalog_lookup_result{};
     auto current_error = caf::error{};
     ctrl.self()
@@ -123,10 +127,10 @@ public:
     -> optimize_result override {
     (void)order;
     auto clauses = std::vector<expression>{};
-    if (expr_ != caf::none) {
+    if (expr_ != caf::none and expr_ != trivially_true_expression()) {
       clauses.push_back(expr_);
     }
-    if (filter != trivially_true_expression()) {
+    if (filter != caf::none and filter != trivially_true_expression()) {
       clauses.push_back(filter);
     }
     auto expr = clauses.empty() ? expression{}

--- a/libtenzir/src/passive_partition.cpp
+++ b/libtenzir/src/passive_partition.cpp
@@ -158,9 +158,9 @@ indexer_actor passive_partition_state::indexer_at(size_t position) const {
     indexer = self->spawn(passive_indexer, id, std::move(value_index));
     return indexer;
   }
-  TENZIR_WARN("passive-partition ({}) failed to deserialize value index for "
-              "field {}",
-              id, qualified_index->field_name()->string_view());
+  TENZIR_DEBUG("passive-partition ({}) failed to deserialize value index for "
+               "field {}",
+               id, qualified_index->field_name()->string_view());
   return {};
 }
 


### PR DESCRIPTION
> [!NOTE]
> This fixes a high-severity performance bug, and we should consider cutting the next release a bit earlier because of it. I've requested @tobim for review as we've identified this bug together when looking at a performance problem.

This fixes a regression that snuck in between the v4.2 and v4.3 releases. We changed slightly how predicate pushdown works for the `export` operator, which caused unnecessary predicates with trivially true expressions to appear after predicate pushdownn. This exposed a bug in the catalog, which did not bind expressions to the schemas before evaluating them. The consequence of this was a too large set of candidate partitions.

This pull request fixes both the unnecessary predicates in the optimization phase of the `export` operator, and causes the catalog (1) to normalize and validate expressions, and (2) to bind expressions exactly once per schema, ignoring partitions for which tailoring fails.

Additionally, this properly sets the UUID for catalog lookup requests in the `export` operator, which makes tracking the query's lifetime in trace and debug logs easier.