### PR TITLE
Add `yield` operator

### DIFF
--- a/changelog/next/features/3651--yield-operator.md
+++ b/changelog/next/features/3651--yield-operator.md
@@ -1,0 +1,2 @@
+The new `yield` operator extracts nested records with the ability to unfold
+lists.

--- a/libtenzir/builtins/operators/yield.cpp
+++ b/libtenzir/builtins/operators/yield.cpp
@@ -1,0 +1,217 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <tenzir/argument_parser.hpp>
+#include <tenzir/pipeline.hpp>
+#include <tenzir/plugin.hpp>
+
+#include <arrow/api.h>
+
+#include <ranges>
+#include <string_view>
+
+namespace tenzir::plugins::yield {
+
+namespace {
+
+struct unnest {};
+
+using projection = located<variant<std::string, unnest>>;
+
+constexpr auto unnest_idx = std::numeric_limits<offset::value_type>::max();
+
+class yield_operator final
+  : public schematic_operator<yield_operator,
+                              std::optional<std::pair<offset, type>>> {
+public:
+  yield_operator() = default;
+
+  explicit yield_operator(parser_interface& p) {
+    auto parser = argument_parser{"yield", "https://docs.tenzir.com/next/"
+                                           "operators/transformations/yield"};
+    auto extractor = located<std::string>{};
+    // TODO: This assumes that the given extractor can be parsed as a shell-like
+    // argument, e.g., spaces must be quoted.
+    parser.add(extractor, "<extractor>");
+    parser.parse(p);
+    // TODO: The locations reported by the parsed can be slightly wrong if the
+    // argument is quoted. This can be resolved as part of the expression revamp.
+    auto field = +(parsers::alnum | parsers::chr{'_'});
+    auto current = extractor.inner.begin();
+    auto end = extractor.inner.end();
+    auto to_offset = [&](std::string::iterator it, int64_t x = 0) -> size_t {
+      if (not extractor.source) {
+        return 0;
+      }
+      return extractor.source.begin + (it - extractor.inner.begin()) + x;
+    };
+    auto parse_field = [&]() -> projection {
+      auto last = current;
+      if (not field(current, end, unused)) {
+        diagnostic::error("expected field name")
+          .primary({to_offset(current), to_offset(current, 1)})
+          .throw_();
+      }
+      return projection{std::string{last, current},
+                        {to_offset(last), to_offset(current)}};
+    };
+    path.emplace_back(parse_field());
+    while (current != end) {
+      if (*current == '.') {
+        ++current;
+        path.push_back(parse_field());
+      } else if (*current == '[') {
+        ++current;
+        if (*current == ']') {
+          ++current;
+          path.emplace_back(unnest{}, tenzir::location{to_offset(current, -2),
+                                                       to_offset(current)});
+        } else {
+          diagnostic::error("expected `]`")
+            .primary({to_offset(current), to_offset(current, 1)})
+            .throw_();
+        }
+      } else {
+        diagnostic::error("expected `.<field>` or `[]`")
+          .primary({to_offset(current), to_offset(current, 1)})
+          .throw_();
+      }
+    }
+  }
+
+  auto initialize(const type& schema, operator_control_plane& ctrl) const
+    -> caf::expected<state_type> override {
+    auto current = schema;
+    auto result = offset{};
+    for (auto& proj : path) {
+      auto success = proj.inner.match(
+        [&](const std::string& field) {
+          auto rec_ty = caf::get_if<record_type>(&current);
+          if (not rec_ty) {
+            diagnostic::warning("expected a record, but got a {}",
+                                current.kind())
+              .primary(proj.source)
+              .note("for schema `{}`", schema)
+              .emit(ctrl.diagnostics());
+            return false;
+          }
+          auto index = rec_ty->resolve_key(field);
+          if (not index) {
+            diagnostic::warning("record has no field `{}`", field)
+              .primary(proj.source)
+              .hint("must be one of: {}",
+                    fmt::join(
+                      rec_ty->fields()
+                        | std::views::transform(&record_type::field_view::name),
+                      ", "))
+              .note("for schema `{}`", schema)
+              .emit(ctrl.diagnostics());
+            return false;
+          }
+          TENZIR_ASSERT_CHEAP(index->size() == 1);
+          current = rec_ty->field(*index).type;
+          result.push_back((*index)[0]);
+          return true;
+        },
+        [&](unnest) {
+          auto list_ty = caf::get_if<list_type>(&current);
+          if (not list_ty) {
+            diagnostic::warning("expected a list, but got a {}", current.kind())
+              .primary(proj.source)
+              .note("for schema `{}`", schema)
+              .emit(ctrl.diagnostics());
+            return false;
+          }
+          current = list_ty->value_type();
+          result.push_back(unnest_idx);
+          return true;
+        });
+      if (not success) {
+        return std::nullopt;
+      }
+    }
+    if (not caf::holds_alternative<record_type>(current)) {
+      diagnostic::warning("expected a record, but got a {}", current.kind())
+        .primary(path.back().source)
+        .note("for schema `{}`", schema)
+        .emit(ctrl.diagnostics());
+      return std::nullopt;
+    }
+    return std::pair{std::move(result), type{"tenzir.yield", current}};
+  }
+
+  auto process(table_slice slice, state_type& state) const
+    -> output_type override {
+    // TODO: We currently resolve fields of `null` records as `null`. If a list
+    // is `null`, then we interpret it as the empty list. We should reconsider
+    // this behavior and whether we want to emit diagnostics when we decide how
+    // nulls should be handled in general.
+    if (not state.has_value()) {
+      return {};
+    }
+    auto batch = to_record_batch(slice);
+    auto array = std::static_pointer_cast<arrow::Array>(
+      batch->ToStructArray().ValueOrDie());
+    auto& [indices, new_type] = *state;
+    for (auto index : indices) {
+      TENZIR_ASSERT_CHEAP(array);
+      if (index == unnest_idx) {
+        auto list_array = dynamic_cast<arrow::ListArray*>(array.get());
+        TENZIR_ASSERT_CHEAP(list_array);
+        array = list_array->Flatten().ValueOrDie();
+      } else {
+        auto struct_array = dynamic_cast<arrow::StructArray*>(array.get());
+        TENZIR_ASSERT_CHEAP(struct_array);
+        array = struct_array->GetFlattenedField(detail::narrow<int>(index))
+                  .ValueOrDie();
+      }
+    }
+    auto record = std::dynamic_pointer_cast<arrow::StructArray>(array);
+    TENZIR_ASSERT_CHEAP(record);
+    auto fields = record->Flatten().ValueOrDie();
+    auto result
+      = table_slice{arrow::RecordBatch::Make(new_type.to_arrow_schema(),
+                                             array->length(), fields),
+                    new_type};
+    TENZIR_ASSERT(to_record_batch(result)->Validate().ok());
+    return result;
+  }
+
+  auto name() const -> std::string override {
+    return "yield";
+  }
+
+  auto optimize(expression const& filter, event_order order) const
+    -> optimize_result override {
+    (void)filter;
+    return optimize_result::order_invariant(*this, order);
+  }
+  friend auto inspect(auto& f, yield_operator& x) -> bool {
+    return f.apply(x.path);
+  }
+
+private:
+  std::vector<projection> path;
+};
+
+class plugin final : public virtual operator_plugin<yield_operator> {
+public:
+  auto signature() const -> operator_signature override {
+    return {.transformation = true};
+  }
+
+  auto parse_operator(parser_interface& p) const -> operator_ptr override {
+    return std::make_unique<yield_operator>(p);
+  }
+};
+
+} // namespace
+
+} // namespace tenzir::plugins::yield
+
+TENZIR_REGISTER_PLUGIN(tenzir::plugins::yield::plugin)

