### PR TITLE
Add `from/load/to/save <uri/file>`

### DIFF
--- a/changelog/next/features/3608--uri-loader.md
+++ b/changelog/next/features/3608--uri-loader.md
@@ -1,0 +1,4 @@
+The operators `from`, `to`, `load`, and `save` support using URIs and file paths
+directly as their argument. For example, `load https://example.com` means
+`load https https://example.com`, and `save local-file.json` means
+`save file local-file.json`.

--- a/libtenzir/builtins/connectors/file.cpp
+++ b/libtenzir/builtins/connectors/file.cpp
@@ -336,7 +336,7 @@ public:
   }
 
   auto to_string() const -> std::string override {
-    auto result = std::string{"file"};
+    auto result = std::string{"file "};
     result += escape_operator_arg(args_.path.inner);
     if (args_.follow) {
       result += " --follow";

--- a/libtenzir/builtins/operators/to_write_save.cpp
+++ b/libtenzir/builtins/operators/to_write_save.cpp
@@ -9,6 +9,7 @@
 #include <tenzir/arrow_table_slice.hpp>
 #include <tenzir/concept/convertible/data.hpp>
 #include <tenzir/concept/convertible/to.hpp>
+#include <tenzir/detail/loader_saver_resolver.hpp>
 #include <tenzir/element_type.hpp>
 #include <tenzir/error.hpp>
 #include <tenzir/parser_interface.hpp>
@@ -40,7 +41,8 @@ namespace {
     .throw_();
 }
 
-[[noreturn]] void throw_saver_not_found(const located<std::string>& x) {
+template <typename String>
+[[noreturn]] void throw_saver_not_found(const located<String>& x) {
   auto available = std::vector<std::string>{};
   for (auto p : plugins::get<saver_parser_plugin>()) {
     available.push_back(p->name());
@@ -236,6 +238,23 @@ private:
   std::unique_ptr<plugin_saver> saver_;
 };
 
+auto get_saver(parser_interface& p, const char* usage, const char* docs)
+  -> std::unique_ptr<plugin_saver> {
+  auto s_name = p.accept_shell_arg();
+  if (not s_name) {
+    diagnostic::error("expected printer name")
+      .primary(p.current_span())
+      .usage(usage)
+      .docs(docs)
+      .throw_();
+  }
+  auto [saver, name] = detail::resolve_saver(p, *s_name);
+  if (not saver) {
+    throw_saver_not_found(name);
+  }
+  return std::move(saver);
+}
+
 class save_plugin final : public virtual operator_plugin<save_operator> {
 public:
   auto signature() const -> operator_signature override {
@@ -245,19 +264,7 @@ public:
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
     auto usage = "save <saver> <args>...";
     auto docs = "https://docs.tenzir.com/next/operators/sinks/save";
-    auto name = p.accept_shell_arg();
-    if (!name) {
-      diagnostic::error("expected saver name", p.current_span())
-        .primary(p.current_span())
-        .usage(usage)
-        .docs(docs)
-        .throw_();
-    }
-    auto plugin = plugins::find<saver_parser_plugin>(name->inner);
-    if (!plugin) {
-      throw_saver_not_found(*name);
-    }
-    auto saver = plugin->parse_saver(p);
+    auto saver = get_saver(p, usage, docs);
     TENZIR_DIAG_ASSERT(saver);
     return std::make_unique<save_operator>(std::move(saver));
   }
@@ -368,20 +375,8 @@ public:
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
     auto usage = "to <saver> <args>... [write <printer> <args>...]";
     auto docs = "https://docs.tenzir.com/next/operators/sinks/to";
-    auto l_name = p.accept_shell_arg();
-    if (!l_name) {
-      diagnostic::error("expected saver name")
-        .primary(p.current_span())
-        .usage(usage)
-        .docs(docs)
-        .throw_();
-    }
-    auto l_plugin = plugins::find<saver_parser_plugin>(l_name->inner);
-    if (!l_plugin) {
-      throw_saver_not_found(*l_name);
-    }
     auto q = until_keyword_parser{"write", p};
-    auto saver = l_plugin->parse_saver(q);
+    auto saver = get_saver(q, usage, docs);
     TENZIR_DIAG_ASSERT(saver);
     TENZIR_DIAG_ASSERT(q.at_end());
     auto printer = std::unique_ptr<plugin_printer>{};

--- a/libtenzir/include/tenzir/detail/loader_saver_resolver.hpp
+++ b/libtenzir/include/tenzir/detail/loader_saver_resolver.hpp
@@ -1,0 +1,22 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2023 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <tenzir/parser_interface.hpp>
+#include <tenzir/plugin.hpp>
+
+namespace tenzir::detail {
+
+auto resolve_loader(parser_interface& parser, const located<std::string>& name)
+  -> std::pair<std::unique_ptr<plugin_loader>, located<std::string_view>>;
+
+auto resolve_saver(parser_interface& parser, const located<std::string>& name)
+-> std::pair<std::unique_ptr<plugin_saver>, located<std::string_view>>;
+
+} // namespace tenzir::detail

--- a/libtenzir/include/tenzir/detail/loader_saver_resolver.hpp
+++ b/libtenzir/include/tenzir/detail/loader_saver_resolver.hpp
@@ -17,6 +17,6 @@ auto resolve_loader(parser_interface& parser, const located<std::string>& name)
   -> std::pair<std::unique_ptr<plugin_loader>, located<std::string_view>>;
 
 auto resolve_saver(parser_interface& parser, const located<std::string>& name)
--> std::pair<std::unique_ptr<plugin_saver>, located<std::string_view>>;
+  -> std::pair<std::unique_ptr<plugin_saver>, located<std::string_view>>;
 
 } // namespace tenzir::detail

--- a/libtenzir/include/tenzir/detail/loader_saver_resolver.hpp
+++ b/libtenzir/include/tenzir/detail/loader_saver_resolver.hpp
@@ -13,10 +13,17 @@
 
 namespace tenzir::detail {
 
+template <typename Plugin>
+struct resolve_loader_saver_result {
+  std::unique_ptr<Plugin> plugin;
+  located<std::string_view> name;
+  bool matched_uri;
+};
+
 auto resolve_loader(parser_interface& parser, const located<std::string>& name)
-  -> std::pair<std::unique_ptr<plugin_loader>, located<std::string_view>>;
+  -> resolve_loader_saver_result<plugin_loader>;
 
 auto resolve_saver(parser_interface& parser, const located<std::string>& name)
-  -> std::pair<std::unique_ptr<plugin_saver>, located<std::string_view>>;
+  -> resolve_loader_saver_result<plugin_saver>;
 
 } // namespace tenzir::detail

--- a/libtenzir/include/tenzir/plugin.hpp
+++ b/libtenzir/include/tenzir/plugin.hpp
@@ -434,6 +434,8 @@ public:
   virtual auto parse_loader(parser_interface& p) const
     -> std::unique_ptr<plugin_loader>
     = 0;
+
+  virtual auto supported_uri_scheme() const -> std::string;
 };
 
 using loader_serialization_plugin = serialization_plugin<plugin_loader>;
@@ -586,6 +588,8 @@ public:
   virtual auto parse_saver(parser_interface& p) const
     -> std::unique_ptr<plugin_saver>
     = 0;
+
+  virtual auto supported_uri_scheme() const -> std::string;
 };
 
 using saver_serialization_plugin = serialization_plugin<plugin_saver>;

--- a/libtenzir/src/detail/loader_saver_resolver.cpp
+++ b/libtenzir/src/detail/loader_saver_resolver.cpp
@@ -1,0 +1,195 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2023 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <tenzir/detail/loader_saver_resolver.hpp>
+
+namespace tenzir::detail {
+
+namespace {
+
+template <typename String>
+class prepend_token final : public parser_interface {
+public:
+  prepend_token(located<String> token, parser_interface& next)
+    : token_{std::move(token)}, next_{next} {
+  }
+
+  auto accept_shell_arg() -> std::optional<located<std::string>> override {
+    if (token_) {
+      auto tmp = make_located_string();
+      token_ = std::nullopt;
+      return tmp;
+    }
+    return next_.accept_shell_arg();
+  }
+
+  auto peek_shell_arg() -> std::optional<located<std::string>> override {
+    if (token_) {
+      return make_located_string();
+    }
+    return next_.peek_shell_arg();
+  }
+
+  auto accept_identifier() -> std::optional<identifier> override {
+    TENZIR_ASSERT(not token_);
+    return next_.accept_identifier();
+  }
+
+  auto peek_identifier() -> std::optional<identifier> override {
+    TENZIR_ASSERT(not token_);
+    return next_.peek_identifier();
+  }
+
+  auto accept_equals() -> std::optional<location> override {
+    TENZIR_ASSERT(not token_);
+    return next_.accept_equals();
+  }
+
+  auto accept_char(char c) -> std::optional<location> override {
+    TENZIR_ASSERT(not token_);
+    return next_.accept_char(c);
+  }
+
+  auto parse_operator() -> located<operator_ptr> override {
+    TENZIR_ASSERT(not token_);
+    return next_.parse_operator();
+  }
+
+  auto parse_expression() -> tql::expression override {
+    TENZIR_ASSERT(not token_);
+    return next_.parse_expression();
+  }
+
+  auto parse_legacy_expression() -> located<expression> override {
+    TENZIR_ASSERT(not token_);
+    return next_.parse_legacy_expression();
+  }
+
+  auto parse_extractor() -> tql::extractor override {
+    TENZIR_ASSERT(not token_);
+    return next_.parse_extractor();
+  }
+
+  auto at_end() -> bool override {
+    return not token_ && next_.at_end();
+  }
+
+  auto current_span() -> location override {
+    if (token_) {
+      return token_->source;
+    }
+    return next_.current_span();
+  }
+
+private:
+  auto make_located_string() const -> located<std::string> {
+    TENZIR_ASSERT(token_);
+    return {std::string{token_->inner}, token_->source};
+  }
+
+  std::optional<located<String>> token_;
+  parser_interface& next_;
+};
+
+template <typename String>
+auto make_located_string_view(const located<String>& str, size_t pos = 0,
+                              size_t count = std::string::npos)
+  -> located<std::string_view> {
+  auto sub = std::string_view{str.inner}.substr(pos, count);
+  auto source = location::unknown;
+  if (str.source && (str.source.end - str.source.begin) == str.inner.size()) {
+    source.begin = str.source.begin + pos;
+    source.end = source.begin + sub.length();
+  }
+  return {sub, source};
+}
+
+template <typename Plugin>
+struct try_plugin_by_uri_result {
+  const Plugin* plugin{nullptr};
+  located<std::string_view> scheme{};
+  located<std::string_view> non_scheme{};
+
+  [[nodiscard]] bool plugin_found() const {
+    return plugin != nullptr;
+  }
+  [[nodiscard]] bool valid_uri_parsed() const {
+    return !scheme.inner.empty();
+  }
+};
+
+template <typename Plugin>
+auto try_plugin_by_uri(const located<std::string>& src)
+  -> try_plugin_by_uri_result<Plugin> {
+  // Not using caf::uri for anything else but checking for URI validity
+  // This is because it makes the interaction with located<...> very difficult
+  if (!caf::uri::can_parse(src.inner))
+    return {};
+  // In a valid URI, the first ':' is guaranteed to separate the scheme from
+  // the rest
+  TENZIR_ASSERT(src.inner.find(':') != std::string::npos);
+  try_plugin_by_uri_result<Plugin> result{};
+  auto scheme_len = src.inner.find(':');
+  result.scheme = make_located_string_view(src, 0, scheme_len);
+  auto non_scheme_offset = scheme_len + 1;
+  if (caf::starts_with(caf::string_view{src.inner}.substr(non_scheme_offset),
+                       "//"))
+    // If the URI has an `authority` component, it starts with "//"
+    // We need to skip that before forwarding it to the loader
+    non_scheme_offset += 2;
+  result.non_scheme = make_located_string_view(src, non_scheme_offset);
+  result.plugin = plugins::find<Plugin>(result.scheme.inner);
+  return result;
+}
+
+template <typename ParserPlugin, typename Plugin, typename Parse>
+auto resolve_impl(parser_interface& parser, const located<std::string>& name,
+                  Parse&& parse)
+  -> std::pair<std::unique_ptr<Plugin>, located<std::string_view>> {
+  if (auto plugin = plugins::find<ParserPlugin>(name.inner)) {
+    // Matches a plugin name, use that
+    return {parse(plugin, parser), make_located_string_view(name)};
+  }
+  if (auto uri = try_plugin_by_uri<ParserPlugin>(name); uri.plugin_found()) {
+    // Valid URI, with a matching plugin name
+    auto r = prepend_token{uri.non_scheme, parser};
+    auto parsed = parse(uri.plugin, r);
+    TENZIR_DIAG_ASSERT(r.at_end());
+    return {std::move(parsed), make_located_string_view(uri.scheme)};
+  } else if (uri.valid_uri_parsed()) {
+    // Valid URI, but no matching plugin name -> error
+    return {nullptr, make_located_string_view(uri.scheme)};
+  }
+  // Try `file` loader, may be a path
+  auto plugin = plugins::find<ParserPlugin>("file");
+  TENZIR_DIAG_ASSERT(plugin);
+  auto name_sv = make_located_string_view(name);
+  auto r = prepend_token{name_sv, parser};
+  auto parsed = parse(plugin, r);
+  TENZIR_DIAG_ASSERT(r.at_end());
+  return {std::move(parsed), name_sv};
+}
+} // namespace
+
+auto resolve_loader(parser_interface& parser, const located<std::string>& name)
+  -> std::pair<std::unique_ptr<plugin_loader>, located<std::string_view>> {
+  return resolve_impl<loader_parser_plugin, plugin_loader>(
+    parser, name, [](const loader_parser_plugin* plugin, parser_interface& p) {
+      return plugin->parse_loader(p);
+    });
+}
+
+auto resolve_saver(parser_interface& parser, const located<std::string>& name)
+  -> std::pair<std::unique_ptr<plugin_saver>, located<std::string_view>> {
+  return resolve_impl<saver_parser_plugin, plugin_saver>(
+    parser, name, [](const saver_parser_plugin* plugin, parser_interface& p) {
+      return plugin->parse_saver(p);
+    });
+}
+
+} // namespace tenzir::detail

--- a/libtenzir/src/plugin.cpp
+++ b/libtenzir/src/plugin.cpp
@@ -392,6 +392,18 @@ component_plugin_actor analyzer_plugin::make_component(
   return analyzer(node);
 }
 
+// -- loader plugin -----------------------------------------------------------
+
+auto loader_parser_plugin::supported_uri_scheme() const -> std::string {
+  return this->name();
+}
+
+// -- saver plugin ------------------------------------------------------------
+
+auto saver_parser_plugin::supported_uri_scheme() const -> std::string {
+  return this->name();
+}
+
 // -- store plugin -------------------------------------------------------------
 
 caf::expected<store_actor_plugin::builder_and_header>

--- a/plugins/gcs/src/plugin.cpp
+++ b/plugins/gcs/src/plugin.cpp
@@ -278,6 +278,10 @@ public:
   auto name() const -> std::string override {
     return "gcs";
   }
+
+  auto supported_uri_scheme() const -> std::string override {
+    return "gs";
+  }
 };
 
 } // namespace tenzir::plugins::gcs

