### PR TITLE
Bring back dark/light mode toggle

### DIFF
--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -188,7 +188,7 @@ async function createConfig() {
           indexName: 'vast',
         },
         colorMode: {
-          disableSwitch: true,
+          disableSwitch: false,
           respectPrefersColorScheme: true,
         },
         navbar: {


### PR DESCRIPTION
This PR brings back the dark/light mode toggle in the docs.

When sharing screens or giving demos, it's arguably easier to quickly click a button than changing the system settings.
