### PR TITLE
Relax type restrictions for queries with numeric literals

### DIFF
--- a/changelog/next/features/3634--numeric-literals.md
+++ b/changelog/next/features/3634--numeric-literals.md
@@ -1,0 +1,4 @@
+In `where <expression>`, the types of numeric literals and numeric fields in an
+equality or relational comparison must no longer match exactly. The literals
+`+42`, `42` or `42.0` now compare against fields of types `int64`, `uint64`, and
+`double` as expected.

--- a/libtenzir/include/tenzir/expression.hpp
+++ b/libtenzir/include/tenzir/expression.hpp
@@ -85,6 +85,9 @@ auto inspect(Inspector& f, field_extractor& x) {
 /// Extracts one or more values according to a given type.
 struct type_extractor : detail::totally_ordered<type_extractor> {
   explicit type_extractor(tenzir::type t = {});
+  explicit type_extractor(concrete_type auto t)
+    : type_extractor(tenzir::type{std::move(t)}) {
+  }
 
   tenzir::type type;
 };

--- a/libtenzir/src/expression_visitors.cpp
+++ b/libtenzir/src/expression_visitors.cpp
@@ -403,9 +403,11 @@ caf::expected<expression>
 type_resolver::operator()(const type_extractor& ex, const data& d) {
   if (!ex.type) {
     auto matches = [&](const type& t) {
-      for (const auto& name : t.names())
-        if (name == ex.type.name())
+      for (const auto& name : t.names()) {
+        if (name == ex.type.name()) {
           return compatible(t, op_, d);
+        }
+      }
       return false;
     };
     return resolve_extractor(matches, d);
@@ -428,8 +430,9 @@ type_resolver::operator()(const field_extractor& ex, const data& d) {
   auto suffixes = schema_.resolve_key_suffix(ex.field, schema_name_);
   for (auto&& offset : suffixes) {
     const auto f = schema_.field(offset);
-    if (!compatible(f.type, op_, d))
+    if (not compatible(f.type, op_, d)) {
       continue;
+    }
     auto x = data_extractor{schema_, offset};
     connective.emplace_back(predicate{std::move(x), op_, d});
   }

--- a/libtenzir/src/type.cpp
+++ b/libtenzir/src/type.cpp
@@ -1474,16 +1474,25 @@ bool compatible(const type& lhs, relational_operator op,
     return caf::holds_alternative<string_type>(x)
            && caf::holds_alternative<pattern>(y);
   };
+  auto numeric = [](auto& x, auto& y) {
+    return (caf::holds_alternative<int64_type>(x)
+            or caf::holds_alternative<uint64_type>(x)
+            or caf::holds_alternative<double_type>(x))
+           and (caf::holds_alternative<int64_t>(y)
+                or caf::holds_alternative<uint64_t>(y)
+                or caf::holds_alternative<double>(y));
+  };
   switch (op) {
     case relational_operator::equal:
     case relational_operator::not_equal:
       return !lhs || caf::holds_alternative<caf::none_t>(rhs)
-             || string_and_pattern(lhs, rhs) || congruent(lhs, rhs);
+             || numeric(lhs, rhs) || string_and_pattern(lhs, rhs)
+             || congruent(lhs, rhs);
     case relational_operator::less:
     case relational_operator::less_equal:
     case relational_operator::greater:
     case relational_operator::greater_equal:
-      return congruent(lhs, rhs);
+      return congruent(lhs, rhs) or numeric(lhs, rhs);
     case relational_operator::in:
     case relational_operator::not_in:
       if (caf::holds_alternative<string_type>(lhs))

--- a/libtenzir/test/expression_parseable.cpp
+++ b/libtenzir/test/expression_parseable.cpp
@@ -164,14 +164,39 @@ TEST(parseable - expression) {
 TEST(parseable - value predicate) {
   expression expr;
   CHECK(parsers::expr("42"s, expr));
-  auto pred = caf::get_if<predicate>(&expr);
-  REQUIRE(pred);
-  auto extractor = caf::get_if<type_extractor>(&pred->lhs);
-  REQUIRE(extractor);
-  CHECK(caf::holds_alternative<uint64_type>(extractor->type));
-  CHECK(caf::holds_alternative<data>(pred->rhs));
-  CHECK_EQUAL(pred->op, relational_operator::equal);
-  CHECK(caf::get<data>(pred->rhs) == data{42u});
+  auto disj = caf::get_if<disjunction>(&expr);
+  REQUIRE(disj);
+  REQUIRE_EQUAL(disj->size(), 3u);
+  {
+    auto pred = caf::get_if<predicate>(&(*disj)[0]);
+    REQUIRE(pred);
+    auto extractor = caf::get_if<type_extractor>(&pred->lhs);
+    REQUIRE(extractor);
+    CHECK(caf::holds_alternative<int64_type>(extractor->type));
+    CHECK(caf::holds_alternative<data>(pred->rhs));
+    CHECK_EQUAL(pred->op, relational_operator::equal);
+    CHECK(caf::get<data>(pred->rhs) == data{int64_t{42}});
+  }
+  {
+    auto pred = caf::get_if<predicate>(&(*disj)[1]);
+    REQUIRE(pred);
+    auto extractor = caf::get_if<type_extractor>(&pred->lhs);
+    REQUIRE(extractor);
+    CHECK(caf::holds_alternative<uint64_type>(extractor->type));
+    CHECK(caf::holds_alternative<data>(pred->rhs));
+    CHECK_EQUAL(pred->op, relational_operator::equal);
+    CHECK(caf::get<data>(pred->rhs) == data{42u});
+  }
+  {
+    auto pred = caf::get_if<predicate>(&(*disj)[2]);
+    REQUIRE(pred);
+    auto extractor = caf::get_if<type_extractor>(&pred->lhs);
+    REQUIRE(extractor);
+    CHECK(caf::holds_alternative<double_type>(extractor->type));
+    CHECK(caf::holds_alternative<data>(pred->rhs));
+    CHECK_EQUAL(pred->op, relational_operator::equal);
+    CHECK(caf::get<data>(pred->rhs) == data{42.0});
+  }
 }
 
 TEST(parseable - field extractor predicate) {

--- a/web/docs/language/expressions.md
+++ b/web/docs/language/expressions.md
@@ -80,9 +80,9 @@ available types. Each letter in a cell denotes a set of operators:
 | | **Bool** | **Int64** | **UInt64** | **Double** | **Duration** | **Time** | **String** | **Pattern** | **IP** | **Subnet** | **Enum** | **List**
 ---|---|---|---|---|---|---|---|---|---|---|---|--
  **Bool** | E |  |  |  |  |  |  |  |  |  |  | M
- **Int64** |  | ER |  |  |  |  |  |  |  |  |  | M
- **UInt64** |  |  | ER |  |  |  |  |  |  |  |  | M
- **Double** |  |  |  | ER |  |  |  |  |  |  |  | M
+ **Int64** |  | ER | ER | ER |  |  |  |  |  |  |  | M
+ **UInt64** |  | ER | ER | ER |  |  |  |  |  |  |  | M
+ **Double** |  | ER | ER | ER |  |  |  |  |  |  |  | M
  **Duration** |  |  |  |  | ER |  |  |  |  |  |  | M
  **Time** |  |  |  |  |  | ER |  |  |  |  |  | M
  **String** |  |  |  |  |  |  | EM | EM |  |  |  | M


### PR DESCRIPTION
This changes expression evaluation for queries with numeric literals in two ways:
1. Queries with a numeric literal against a field or type extractor no longer require the field's type and the numeric literal's inferred type to match exactly. This allows for querying without knowing whether a value is a signed or unsigned integer or a floating point number.
2. Queries with value predicates (i.e., just a value without a field or type to compare against) now automatically expand to a disjunction covering all three numeric types when the value predicate is a numeric literal.

```[tasklist]
### Tasks
- [x] Relax compatibility check for predicates with numeric values
- [x] Make sure that expression evaluation handles overflow correctly (i.e., uses `std::cmp_*` functions)
- [x] Expand value predicates for numeric literals to a disjunction covering all three types
- [x] Update test expectations
- [x] Write a changelog entry
- [x] Check if documentation must be updated
```