--- a/tenzir/integration/reference/parse-operators/step_03.ref
+++ b/tenzir/integration/reference/parse-operators/step_03.ref
@@ -1,8 +1,6 @@
-error: loader `a/b/c.json` could not be found
+error: the file `a/b/c.json` does not exist
  --> <input>:1:6
   |
 1 | from a/b/c.json read json
   |      ^^^^^^^^^^ 
   |
-  = hint: must be one of -, file, ftp, ftps, http, https, s3, stdin
-  = docs: https://docs.tenzir.com/next/connectors

--- a/tenzir/integration/reference/parse-operators/step_11.ref
+++ b/tenzir/integration/reference/parse-operators/step_11.ref
@@ -1,8 +1,16 @@
-error: loader `schema` could not be found
- --> <input>:1:6
-  |
-1 | from schema://foo.json read json
-  |      ^^^^^^ 
-  |
-  = hint: must be one of -, file, ftp, ftps, http, https, s3, stdin
-  = docs: https://docs.tenzir.com/next/connectors
+{
+  "b": true,
+  "e": "A"
+}
+{
+  "b": false,
+  "e": "B"
+}
+{
+  "b": false,
+  "e": "C"
+}
+{
+  "b": false,
+  "e": "D"
+}

--- a/tenzir/integration/reference/parse-operators/step_11.ref
+++ b/tenzir/integration/reference/parse-operators/step_11.ref
@@ -1,3 +1,8 @@
-write "json", printer_args(null, null, null, null, null, null, null) | save "file", saver_args(located("xyz.json", location(8, 16)), null, null, null)
------
-located("<pipeline>", [[["write", "json", printer_args(null, null, null, null, null, null, null)]], [["save", "file", saver_args(located("xyz.json", location(8, 16)), null, null, null)]]], location(0, 16))
+error: loader `schema` could not be found
+ --> <input>:1:6
+  |
+1 | from schema://foo.json read json
+  |      ^^^^^^ 
+  |
+  = hint: must be one of -, file, ftp, ftps, http, https, s3, stdin
+  = docs: https://docs.tenzir.com/next/connectors

