### PR TITLE
Ensure exporter metrics don't get lost

### DIFF
--- a/changelog/next/bug-fixes/3633--ensure-exporter-metrics.md
+++ b/changelog/next/bug-fixes/3633--ensure-exporter-metrics.md
@@ -1,1 +1,2 @@
-The "exporter" metrics will now be emitted in case the exporter finishes early.
+The `exporter.*` metrics will now be emitted in case the exporter finishes
+early.

--- a/changelog/next/bug-fixes/3633--ensure-exporter-metrics.md
+++ b/changelog/next/bug-fixes/3633--ensure-exporter-metrics.md
@@ -1,0 +1,1 @@
+The "exporter" metrics will now be emitted in case the exporter finishes early.

--- a/libtenzir/src/exporter.cpp
+++ b/libtenzir/src/exporter.cpp
@@ -95,8 +95,8 @@ void attach_result_stream(
                   {"query",
                    fmt::to_string(state.self_ptr->state.query_context.id)}},
             };
-            state.self->send(state.self_ptr->state.accountant, atom::metrics_v,
-                             std::move(r));
+            state.self_ptr->send(state.self_ptr->state.accountant,
+                                 atom::metrics_v, std::move(r));
           }
           shutdown_stream(state.self_ptr->state.result_stream);
         }

--- a/libtenzir/src/exporter.cpp
+++ b/libtenzir/src/exporter.cpp
@@ -57,6 +57,7 @@ void attach_result_stream(
   struct stream_state {
     exporter_actor self;
     exporter_actor::stateful_pointer<exporter_state> self_ptr{nullptr};
+    size_t num_shipped = 0;
   };
   self->state.result_stream = // [formatting]
     caf::attach_stream_source(
@@ -69,6 +70,7 @@ void attach_result_stream(
         auto& results = state.self_ptr->state.sink_buffer;
         (void)hint; // We could consider using `hint`.
         if (!results.empty()) {
+          state.num_shipped += results.front().rows();
           out.push(std::move(results.front()));
           results.pop_front();
         }
@@ -79,8 +81,17 @@ void attach_result_stream(
         auto should_end = state.self_ptr->state.executor.unsafe_current()
                             == state.self_ptr->state.executor.end()
                           && state.self_ptr->state.sink_buffer.empty();
-        if (should_end)
+        if (should_end) {
+          if (state.self_ptr->state.accountant) {
+            state.self_ptr->send(
+              state.self_ptr->state.accountant, atom::metrics_v,
+              "exporter.shipped", state.num_shipped,
+              metrics_metadata{
+                {"query",
+                 fmt::to_string(state.self_ptr->state.query_context.id)}});
+          }
           shutdown_stream(state.self_ptr->state.result_stream);
+        }
         return should_end;
       })
       .ptr();
@@ -450,18 +461,12 @@ auto exporter(exporter_actor::stateful_pointer<exporter_state> self,
                      self->state.query_status.expected,
                      tenzir::to_string(runtime));
         TENZIR_TRACEPOINT(query_done, self->state.id.as_u64().first);
-        if (self->state.accountant) {
-          auto r = report {
-            .data = {
-              {"exporter.hits.runtime", runtime},
-              {"exporter.shipped", self->state.query_status.shipped},
-            },
-            .metadata =
-              metrics_metadata{
-                {"query", fmt::to_string(self->state.query_context.id)}},
-          };
-          self->send(self->state.accountant, atom::metrics_v, std::move(r));
-        }
+        if (self->state.accountant)
+          self->send(
+            self->state.accountant, atom::metrics_v, "exporter.hits.runtime",
+            runtime,
+            metrics_metadata{
+              {"query", fmt::to_string(self->state.query_context.id)}});
         if (!self->state.result_stream)
           self->send_exit(self->state.sink, caf::exit_reason::user_shutdown);
       }


### PR DESCRIPTION
Before this change metrics from the exporter were not sent in case the exporter itself hit a completion condition (either by shipping the requester number of events or hitting a timeout), while the database was still able to provide more results.

We solve the issue by moving the complete metrics reporting into a code path that is guaranteed to be called once.