### PR TITLE
Demo node improvements

### DIFF
--- a/.github/workflows/docker-config-base.json
+++ b/.github/workflows/docker-config-base.json
@@ -46,7 +46,8 @@
       "name": "tenzir-demo",
       "target": "tenzir-demo",
       "registries": [
-        "622024652768.dkr.ecr.eu-west-1.amazonaws.com"
+        "622024652768.dkr.ecr.eu-west-1.amazonaws.com",
+        "docker.io"
       ]
     },
     {

--- a/Dockerfile
+++ b/Dockerfile
@@ -214,7 +214,6 @@ ENTRYPOINT ["tenzir-node"]
 FROM tenzir-ce AS tenzir-demo
 
 USER root:root
-COPY demo-node /demo-node
 RUN apt-get update && \
     apt install -y \
         curl \
@@ -222,7 +221,9 @@ RUN apt-get update && \
         procps \
         zstd && \
     rm -rf /var/lib/apt/lists/*
-
+COPY demo-node /demo-node
+ENV SURICATA_PIPE='load https https://storage.googleapis.com/tenzir-datasets/M57/suricata.json.zst | decompress zstd | read suricata | where #schema != "suricata.stats" | import'
+ENV ZEEK_PIPE='load https https://storage.googleapis.com/tenzir-datasets/M57/zeek-all.log.zst | decompress zstd | read zeek-tsv | import'
 RUN /demo-node/import.bash
 ENTRYPOINT ["/demo-node/entrypoint.bash"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -223,7 +223,6 @@ RUN apt-get update && \
         zstd && \
     rm -rf /var/lib/apt/lists/*
 
-RUN /demo-node/load.bash
 RUN /demo-node/import.bash
 ENTRYPOINT ["/demo-node/entrypoint.bash"]
 

--- a/demo-node/entrypoint.bash
+++ b/demo-node/entrypoint.bash
@@ -45,7 +45,7 @@ curl -X POST \
 
 # !! Not started because the data has already been imported while building the image.
 # Newlines improve readability in the app.
-suricata_pipe="tenzir 'load https https://storage.googleapis.com/tenzir-datasets/M57/suricata.json.zst \n| decompress zstd \n| read suricata \n| import'"
+suricata_pipe="tenzir 'load https https://storage.googleapis.com/tenzir-datasets/M57/suricata.json.zst \n| decompress zstd \n| read suricata \n| where #schema != \\\"suricata.stats\\\" \n| import'"
 curl -X POST \
   -H "Content-Type: application/json" \
   -d "{\"name\": \"M57 Suricata Import\", \"definition\": \"${suricata_pipe}\", \"start_when_created\": false}" \

--- a/demo-node/entrypoint.bash
+++ b/demo-node/entrypoint.bash
@@ -44,14 +44,16 @@ curl -X POST \
 #  http://127.0.0.1:5160/api/v0/pipeline/create
 
 # !! Not started because the data has already been imported while building the image.
-suricata_pipe="tenzir 'load https https://storage.googleapis.com/tenzir-datasets/M57/suricata.json.zst | decompress zstd | read suricata | import'"
+# Newlines improve readability in the app.
+suricata_pipe="tenzir 'load https https://storage.googleapis.com/tenzir-datasets/M57/suricata.json.zst \n| decompress zstd \n| read suricata \n| import'"
 curl -X POST \
   -H "Content-Type: application/json" \
   -d "{\"name\": \"M57 Suricata Import\", \"definition\": \"${suricata_pipe}\", \"start_when_created\": false}" \
   http://127.0.0.1:5160/api/v0/pipeline/create
 
 # !! Not started because the data has already been imported while building the image.
-zeek_pipe="tenzir 'load https https://storage.googleapis.com/tenzir-datasets/M57/zeek-all.log.zst | decompress zstd | read zeek-tsv | import'"
+# Newlines improve readability in the app.
+zeek_pipe="tenzir 'load https https://storage.googleapis.com/tenzir-datasets/M57/zeek-all.log.zst \n| decompress zstd \n| read zeek-tsv \n| import'"
 
 curl -X POST \
   -H "Content-Type: application/json" \

--- a/demo-node/entrypoint.bash
+++ b/demo-node/entrypoint.bash
@@ -43,20 +43,16 @@ curl -X POST \
 #  -d "{\"name\": \"Live CVE Notifications from the NIST API\", \"definition\": \"${cve_pipe}\", \"start_when_created\": true}" \
 #  http://127.0.0.1:5160/api/v0/pipeline/create
 
-# The shell operator decompresses the data and writes it to `read suricata` on
-# the fly.
 # !! Not started because the data has already been imported while building the image.
-suricata_pipe="shell 'bash -c \\\"curl -s -L https://storage.googleapis.com/tenzir-datasets/M57/suricata.tar.zst | tar -x --zstd --to-stdout\\\"' | read suricata | where #schema != \\\"suricata.stats\\\" | import"
+suricata_pipe="tenzir 'load https https://storage.googleapis.com/tenzir-datasets/M57/suricata.json.zst | decompress zstd | read suricata | import'"
 curl -X POST \
   -H "Content-Type: application/json" \
   -d "{\"name\": \"M57 Suricata Import\", \"definition\": \"${suricata_pipe}\", \"start_when_created\": false}" \
   http://127.0.0.1:5160/api/v0/pipeline/create
 
-# The shell operator "streams" the data into a `Zeek/` directory on disk, calls
-# `sync` to flush the OS write buffers, and finally sends the concatenation of
-# the logs into `read zeek-tsv`.
 # !! Not started because the data has already been imported while building the image.
-zeek_pipe="shell 'bash -c \\\"curl -s -L https://storage.googleapis.com/tenzir-datasets/M57/zeek.tar.zst | tar -x --zstd; sync; cat Zeek/*.log\\\"' | read zeek-tsv | import"
+zeek_pipe="tenzir 'load https https://storage.googleapis.com/tenzir-datasets/M57/zeek-all.log.zst | decompress zstd | read zeek-tsv | import'"
+
 curl -X POST \
   -H "Content-Type: application/json" \
   -d "{\"name\": \"M57 Zeek Import\", \"definition\": \"${zeek_pipe}\", \"start_when_created\": false}" \

--- a/demo-node/entrypoint.bash
+++ b/demo-node/entrypoint.bash
@@ -29,13 +29,14 @@ done
 #   http://127.0.0.1:5160/api/v0/pipeline/create
 
 # Continuously import system load data from `vmstat -a -n 1`.
-stat_pipe="shell /demo-node/csvstat.sh | read csv | replace #schema=\\\"vmstat.all\\\" | unflatten | import"
-echo $stat_pipe
-curl -X POST \
-  -H "Content-Type: application/json" \
-  -d "{\"name\": \"System Load\", \"definition\": \"${stat_pipe}\", \"start_when_created\": true}" \
-  http://127.0.0.1:5160/api/v0/pipeline/create
-echo
+# !! Currently disabled because the source shell command is too cryptic
+# stat_pipe="shell /demo-node/csvstat.sh | read csv | replace #schema=\\\"vmstat.all\\\" | unflatten | import"
+# echo $stat_pipe
+# curl -X POST \
+#   -H "Content-Type: application/json" \
+#   -d "{\"name\": \"System Load\", \"definition\": \"${stat_pipe}\", \"start_when_created\": true}" \
+#   http://127.0.0.1:5160/api/v0/pipeline/create
+# echo
 
 # Ingest CVEs from https://services.nvd.nist.gov/rest/json/cves/2.0.
 # !! Currently disabled because of a scheduling bug.

--- a/demo-node/import.bash
+++ b/demo-node/import.bash
@@ -12,8 +12,8 @@ coproc NODE { exec tenzir-node --print-endpoint; }
 # shellcheck disable=SC2034
 read -r -u "${NODE[0]}" DUMMY
 
-tenzir 'read suricata | where #schema != "suricata.stats" | import' < suricata.json
-tenzir 'read zeek-tsv | import' < zeek-all.log
+tenzir 'load https https://storage.googleapis.com/tenzir-datasets/M57/suricata.json.zst | decompress zstd | read suricata | where #schema != "suricata.stats" | import'
+tenzir 'load https https://storage.googleapis.com/tenzir-datasets/M57/zeek-all.log.zst | decompress zstd | read zeek-tsv | import'
 
 tenzir-ctl flush
 tenzir-ctl rebuild --undersized

--- a/demo-node/import.bash
+++ b/demo-node/import.bash
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 export TENZIR_AUTOMATIC_REBUILD="${TENZIR_AUTOMATIC_REBUILD:-0}"
 export TENZIR_ALLOW_UNSAFE_PIPELINES=true
 
@@ -10,8 +12,8 @@ coproc NODE { exec tenzir-node --print-endpoint; }
 # shellcheck disable=SC2034
 read -r -u "${NODE[0]}" DUMMY
 
-tenzir 'read suricata | where #schema != "suricata.stats" | import' < Suricata/eve.json
-cat Zeek/*.log | tenzir 'read zeek-tsv | import'
+tenzir 'read suricata | where #schema != "suricata.stats" | import' < suricata.json
+tenzir 'read zeek-tsv | import' < zeek-all.log
 
 tenzir-ctl flush
 tenzir-ctl rebuild --undersized

--- a/demo-node/import.bash
+++ b/demo-node/import.bash
@@ -11,9 +11,9 @@ trap 'trap " " SIGTERM; kill 0; wait' SIGINT SIGTERM
 coproc NODE { exec tenzir-node --print-endpoint; }
 # shellcheck disable=SC2034
 read -r -u "${NODE[0]}" DUMMY
-
-tenzir 'load https https://storage.googleapis.com/tenzir-datasets/M57/suricata.json.zst | decompress zstd | read suricata | where #schema != "suricata.stats" | import'
-tenzir 'load https https://storage.googleapis.com/tenzir-datasets/M57/zeek-all.log.zst | decompress zstd | read zeek-tsv | import'
+echo $SURICATA_PIPE
+tenzir "$SURICATA_PIPE"
+tenzir "$ZEEK_PIPE"
 
 tenzir-ctl flush
 tenzir-ctl rebuild --undersized

--- a/demo-node/load.bash
+++ b/demo-node/load.bash
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-
-curl -L https://storage.googleapis.com/tenzir-datasets/M57/suricata.json.zst | unzstd > suricata.json
-curl -L https://storage.googleapis.com/tenzir-datasets/M57/zeek-all.log.zst | unzstd > zeek-all.log

--- a/demo-node/load.bash
+++ b/demo-node/load.bash
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
-curl -L https://storage.googleapis.com/tenzir-datasets/M57/suricata.tar.zst | tar -x --zstd
-curl -L https://storage.googleapis.com/tenzir-datasets/M57/zeek.tar.zst | tar -x --zstd
+set -e
+
+curl -L https://storage.googleapis.com/tenzir-datasets/M57/suricata.json.zst | unzstd > suricata.json
+curl -L https://storage.googleapis.com/tenzir-datasets/M57/zeek-all.log.zst | unzstd > zeek-all.log


### PR DESCRIPTION
- Push the demo node image to DockerHub because it can be handy to play with the Demo node locally. 
- Change the import to use the http operator. To make that possible we also switch to the compressed file data instead of the tarballs.
- Remove the intermediate image layer with data files

