### PR TITLE
Use prefix matching instead of suffix matching

### DIFF
--- a/changelog/next/changes/3616--prefix-matching.md
+++ b/changelog/next/changes/3616--prefix-matching.md
@@ -1,0 +1,3 @@
+The operators `drop`, `pseudonymize`, `put`, `extend`, `replace`, `rename` and
+`select` were converted from suffix matching to prefix matching and can
+therefore address records now.

--- a/libtenzir/builtins/operators/drop.cpp
+++ b/libtenzir/builtins/operators/drop.cpp
@@ -78,10 +78,11 @@ public:
       return {};
     };
     auto transformations = std::vector<indexed_transformation>{};
-    for (const auto& field : config_.fields)
-      for (auto&& index : caf::get<record_type>(schema).resolve_key_suffix(
-             field, schema.name()))
-        transformations.push_back({std::move(index), transform_fn});
+    for (const auto& field : config_.fields) {
+      if (auto index = caf::get<record_type>(schema).resolve_key(field)) {
+        transformations.push_back({std::move(*index), transform_fn});
+      }
+    }
     // transform_columns requires the transformations to be sorted, and that may
     // not necessarily be true if we have multiple fields configured, so we sort
     // again in that case.

--- a/libtenzir/builtins/operators/pseudonymize.cpp
+++ b/libtenzir/builtins/operators/pseudonymize.cpp
@@ -85,16 +85,16 @@ public:
       };
     };
     for (const auto& field_name : config_.fields) {
-      for (const auto& index : caf::get<record_type>(schema).resolve_key_suffix(
-             field_name, schema.name())) {
-        auto index_type = caf::get<record_type>(schema).field(index).type;
+      if (auto index = caf::get<record_type>(schema).resolve_key(field_name)) {
+        auto index_type = caf::get<record_type>(schema).field(*index).type;
         if (!caf::holds_alternative<ip_type>(index_type)) {
           TENZIR_DEBUG("pseudonymize operator skips field '{}' of unsupported "
                        "type '{}'",
                        field_name, index_type.name());
           continue;
         }
-        transformations.push_back({index, std::move(transformation)});
+        transformations.push_back(
+          {std::move(*index), std::move(transformation)});
       }
     }
     std::sort(transformations.begin(), transformations.end());

--- a/libtenzir/builtins/operators/put_extend_replace.cpp
+++ b/libtenzir/builtins/operators/put_extend_replace.cpp
@@ -205,9 +205,8 @@ public:
                           operator_name(Mode), extractor)));
             continue;
           }
-          for (const auto& index :
-               layout.resolve_key_suffix(extractor, slice.schema().name())) {
-            index_to_operand.emplace_back(index, &*operand);
+          if (auto index = layout.resolve_key(extractor)) {
+            index_to_operand.emplace_back(std::move(*index), &*operand);
           }
           for (const auto& index : layout.resolve_type_extractor(extractor)) {
             index_to_operand.emplace_back(index, &*operand);

--- a/libtenzir/builtins/operators/rename.cpp
+++ b/libtenzir/builtins/operators/rename.cpp
@@ -87,9 +87,8 @@ public:
     auto field_transformations = std::vector<indexed_transformation>{};
     if (!config_.fields.empty()) {
       for (const auto& field : config_.fields) {
-        for (const auto& index :
-             caf::get<record_type>(schema).resolve_key_suffix(field.from,
-                                                              schema.name())) {
+        if (auto index
+            = caf::get<record_type>(schema).resolve_key(field.from)) {
           auto transformation
             = [&](struct record_type::field old_field,
                   std::shared_ptr<arrow::Array> array) noexcept
@@ -99,7 +98,8 @@ public:
               {{field.to, old_field.type}, array},
             };
           };
-          field_transformations.push_back({index, std::move(transformation)});
+          field_transformations.push_back(
+            {std::move(*index), std::move(transformation)});
         }
       }
       std::sort(field_transformations.begin(), field_transformations.end());

--- a/libtenzir/builtins/operators/select.cpp
+++ b/libtenzir/builtins/operators/select.cpp
@@ -58,10 +58,11 @@ public:
   auto initialize(const type& schema, operator_control_plane&) const
     -> caf::expected<state_type> override {
     auto indices = state_type{};
-    for (const auto& field : config_.fields)
-      for (auto&& index : caf::get<record_type>(schema).resolve_key_suffix(
-             field, schema.name()))
-        indices.push_back(std::move(index));
+    for (const auto& field : config_.fields) {
+      if (auto index = caf::get<record_type>(schema).resolve_key(field)) {
+        indices.push_back(std::move(*index));
+      }
+    }
     std::sort(indices.begin(), indices.end());
     return indices;
   }

--- a/libtenzir/include/tenzir/table_slice.hpp
+++ b/libtenzir/include/tenzir/table_slice.hpp
@@ -392,7 +392,8 @@ filter(const table_slice& slice, const ids& hints);
 auto resolve_meta_extractor(const table_slice& slice, const meta_extractor& ex)
   -> data;
 
-/// Resolve an operand into an Array for a given table slice.
+/// Resolve an operand into an Array for a given table slice. Note that this
+/// already uses prefix matching instead of suffix matching.
 auto resolve_operand(const table_slice& slice, const operand& op)
   -> std::pair<type, std::shared_ptr<arrow::Array>>;
 

--- a/libtenzir/src/table_slice.cpp
+++ b/libtenzir/src/table_slice.cpp
@@ -880,9 +880,8 @@ auto resolve_operand(const table_slice& slice, const operand& op)
       bind_value(value);
     },
     [&](const field_extractor& ex) {
-      for (const auto& index :
-           layout.resolve_key_suffix(ex.field, slice.schema().name())) {
-        bind_array(index);
+      if (auto index = layout.resolve_key(ex.field)) {
+        bind_array(*index);
         return;
       }
       bind_value({});


### PR DESCRIPTION
This PR enables `select <field_of_record_type>` and similar examples by using prefix matching instead of suffix matching. This is a breaking change because it also makes it so that `select bar` does not select the inner field of `{"foo": {"bar": 42}}` anymore. However, we wanted to make this change anyway in the near future.

Some uses of `record_type::resolve_key_suffix` still remain for now. In particular, expressions are still resolved using suffix semantics. 