### PR TITLE
Rename `--appending` option for `save file` to `--append`

### DIFF
--- a/changelog/next/bug-fixes/3629.md
+++ b/changelog/next/bug-fixes/3629.md
@@ -1,0 +1,2 @@
+The long option `--append` for the `file` and `directory` savers now works as
+documented. Previously, only the short option worked correctly.

--- a/libtenzir/builtins/connectors/directory.cpp
+++ b/libtenzir/builtins/connectors/directory.cpp
@@ -21,14 +21,14 @@ namespace tenzir::plugins::directory {
 
 struct saver_args {
   std::string path;
-  bool appending;
+  bool append;
   bool real_time;
 
   template <class Inspector>
   friend auto inspect(Inspector& f, saver_args& x) -> bool {
     return f.object(x)
       .pretty_name("saver_args")
-      .fields(f.field("path", x.path), f.field("appending", x.appending),
+      .fields(f.field("path", x.path), f.field("append", x.append),
               f.field("real_time", x.real_time));
   }
 };
@@ -70,8 +70,8 @@ public:
     }
     auto diag = null_diagnostic_handler{};
     auto file_pipeline = escape_operator_arg(file_path.string());
-    if (args_.appending)
-      file_pipeline += " --appending";
+    if (args_.append)
+      file_pipeline += " --append";
     if (args_.real_time)
       file_pipeline += " --real-time";
     // TODO: We should probably use a better mechanism here than escaping and
@@ -125,7 +125,7 @@ public:
                                           "connectors/directory"};
     auto args = saver_args{};
     parser.add(args.path, "<path>");
-    parser.add("-a,--appending", args.appending);
+    parser.add("-a,--append", args.append);
     parser.add("-r,--real-time", args.real_time);
     parser.parse(p);
     return std::make_unique<directory_saver>(std::move(args));

--- a/libtenzir/builtins/connectors/file.cpp
+++ b/libtenzir/builtins/connectors/file.cpp
@@ -180,7 +180,7 @@ struct loader_args {
 
 struct saver_args {
   located<std::string> path;
-  std::optional<location> appending;
+  std::optional<location> append;
   std::optional<location> real_time;
   std::optional<location> uds;
 
@@ -188,7 +188,7 @@ struct saver_args {
   friend auto inspect(Inspector& f, saver_args& x) -> bool {
     return f.object(x)
       .pretty_name("saver_args")
-      .fields(f.field("path", x.path), f.field("appending", x.appending),
+      .fields(f.field("path", x.path), f.field("append", x.append),
               f.field("real_time", x.real_time), f.field("uds", x.uds));
   }
 };
@@ -409,7 +409,7 @@ public:
         }
       }
       // We use `fopen` because we want buffered writes.
-      auto handle = std::fopen(path.c_str(), args_.appending ? "ab" : "wb");
+      auto handle = std::fopen(path.c_str(), args_.append ? "ab" : "wb");
       if (handle == nullptr) {
         return caf::make_error(ec::filesystem_error,
                                fmt::format("failed to open {}: {}", path,
@@ -517,13 +517,13 @@ public:
     auto parser = argument_parser{"file", "https://docs.tenzir.com/next/"
                                           "connectors/file"};
     parser.add(args.path, "<path>");
-    parser.add("-a,--appending", args.appending);
+    parser.add("-a,--append", args.append);
     parser.add("-r,--real-time", args.real_time);
     parser.add("--uds", args.uds);
     parser.parse(p);
     // TODO: Better argument validation
     if (args.path.inner == "-") {
-      for (auto& other : {args.appending, args.real_time, args.uds}) {
+      for (auto& other : {args.append, args.real_time, args.uds}) {
         if (other) {
           diagnostic::error("flags are mutually exclusive")
             .primary(*other)


### PR DESCRIPTION
This makes the language as a whole more consistent. This is how the option was originally specified, and somehow that slipped through in review and hasn't been noticed before.

Categorizing this as a bug fix since it aligns the connector with the documentation.