### PR TITLE
Fix parsing of subnet columns in zeek-tsv

### DIFF
--- a/changelog/next/bug-fixes/3605--fix-zeek-tsv-subnet.md
+++ b/changelog/next/bug-fixes/3605--fix-zeek-tsv-subnet.md
@@ -1,1 +1,0 @@
-The zeek-tsv format parser is now able to handle fields of the type correctly.

--- a/changelog/next/bug-fixes/3605--fix-zeek-tsv-subnet.md
+++ b/changelog/next/bug-fixes/3605--fix-zeek-tsv-subnet.md
@@ -1,0 +1,1 @@
+The zeek-tsv format parser is now able to handle fields of the type correctly.

--- a/changelog/next/bug-fixes/3606--fix-zeek-tsv-subnet.md
+++ b/changelog/next/bug-fixes/3606--fix-zeek-tsv-subnet.md
@@ -1,0 +1,1 @@
+The `zeek-tsv` parser is now able to handle fields of type `subnet` correctly.

--- a/libtenzir/builtins/formats/zeek_tsv.cpp
+++ b/libtenzir/builtins/formats/zeek_tsv.cpp
@@ -126,7 +126,7 @@ struct zeek_parser<ip_type> {
 template <>
 struct zeek_parser<subnet_type> {
   auto operator()(const subnet_type&, char, const std::string&) const {
-    return parsers::ip;
+    return parsers::net;
   }
 };
 


### PR DESCRIPTION
Correcting a small oversight from the the zeek-tsv parser rewrite.