--- a/tenzir/integration/reference/parse-operators/step_12.ref
+++ b/tenzir/integration/reference/parse-operators/step_12.ref
@@ -1,8 +1,16 @@
-error: loader `schema` could not be found
- --> <input>:1:6
-  |
-1 | from schema:foo.json read json
-  |      ^^^^^^ 
-  |
-  = hint: must be one of -, file, ftp, ftps, http, https, s3, stdin
-  = docs: https://docs.tenzir.com/next/connectors
+{
+  "b": true,
+  "e": "A"
+}
+{
+  "b": false,
+  "e": "B"
+}
+{
+  "b": false,
+  "e": "C"
+}
+{
+  "b": false,
+  "e": "D"
+}

--- a/tenzir/integration/reference/parse-operators/step_12.ref
+++ b/tenzir/integration/reference/parse-operators/step_12.ref
@@ -1,0 +1,8 @@
+error: loader `schema` could not be found
+ --> <input>:1:6
+  |
+1 | from schema:foo.json read json
+  |      ^^^^^^ 
+  |
+  = hint: must be one of -, file, ftp, ftps, http, https, s3, stdin
+  = docs: https://docs.tenzir.com/next/connectors

--- a/tenzir/integration/reference/parse-operators/step_13.ref
+++ b/tenzir/integration/reference/parse-operators/step_13.ref
@@ -1,0 +1,6 @@
+error: the file `/foo.json` does not exist
+ --> <input>:1:13
+  |
+1 | from file:///foo.json read json
+  |             ^^^^^^^^^ 
+  |

