### PR TITLE
Add an operator blocklist

### DIFF
--- a/changelog/next/features/3642--operator-blocklist.md
+++ b/changelog/next/features/3642--operator-blocklist.md
@@ -1,0 +1,5 @@
+The `tenzir.disable-plugins` option is a list of names of plugins and builtins
+to explicitly forbid from being used in Tenzir. For example, adding `export`
+will prohibit use of the `shell` operator builtin, and adding `shell` will
+prohibit use of the `kafka` connector plugin. This allows for a more
+fine-grained control than the `tenzir.allow-unsafe-pipelines` option.

--- a/libtenzir/src/application.cpp
+++ b/libtenzir/src/application.cpp
@@ -83,6 +83,10 @@ void add_root_opts(command& cmd) {
     "plugins to load at startup; the special values 'bundled' "
     "and 'all' enable autoloading of bundled and all plugins "
     "respectively.");
+  cmd.options.add<caf::config_value::list>(
+    "?tenzir", "disable-plugins",
+    "plugins and builtins to explicitly disable; use to forbid use of "
+    "operators, connectors, or formats by policy.");
   cmd.options.add<std::string>("?tenzir", "aging-frequency",
                                "interval between two aging "
                                "cycles");

--- a/libtenzir/src/plugin.cpp
+++ b/libtenzir/src/plugin.cpp
@@ -250,6 +250,16 @@ load(const std::vector<std::string>& bundled_plugins,
       return std::move(plugin.error());
     }
   }
+  // Remove plugins that are explicitly disabled.
+  const auto disabled_plugins
+    = caf::get_or(cfg, "tenzir.disable-plugins", std::vector<std::string>{""});
+  const auto is_disabled_plugin = [&](const auto& plugin) {
+    return std::find(disabled_plugins.begin(), disabled_plugins.end(), plugin)
+           != disabled_plugins.end();
+  };
+  get_mutable().erase(std::remove_if(get_mutable().begin(), get_mutable().end(),
+                                     is_disabled_plugin),
+                      get_mutable().end());
   // Sort loaded plugins by name (case-insensitive).
   std::sort(get_mutable().begin(), get_mutable().end());
   return loaded_plugin_paths;

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -85,6 +85,13 @@ tenzir:
   # to load the example plugin.
   plugins: []
 
+  # Names of plugins and builtins to explicitly forbid from being used in
+  # Tenzir. For example, adding `shell` will prohibit use of the `shell`
+  # operator builtin, and adding `kafka` will prohibit use of the `kafka`
+  # connector plugin. This allows more fine-grained control than the
+  # `tenzir.allow-unsafe-pipelines` option.
+  disable-plugins: []
+
   # The unique ID of this node.
   node-id: "node"
 

--- a/web/docs/command-line.md
+++ b/web/docs/command-line.md
@@ -232,3 +232,17 @@ You can get the list of available plugins using the
 ```bash
 tenzir 'show plugins'
 ```
+
+### Block plugins
+
+As part of your Tenzir deployment, you can selectively disable plugins by name.
+For example, if you do not want the `shell` operator and the `kafka` connector
+to be available, set this in your configuration:
+
+```yaml
+# <configdir>/tenzir/tenzir.yaml
+tenzir:
+  disable-plugins
+    - shell
+    - kafka
+```

--- a/web/docs/operators/modifier.md
+++ b/web/docs/operators/modifier.md
@@ -42,3 +42,15 @@ overrides:
    tenzir:
      allow-unsafe-pipelines: true
    ```
+
+   If you want more fine-grained control about which operators, operator
+   modifiers, formats, and connectors are available, you can selectively disable
+   them in the configuration:
+
+   ```yaml {0} title="tenzir.yaml"
+   tenzir:
+     allow-unsafe-pipelines: true
+     disable-plugins:
+       - shell
+       - remote
+   ```


### PR DESCRIPTION
The `tenzir.disable-plugins` option is a list of names of plugins and builtins to explicitly forbid from being used in Tenzir.

For example, adding `export` will prohibit use of the `export` operator builtin, and adding `kafka` will prohibit use of the `kafka` connector plugin. This allows for a more fine-grained control than the `tenzir.allow-unsafe-pipelines` option.

```[tasklist]
### Tasks
- [x] Implement the blocklist
- [x] Write a changelog entry
- [x] Write documentation
```