### PR TITLE
Support `show`-ing all aspects at once

### DIFF
--- a/changelog/next/features/3650--show-all.md
+++ b/changelog/next/features/3650--show-all.md
@@ -1,0 +1,1 @@
+Use `show` without an aspect to return information about all aspects of a node.

--- a/libtenzir/builtins/operators/show.cpp
+++ b/libtenzir/builtins/operators/show.cpp
@@ -20,7 +20,7 @@ namespace tenzir::plugins::show {
 namespace {
 
 struct operator_args {
-  located<std::string> aspect;
+  std::optional<located<std::string>> aspect;
 
   friend auto inspect(auto& f, operator_args& x) -> bool {
     return f.object(x)
@@ -39,7 +39,18 @@ public:
 
   auto operator()(operator_control_plane& ctrl) const
     -> generator<table_slice> {
-    return get()->show(ctrl);
+    if (auto plugin = get()) {
+      return plugin->show(ctrl);
+    }
+    return
+      [](operator_control_plane& ctrl,
+         std::vector<const aspect_plugin*> plugins) -> generator<table_slice> {
+        for (const auto* plugin : plugins) {
+          for (auto&& slice : plugin->show(ctrl)) {
+            co_yield std::move(slice);
+          }
+        }
+      }(ctrl, get_all());
   }
 
   auto name() const -> std::string override {
@@ -51,7 +62,10 @@ public:
   }
 
   auto location() const -> operator_location override {
-    return get()->location();
+    if (const auto* plugin = get()) {
+      return plugin->location();
+    }
+    return operator_location::remote;
   }
 
   auto optimize(expression const& filter, event_order order) const
@@ -67,12 +81,17 @@ public:
 
 private:
   auto get() const -> const aspect_plugin* {
-    const auto* plugin = plugins::find<aspect_plugin>(aspect_plugin_);
-    TENZIR_ASSERT_CHEAP(plugin != nullptr);
-    return plugin;
+    if (aspect_plugin_) {
+      return plugins::find<aspect_plugin>(*aspect_plugin_);
+    }
+    return nullptr;
   }
 
-  std::string aspect_plugin_;
+  auto get_all() const -> std::vector<const aspect_plugin*> {
+    return collect(plugins::get<aspect_plugin>());
+  }
+
+  std::optional<std::string> aspect_plugin_;
 };
 
 class plugin final : public virtual operator_plugin<show_operator> {
@@ -87,19 +106,22 @@ public:
     operator_args args;
     parser.add(args.aspect, "<aspect>");
     parser.parse(p);
-    auto available = std::map<std::string, std::string>{};
-    for (const auto& aspect : collect(plugins::get<aspect_plugin>()))
-      available.emplace(aspect->aspect_name(), aspect->name());
-    if (not available.contains(args.aspect.inner)) {
-      auto aspects = std::vector<std::string>{};
-      for (const auto& [aspect_name, plugin_name] : available)
-        aspects.push_back(aspect_name);
-      diagnostic::error("aspect `{}` could not be found", args.aspect.inner)
-        .primary(args.aspect.source)
-        .hint("must be one of {}", fmt::join(aspects, ", "))
-        .throw_();
+    if (args.aspect) {
+      auto available = std::map<std::string, std::string>{};
+      for (const auto& aspect : collect(plugins::get<aspect_plugin>()))
+        available.emplace(aspect->aspect_name(), aspect->name());
+      if (not available.contains(args.aspect->inner)) {
+        auto aspects = std::vector<std::string>{};
+        for (const auto& [aspect_name, plugin_name] : available)
+          aspects.push_back(aspect_name);
+        diagnostic::error("aspect `{}` could not be found", args.aspect->inner)
+          .primary(args.aspect->source)
+          .hint("must be one of {}", fmt::join(aspects, ", "))
+          .throw_();
+      }
+      return std::make_unique<show_operator>(available[args.aspect->inner]);
     }
-    return std::make_unique<show_operator>(available[args.aspect.inner]);
+    return std::make_unique<show_operator>();
   }
 };
 

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "604f62ff267c39b8388b2cade50402351cb0fe6d",
+  "rev": "736b72418552276b440fea7e64895b91feb72f33",
   "submodules": true,
   "shallow": true
 }

--- a/tenzir/integration/reference/parse-operators/step_00.ref
+++ b/tenzir/integration/reference/parse-operators/step_00.ref
@@ -1,3 +1,3 @@
-show "version"
+show anonymous(*"version")
 -----
-located("show", "version", location(0, 12))
+located("show", anonymous(*"version"), location(0, 12))

--- a/tenzir/integration/reference/parse-operators/step_01.ref
+++ b/tenzir/integration/reference/parse-operators/step_01.ref
@@ -4,5 +4,5 @@ error: unknown option `--tev`
 1 | show version --tev
   |              ^^^^^ 
   |
-  = usage: show <aspect>
+  = usage: show [<aspect>]
   = docs: https://docs.tenzir.com/next/operators/sources/show

--- a/tenzir/integration/reference/parse-operators/step_02.ref
+++ b/tenzir/integration/reference/parse-operators/step_02.ref
@@ -4,5 +4,5 @@ error: unexpected positional argument
 1 | show version 42
   |              ^^ 
   |
-  = usage: show <aspect>
+  = usage: show [<aspect>]
   = docs: https://docs.tenzir.com/next/operators/sources/show

--- a/web/docs/operators/sources/show.md
+++ b/web/docs/operators/sources/show.md
@@ -69,12 +69,6 @@ show fields
 show partitions
 ```
 
-Show the version of a remote node:
-
-```
-remote show version
-```
-
 Show all aspects of a remote node:
 
 ```

--- a/web/docs/operators/sources/show.md
+++ b/web/docs/operators/sources/show.md
@@ -10,7 +10,7 @@ minor or patch releases.
 ## Synopsis
 
 ```
-show <aspect> [options]
+show [<aspect>]
 ```
 
 ## Description
@@ -45,6 +45,8 @@ look at what's going on:
   available from the `/serve` API endpoint.
 - `types`: shows all known types at a remote node.
 
+When no aspect is not specified, all are shown.
+
 ## Examples
 
 Show all available connectors and formats:
@@ -71,4 +73,10 @@ Show the version of a remote node:
 
 ```
 remote show version
+```
+
+Show all aspects of a remote node:
+
+```
+show
 ```

--- a/web/docs/operators/sources/show.md
+++ b/web/docs/operators/sources/show.md
@@ -45,7 +45,7 @@ look at what's going on:
   available from the `/serve` API endpoint.
 - `types`: shows all known types at a remote node.
 
-When no aspect is not specified, all are shown.
+When no aspect is specified, all are shown.
 
 ## Examples
 


### PR DESCRIPTION
This makes the aspect in `show <aspect>` optional. When the aspect is not specified, all aspects are used automatically.

<img width="2416" alt="image" src="https://github.com/tenzir/tenzir/assets/4488655/11f4b4e9-3d3c-45d8-afba-0dd3c8fcad4f">