--- a/tenzir/integration/reference/parse-operators/step_14.ref
+++ b/tenzir/integration/reference/parse-operators/step_14.ref
@@ -1,0 +1,6 @@
+error: the file `foo.json` does not exist
+ --> <input>:1:13
+  |
+1 | from file://foo.json read json
+  |             ^^^^^^^^ 
+  |

--- a/tenzir/integration/reference/parse-operators/step_14.ref
+++ b/tenzir/integration/reference/parse-operators/step_14.ref
@@ -1,6 +1,8 @@
-error: the file `foo.json` does not exist
- --> <input>:1:13
+error: loader for `scheme` scheme could not be found
+ --> <input>:1:6
   |
-1 | from file://foo.json read json
-  |             ^^^^^^^^ 
+1 | from scheme://foo.json read json
+  |      ^^^^^^ 
   |
+  = hint: must be one of -, file, ftp, ftps, http, https, s3, stdin
+  = docs: https://docs.tenzir.com/next/connectors

--- a/tenzir/integration/reference/parse-operators/step_15.ref
+++ b/tenzir/integration/reference/parse-operators/step_15.ref
@@ -1,0 +1,6 @@
+error: the file `foo.json` does not exist
+ --> <input>:1:11
+  |
+1 | from file:foo.json read json
+  |           ^^^^^^^^ 
+  |

