### PR TITLE
Allow pushing the demo node image to public registries

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -21,8 +21,8 @@ jobs:
           # Create 'name registry' pairs
           jq -r '.editions[] | select(.registries | length > 0) | .name as $name | .registries[]? // .registries | [ $name, . ] | join(" ")' \
             <<< '${{ inputs.config }}' | while read -r name registry; do
-            # Explicitly allow tenzir and dev images.
-            [[ "${name}" =~ ^tenzir(|-dev|-deps|-node|-de|-node-de)$ ]] && continue
+            # Explicitly allow tenzir, demo and dev images.
+            [[ "${name}" =~ ^tenzir(|-dev|-deps|-node|-de|-node-de|-demo)$ ]] && continue
             # Explicitly allow private registries.
             [[ "${registry}" == "622024652768.dkr.ecr.eu-west-1.amazonaws.com" ]] && continue
             echo "::error Pushing ${name} to ${registry} is forbidden"


### PR DESCRIPTION
Originally we considered putting enterprise features in the demo node, so we needed to enforce a private registry.

However, the current demo node is just the community addition in combination with a public dataset, so
we can drop this restriction for now.