### PR TITLE
Fix predicate pushdown in `export` and other small fixes

### DIFF
--- a/changelog/next/bug-fixes/3599--predicate-pushdown.md
+++ b/changelog/next/bug-fixes/3599--predicate-pushdown.md
@@ -1,0 +1,5 @@
+A regression in Tenzir v4.3 caused exports to often consider all partitions as
+candidates. Pipelines of the form `export | where <expr>` now work as expected
+again and only load relevant partitions from disk.
+
+The long option `--skip-empty` for `read lines` now works as documented.

--- a/libtenzir/builtins/formats/lines.cpp
+++ b/libtenzir/builtins/formats/lines.cpp
@@ -111,7 +111,7 @@ public:
     auto parser = argument_parser{
       name(), fmt::format("https://docs.tenzir.com/docs/formats/{}", name())};
     auto args = parser_args{};
-    parser.add("-s,--skip-empty-lines", args.skip_empty);
+    parser.add("-s,--skip-empty", args.skip_empty);
     parser.parse(p);
     return std::make_unique<lines_parser>(std::move(args));
   }

--- a/libtenzir/builtins/operators/export.cpp
+++ b/libtenzir/builtins/operators/export.cpp
@@ -56,6 +56,10 @@ public:
     auto current_slice = std::optional<table_slice>{};
     auto query_context
       = tenzir::query_context::make_extract("export", blocking_self, expr_);
+    query_context.id = uuid::random();
+    TENZIR_DEBUG("export operator starts catalog lookup with id {} and "
+                 "expression {}",
+                 query_context.id, expr_);
     auto current_result = catalog_lookup_result{};
     auto current_error = caf::error{};
     ctrl.self()