--- a/tenzir/integration/reference/parse-operators/step_16.ref
+++ b/tenzir/integration/reference/parse-operators/step_16.ref
@@ -1,0 +1,6 @@
+error: the file `foo.json` does not exist
+ --> <input>:1:11
+  |
+1 | load file foo.json | read json
+  |           ^^^^^^^^ 
+  |

--- a/tenzir/integration/reference/parse-operators/step_17.ref
+++ b/tenzir/integration/reference/parse-operators/step_17.ref
@@ -1,6 +1,8 @@
-error: the file `foo.json` does not exist
- --> <input>:1:13
+error: expected 1 positional arguments, but got 0
+ --> <input>:1:10
   |
-1 | load file://foo.json | read json
-  |             ^^^^^^^^ 
+1 | load file | read json
+  |          ^ 
   |
+  = usage: file <path> [-f|--follow] [-m|--mmap] [-t|--timeout <duration>]
+  = docs: https://docs.tenzir.com/next/connectors/file

--- a/tenzir/integration/reference/parse-operators/step_17.ref
+++ b/tenzir/integration/reference/parse-operators/step_17.ref
@@ -1,0 +1,6 @@
+error: the file `foo.json` does not exist
+ --> <input>:1:13
+  |
+1 | load file://foo.json | read json
+  |             ^^^^^^^^ 
+  |