--- a/tenzir/integration/reference/yield-operator/step_00.ref
+++ b/tenzir/integration/reference/yield-operator/step_00.ref
@@ -1,0 +1,112 @@
+{
+  "version": null,
+  "type": "query",
+  "id": 22038,
+  "flags": null,
+  "qr": null,
+  "rd": null,
+  "ra": null,
+  "aa": null,
+  "tc": null,
+  "rrname": "google.com",
+  "rrtype": "MX",
+  "rcode": null,
+  "ttl": null,
+  "tx_id": 0,
+  "grouped": null,
+  "answers": null
+}
+{
+  "version": 2,
+  "type": "answer",
+  "id": 22038,
+  "flags": "8180",
+  "qr": true,
+  "rd": true,
+  "ra": true,
+  "aa": null,
+  "tc": null,
+  "rrname": "google.com",
+  "rrtype": "MX",
+  "rcode": "NOERROR",
+  "ttl": null,
+  "tx_id": null,
+  "grouped": {
+    "A": null,
+    "NS": null,
+    "AAAA": null,
+    "CNAME": null,
+    "TXT": null,
+    "MX": [
+      "aspmx.l.google.com",
+      "alt1.aspmx.l.google.com",
+      "alt2.aspmx.l.google.com",
+      "alt3.aspmx.l.google.com",
+      "alt4.aspmx.l.google.com"
+    ],
+    "PTR": null,
+    "SOA": null,
+    "SSHFP": null,
+    "SRV": null
+  },
+  "answers": [
+    {
+      "rrname": "google.com",
+      "rrtype": "MX",
+      "ttl": 599,
+      "rdata": "aspmx.l.google.com",
+      "soa": null,
+      "sshfp": null,
+      "srv": null
+    },
+    {
+      "rrname": "google.com",
+      "rrtype": "MX",
+      "ttl": 599,
+      "rdata": "alt1.aspmx.l.google.com",
+      "soa": null,
+      "sshfp": null,
+      "srv": {
+        "priority": null,
+        "weight": null,
+        "port": null,
+        "name": "xxx"
+      }
+    },
+    {
+      "rrname": "google.com",
+      "rrtype": "MX",
+      "ttl": 599,
+      "rdata": "alt2.aspmx.l.google.com",
+      "soa": {
+        "mname": "foo",
+        "rname": null,
+        "serial": null,
+        "refresh": null,
+        "retry": 42,
+        "expire": null,
+        "minimum": null
+      },
+      "sshfp": null,
+      "srv": null
+    },
+    {
+      "rrname": "google.com",
+      "rrtype": "MX",
+      "ttl": 599,
+      "rdata": "alt3.aspmx.l.google.com",
+      "soa": null,
+      "sshfp": null,
+      "srv": null
+    },
+    {
+      "rrname": "google.com",
+      "rrtype": "MX",
+      "ttl": 599,
+      "rdata": "alt4.aspmx.l.google.com",
+      "soa": null,
+      "sshfp": null,
+      "srv": null
+    }
+  ]
+}

