### PR TITLE
Consider discard, export, and import as internal operators

### DIFF
--- a/changelog/next/changes/3658--ingress-egress-redef.md
+++ b/changelog/next/changes/3658--ingress-egress-redef.md
@@ -1,0 +1,4 @@
+Ingress and egress metrics for pipelines now indicate whether the pipeline
+sent/received events to/from outside of the node with a new `internal` flag. For
+example, when using the `export` operator, data is entering the pipeline from
+within the node, so its ingress is considered internal.

--- a/libtenzir/builtins/operators/discard.cpp
+++ b/libtenzir/builtins/operators/discard.cpp
@@ -29,6 +29,10 @@ public:
     }
   }
 
+  auto internal() const -> bool override {
+    return true;
+  }
+
   auto optimize(expression const& filter, event_order order) const
     -> optimize_result override {
     (void)filter, (void)order;

--- a/libtenzir/builtins/operators/export.cpp
+++ b/libtenzir/builtins/operators/export.cpp
@@ -224,6 +224,10 @@ public:
     return operator_location::remote;
   }
 
+  auto internal() const -> bool override {
+    return true;
+  }
+
   auto optimize(expression const& filter, event_order order) const
     -> optimize_result override {
     (void)order;

--- a/libtenzir/builtins/operators/import.cpp
+++ b/libtenzir/builtins/operators/import.cpp
@@ -156,6 +156,10 @@ public:
   auto location() const -> operator_location override {
     return operator_location::remote;
   }
+
+  auto internal() const -> bool override {
+    return true;
+  }
 };
 
 class plugin final : public virtual operator_plugin<import_operator> {

--- a/libtenzir/builtins/operators/local_remote.cpp
+++ b/libtenzir/builtins/operators/local_remote.cpp
@@ -67,6 +67,10 @@ public:
     return op_->detached();
   }
 
+  auto internal() const -> bool override {
+    return op_->internal();
+  }
+
   auto infer_type_impl(operator_type input) const
     -> caf::expected<operator_type> override {
     return op_->infer_type(input);

--- a/libtenzir/include/tenzir/pipeline.hpp
+++ b/libtenzir/include/tenzir/pipeline.hpp
@@ -175,12 +175,17 @@ struct operator_measurement {
   // Approximate byte amount for events, exact byte amount for bytes.
   uint64_t num_approx_bytes = {};
 
+  // Whether this metric is considered internal or not; only external metrics
+  // may be counted for ingress and egress.
+  bool internal = {};
+
   template <class Inspector>
   friend auto inspect(Inspector& f, operator_measurement& x) -> bool {
     return f.object(x).pretty_name("metric").fields(
       f.field("unit", x.unit), f.field("num_elements", x.num_elements),
       f.field("num_batches", x.num_batches),
-      f.field("num_approx_bytes", x.num_approx_bytes));
+      f.field("num_approx_bytes", x.num_approx_bytes),
+      f.field("internal", x.internal));
   }
 };
 
@@ -334,6 +339,12 @@ public:
     return false;
   }
 
+  /// Returns whether is considered "internal," i.e., whether its metrics count
+  /// as ingress or egress or not.
+  virtual auto internal() const -> bool {
+    return false;
+  }
+
   /// Retrieve the output type of this operator for a given input.
   ///
   /// The default implementation will try to instantiate the operator and then
@@ -461,6 +472,10 @@ public:
 
   auto detached() const -> bool override {
     die("pipeline::detached() must not be called");
+  }
+
+  auto internal() const -> bool override {
+    die("pipeline::internal() must not be called");
   }
 
   auto instantiate(operator_input input, operator_control_plane& control) const

--- a/libtenzir/src/execution_node.cpp
+++ b/libtenzir/src/execution_node.cpp
@@ -895,11 +895,11 @@ auto exec_node(
   self->state.metrics->values.inbound_measurement.unit
     = operator_type_name<Input>();
   self->state.metrics->values.inbound_measurement.internal
-    = std::is_void_v<Input> && self->state.op->internal();
+    = not std::is_void_v<Input> or self->state.op->internal();
   self->state.metrics->values.outbound_measurement.unit
     = operator_type_name<Output>();
   self->state.metrics->values.outbound_measurement.internal
-    = std::is_void_v<Output> && self->state.op->internal();
+    = not std::is_void_v<Output> or self->state.op->internal();
   self->state.ctrl = std::make_unique<exec_node_control_plane<Input, Output>>(
     self, std::move(diagnostic_handler), has_terminal);
   // The node actor must be set when the operator is not a source.

--- a/libtenzir/src/execution_node.cpp
+++ b/libtenzir/src/execution_node.cpp
@@ -894,8 +894,12 @@ auto exec_node(
   self->state.metrics->values.operator_name = self->state.op->name();
   self->state.metrics->values.inbound_measurement.unit
     = operator_type_name<Input>();
+  self->state.metrics->values.inbound_measurement.internal
+    = std::is_void_v<Input> && self->state.op->internal();
   self->state.metrics->values.outbound_measurement.unit
     = operator_type_name<Output>();
+  self->state.metrics->values.outbound_measurement.internal
+    = std::is_void_v<Output> && self->state.op->internal();
   self->state.ctrl = std::make_unique<exec_node_control_plane<Input, Output>>(
     self, std::move(diagnostic_handler), has_terminal);
   // The node actor must be set when the operator is not a source.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,8 +2,7 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "05fa3510ff3e5e997c8c8856b6e1096910ece5dc",
+  "rev": "fc7d894a10a6a2ad55980b09e457f6fbdcaca171",
   "submodules": true,
-  "shallow": true,
-  "allRefs": true
+  "shallow": true
 }

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "509843886c0ceac746d9b2a6c2a000dbb4e8460e",
+  "rev": "05fa3510ff3e5e997c8c8856b6e1096910ece5dc",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "fc7d894a10a6a2ad55980b09e457f6fbdcaca171",
+  "rev": "604f62ff267c39b8388b2cade50402351cb0fe6d",
   "submodules": true,
   "shallow": true
 }

--- a/plugins/web/src/specification_command.cpp
+++ b/plugins/web/src/specification_command.cpp
@@ -41,6 +41,10 @@ Metrics:
                 - events
               description: The unit of the input data.
               example: bytes
+            internal:
+              type: boolean
+              description: Whether the operator's ingress is internal.
+              example: false
             num_elements:
               type: integer
               description: The total amount of elements that entered the pipeline source.
@@ -72,6 +76,10 @@ Metrics:
                 - events
               description: The unit of the output data.
               example: bytes
+            internal:
+              type: boolean
+              description: Whether the operator's egress is internal.
+              example: false
             num_elements:
               type: integer
               description: The total amount of elements that entered the pipeline sink.

--- a/web/openapi/openapi.yaml
+++ b/web/openapi/openapi.yaml
@@ -30,6 +30,10 @@ components:
                     - events
                   description: The unit of the input data.
                   example: bytes
+                internal:
+                  type: boolean
+                  description: Whether the operator's ingress is internal.
+                  example: false
                 num_elements:
                   type: integer
                   description: The total amount of elements that entered the pipeline source.
@@ -61,6 +65,10 @@ components:
                     - events
                   description: The unit of the output data.
                   example: bytes
+                internal:
+                  type: boolean
+                  description: Whether the operator's egress is internal.
+                  example: false
                 num_elements:
                   type: integer
                   description: The total amount of elements that entered the pipeline sink.


### PR DESCRIPTION
We do not want to count egress or ingress for discard, export, and import. This makes it so their metrics are specifically annotated to be internal, as they are technically not ingress or egress.