### PR TITLE
Improve `summarize` result for empty inputs

### DIFF
--- a/changelog/next/features/3640--summarize-empty-input.md
+++ b/changelog/next/features/3640--summarize-empty-input.md
@@ -1,0 +1,4 @@
+If the `summarize` operator has no `by` clause, it now returns a result even
+if there is no input. For example, `summarize num=count(.)` returns an event
+with `{"num": 0}`. Aggregation functions which do not have a single default
+value, for example because it would depend on the input type, return `null`.

--- a/libtenzir/builtins/aggregation-functions/all.cpp
+++ b/libtenzir/builtins/aggregation-functions/all.cpp
@@ -70,6 +70,10 @@ class plugin : public virtual aggregation_function_plugin {
                                        "support type {}",
                                        input_type));
   }
+
+  auto aggregation_default() const -> data override {
+    return true;
+  }
 };
 
 } // namespace

--- a/libtenzir/builtins/aggregation-functions/any.cpp
+++ b/libtenzir/builtins/aggregation-functions/any.cpp
@@ -70,6 +70,10 @@ class plugin : public virtual aggregation_function_plugin {
                                        "support type {}",
                                        input_type));
   }
+
+  auto aggregation_default() const -> data override {
+    return false;
+  }
 };
 
 } // namespace

--- a/libtenzir/builtins/aggregation-functions/count.cpp
+++ b/libtenzir/builtins/aggregation-functions/count.cpp
@@ -59,6 +59,10 @@ class plugin : public virtual aggregation_function_plugin {
   make_aggregation_function(const type& input_type) const override {
     return std::make_unique<count_function>(input_type);
   }
+
+  auto aggregation_default() const -> data override {
+    return uint64_t{0};
+  }
 };
 
 } // namespace

--- a/libtenzir/builtins/aggregation-functions/count_distinct.cpp
+++ b/libtenzir/builtins/aggregation-functions/count_distinct.cpp
@@ -103,6 +103,10 @@ class plugin : public virtual aggregation_function_plugin {
     };
     return caf::visit(f, input_type);
   }
+
+  auto aggregation_default() const -> data override {
+    return uint64_t{0};
+  }
 };
 
 } // namespace

--- a/libtenzir/builtins/aggregation-functions/distinct.cpp
+++ b/libtenzir/builtins/aggregation-functions/distinct.cpp
@@ -109,6 +109,10 @@ class plugin : public virtual aggregation_function_plugin {
     };
     return caf::visit(f, input_type);
   }
+
+  auto aggregation_default() const -> data override {
+    return caf::none;
+  }
 };
 
 } // namespace

--- a/libtenzir/builtins/aggregation-functions/distinct.cpp
+++ b/libtenzir/builtins/aggregation-functions/distinct.cpp
@@ -111,7 +111,7 @@ class plugin : public virtual aggregation_function_plugin {
   }
 
   auto aggregation_default() const -> data override {
-    return caf::none;
+    return list{};
   }
 };
 

--- a/libtenzir/builtins/aggregation-functions/max.cpp
+++ b/libtenzir/builtins/aggregation-functions/max.cpp
@@ -69,6 +69,10 @@ class plugin : public virtual aggregation_function_plugin {
     };
     return caf::visit(f, input_type);
   }
+
+  auto aggregation_default() const -> data override {
+    return caf::none;
+  }
 };
 
 } // namespace

--- a/libtenzir/builtins/aggregation-functions/min.cpp
+++ b/libtenzir/builtins/aggregation-functions/min.cpp
@@ -69,6 +69,10 @@ class plugin : public virtual aggregation_function_plugin {
     };
     return caf::visit(f, input_type);
   }
+
+  auto aggregation_default() const -> data override {
+    return caf::none;
+  }
 };
 
 } // namespace

--- a/libtenzir/builtins/aggregation-functions/sample.cpp
+++ b/libtenzir/builtins/aggregation-functions/sample.cpp
@@ -64,6 +64,10 @@ class plugin : public virtual aggregation_function_plugin {
   make_aggregation_function(const type& input_type) const override {
     return std::make_unique<sample_function>(input_type);
   }
+
+  auto aggregation_default() const -> data override {
+    return caf::none;
+  }
 };
 
 } // namespace