--- a/tenzir/integration/reference/yield-operator/step_01.ref
+++ b/tenzir/integration/reference/yield-operator/step_01.ref
@@ -1,0 +1,8 @@
+warning: record has no field `foo`
+ --> <input>:1:27
+  |
+1 | read suricata | yield dns.foo
+  |                           ~~~ 
+  |
+  = hint: must be one of: version, type, id, flags, qr, rd, ra, aa, tc, rrname, rrtype, rcode, ttl, tx_id, grouped, answers
+  = note: for schema `suricata.dns`

--- a/tenzir/integration/reference/yield-operator/step_02.ref
+++ b/tenzir/integration/reference/yield-operator/step_02.ref
@@ -1,0 +1,7 @@
+warning: expected a record, but got a list
+ --> <input>:1:27
+  |
+1 | read suricata | yield dns.answers
+  |                           ~~~~~~~ 
+  |
+  = note: for schema `suricata.dns`

--- a/tenzir/integration/reference/yield-operator/step_03.ref
+++ b/tenzir/integration/reference/yield-operator/step_03.ref
@@ -1,0 +1,58 @@
+{
+  "rrname": "google.com",
+  "rrtype": "MX",
+  "ttl": 599,
+  "rdata": "aspmx.l.google.com",
+  "soa": null,
+  "sshfp": null,
+  "srv": null
+}
+{
+  "rrname": "google.com",
+  "rrtype": "MX",
+  "ttl": 599,
+  "rdata": "alt1.aspmx.l.google.com",
+  "soa": null,
+  "sshfp": null,
+  "srv": {
+    "priority": null,
+    "weight": null,
+    "port": null,
+    "name": "xxx"
+  }
+}
+{
+  "rrname": "google.com",
+  "rrtype": "MX",
+  "ttl": 599,
+  "rdata": "alt2.aspmx.l.google.com",
+  "soa": {
+    "mname": "foo",
+    "rname": null,
+    "serial": null,
+    "refresh": null,
+    "retry": 42,
+    "expire": null,
+    "minimum": null
+  },
+  "sshfp": null,
+  "srv": null
+}
+{
+  "rrname": "google.com",
+  "rrtype": "MX",
+  "ttl": 599,
+  "rdata": "alt3.aspmx.l.google.com",
+  "soa": null,
+  "sshfp": null,
+  "srv": null
+}
+{
+  "rrname": "google.com",
+  "rrtype": "MX",
+  "ttl": 599,
+  "rdata": "alt4.aspmx.l.google.com",
+  "soa": null,
+  "sshfp": null,
+  "srv": null
+}

