### PR TITLE
Add `show serves` for debugging the `serve` operator

### DIFF
--- a/changelog/next/features/3596--show-serves.md
+++ b/changelog/next/features/3596--show-serves.md
@@ -1,2 +1,2 @@
-`show serves` displays all currently active serve ids in the `/serve` API
+`show serves` displays all currently active serve IDs in the `/serve` API
 endpoint, showing an overview of active pipelines with an on-demand API.

--- a/changelog/next/features/3596--show-serves.md
+++ b/changelog/next/features/3596--show-serves.md
@@ -1,0 +1,2 @@
+`show serves` displays all currently active serve ids in the `/serve` API
+endpoint, showing an overview of active pipelines with an on-demand API.

--- a/web/docs/operators/sources/show.md
+++ b/web/docs/operators/sources/show.md
@@ -24,10 +24,8 @@ Describes the part of Tenzir to look at.
 
 Available aspects:
 
-- `build`: shows compile-time build information.
 - `config`: shows all current configuration options.
 - `connectors`: shows all available [connectors](../../connectors.md).
-- `dependencies`: shows information about build-time dependencies.
 - `fields`: shows all fields of existing tables at a remote node.
 - `formats`: shows all available [formats](../../formats.md).
 - `nics`: shows all network interfaces for the [`nic`](../../connectors/nic.md)
@@ -36,8 +34,16 @@ Available aspects:
 - `partitions`: shows all table partitions of a remote node.
 - `pipelines`: shows all managed pipelines of a remote node.
 - `plugins`: shows all loaded plugins.
-- `types`: shows all known types at a remote node.
 - `version`: shows the Tenzir version.
+
+We also offer some additional aspects for experts that want to take a deeper
+look at what's going on:
+
+- `build`: shows compile-time build information.
+- `dependencies`: shows information about build-time dependencies.
+- `serves` shows all pipelines with the `serve` sink operator currently
+  available from the `/serve` API endpoint.
+- `types`: shows all known types at a remote node.
 
 ## Examples
 


### PR DESCRIPTION
The new `serves` aspect shows all currently active serve ids in the `/serve` API endpoint.

I developed this when debugging the TTL problems last week, and I figured it was useful enough to just be added to the codebase with a small disclaimer in the docs.

<img width="1667" alt="image" src="https://github.com/tenzir/tenzir/assets/4488655/a8addf89-23a9-47f5-9ece-981c24a33e4d">