--- a/libtenzir/builtins/aggregation-functions/sum.cpp
+++ b/libtenzir/builtins/aggregation-functions/sum.cpp
@@ -106,6 +106,10 @@ class plugin : public virtual aggregation_function_plugin {
     };
     return caf::visit(f, input_type);
   }
+
+  auto aggregation_default() const -> data override {
+    return caf::none;
+  }
 };
 
 } // namespace

--- a/libtenzir/include/tenzir/plugin.hpp
+++ b/libtenzir/include/tenzir/plugin.hpp
@@ -609,6 +609,9 @@ public:
   /// function.
   [[nodiscard]] virtual caf::expected<std::unique_ptr<aggregation_function>>
   make_aggregation_function(const type& input_type) const = 0;
+
+  /// Return the value that should be used if there is no input.
+  virtual auto aggregation_default() const -> data = 0;
 };
 
 // -- language plugin ---------------------------------------------------
@@ -976,41 +979,41 @@ extern const char* TENZIR_PLUGIN_VERSION;
 #else
 
 #  define TENZIR_REGISTER_PLUGIN(name)                                         \
-    extern "C" auto tenzir_plugin_create()->::tenzir::plugin* {                \
+    extern "C" auto tenzir_plugin_create() -> ::tenzir::plugin* {              \
       /* NOLINTNEXTLINE(cppcoreguidelines-owning-memory) */                    \
       return new (name);                                                       \
     }                                                                          \
     extern "C" auto tenzir_plugin_destroy(class ::tenzir::plugin* plugin)      \
-      ->void {                                                                 \
+      -> void {                                                                \
       /* NOLINTNEXTLINE(cppcoreguidelines-owning-memory) */                    \
       delete plugin;                                                           \
     }                                                                          \
-    extern "C" auto tenzir_plugin_version()->const char* {                     \
+    extern "C" auto tenzir_plugin_version() -> const char* {                   \
       return TENZIR_PLUGIN_VERSION;                                            \
     }                                                                          \
-    extern "C" auto tenzir_libtenzir_version()->const char* {                  \
+    extern "C" auto tenzir_libtenzir_version() -> const char* {                \
       return ::tenzir::version::version;                                       \
     }                                                                          \
-    extern "C" auto tenzir_libtenzir_build_tree_hash()->const char* {          \
+    extern "C" auto tenzir_libtenzir_build_tree_hash() -> const char* {        \
       return ::tenzir::version::build::tree_hash;                              \
     }
 
 #  define TENZIR_REGISTER_PLUGIN_TYPE_ID_BLOCK_1(name)                         \
-    extern "C" auto tenzir_plugin_register_type_id_block()->void {             \
+    extern "C" auto tenzir_plugin_register_type_id_block() -> void {           \
       caf::init_global_meta_objects<::caf::id_block::name>();                  \
     }                                                                          \
     extern "C" auto tenzir_plugin_type_id_block()                              \
-      ->::tenzir::plugin_type_id_block {                                       \
+      -> ::tenzir::plugin_type_id_block {                                      \
       return {::caf::id_block::name::begin, ::caf::id_block::name::end};       \
     }
 
 #  define TENZIR_REGISTER_PLUGIN_TYPE_ID_BLOCK_2(name1, name2)                 \
-    extern "C" auto tenzir_plugin_register_type_id_block()->void {             \
+    extern "C" auto tenzir_plugin_register_type_id_block() -> void {           \
       caf::init_global_meta_objects<::caf::id_block::name1>();                 \
       caf::init_global_meta_objects<::caf::id_block::name2>();                 \
     }                                                                          \
     extern "C" auto tenzir_plugin_type_id_block()                              \
-      ->::tenzir::plugin_type_id_block {                                       \
+      -> ::tenzir::plugin_type_id_block {                                      \
       return {::caf::id_block::name1::begin < ::caf::id_block::name2::begin    \
                 ? ::caf::id_block::name1::begin                                \
                 : ::caf::id_block::name2::begin,                               \

--- a/tenzir/integration/reference/summarize-all-none-some/step_00.ref
+++ b/tenzir/integration/reference/summarize-all-none-some/step_00.ref
@@ -1,4 +1,8 @@
 {
+  "_path": null,
+  "x": null
+}
+{
   "_path": "sip",
   "x": [
     "sip"
@@ -195,10 +199,6 @@
   "x": [
     "corelight_metrics_disk"
   ]
-}
-{
-  "_path": null,
-  "x": null
 }
 warning: group-by column `_path` does not exist for schema `tenzir.json`
 warning: aggregation column `_path` does not exist for schema `tenzir.json`

--- a/tenzir/integration/reference/summarize-all-none-some/step_02.ref
+++ b/tenzir/integration/reference/summarize-all-none-some/step_02.ref
@@ -83,10 +83,6 @@
   "x": null
 }
 {
-  "_path": null,
-  "x": null
-}
-{
   "_path": "corelight_metrics_system",
   "x": null
 }
@@ -132,6 +128,10 @@
 }
 {
   "_path": "corelight_metrics_disk",
+  "x": null
+}
+{
+  "_path": null,
   "x": null
 }
 warning: group-by column `_path` does not exist for schema `tenzir.json`

--- a/tenzir/integration/reference/summarize-all-none-some/step_04.ref
+++ b/tenzir/integration/reference/summarize-all-none-some/step_04.ref
@@ -1,4 +1,8 @@
 {
+  "id.orig_h": null,
+  "x": null
+}
+{
   "id.orig_h": "213.32.39.37",
   "x": null
 }
@@ -84,10 +88,6 @@
 }
 {
   "id.orig_h": "106.75.22.216",
-  "x": null
-}
-{
-  "id.orig_h": null,
   "x": null
 }
 warning: aggregation column `y` does not exist for schema `tenzir.json`

--- a/tenzir/integration/reference/summarize-all-none-some/step_06.ref
+++ b/tenzir/integration/reference/summarize-all-none-some/step_06.ref
@@ -1,4 +1,21 @@
 {
+  "id.orig_h": null,
+  "x": [
+    "corelight_metrics_bro",
+    "corelight_metrics_cpu",
+    "corelight_metrics_disk",
+    "corelight_metrics_iface",
+    "corelight_metrics_memory",
+    "corelight_metrics_system",
+    "dhcp",
+    "files",
+    "pe",
+    "reporter",
+    "software",
+    "weird.123.190"
+  ]
+}
+{
   "id.orig_h": "193.10.255.99",
   "x": null
 }
@@ -127,23 +144,6 @@
   "id.orig_h": "106.75.22.216",
   "x": [
     "radius"
-  ]
-}
-{
-  "id.orig_h": null,
-  "x": [
-    "corelight_metrics_bro",
-    "corelight_metrics_cpu",
-    "corelight_metrics_disk",
-    "corelight_metrics_iface",
-    "corelight_metrics_memory",
-    "corelight_metrics_system",
-    "dhcp",
-    "files",
-    "pe",
-    "reporter",
-    "software",
-    "weird.123.190"
   ]
 }
 warning: aggregation column `_path` does not exist for schema `tenzir.json`

--- a/tenzir/integration/reference/summarize-all-none-some/step_07.ref
+++ b/tenzir/integration/reference/summarize-all-none-some/step_07.ref
@@ -132,12 +132,6 @@
   ]
 }
 {
-  "_path": null,
-  "x": [
-    "193.10.255.99"
-  ]
-}
-{
   "_path": "ftp",
   "x": [
     "152.136.69.32"
@@ -177,6 +171,12 @@
   "_path": "http",
   "x": [
     "113.107.111.117"
+  ]
+}
+{
+  "_path": null,
+  "x": [
+    "193.10.255.99"
   ]
 }
 warning: group-by column `_path` does not exist for schema `tenzir.json`


### PR DESCRIPTION
If the `summarize` operator has no `by` clause, it now returns a result even if there is no input. For example, `summarize num=count(.)` returns an event with `{"num": 0}`. Aggregation functions which do not have a single default value, for example because it would depend on the input type, return `null`.