### PR TITLE
Build arm64 macOS packages

### DIFF
--- a/.github/workflows/nix-config-base.json
+++ b/.github/workflows/nix-config-base.json
@@ -30,16 +30,6 @@
       "upload-package-to-github": true,
       "package-stores": [],
       "image-registries": []
-    },
-    {
-      "name": "tenzir-ee",
-      "gha-runner-labels": ["macOS", "ARM64"],
-      "static": true,
-      "upload-package-to-github": false,
-      "package-stores": [
-        "gcs:tenzir-dist-private/packages/main"
-      ],
-      "image-registries": []
     }
   ]
 }

--- a/.github/workflows/nix-config-base.json
+++ b/.github/workflows/nix-config-base.json
@@ -2,6 +2,7 @@
   "editions": [
     {
       "name": "tenzir",
+      "gha-runner-labels": ["ubuntu-latest"],
       "static": true,
       "upload-package-to-github": true,
       "package-stores": [
@@ -14,6 +15,25 @@
     },
     {
       "name": "tenzir-ee",
+      "gha-runner-labels": ["ubuntu-latest"],
+      "static": true,
+      "upload-package-to-github": false,
+      "package-stores": [
+        "gcs:tenzir-dist-private/packages/main"
+      ],
+      "image-registries": []
+    },
+    {
+      "name": "tenzir",
+      "gha-runner-labels": ["macOS", "ARM64"],
+      "static": true,
+      "upload-package-to-github": true,
+      "package-stores": [],
+      "image-registries": []
+    },
+    {
+      "name": "tenzir-ee",
+      "gha-runner-labels": ["macOS", "ARM64"],
       "static": true,
       "upload-package-to-github": false,
       "package-stores": [

--- a/.github/workflows/nix.nu
+++ b/.github/workflows/nix.nu
@@ -71,7 +71,8 @@ def push_images [
   image_registries: list<string>
   container_tags # annotation breaks in nu 0.78 : list<string>
 ] {
-  if ($image_registries == [] or $container_tags == []) {
+  let os = (uname -s)
+  if ($os != "Linux" or $image_registries == [] or $container_tags == []) {
     return
   }
   # We always push two images: `tenzir` and `tenzir-node`.

--- a/.github/workflows/nix.nu
+++ b/.github/workflows/nix.nu
@@ -23,6 +23,7 @@ def upload_packages [
 ] {
   let pkg_dir = (nix --accept-flake-config --print-build-logs build $".#($name)^package" --no-link --print-out-paths)
   let debs = (glob $"($pkg_dir)/*.deb")
+  let pkgs = (glob $"($pkg_dir)/*.pkg")
   let tgzs = (glob $"($pkg_dir)/*.tar.gz")
   for store in $package_stores {
     let type = ($store | split row ':' | get 0)
@@ -43,6 +44,7 @@ def upload_packages [
         }
       }
       do $run "debian" $debs
+      do $run "macOS" $pkgs
       do $run "tarball" $tgzs
     }
   }
@@ -52,6 +54,9 @@ def upload_packages [
     for deb in $debs {
       cp -v $deb ./packages/debian
     }
+    for pkg in $pkgs {
+      cp -v $pkg ./packages/macOS
+    }
     for tgz in $tgzs {
       cp -v $tgz ./packages/tarball
     }
@@ -59,6 +64,9 @@ def upload_packages [
       cp ($debs | get 0) $"($name)-amd64-linux.deb"
       print $"::attaching ($name)-amd64-linux.deb to ($git_tag)"
       gh release upload $git_tag $"($name)-amd64-linux.deb" --clobber
+      cp ($pkgs | get 0) $"($name)-arm64-darwin.pkg"
+      print $"::attaching ($name)-arm64-darwin.pkg to ($git_tag)"
+      gh release upload $git_tag $"($name)-arm64-darwin.pkg" --clobber
       cp ($tgzs | get 0) $"($name)-x86_64-linux.tar.gz"
       print $"::attaching ($name)-x86_64-linux.tar.gz to ($git_tag)"
       gh release upload $git_tag $"($name)-x86_64-linux.tar.gz" --clobber

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   tenzir:
-    name: Tenzir (${{ runner.os }} ${{ runner.arch }})
+    name: Tenzir
     runs-on: ${{ fromJSON(inputs.config).editions[0].gha-runner-labels }}
     steps:
       - name: Prevent pushing protected editions to public repos

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -13,15 +13,15 @@ permissions:
 
 jobs:
   tenzir:
-    name: Tenzir
-    runs-on: ubuntu-20.04
+    name: Tenzir (${{ runner.os }} ${{ runner.arch }})
+    runs-on: ${{ fromJSON(inputs.config).editions[0].gha-runner-labels }}
     steps:
       - name: Prevent pushing protected editions to public repos
         run: |
           # Create 'name registry' pairs
           jq -r '.editions[] | select(."image-registries" | length > 0) | .name as $name | ."image-registries"[]? // ."image-registries" | [ $name, . ] | join(" ")' \
             <<< '${{ inputs.config }}' | while read -r name registry; do
-            # Explicitly allow open source images.
+            # Explicitly allow blessed images.
             [[ "${name}" =~ ^tenzir$ ]] && continue
             # Explicitly allow private registries.
             [[ "${registry}" == "622024652768.dkr.ecr.eu-west-1.amazonaws.com" ]] && continue
@@ -42,18 +42,20 @@ jobs:
           echo "needs-docker-hub=false" >> "$GITHUB_OUTPUT"
           echo "needs-ghcr=false" >> "$GITHUB_OUTPUT"
           echo "needs-ecr=false" >> "$GITHUB_OUTPUT"
-          jq -r '.editions | map( ."image-registries"[]) | unique | .[]
-                 | if . == "docker.io" then
-                     "needs-docker-hub=true"
-                   elif . == "ghcr.io" then
-                     "needs-ghcr=true"
-                   elif . == "622024652768.dkr.ecr.eu-west-1.amazonaws.com" then
-                     "needs-ecr=true"
-                   else
-                     empty
-                   end
-                 | @text' \
-                 <<< '${{ inputs.config }}' >> "${GITHUB_OUTPUT}"
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            jq -r '.editions | map( ."image-registries"[]) | unique | .[]
+                   | if . == "docker.io" then
+                       "needs-docker-hub=true"
+                     elif . == "ghcr.io" then
+                       "needs-ghcr=true"
+                     elif . == "622024652768.dkr.ecr.eu-west-1.amazonaws.com" then
+                       "needs-ecr=true"
+                     else
+                       empty
+                     end
+                   | @text' \
+                   <<< '${{ inputs.config }}' >> "${GITHUB_OUTPUT}"
+          fi
           echo "::notice checking tenzir-plugins..."
           jq -r '@text "upload-to-github=\(.editions | any(."upload-package-to-github"))"' \
                    <<< '${{ inputs.config }}' >> "$GITHUB_OUTPUT"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,6 +229,9 @@ endif ()
 
 # -- optimizations -------------------------------------------------------------
 
+option(CMAKE_INTERPROCEDURAL_OPTIMIZATION_Release
+       "Enable link time optimizations for the Release build" ON)
+
 option(TENZIR_ENABLE_AUTO_VECTORIZATION "Enable SSE instructions" ON)
 add_feature_info(
   "TENZIR_ENABLE_AUTO_VECTORIZATION" TENZIR_ENABLE_AUTO_VECTORIZATION
@@ -392,8 +395,12 @@ cmake_dependent_option(
 add_feature_info("TENZIR_ENABLE_STATIC_EXECUTABLE"
                  TENZIR_ENABLE_STATIC_EXECUTABLE "link Tenzir statically.")
 if (TENZIR_ENABLE_STATIC_EXECUTABLE)
-  target_link_libraries(libtenzir_internal INTERFACE -static-libgcc
-                                                     -static-libstdc++ -static)
+  # Not desired on darwin.
+  if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
+    # This works with clang as well, so we don't need an extra condition here.
+    target_link_libraries(libtenzir_internal INTERFACE -static-libgcc
+                                                       -static-libstdc++ -static)
+  endif ()
 endif ()
 
 if (TENZIR_ENABLE_STATIC_EXECUTABLE AND BUILD_SHARED_LIBS)
@@ -480,9 +487,6 @@ add_feature_info("TENZIR_ENABLE_JEMALLOC" TENZIR_ENABLE_JEMALLOC
                  "use jemalloc instead of libc malloc.")
 if (TENZIR_ENABLE_JEMALLOC)
   find_package(jemalloc REQUIRED)
-  provide_find_module(jemalloc)
-  string(APPEND TENZIR_FIND_DEPENDENCY_LIST "\nfind_package(jemalloc REQUIRED)")
-  target_link_libraries(libtenzir_internal INTERFACE jemalloc::jemalloc_)
   dependency_summary("jemalloc" jemalloc::jemalloc_ "Dependencies")
 endif ()
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -11,6 +11,7 @@
         "CMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY": "OFF",
         "CMAKE_FIND_USE_PACKAGE_REGISTRY": "OFF",
         "CMAKE_OSX_SYSROOT": "",
+        "_MAC_DEPENDENCY_PATHS": "DISABLED",
         "TENZIR_ENABLE_BUNDLED_AND_PATCHED_RESTINIO": "OFF",
         "TENZIR_ENABLE_BUNDLED_CAF": "OFF",
         "TENZIR_ENABLE_DEVELOPER_MODE": "ON",
@@ -146,7 +147,7 @@
       }
     },
     {
-      "name": "nix-static",
+      "name": "nix-gcc-static",
       "inherits": ["nix-base"],
       "hidden": true,
       "cacheVariables": {
@@ -161,8 +162,53 @@
       }
     },
     {
+      "name": "nix-clang-static",
+      "inherits": ["nix-base"],
+      "hidden": true,
+      "cacheVariables": {
+        "BUILD_SHARED_LIBS": "OFF",
+        "BUILD_TESTING": "OFF",
+        "CMAKE_C_COMPILER": "aarch64-apple-darwin-cc",
+        "CMAKE_CXX_COMPILER": "aarch64-apple-darwin-c++",
+        "TENZIR_ENABLE_JEMALLOC": "OFF",
+        "TENZIR_ENABLE_UNIT_TESTS": "OFF",
+        "TENZIR_ENABLE_STATIC_EXECUTABLE": "ON"
+      }
+    },
+    {
+      "name": "nix-clang-static-debug",
+      "inherits": ["nix-clang-static"],
+      "displayName": "Nix GCC Static Debug Config",
+      "binaryDir": "${sourceDir}/build/clang-static/debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/install/clang-static/debug"
+      }
+    },
+    {
+      "name": "nix-clang-static-relwithdebinfo",
+      "inherits": ["nix-clang-static"],
+      "displayName": "Nix GCC Static RelWithDebInfo Config",
+      "binaryDir": "${sourceDir}/build/clang-static/relwithdebinfo",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/install/clang-static/relwithdebinfo"
+      }
+    },
+    {
+      "name": "nix-clang-static-release",
+      "inherits": ["nix-clang-static"],
+      "displayName": "Nix GCC Static Release Config",
+      "binaryDir": "${sourceDir}/build/clang-static/release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/install/clang-static/release",
+        "CMAKE_INTERPROCEDURAL_OPTIMIZATION": "OFF"
+      }
+    },
+    {
       "name": "nix-gcc-static-debug",
-      "inherits": ["nix-static"],
+      "inherits": ["nix-gcc-static"],
       "displayName": "Nix GCC Static Debug Config",
       "binaryDir": "${sourceDir}/build/gcc-static/debug",
       "cacheVariables": {
@@ -172,7 +218,7 @@
     },
     {
       "name": "nix-gcc-static-relwithdebinfo",
-      "inherits": ["nix-static"],
+      "inherits": ["nix-gcc-static"],
       "displayName": "Nix GCC Static RelWithDebInfo Config",
       "binaryDir": "${sourceDir}/build/gcc-static/relwithdebinfo",
       "cacheVariables": {
@@ -182,7 +228,7 @@
     },
     {
       "name": "nix-gcc-static-release",
-      "inherits": ["nix-static"],
+      "inherits": ["nix-gcc-static"],
       "displayName": "Nix GCC Static Release Config",
       "binaryDir": "${sourceDir}/build/gcc-static/release",
       "cacheVariables": {

--- a/cmake/TenzirPackage.cmake
+++ b/cmake/TenzirPackage.cmake
@@ -62,8 +62,11 @@ endif ()
 set(CPACK_PACKAGE_DIRECTORY "package")
 set(CPACK_VERBATIM_VARIABLES ON)
 
-set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
-set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
+# TODO: Must be html files for productbuild.
+if (NOT APPLE)
+  set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
+  set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
+endif ()
 set(CPACK_INSTALLED_DIRECTORIES "/var/lib/tenzir" "/var/log/tenzir")
 
 set(CPACK_DEBIAN_PACKAGE_RELEASE "1")
@@ -101,6 +104,7 @@ set(CPACK_COMPONENTS_GROUPING ALL_COMPONENTS_IN_ONE)
 # https://cmake.org/cmake/help/latest/module/CPackComponent.html#variable:CPACK_%3CGENNAME%3E_COMPONENT_INSTALL
 set(CPACK_DEB_COMPONENT_INSTALL ON)
 set(CPACK_ARCHIVE_COMPONENT_INSTALL ON)
+set(CPACK_PRODUCTBUILD_COMPONENT_INSTALL ON)
 
 # Set up CPack as configured above. Note that the calls to cpack_add_component
 # must come _after_ the CPack include, while the variables must be set _before_

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
         "type": "github"
       },
       "original": {
@@ -21,11 +21,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1692799911,
-        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nix-filter": {
       "locked": {
-        "lastModified": 1687178632,
-        "narHash": "sha256-HS7YR5erss0JCaUijPeyg2XrisEb959FIct3n2TMGbE=",
+        "lastModified": 1694857738,
+        "narHash": "sha256-bxxNyLHjhu0N8T3REINXQ2ZkJco0ABFPn6PIe2QUfqo=",
         "owner": "numtide",
         "repo": "nix-filter",
-        "rev": "d90c75e8319d0dd9be67d933d8eb9d0894ec9174",
+        "rev": "41fd48e00c22b4ced525af521ead8792402de0ea",
         "type": "github"
       },
       "original": {
@@ -65,12 +65,29 @@
         "type": "github"
       }
     },
+    "nixpkgs-darwin": {
+      "locked": {
+        "lastModified": 1699608742,
+        "narHash": "sha256-F6C39EbMyTWKpc8sBov/QyiLh2NBTzD6lN1pag8GFDU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "9a0c85ffc5aedc46b4d81f3b9fc22d7f488e3ff9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "9a0c85ffc5aedc46b4d81f3b9fc22d7f488e3ff9",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nix-filter": "nix-filter",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-darwin": "nixpkgs-darwin",
         "sbomnix": "sbomnix"
       }
     },
@@ -81,11 +98,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1691143226,
-        "narHash": "sha256-tz+qE/oLgqG9E2/me07D34KC+x/1/Ve3lEdoVyonUt0=",
+        "lastModified": 1694436134,
+        "narHash": "sha256-i+n1tkYT2hHUD6esjVqjEnkTMKffVT4TS6DvEiOwTic=",
         "owner": "tiiuae",
         "repo": "sbomnix",
-        "rev": "41c5d3a692a98d8dccc7a6df7d27d916cd27ad4f",
+        "rev": "24007b6ad064c2f6055ffb4e59a8491b08357353",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -16,6 +16,55 @@
         "type": "github"
       }
     },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1688025799,
+        "narHash": "sha256-ktpB4dRtnksm9F5WawoIkEneh1nrEvuxb5lJFt1iOyw=",
+        "owner": "nix-community",
+        "repo": "flake-compat",
+        "rev": "8bf105319d44f6b9f0d764efa4fdef9f1cc9ba1c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1698882062,
+        "narHash": "sha256-HkhafUayIqxXyHH1X8d9RDl1M2CkFgZLjKD3MzabiEo=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "8c9fa2545007b49a5db5f650ae91f227672c3877",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-root": {
+      "locked": {
+        "lastModified": 1692742795,
+        "narHash": "sha256-f+Y0YhVCIJ06LemO+3Xx00lIcqQxSKJHXT/yk1RTKxw=",
+        "owner": "srid",
+        "repo": "flake-root",
+        "rev": "d9a70d9c7a5fd7f3258ccf48da9335e9b47c3937",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "flake-root",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -49,35 +98,53 @@
         "type": "github"
       }
     },
-    "nixpkgs": {
+    "nix-visualize": {
+      "flake": false,
       "locked": {
-        "lastModified": 1694343207,
-        "narHash": "sha256-jWi7OwFxU5Owi4k2JmiL1sa/OuBCQtpaAesuj5LXC8w=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "78058d810644f5ed276804ce7ea9e82d92bee293",
+        "lastModified": 1687577587,
+        "narHash": "sha256-Z1r8XHszoUnQinl63yXvQG6Czp5HnYNG37AY+EEiT4w=",
+        "owner": "craigmbooth",
+        "repo": "nix-visualize",
+        "rev": "cafaba50cd63ba9c759c56af71fd0d22fd60a548",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "78058d810644f5ed276804ce7ea9e82d92bee293",
+        "owner": "craigmbooth",
+        "repo": "nix-visualize",
         "type": "github"
       }
     },
-    "nixpkgs-darwin": {
+    "nixpkgs": {
       "locked": {
-        "lastModified": 1699608742,
-        "narHash": "sha256-F6C39EbMyTWKpc8sBov/QyiLh2NBTzD6lN1pag8GFDU=",
+        "lastModified": 1700948707,
+        "narHash": "sha256-W4TRYSGaD8Gybw0u66aJM6IVClOtjZaXsSCpkWbZMQ4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9a0c85ffc5aedc46b4d81f3b9fc22d7f488e3ff9",
+        "rev": "7086fd448fbe174a8c05a87a475bedd704520b68",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9a0c85ffc5aedc46b4d81f3b9fc22d7f488e3ff9",
+        "rev": "7086fd448fbe174a8c05a87a475bedd704520b68",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1698611440,
+        "narHash": "sha256-jPjHjrerhYDy3q9+s5EAsuhyhuknNfowY6yt6pjn9pc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0cbe9f69c234a7700596e943bfae7ef27a31b735",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
         "type": "github"
       }
     },
@@ -87,22 +154,27 @@
         "flake-utils": "flake-utils",
         "nix-filter": "nix-filter",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-darwin": "nixpkgs-darwin",
         "sbomnix": "sbomnix"
       }
     },
     "sbomnix": {
       "inputs": {
+        "flake-compat": "flake-compat_2",
+        "flake-parts": "flake-parts",
+        "flake-root": "flake-root",
+        "nix-visualize": "nix-visualize",
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "treefmt-nix": "treefmt-nix",
+        "vulnix": "vulnix"
       },
       "locked": {
-        "lastModified": 1694436134,
-        "narHash": "sha256-i+n1tkYT2hHUD6esjVqjEnkTMKffVT4TS6DvEiOwTic=",
+        "lastModified": 1700064189,
+        "narHash": "sha256-1W5mCsNZ0ttiO8HW10wKHsy9ZwCZa/rCLH0Rrmtw/wE=",
         "owner": "tiiuae",
         "repo": "sbomnix",
-        "rev": "24007b6ad064c2f6055ffb4e59a8491b08357353",
+        "rev": "b920aa90ee291defa00e1757d81399f37c76c853",
         "type": "github"
       },
       "original": {
@@ -123,6 +195,43 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "sbomnix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1698438538,
+        "narHash": "sha256-AWxaKTDL3MtxaVTVU5lYBvSnlspOS0Fjt8GxBgnU0Do=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "5deb8dc125a9f83b65ca86cf0c8167c46593e0b1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "vulnix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1676379453,
+        "narHash": "sha256-KXvmnaMjv//zd4aSwu4qmbon1Iyzdod6CPms7LIxeVU=",
+        "owner": "henrirosten",
+        "repo": "vulnix",
+        "rev": "ad28b2924027a44a9b81493a0f9de1b0e8641005",
+        "type": "github"
+      },
+      "original": {
+        "owner": "henrirosten",
+        "repo": "vulnix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,7 @@
   };
 
   inputs.nixpkgs.url = "github:nixos/nixpkgs/78058d810644f5ed276804ce7ea9e82d92bee293";
+  inputs.nixpkgs-darwin.url = "github:nixos/nixpkgs/9a0c85ffc5aedc46b4d81f3b9fc22d7f488e3ff9";
   inputs.flake-compat.url = "github:edolstra/flake-compat";
   inputs.flake-compat.flake = false;
   inputs.flake-utils.url = "github:numtide/flake-utils";
@@ -20,6 +21,7 @@
   outputs = {
     self,
     nixpkgs,
+    nixpkgs-darwin,
     flake-utils,
     ...
   } @ inputs:
@@ -33,10 +35,13 @@
         };
       };
     }
-    // flake-utils.lib.eachSystem ["x86_64-linux" "x86_64-darwin"] (
+    // flake-utils.lib.eachSystem ["x86_64-linux" "x86_64-darwin" "aarch64-darwin" ] (
       system: let
         overlay = import ./nix/overlay.nix {inherit inputs versionShortOverride versionLongOverride;};
-        pkgs = nixpkgs.legacyPackages."${system}".appendOverlays [overlay];
+        npkgs = if (system == "x86_64-darwin" || system == "aarch64-darwin")
+                then nixpkgs-darwin
+                else nixpkgs;
+        pkgs = npkgs.legacyPackages."${system}".appendOverlays [overlay];
         inherit
           (builtins.fromJSON (builtins.readFile ./version.json))
           tenzir-version-fallback

--- a/flake.nix
+++ b/flake.nix
@@ -9,8 +9,7 @@
     ];
   };
 
-  inputs.nixpkgs.url = "github:nixos/nixpkgs/78058d810644f5ed276804ce7ea9e82d92bee293";
-  inputs.nixpkgs-darwin.url = "github:nixos/nixpkgs/9a0c85ffc5aedc46b4d81f3b9fc22d7f488e3ff9";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/7086fd448fbe174a8c05a87a475bedd704520b68";
   inputs.flake-compat.url = "github:edolstra/flake-compat";
   inputs.flake-compat.flake = false;
   inputs.flake-utils.url = "github:numtide/flake-utils";
@@ -21,7 +20,6 @@
   outputs = {
     self,
     nixpkgs,
-    nixpkgs-darwin,
     flake-utils,
     ...
   } @ inputs:
@@ -38,10 +36,7 @@
     // flake-utils.lib.eachSystem ["x86_64-linux" "x86_64-darwin" "aarch64-darwin" ] (
       system: let
         overlay = import ./nix/overlay.nix {inherit inputs versionShortOverride versionLongOverride;};
-        npkgs = if (system == "x86_64-darwin" || system == "aarch64-darwin")
-                then nixpkgs-darwin
-                else nixpkgs;
-        pkgs = npkgs.legacyPackages."${system}".appendOverlays [overlay];
+        pkgs = nixpkgs.legacyPackages."${system}".appendOverlays [overlay];
         inherit
           (builtins.fromJSON (builtins.readFile ./version.json))
           tenzir-version-fallback

--- a/libtenzir/CMakeLists.txt
+++ b/libtenzir/CMakeLists.txt
@@ -184,9 +184,6 @@ add_library(tenzir::libtenzir_builtins ALIAS libtenzir_builtins)
 target_link_libraries(libtenzir PRIVATE libtenzir_internal)
 target_link_libraries(libtenzir_builtins PRIVATE libtenzir libtenzir_internal)
 
-set_target_properties(libtenzir PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE
-                                           ON)
-
 # Set the libtenzir SOVERSION to '<256 * (major + 7) + minor>.<patch>' to indicate
 # that libtenzir is considered to have an unstable API and ABI. The +7 is a
 # remnant of Tenzir using CalVer before 2022, with the last CalVer release having
@@ -239,7 +236,7 @@ target_compile_definitions(
   PUBLIC # Allow null pointer input when hashing data of length greater 0.
          # TODO: Remove this when requiring xxHash >= 0.8.1.
          XXH_ACCEPT_NULL_INPUT_POINTER=1)
-find_package(xxhash REQUIRED)
+find_package(xxhash MODULE REQUIRED)
 provide_find_module(xxhash)
 string(APPEND TENZIR_FIND_DEPENDENCY_LIST "\nfind_package(xxhash REQUIRED)")
 target_link_libraries(libtenzir PUBLIC xxhash::xxhash_header_only)

--- a/libtenzir/src/store.cpp
+++ b/libtenzir/src/store.cpp
@@ -99,7 +99,7 @@ handle_query(const auto& self, const query_context& query_context) {
             }
             rp.deliver(it->second.num_hits);
             self->send(it->second.sink, it->second.num_hits);
-            const auto runtime
+            const duration runtime
               = std::chrono::steady_clock::now() - it->second.start;
             const auto id_str = fmt::to_string(query_id);
             self->send(self->state.accountant, atom::metrics_v,
@@ -159,7 +159,7 @@ handle_query(const auto& self, const query_context& query_context) {
               return;
             }
             rp.deliver(it->second.num_hits);
-            const auto runtime
+            const duration runtime
               = std::chrono::steady_clock::now() - it->second.start;
             const auto id_str = fmt::to_string(query_id);
             self->send(self->state.accountant, atom::metrics_v,
@@ -257,7 +257,7 @@ default_passive_store_actor::behavior_type default_passive_store(
     .await(
       [self, start](chunk_ptr& chunk) {
         auto load_error = self->state.store->load(std::move(chunk));
-        auto startup_duration = std::chrono::steady_clock::now() - start;
+        duration startup_duration = std::chrono::steady_clock::now() - start;
         self->send(self->state.accountant, atom::metrics_v,
                    "passive-store.init.runtime", startup_duration,
                    metrics_metadata{

--- a/nix/fix-protobuf-dep.patch
+++ b/nix/fix-protobuf-dep.patch
@@ -1,0 +1,21 @@
+diff --git a/cmake_modules/ThirdpartyToolchain.cmake b/cmake_modules/ThirdpartyToolchain.cmake
+index 559ddf14f..c5b14e171 100644
+--- a/cmake_modules/ThirdpartyToolchain.cmake
++++ b/cmake_modules/ThirdpartyToolchain.cmake
+@@ -1801,12 +1801,12 @@ if(ARROW_WITH_PROTOBUF)
+   else()
+     set(ARROW_PROTOBUF_REQUIRED_VERSION "2.6.1")
+   endif()
+-  if(ARROW_FLIGHT)
+-    set(ARROW_PROTOBUF_ARROW_CMAKE_PACKAGE_NAME "ArrowFlight")
+-    set(ARROW_PROTOBUF_ARROW_PC_PACKAGE_NAME "arrow-flight")
+-  else()
++  if(ARROW_ORC OR ARROW_HDFS OR ARROW_WITH_OPENTELEMETRY)
+     set(ARROW_PROTOBUF_ARROW_CMAKE_PACKAGE_NAME "Arrow")
+     set(ARROW_PROTOBUF_ARROW_PC_PACKAGE_NAME "arrow")
++  elseif(ARROW_FLIGHT)
++    set(ARROW_PROTOBUF_ARROW_CMAKE_PACKAGE_NAME "ArrowFlight")
++    set(ARROW_PROTOBUF_ARROW_PC_PACKAGE_NAME "arrow-flight")
+   endif()
+   # We need to use FORCE_ANY_NEWER_VERSION here to accept Protobuf
+   # newer version such as 23.4. If we don't use it, 23.4 is processed

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -35,16 +35,24 @@ in {
         ];
       });
   arrow-cpp =
-    if !isStatic
-    then prev.arrow-cpp
-    else
-      (prev.arrow-cpp.override {
+    let
+      arrow-cpp' = prev.arrow-cpp.overrideAttrs (orig: {
+        buildInputs = orig.buildInputs ++ [final.bzip2];
+        cmakeFlags =
+          orig.cmakeFlags
+          ++ [
+            "-DARROW_WITH_BZ2=ON"
+          ];
+      });
+    in
+    overrideAttrsIf isStatic
+      (arrow-cpp'.override {
         enableShared = false;
         google-cloud-cpp = final.google-cloud-cpp.override {
           apis = [ "storage" ];
         };
       })
-      .overrideAttrs (orig: {
+      (orig: {
         nativeBuildInputs = orig.nativeBuildInputs ++ lib.optionals isDarwin [
           (prev.buildPackages.writeScriptBin "libtool" ''
             #!${stdenv.shell}

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -47,6 +47,9 @@ in {
             exec ${lib.getBin prev.buildPackages.darwin.cctools}/bin/${stdenv.cc.targetPrefix}libtool $@
           '')
         ];
+        patches = (orig.patches or []) ++ [
+          ./fix-protobuf-dep.patch
+        ];
         buildInputs = orig.buildInputs ++ [final.sqlite];
         cmakeFlags =
           orig.cmakeFlags

--- a/nix/restinio/default.nix
+++ b/nix/restinio/default.nix
@@ -7,6 +7,7 @@
   fmt,
   asio,
   openssl,
+  zlib,
 }: let
   pname = "restinio";
   version = "v.0.6.17";
@@ -43,6 +44,7 @@ in
       fmt
       asio
       openssl
+      zlib
     ];
 
     meta = with lib; {

--- a/nix/tenzir/default.nix
+++ b/nix/tenzir/default.nix
@@ -189,13 +189,6 @@
               "unknown" = "ranlib";
             }."${compilerName}";
           in [
-            #"-DCMAKE_EXE_LINKER_FLAGS=\"-fuse-ld=lld\""
-            #"-DCMAKE_MODULE_LINKER_FLAGS=\"-fuse-ld=lld\""
-            #"-DCMAKE_SHARED_LINKER_FLAGS=\"-fuse-ld=lld\""
-            #"-DCMAKE_C_COMPILER_AR=${ar}"
-            #"-DCMAKE_CXX_COMPILER_AR=${ar}"
-            #"-DCMAKE_C_COMPILER_RANLIB=${ranlib}"
-            #"-DCMAKE_CXX_COMPILER_RANLIB=${ranlib}"
             # Want's to install into the users home, but that would be the
             # builder in the Nix context, and that doesn't make sense.
             "-DTENZIR_ENABLE_INIT_SYSTEM_INTEGRATION=OFF"
@@ -219,8 +212,6 @@
           "fortify"
           "pic"
         ];
-
-        #env.DYLD_LIBRARY_PATH = lib.optionalString stdenv.isDarwin "${lib.getLib stdenv.cc.cc.libllvm.out}/lib";
 
         postBuild = lib.optionalString isStatic ''
           ${pkgsBuildHost.nukeReferences}/bin/nuke-refs bin/*
@@ -271,7 +262,7 @@
           maintainers = with maintainers; [tobim];
         };
       }
-      # Buggy on darwin?
+      # allowedRequisites does not work on darwin.
       // lib.optionalAttrs (isStatic && stdenv.isLinux) {
         allowedRequisites = ["out"];
       }

--- a/nix/tenzir/default.nix
+++ b/nix/tenzir/default.nix
@@ -72,8 +72,12 @@
         "plugins/sigma"
         "plugins/velociraptor"
         "plugins/web"
-        "plugins/yara"
         "plugins/zmq"
+      ]
+      # Temporarily disable yara on the static mac build because of issues
+      # building protobufc.
+      ++ lib.optionals (!(stdenv.isDarwin && isStatic)) [
+        "plugins/yara"
       ]
       ++ extraPlugins';
   in
@@ -114,6 +118,7 @@
           cppzmq
           re2
           restinio
+        ] ++ lib.optionals (!(stdenv.isDarwin && isStatic)) [
           yara
         ];
         propagatedBuildInputs = [

--- a/nix/tenzir/default.nix
+++ b/nix/tenzir/default.nix
@@ -7,8 +7,9 @@
     pname,
     tenzir-source,
     cmake,
-    cmake-format,
+    ninja,
     pkg-config,
+    lld,
     git,
     boost,
     caf,
@@ -46,7 +47,7 @@
     disableTests ? true,
     pkgsBuildHost,
   }: let
-    inherit (stdenv.hostPlatform) isStatic;
+    inherit (stdenv.hostPlatform) isMusl isStatic;
 
     versionLongOverride' = lib.removePrefix "v" versionLongOverride;
     versionShortOverride' = lib.removePrefix "v" versionShortOverride;
@@ -93,8 +94,11 @@
 
         nativeBuildInputs = [
           cmake
+          ninja
           dpkg
           protobuf
+        ] ++ lib.optionals stdenv.isDarwin [
+          lld
         ];
         propagatedNativeBuildInputs = [pkg-config];
         buildInputs = [
@@ -118,11 +122,12 @@
           caf
           curl
           flatbuffers
-          jemalloc
           robin-map
           simdjson
           spdlog
           xxHash
+        ] ++ lib.optionals isMusl [
+          jemalloc
         ];
 
         cmakeFlags =
@@ -132,13 +137,9 @@
             "-DTENZIR_EDITION_NAME=${lib.toUpper pname}"
             "-DTENZIR_VERSION_TAG=v${versionLong}"
             "-DTENZIR_VERSION_SHORT=v${versionShort}"
-            "-DTENZIR_ENABLE_RELOCATABLE_INSTALLATIONS=${
-              if isStatic
-              then "ON"
-              else "OFF"
-            }"
+            "-DTENZIR_ENABLE_RELOCATABLE_INSTALLATIONS=${lib.boolToString isStatic}"
             "-DTENZIR_ENABLE_BACKTRACE=ON"
-            "-DTENZIR_ENABLE_JEMALLOC=ON"
+            "-DTENZIR_ENABLE_JEMALLOC=${lib.boolToString isMusl}"
             "-DTENZIR_ENABLE_MANPAGES=OFF"
             "-DTENZIR_ENABLE_PYTHON_BINDINGS=OFF"
             "-DTENZIR_ENABLE_BUNDLED_AND_PATCHED_RESTINIO=OFF"
@@ -147,10 +148,11 @@
           ]
           ++ lib.optionals isStatic [
             "-DBUILD_SHARED_LIBS:BOOL=OFF"
-            "-DCMAKE_INTERPROCEDURAL_OPTIMIZATION:BOOL=ON"
-            "-DCPACK_GENERATOR=TGZ;DEB"
+            #"-DCMAKE_INTERPROCEDURAL_OPTIMIZATION:BOOL=ON"
+            "-DCPACK_GENERATOR=${if stdenv.isDarwin then "productbuild" else "TGZ;DEB"}"
             "-DTENZIR_ENABLE_STATIC_EXECUTABLE:BOOL=ON"
             "-DTENZIR_PACKAGE_FILE_NAME_SUFFIX=static"
+            "-DTENZIR_ENABLE_BACKTRACE=${lib.boolToString (!stdenv.isDarwin)}"
           ]
           ++ lib.optionals stdenv.hostPlatform.isx86_64 [
             "-DTENZIR_ENABLE_SSE3_INSTRUCTIONS=ON"
@@ -161,21 +163,63 @@
             "-DTENZIR_ENABLE_AVX_INSTRUCTIONS=OFF"
             "-DTENZIR_ENABLE_AVX2_INSTRUCTIONS=OFF"
           ]
+          ++ lib.optionals stdenv.isDarwin (
+          let
+            compilerName =
+              if stdenv.cc.isClang
+              then "clang"
+              else if stdenv.cc.isGNU
+              then "gcc"
+              else "unknown";
+            # ar with lto support
+            ar = stdenv.cc.bintools.targetPrefix + {
+              "clang" = "ar";
+              "gcc" = "gcc-ar";
+              "unknown" = "ar";
+            }."${compilerName}";
+            # ranlib with lto support
+            ranlib = stdenv.cc.bintools.targetPrefix + {
+              "clang" = "ranlib";
+              "gcc" = "gcc-ranlib";
+              "unknown" = "ranlib";
+            }."${compilerName}";
+          in [
+            #"-DCMAKE_EXE_LINKER_FLAGS=\"-fuse-ld=lld\""
+            #"-DCMAKE_MODULE_LINKER_FLAGS=\"-fuse-ld=lld\""
+            #"-DCMAKE_SHARED_LINKER_FLAGS=\"-fuse-ld=lld\""
+            #"-DCMAKE_C_COMPILER_AR=${ar}"
+            #"-DCMAKE_CXX_COMPILER_AR=${ar}"
+            #"-DCMAKE_C_COMPILER_RANLIB=${ranlib}"
+            #"-DCMAKE_CXX_COMPILER_RANLIB=${ranlib}"
+            # Want's to install into the users home, but that would be the
+            # builder in the Nix context, and that doesn't make sense.
+            "-DTENZIR_ENABLE_INIT_SYSTEM_INTEGRATION=OFF"
+          ])
           ++ lib.optionals disableTests [
             "-DTENZIR_ENABLE_UNIT_TESTS=OFF"
           ]
           ++ extraCmakeFlags;
+
+        # TODO: Fix LTO on darwin by passing these commands by their original
+        # executable names "llvm-ar" and "llvm-ranlib". Should work with
+        # `readlink -f $AR` to find the correct ones.
+        #preConfigure = lib.optionalString stdenv.isDarwin ''
+        #  cmakeFlagsArray+=("-DCMAKE_C_COMPILER_AR=$(command -v $AR)")
+        #  cmakeFlagsArray+=("-DCMAKE_CXX_COMPILER_AR=$(command -v $AR)")
+        #  cmakeFlagsArray+=("-DCMAKE_C_COMPILER_RANLIB=$(command -v $RANLIB)")
+        #  cmakeFlagsArray+=("-DCMAKE_CXX_COMPILER_RANLIB=$(command -v $RANLIB)")
+        #'';
 
         hardeningDisable = lib.optionals isStatic [
           "fortify"
           "pic"
         ];
 
+        #env.DYLD_LIBRARY_PATH = lib.optionalString stdenv.isDarwin "${lib.getLib stdenv.cc.cc.libllvm.out}/lib";
+
         postBuild = lib.optionalString isStatic ''
           ${pkgsBuildHost.nukeReferences}/bin/nuke-refs bin/*
         '';
-        allowedRequisites = lib.optionals isStatic ["out"];
-
         fixupPhase = lib.optionalString isStatic ''
           rm -rf $out/nix-support
         '';
@@ -222,9 +266,16 @@
           maintainers = with maintainers; [tobim];
         };
       }
+      # Buggy on darwin?
+      // lib.optionalAttrs (isStatic && stdenv.isLinux) {
+        allowedRequisites = ["out"];
+      }
       // lib.optionalAttrs isStatic {
+        __noChroot = stdenv.isDarwin;
+
         installPhase = ''
           runHook preInstall
+          PATH=$PATH:/usr/bin
           cmake --install . --component Runtime
           cmakeFlagsArray+=(
             "-UCMAKE_INSTALL_BINDIR"
@@ -242,7 +293,8 @@
           echo "cmake flags: $cmakeFlags ''${cmakeFlagsArray[@]}"
           cmake "$cmakeDir" $cmakeFlags "''${cmakeFlagsArray[@]}"
           cmake --build . --target package
-          install -m 644 -Dt $package package/*.deb package/*.tar.gz
+          rm -rf package/_CPack_Packages
+          install -m 644 -Dt $package package/*
           runHook postInstall
         '';
       });

--- a/plugins/fluent-bit/cmake/Findfluentbit.cmake
+++ b/plugins/fluent-bit/cmake/Findfluentbit.cmake
@@ -34,7 +34,7 @@ if (NOT TARGET fluentbit::fluentbit)
       list(APPEND _link_libs PkgConfig::PC_MUSL_FTS)
     endif ()
     if (APPLE)
-      list(APPEND _link_libs resolv)
+      list(APPEND _link_libs resolv "-framework IOKit")
     endif ()
     set_property(
       TARGET fluentbit::fluentbit

--- a/plugins/fluent-bit/cmake/Findfluentbit.cmake
+++ b/plugins/fluent-bit/cmake/Findfluentbit.cmake
@@ -25,14 +25,21 @@ if (NOT TARGET fluentbit::fluentbit)
     # The target dependencies need to be aligned with how the provided library
     # was built. In this case we assume the fluent-bit package from our Nix
     # scaffold.
+    set(_link_libs)
     find_package(PkgConfig)
     pkg_check_modules(PC_YAML REQUIRED IMPORTED_TARGET yaml-0.1)
-    pkg_check_modules(PC_MUSL_FTS REQUIRED IMPORTED_TARGET musl-fts)
+    list(APPEND _link_libs PkgConfig::PC_YAML)
+    if (NOT APPLE) # We should really have a check for musl here.
+      pkg_check_modules(PC_MUSL_FTS REQUIRED IMPORTED_TARGET musl-fts)
+      list(APPEND _link_libs PkgConfig::PC_MUSL_FTS)
+    endif ()
+    if (APPLE)
+      list(APPEND _link_libs resolv)
+    endif ()
     set_property(
       TARGET fluentbit::fluentbit
       APPEND
-      PROPERTY INTERFACE_LINK_LIBRARIES PkgConfig::PC_YAML
-               PkgConfig::PC_MUSL_FTS)
+      PROPERTY INTERFACE_LINK_LIBRARIES "${_link_libs}")
     # Inject the vendored static libs.
     file(GLOB FLUENT_BIT_LIBS "${FLUENT_BIT_LOCATION}/*.a")
     set_property(

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -105,6 +105,9 @@ then
   echo "flake inputs, or use your preferred method to include third-party"
   echo "modules on classic NixOS."
   exit 0
+elif [ "${platform}" = "macOS" ]
+then
+  package_url="https://storage.googleapis.com/tenzir-dist-public/packages/main/macOS/tenzir-static-latest.pkg"
 else
   echo "We do not offer pre-built packages for ${platform}." \
       "Your options:"
@@ -198,6 +201,15 @@ then
   confirm
   action "Unpacking tarball"
   eval "${cmd1}"
+elif [ "${platform}" = "macOS" ]
+then
+  cmd1="sudo installer -pkg \"${tmpdir}/${package}\" -target /"
+  echo "This script is about to run the following command:"
+  echo
+  echo "  - ${cmd1}"
+  confirm
+  action "Installing Tenzir"
+  eval "${cmd1}"
 fi
 
 # Test the installation.
@@ -211,7 +223,7 @@ echo "You're all set! Next steps:"
 echo
 echo "  - Ensure that ${bold}${prefix}/bin${normal} is in your \$PATH"
 echo "  - Run a pipeline via ${green}tenzir <pipeline>${normal}"
-if [ "${platform}" = "Linux" ]
+if [ "${platform}" = "Linux" ] || [ "${platform}" = "macOS" ]
 then
   echo "  - Spawn a node via ${green}tenzir-node${normal}"
 fi

--- a/scripts/macOS/install-dev-dependencies.sh
+++ b/scripts/macOS/install-dev-dependencies.sh
@@ -21,6 +21,7 @@ brew install \
     libunwind-headers \
     llvm \
     ninja \
+    node \
     openssl \
     pandoc \
     pkg-config \

--- a/shell.nix
+++ b/shell.nix
@@ -9,8 +9,11 @@ in
       nativeBuildInputs =
         [
           pkgs.ccache
-          pkgs.speeve
           pkgs.clang-tools_16
+          pkgs.cmake-format
+          pkgs.speeve
+          pkgs.poetry
+          pkgs.python3Packages.spdx-tools
         ] ++ pkgs.tenzir-functional-test-deps
           ++ pkgs.tenzir-integration-test-deps
           ++ lib.optionals (!(pkgs.stdenv.hostPlatform.useLLVM or false)) [
@@ -18,10 +21,9 @@ in
           pkgs.clang_16
           # Bintools come with a wrapped lld for faster linking.
           pkgs.llvmPackages_16.bintools
-          pkgs.cmake-format
+        ] # Temporarily only on Linux.
+          ++ lib.optionals pkgs.stdenv.isLinux [
           pkgs.pandoc
-          pkgs.poetry
-          pkgs.python3Packages.spdx-tools
         ];
       # To build libcaf_openssl with bundled CAF.
       buildInputs = [pkgs.openssl];

--- a/tenzir/CMakeLists.txt
+++ b/tenzir/CMakeLists.txt
@@ -1,6 +1,9 @@
 add_executable(tenzir tenzir.cpp)
 TenzirTargetEnableTooling(tenzir)
 target_link_libraries(tenzir PRIVATE tenzir::internal tenzir::libtenzir)
+if (TENZIR_ENABLE_JEMALLOC)
+  target_link_libraries(tenzir PRIVATE jemalloc::jemalloc_)
+endif ()
 TenzirTargetLinkWholeArchive(tenzir PRIVATE tenzir::libtenzir_builtins)
 add_executable(tenzir::tenzir ALIAS tenzir)
 

--- a/tenzir/CMakeLists.txt
+++ b/tenzir/CMakeLists.txt
@@ -62,48 +62,54 @@ TenzirInstallExampleConfiguration(
 
 # -- init system integration ---------------------------------------------------
 
-# TODO: This should be behind an option, and work for Linux as well.
+option(TENZIR_ENABLE_INIT_SYSTEM_INTEGRATION
+       "Integrate with init systems when installing" ON)
+add_feature_info(
+  "TENZIR_ENABLE_INIT_SYSTEM_INTEGRATION" TENZIR_ENABLE_INIT_SYSTEM_INTEGRATION
+  "integrate with init systems when installing")
 
-if (${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
-  # Install rc.d script on FreeBSD into PREFIX/etc/rc.d.
-  # TODO: Technically this can break for relocatable binaries when the install
-  # prefix at build-time is different than the install prefix at install-time.
-  # The macOS installation below handles this correctly, and the FreeBSD
-  # installation should be adapted to work similarly.
-  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/services/rc.d/tenzir.in"
-                 "${CMAKE_CURRENT_BINARY_DIR}/services/rc.d/tenzir" @ONLY)
-  install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/services/rc.d/tenzir"
-    DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}/rc.d"
-    PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_EXECUTE
-    COMPONENT Runtime)
-elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
-  # Install launchd script on macOS into ~/Library/LaunchAgents
-  install(
-    CODE "\
-    if (NOT IS_ABSOLUTE \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}\")
-      string(PREPEND CMAKE_INSTALL_PREFIX \"${CMAKE_SOURCE_DIR}/\")
-    endif ()
-    set(TENZIR_BINARY \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/bin/$<TARGET_FILE_NAME:tenzir>\")
-    set(TENZIR_WORKING_DIRECTORY \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/share/tenzir\")
-    message(STATUS
-      \"Installing: \$ENV{HOME}/Library/LaunchAgents/com.tenzir.tenzir.plist\")
+if (TENZIR_ENABLE_INIT_SYSTEM_INTEGRATION)
+  if (${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
+    # Install rc.d script on FreeBSD into PREFIX/etc/rc.d.
+    # TODO: Technically this can break for relocatable binaries when the install
+    # prefix at build-time is different than the install prefix at install-time.
+    # The macOS installation below handles this correctly, and the FreeBSD
+    # installation should be adapted to work similarly.
+    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/services/rc.d/tenzir.in"
+                   "${CMAKE_CURRENT_BINARY_DIR}/services/rc.d/tenzir" @ONLY)
+    install(
+      FILES "${CMAKE_CURRENT_BINARY_DIR}/services/rc.d/tenzir"
+      DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}/rc.d"
+      PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_EXECUTE
+      COMPONENT Runtime)
+  elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+    # Install launchd script on macOS into ~/Library/LaunchAgents
+    install(
+      CODE "\
+      if (NOT IS_ABSOLUTE \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}\")
+        string(PREPEND CMAKE_INSTALL_PREFIX \"${CMAKE_SOURCE_DIR}/\")
+      endif ()
+      set(TENZIR_BINARY \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/bin/$<TARGET_FILE_NAME:tenzir>\")
+      set(TENZIR_WORKING_DIRECTORY \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/share/tenzir\")
+      message(STATUS
+        \"Installing: \$ENV{HOME}/Library/LaunchAgents/com.tenzir.tenzir.plist\")
+      configure_file(
+        \"${CMAKE_CURRENT_SOURCE_DIR}/services/launchd/com.tenzir.tenzir.plist.in\"
+        \"\$ENV{HOME}/Library/LaunchAgents/com.tenzir.tenzir.plist\" @ONLY)"
+      COMPONENT Runtime)
+  elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    # Not all Linux distros use systemd, but those we care about at the moment do.
+    # TODO: We don't consider CPACK_PACKAGE_INSTALL_PREFIX here, this could
+    # potentially be solved with a more involved CPack setup. See also the
+    # comment at the beginning of cmake/Package.cmake.
     configure_file(
-      \"${CMAKE_CURRENT_SOURCE_DIR}/services/launchd/com.tenzir.tenzir.plist.in\"
-      \"\$ENV{HOME}/Library/LaunchAgents/com.tenzir.tenzir.plist\" @ONLY)"
-    COMPONENT Runtime)
-elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-  # Not all Linux distros use systemd, but those we care about at the moment do.
-  # TODO: We don't consider CPACK_PACKAGE_INSTALL_PREFIX here, this could
-  # potentially be solved with a more involved CPack setup. See also the
-  # comment at the beginning of cmake/Package.cmake.
-  configure_file(
-    "${CMAKE_CURRENT_SOURCE_DIR}/services/systemd/tenzir-node.service.in"
-    "${CMAKE_CURRENT_BINARY_DIR}/tenzir-node.service" @ONLY)
-  install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/tenzir-node.service"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/systemd/system/"
-    COMPONENT Runtime)
+      "${CMAKE_CURRENT_SOURCE_DIR}/services/systemd/tenzir-node.service.in"
+      "${CMAKE_CURRENT_BINARY_DIR}/tenzir-node.service" @ONLY)
+    install(
+      FILES "${CMAKE_CURRENT_BINARY_DIR}/tenzir-node.service"
+      DESTINATION "${CMAKE_INSTALL_LIBDIR}/systemd/system/"
+      COMPONENT Runtime)
+  endif ()
 endif ()
 
 # -- functional tests ----------------------------------------------------------


### PR DESCRIPTION
This PR makes it possible to build macOS packages that only need standard system libraries to run.

Our approach uses the same Nix dependency management as for the static Linux package under the hood.