--- a/tenzir/integration/reference/yield-operator/step_04.ref
+++ b/tenzir/integration/reference/yield-operator/step_04.ref
@@ -1,0 +1,7 @@
+warning: expected a record, but got a uint64
+ --> <input>:1:37
+  |
+1 | read suricata | yield dns.answers[].ttl
+  |                                     ~~~ 
+  |
+  = note: for schema `suricata.dns`

--- a/tenzir/integration/reference/yield-operator/step_05.ref
+++ b/tenzir/integration/reference/yield-operator/step_05.ref
@@ -1,0 +1,45 @@
+{
+  "mname": null,
+  "rname": null,
+  "serial": null,
+  "refresh": null,
+  "retry": null,
+  "expire": null,
+  "minimum": null
+}
+{
+  "mname": null,
+  "rname": null,
+  "serial": null,
+  "refresh": null,
+  "retry": null,
+  "expire": null,
+  "minimum": null
+}
+{
+  "mname": "foo",
+  "rname": null,
+  "serial": null,
+  "refresh": null,
+  "retry": 42,
+  "expire": null,
+  "minimum": null
+}
+{
+  "mname": null,
+  "rname": null,
+  "serial": null,
+  "refresh": null,
+  "retry": null,
+  "expire": null,
+  "minimum": null
+}
+{
+  "mname": null,
+  "rname": null,
+  "serial": null,
+  "refresh": null,
+  "retry": null,
+  "expire": null,
+  "minimum": null
+}

--- a/tenzir/integration/tests.yaml
+++ b/tenzir/integration/tests.yaml
@@ -1158,3 +1158,19 @@ tests:
       - command: exec 'from - read json | chart donuttt value=b'
         input: data/json/all-types.json
         expected_result: error
+
+  Yield Operator:
+    tags: [pipelines]
+    steps:
+      - command: exec 'read suricata | yield dns'
+        input: data/suricata/rrdata-eve.json
+      - command: exec 'read suricata | yield dns.foo'
+        input: data/suricata/rrdata-eve.json
+      - command: exec 'read suricata | yield dns.answers'
+        input: data/suricata/rrdata-eve.json
+      - command: exec 'read suricata | yield dns.answers[]'
+        input: data/suricata/rrdata-eve.json
+      - command: exec 'read suricata | yield dns.answers[].ttl'
+        input: data/suricata/rrdata-eve.json
+      - command: exec 'read suricata | yield dns.answers[].soa'
+        input: data/suricata/rrdata-eve.json

--- a/web/docs/operators/transformations/yield.md
+++ b/web/docs/operators/transformations/yield.md
@@ -1,0 +1,31 @@
+# yield
+
+Extracts nested records with the ability to unfold lists.
+
+## Synopsis
+
+```
+yield <extractor>
+```
+
+## Description
+
+The `yield` operator can be used to "zoom into" the extracted part of the
+incoming events. It can also return a new event for each element of a list.
+
+### `<extractor>`
+
+The extractor must start with a field name. This can be followed by `.` and
+another field name, or by `[]` to extract all elements from the given list.
+
+## Examples
+
+The schema `suricata.dns` provides a list of answers for DNS queries. Assume we
+want to extract all answers for `CNAME` records.
+
+```
+from eve.json
+| where #schema == "suricata.dns"
+| yield dns.answers[]
+| where rrtype == "CNAME"
+```


### PR DESCRIPTION
The remaining todos are mostly something for the language revamp. Also, the operator is intentionally a bit under-specified because we are not sure yet how exactly nulls, unknown fields, etc., will be handled eventually.