--- a/tenzir/integration/reference/parse-operators/step_18.ref
+++ b/tenzir/integration/reference/parse-operators/step_18.ref
@@ -1,0 +1,6 @@
+error: the file `./file` does not exist
+ --> <input>:1:6
+  |
+1 | load ./file | read json
+  |      ^^^^^^ 
+  |

--- a/tenzir/integration/reference/parse-operators/step_19.ref
+++ b/tenzir/integration/reference/parse-operators/step_19.ref
@@ -1,8 +1,8 @@
-error: loader for `scheme` scheme could not be found
+error: loader `filee` could not be found
  --> <input>:1:6
   |
-1 | from scheme:foo.json read json
-  |      ^^^^^^ 
+1 | load filee | read json
+  |      ^^^^^ 
   |
   = hint: must be one of -, file, ftp, ftps, http, https, s3, stdin
   = docs: https://docs.tenzir.com/next/connectors

--- a/tenzir/integration/tests.yaml
+++ b/tenzir/integration/tests.yaml
@@ -77,6 +77,8 @@ tests:
       - command: exec --dump-ast "local remote local pass"
       - command: exec --dump-ast "where :ip == 1.2.3.4"
       - command: exec --dump-ast "to file xyz.json"
+      - command: exec "from schema://foo.json read json"
+        expected_result: error
 
   Conn log counting:
     tags: [node, counting, zeek]

--- a/tenzir/integration/tests.yaml
+++ b/tenzir/integration/tests.yaml
@@ -87,6 +87,10 @@ tests:
         expected_result: error
       - command: exec "from file:foo.json read json"
         expected_result: error
+      - command: exec "load file foo.json | read json"
+        expected_result: error
+      - command: exec "load file://foo.json | read json"
+        expected_result: error
 
   Conn log counting:
     tags: [node, counting, zeek]

--- a/tenzir/integration/tests.yaml
+++ b/tenzir/integration/tests.yaml
@@ -77,19 +77,21 @@ tests:
       - command: exec --dump-ast "local remote local pass"
       - command: exec --dump-ast "where :ip == 1.2.3.4"
       - command: exec --dump-ast "to file xyz.json"
-      - command: exec "from schema://foo.json read json"
-        expected_result: error
-      - command: exec "from schema:foo.json read json"
-        expected_result: error
+      - command: exec "from @./data/json/all-types.json read json"
+      - command: exec "from file://@./data/json/all-types.json read json"
       - command: exec "from file:///foo.json read json"
         expected_result: error
-      - command: exec "from file://foo.json read json"
+      - command: exec "from scheme://foo.json read json"
         expected_result: error
-      - command: exec "from file:foo.json read json"
+      - command: exec "from scheme:foo.json read json"
         expected_result: error
       - command: exec "load file foo.json | read json"
         expected_result: error
-      - command: exec "load file://foo.json | read json"
+      - command: exec "load file | read json"
+        expected_result: error
+      - command: exec "load ./file | read json"
+        expected_result: error
+      - command: exec "load filee | read json"
         expected_result: error
 
   Conn log counting:

--- a/tenzir/integration/tests.yaml
+++ b/tenzir/integration/tests.yaml
@@ -79,6 +79,14 @@ tests:
       - command: exec --dump-ast "to file xyz.json"
       - command: exec "from schema://foo.json read json"
         expected_result: error
+      - command: exec "from schema:foo.json read json"
+        expected_result: error
+      - command: exec "from file:///foo.json read json"
+        expected_result: error
+      - command: exec "from file://foo.json read json"
+        expected_result: error
+      - command: exec "from file:foo.json read json"
+        expected_result: error
 
   Conn log counting:
     tags: [node, counting, zeek]

--- a/web/docs/connectors.md
+++ b/web/docs/connectors.md
@@ -22,6 +22,44 @@ to <connector> [write <format>]
 
 If the format is omitted, the default depends on the connector.
 
+Alternatively, instead of a connector, the `from` and `to` operators
+can take a URI or a filesystem path directly:
+
+```
+from <uri> [read <format>]
+from <path> [read <format>]
+
+to <uri> [write <format>]
+to <path> [write <format>]
+```
+
+When given a URI, the scheme is used to determine the connector to use.
+For example, if the URI scheme is `http`, the [`http`](connectors/http.md) connector is used.
+The [`gcs`](connectors/gcs.md) connector is an exception, as it will get used if the URI scheme is `gs`.
+
+```
+from https://example.com/foo.json
+from https https://example.com/foo.json
+from https example.com/foo.json
+
+from gs://bucket/logs/log.json
+from gcs gs://bucket/logs/log.json
+```
+
+When given a filesystem a path, the [`file`](connectors/file.md) connector is used implicitly.
+To disambiguate between a relative filesystem path without any slashes or a file extension, and
+a connector name, the path must contain at least one character that doesn't conform to the pattern `[A-Za-z0-9-_]`.
+If the input conforms to that pattern, it's assumed to be a connector name.
+
+```
+# Parsed as a filesystem path
+from /tmp/plugin.json
+# `plugin` is parsed as a connector name
+from plugin
+# `./plugin` is parsed as a filesystem path, again (contains a `.` and a `/`)
+from ./plugin
+```
+
 Tenzir ships with the following connectors:
 
 import DocCardList from '@theme/DocCardList';

--- a/web/docs/connectors/gcs.md
+++ b/web/docs/connectors/gcs.md
@@ -43,10 +43,12 @@ credentials.
 
 ## Examples
 
-Read JSON from an object `log.json` in the folder `logs` in `bucket`:
+Read JSON from an object `log.json` in the folder `logs` in `bucket`.
+Note how the `gcs` loader is used automatically, when the URI scheme is `gs://`.
 
 ```
 from gcs gs://bucket/logs/log.json
+from gs://bucket/logs/log.json
 ```
 
 Read JSON from an object `test.json` in `bucket`, but using a different

--- a/web/docs/formats/yaml.md
+++ b/web/docs/formats/yaml.md
@@ -1,4 +1,4 @@
-# json
+# yaml
 
 Reads and writes YAML.
 

--- a/web/docs/operators/sinks/save.md
+++ b/web/docs/operators/sinks/save.md
@@ -10,6 +10,8 @@ operator. Only use this if you need to operate on raw bytes.
 ## Synopsis
 
 ```
+save <uri>
+save <path>
 save <connector>
 ```
 
@@ -39,5 +41,6 @@ save stdin
 Write bytes to the file `path/to/eve.json`:
 
 ```
+save path/to/eve.json
 save file path/to/eve.json
 ```

--- a/web/docs/operators/sinks/to.md
+++ b/web/docs/operators/sinks/to.md
@@ -5,6 +5,8 @@ Consumes events by combining a [connector][connectors] and a [format][formats].
 ## Synopsis
 
 ```
+to <uri> [write <format>]
+to <path> [write <format>]
 to <connector> [write <format>]
 ```
 
@@ -48,6 +50,7 @@ to stdout write csv
 Write events to the file `path/to/eve.json` formatted as JSON.
 
 ```
+to path/to/eve.json write json
 to file path/to/eve.json write json
 ```
 