@@ -123,13 +127,13 @@ public:
     -> optimize_result override {
     (void)order;
     auto clauses = std::vector<expression>{};
-    if (expr_ != caf::none) {
+    if (expr_ != caf::none and expr_ != trivially_true_expression()) {
       clauses.push_back(expr_);
     }
-    if (filter != trivially_true_expression()) {
+    if (filter != caf::none and filter != trivially_true_expression()) {
       clauses.push_back(filter);
     }
-    auto expr = clauses.empty() ? expression{}
+    auto expr = clauses.empty() ? trivially_true_expression()
                                 : expression{conjunction{std::move(clauses)}};
     return optimize_result{trivially_true_expression(), event_order::ordered,
                            std::make_unique<export_operator>(std::move(expr))};

--- a/libtenzir/builtins/operators/export.cpp
+++ b/libtenzir/builtins/operators/export.cpp
@@ -77,6 +77,12 @@ public:
       co_return;
     }
     for (const auto& [type, info] : current_result.candidate_infos) {
+      auto bound_expr = tailor(info.exp, type);
+      if (not bound_expr) {
+        // failing to bind is not an error.
+        continue;
+      }
+      query_context.expr = std::move(*bound_expr);
       for (const auto& partition_info : info.partition_infos) {
         const auto& uuid = partition_info.uuid;
         auto partition = blocking_self->spawn(

--- a/libtenzir/include/tenzir/catalog.hpp
+++ b/libtenzir/include/tenzir/catalog.hpp
@@ -107,7 +107,7 @@ public:
   /// @param expr The expression to lookup.
   /// @returns A lookup result of candidate partitions categorized by type.
   [[nodiscard]] caf::expected<catalog_lookup_result>
-  lookup(const expression& expr) const;
+  lookup(expression expr) const;
 
   [[nodiscard]] catalog_lookup_result::candidate_info
   lookup_impl(const expression& expr, const type& schema) const;

--- a/libtenzir/src/catalog.cpp
+++ b/libtenzir/src/catalog.cpp
@@ -730,7 +730,7 @@ catalog(catalog_actor::stateful_pointer<catalog_state> self,
         self->state.merge(uuid, std::move(partition_synopsis));
       return atom::ok_v;
     },
-    [self](atom::candidates, tenzir::query_context& query_context)
+    [self](atom::candidates, const tenzir::query_context& query_context)
       -> caf::result<catalog_lookup_result> {
       TENZIR_TRACE_SCOPE("{} {}", *self, TENZIR_ARG(query_context));
       if (not query_context.ids.empty()) {

--- a/libtenzir/src/catalog.cpp
+++ b/libtenzir/src/catalog.cpp
@@ -31,6 +31,7 @@
 #include "tenzir/logger.hpp"
 #include "tenzir/modules.hpp"
 #include "tenzir/partition_synopsis.hpp"
+#include "tenzir/pipeline.hpp"
 #include "tenzir/prune.hpp"
 #include "tenzir/query_context.hpp"
 #include "tenzir/report.hpp"
@@ -86,17 +87,31 @@ void catalog_state::erase(const uuid& partition) {
 }
 
 caf::expected<catalog_lookup_result>
-catalog_state::lookup(const expression& expr) const {
+catalog_state::lookup(expression expr) const {
   auto start = stopwatch::now();
   auto total_candidates = catalog_lookup_result{};
-  auto num_candidates = size_t{0};
-  auto pruned = prune(expr, unprunable_fields);
+  auto num_candidate_partitions = size_t{0};
+  auto num_candidate_events = size_t{0};
+  if (expr == caf::none) {
+    expr = trivially_true_expression();
+  }
+  auto normalized = normalize_and_validate(expr);
+  if (not normalized) {
+    return caf::make_error(ec::invalid_argument,
+                           fmt::format("{} failed to normalize and validate "
+                                       "epxression {}: {}",
+                                       *self, expr, normalized.error()));
+  }
   for (const auto& [type, _] : synopses_per_type) {
-    auto resolved = resolve(taxonomies, pruned, type);
-    if (!resolved) {
-      return resolved.error();
+    auto resolved = resolve(taxonomies, *normalized, type);
+    if (not resolved) {
+      return caf::make_error(ec::invalid_argument,
+                             fmt::format("{} failed to resolve epxression {}: "
+                                         "{}",
+                                         *self, expr, resolved.error()));
     }
-    auto candidates_per_type = lookup_impl(*resolved, type);
+    auto pruned = prune(*resolved, unprunable_fields);
+    auto candidates_per_type = lookup_impl(pruned, type);
     // Sort partitions by their max import time, returning the most recent
     // partitions first.
     std::sort(candidates_per_type.partition_infos.begin(),
@@ -104,14 +119,22 @@ catalog_state::lookup(const expression& expr) const {
               [&](const partition_info& lhs, const partition_info& rhs) {
                 return lhs.max_import_time > rhs.max_import_time;
               });
-    num_candidates += candidates_per_type.partition_infos.size();
+    num_candidate_partitions += candidates_per_type.partition_infos.size();
+    num_candidate_events
+      += std::transform_reduce(candidates_per_type.partition_infos.begin(),
+                               candidates_per_type.partition_infos.end(),
+                               size_t{0}, std::plus<>{},
+                               [](const auto& partition) {
+                                 return partition.events;
+                               });
     total_candidates.candidate_infos[type] = std::move(candidates_per_type);
   }
   auto delta = std::chrono::duration_cast<std::chrono::microseconds>(
     stopwatch::now() - start);
-  TENZIR_VERBOSE("catalog lookup found {} candidates in {} microseconds",
-                 num_candidates, delta.count());
-  TENZIR_TRACEPOINT(catalog_lookup, delta.count(), num_candidates);
+  TENZIR_VERBOSE("catalog found {} candidate partitions ({} events) in "
+                 "{} microseconds",
+                 num_candidate_partitions, num_candidate_events, delta.count());
+  TENZIR_TRACEPOINT(catalog_lookup, delta.count(), num_candidate_partitions);
   return total_candidates;
 }
 
@@ -133,7 +156,6 @@ catalog_state::lookup_impl(const expression& expr, const type& schema) const {
         || partition_synopses.empty())
       return memoized_partitions;
     for (const auto& [partition_id, synopsis] : partition_synopses) {
-      memoized_partitions.exp = expr;
       memoized_partitions.partition_infos.emplace_back(partition_id, *synopsis);
     }
     return memoized_partitions;
@@ -256,7 +278,6 @@ catalog_state::lookup_impl(const expression& expr, const type& schema) const {
                 // short, so we're probably not hitting the allocator due to
                 // SSO.
                 if (evaluate(std::string{fqf.schema_name()}, x.op, d)) {
-                  result.exp = expr;
                   result.partition_infos.emplace_back(part_id, *part_syn);
                   break;
                 }
@@ -268,7 +289,6 @@ catalog_state::lookup_impl(const expression& expr, const type& schema) const {
           }
           if (lhs.kind == meta_extractor::schema_id) {
             auto result = catalog_lookup_result::candidate_info{};
-            result.exp = expr;
             for (const auto& [part_id, part_syn] : partition_synopses) {
               TENZIR_ASSERT(part_syn->schema == schema);
             }
@@ -293,7 +313,6 @@ catalog_state::lookup_impl(const expression& expr, const type& schema) const {
               };
               auto add = ts.lookup(x.op, caf::get<tenzir::time>(d));
               if (!add || *add) {
-                result.exp = expr;
                 result.partition_infos.emplace_back(part_id, *part_syn);
               }
             }
@@ -387,7 +406,8 @@ size_t catalog_state::memusage() const {
 
 void catalog_state::update_unprunable_fields(const partition_synopsis& ps) {
   for (auto const& [field, synopsis] : ps.field_synopses_)
-    if (synopsis != nullptr && field.type() == string_type{})
+    if (synopsis != nullptr
+        && caf::holds_alternative<string_type>(field.type()))
       unprunable_fields.insert(std::string{field.name()});
   // TODO/BUG: We also need to prevent pruning for enum types,
   // which also use string literals for lookup. We must be even
@@ -710,23 +730,23 @@ catalog(catalog_actor::stateful_pointer<catalog_state> self,
         self->state.merge(uuid, std::move(partition_synopsis));
       return atom::ok_v;
     },
-    [self](atom::candidates, const tenzir::query_context& query_context)
+    [self](atom::candidates, tenzir::query_context& query_context)
       -> caf::result<catalog_lookup_result> {
       TENZIR_TRACE_SCOPE("{} {}", *self, TENZIR_ARG(query_context));
-      bool has_expression = query_context.expr != tenzir::expression{};
-      bool has_ids = !query_context.ids.empty();
-      if (has_ids)
+      if (not query_context.ids.empty()) {
         return caf::make_error(ec::invalid_argument, "catalog expects queries "
                                                      "not to have ids");
-      if (!has_expression)
-        return caf::make_error(ec::invalid_argument, "catalog expects queries "
-                                                     "to have an expression");
+      }
       auto start = std::chrono::steady_clock::now();
       auto result = self->state.lookup(query_context.expr);
       if (!result) {
         return result.error();
       }
-      auto total_candidate_amount = result->size();
+      auto total_candidate_amount = std::transform_reduce(
+        result->candidate_infos.begin(), result->candidate_infos.end(),
+        size_t{0}, std::plus<>{}, [](const auto& candidate) {
+          return candidate.second.partition_infos.size();
+        });
       auto id_str = fmt::to_string(query_context.id);
       duration runtime = std::chrono::steady_clock::now() - start;
       self->send(self->state.accountant, atom::metrics_v,

--- a/libtenzir/src/execution_node.cpp
+++ b/libtenzir/src/execution_node.cpp
@@ -770,7 +770,6 @@ struct exec_node_state : inbound_state_mixin<Input>,
         if (this->current_demand or this->outbound_buffer_size > 0) {
           TENZIR_DEBUG("{} forcibly delivers batches", op->name());
           deliver_batches(now, true);
-          schedule_run();
           return;
         }
         TENZIR_ASSERT(not this->current_demand);
@@ -802,7 +801,7 @@ struct exec_node_state : inbound_state_mixin<Input>,
     // consider this the case when neither the input nor the output have
     // stalled, i.e., when there is more input to be consumed and room for
     // output to be produced or further output desired.
-    if (not input_stalled and not output_stalled) {
+    if (not input_stalled or not output_stalled) {
       schedule_run();
     }
     // Adjust performance counters for this run.

--- a/libtenzir/src/expression.cpp
+++ b/libtenzir/src/expression.cpp
@@ -289,7 +289,6 @@ bool resolve_impl(std::vector<std::pair<offset, predicate>>& result,
       return true;
     },
     [&](caf::none_t) {
-      TENZIR_ASSERT(!"invalid expression node");
       return false;
     },
   };

--- a/libtenzir/src/passive_partition.cpp
+++ b/libtenzir/src/passive_partition.cpp
@@ -158,9 +158,9 @@ indexer_actor passive_partition_state::indexer_at(size_t position) const {
     indexer = self->spawn(passive_indexer, id, std::move(value_index));
     return indexer;
   }
-  TENZIR_WARN("passive-partition ({}) failed to deserialize value index for "
-              "field {}",
-              id, qualified_index->field_name()->string_view());
+  TENZIR_DEBUG("passive-partition {} has no index or failed to index for field "
+               "{}",
+               id, qualified_index->field_name()->string_view());
   return {};
 }
 

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "eb90d6e538e23ecbb7526ef1d4cf468d69a23224",
+  "rev": "7c240c05ae4602e178e130460d82a35edc9987be",
   "submodules": true,
   "shallow": true
 }


### PR DESCRIPTION
This is five fixes in one PR:
1. Predicate pushdown did not work in v4.3; this supersedes my previous attempt in #3590
2. The catalog expected expressions to be already normalized and validated, which for non-normalized expressions caused all partitions to be returned
3. We introduced a race in #3562 that caused operators to sometimes hang on shutdown; this mostly occurred in release builds with high-volume pipelines at the process boundary (no changelog entry for this one as we never released with this bug)
4. The long option `--skip-empty` for `read lines` now works as expected
5. We now include the feature flags in `show build`