### PR TITLE
Remove flaky integration test

### DIFF
--- a/plugins/fluent-bit/functional-test/reference/tests/test_Print_data_in_the_fluent-2dbit_output_format/step_00.ref
+++ b/plugins/fluent-bit/functional-test/reference/tests/test_Print_data_in_the_fluent-2dbit_output_format/step_00.ref
@@ -1,1 +1,0 @@
-{"name"=>"unique", "source"=>false, "transformation"=>true, "sink"=>false}]

--- a/plugins/fluent-bit/functional-test/tests/tests.bats
+++ b/plugins/fluent-bit/functional-test/tests/tests.bats
@@ -24,12 +24,6 @@ setup() {
   check tenzir 'show operators | fluent-bit null'
 }
 
-@test "Print data in the fluent-bit output format" {
-  run -0 --separate-stderr \
-    tenzir 'show operators | where name == "unique" | fluent-bit stdout'
-  { check cut -d ' ' -f 5-; } <<< "$output"
-}
-
 @test "Use fluent-bit to count to 10" {
   run -0 --separate-stderr \
     tenzir 'show operators | head | fluent-bit counter'


### PR DESCRIPTION
This PR removes a flaky Fluent Bit integration test. The flakiness is a result of the time-based ramp-up and teardown of the Fluent Bit mainloop. The API doesn't have wait-until-complete semantics, so races may occur.

Removing this test is okay because we have a similar test that covers the tested functionality.