--- a/web/docs/operators/sources/from.md
+++ b/web/docs/operators/sources/from.md
@@ -5,6 +5,8 @@ Produces events by combining a [connector][connectors] and a [format][formats].
 ## Synopsis
 
 ```
+from <uri> [read <format>]
+from <path> [read <format>]
 from <connector> [read <format>]
 ```
 
@@ -51,10 +53,20 @@ from - read json
 Read bytes from the file `path/to/eve.json` and parse them as Suricata.
 Note that the `file` connector automatically assigns the Suricata parser for
 `eve.json` files when no other parser is specified.
+Also, when directly passed a filesystem path, the `file` connector is automatically used.
 
 ```
+from path/to/eve.json
 from file path/to/eve.json
 from file path/to/eve.json read suricata
+```
+
+Read bytes from the URI `https://example.com/data.json` over HTTPS and parse them as JSON.
+Note that when `from` is passed a URI directly, the `https` connector is automatically used.
+
+```
+from https://example.com/data.json read json
+from https example.com/data.json read json
 ```
 
 [connectors]: ../../connectors.md

--- a/web/docs/operators/sources/load.md
+++ b/web/docs/operators/sources/load.md
@@ -10,6 +10,8 @@ operator. Only use this if you need to operate on raw bytes.
 ## Synopsis
 
 ```
+load <uri>
+load <path>
 load <connector>
 ```
 
@@ -36,8 +38,16 @@ Read bytes from stdin:
 load stdin
 ```
 
+Read bytes from the URI `https://example.com/file.json`:
+
+```
+load https://example.com/file.json
+load https example.com/file.json
+```
+
 Read bytes from the file `path/to/eve.json`:
 
 ```
-from file path/to/eve.json
+load path/to/eve.json
+load file path/to/eve.json
 ```

--- a/web/versioned_docs/version-Tenzir v4.3/formats/yaml.md
+++ b/web/versioned_docs/version-Tenzir v4.3/formats/yaml.md
@@ -1,4 +1,4 @@
-# json
+# yaml
 
 Reads and writes YAML.
 

--- a/web/versioned_docs/version-Tenzir v4.4/formats/yaml.md
+++ b/web/versioned_docs/version-Tenzir v4.4/formats/yaml.md
@@ -1,4 +1,4 @@
-# json
+# yaml
 
 Reads and writes YAML.
 

--- a/web/versioned_docs/version-Tenzir v4.5/formats/yaml.md
+++ b/web/versioned_docs/version-Tenzir v4.5/formats/yaml.md
@@ -1,4 +1,4 @@
-# json
+# yaml
 
 Reads and writes YAML.
 


### PR DESCRIPTION
Supersedes https://github.com/tenzir/tenzir/pull/3500, related to https://github.com/tenzir/issues/issues/328

In this PR:
 - `OP <uri>` is mapped to `OP <uri-scheme> <rest-of-uri>`, where `OP` is one of `(from, load, to, save)`, and `<uri>` is a RFC 3986 -compliant URI.
 - `OP <something-else>` is mapped to `OP file <something-else>` if `<something-else>` isn't a possible plugin name (doesn't conform to the pattern `[A-Za-z0-9-_]*`)

This effectively means, that the following mappings are implemented:
 - `from https://example.com/foo` -> `from https example.com/foo`
 - `from gs://foo/bar` -> `from gcs gs://foo/bar`
 - `from file:///tmp/file` -> `from file /tmp/file`
 - `from /tmp/file` -> `from file /tmp/file`
 - `from ./local-file` -> `from file ./local-file`
 - `from local-file` -> error (no loader `local-file` found)
 - `from https` -> error (no URL given to `https` loader)

The logic implemented in this PR is as follows:
![image](https://github.com/tenzir/tenzir/assets/9979059/efde3286-1804-439b-b798-b675c6b7c4fb)

This current implementation accepts `from https:foo.bar/baz` as `from https foo.bar/baz`. It's strictly not RFC 3986 -compliant, but I don't think it's that big of an issue.

- [X] Implement `from <uri> [options...] [read <parser>]`
- [X] Implement `from <path>` for `from file <path>`
- [x] Same for `load`
- [x] Same for `to` and `save`
- [x] Consider some loader restrictions + remapping (e.g., for `gcs`)