### PR TITLE
Improve error in `/serve` endpoint for expired pipelines

### DIFF
--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,8 +2,7 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "ad4d5748e4975d2d8336b111e4d924b9ffa0497d",
+  "rev": "eb90d6e538e23ecbb7526ef1d4cf468d69a23224",
   "submodules": true,
-  "shallow": true,
-  "allRefs": true
+  "shallow": true
 }

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "84c174de8ecf7cb889ead11dadd3bf502bbf2427",
+  "rev": "ad4d5748e4975d2d8336b111e4d924b9ffa0497d",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
This changes the `/serve` endpoint to keep track of previously known but expired serve ids to display a richer error message. Previously, this was indistinguishable from unknown serve ids.

Additionally, this silences a bogus warning for pipelines with an expired TTL.