### PR TITLE
Fix velociraptor-plugin build with Abseil 2023.*

### DIFF
--- a/plugins/velociraptor/CMakeLists.txt
+++ b/plugins/velociraptor/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(velociraptor-proto STATIC
 if (NOT TENZIR_ENABLE_STATIC_EXECUTABLE)
   set_property(TARGET velociraptor-proto PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif ()
+target_compile_features(velociraptor-proto PRIVATE cxx_std_20)
 target_link_libraries(velociraptor-proto PUBLIC protobuf::libprotobuf
                                                 gRPC::grpc++)
 dependency_summary("protobuf" protobuf::libprotobuf "Dependencies")


### PR DESCRIPTION
Abseil versions 2023 and later require C++14 or newer. The previous versions only required C++11. `libprotobuf`, which depends on Abseil, only declares that it needs C++11, and doesn't check what Abseil needs. This caused `velociraptor-proto` to be built with `-std=gnu++11`, leading to errors in Abseil.

Abseil version 2023.* is shipping with Fedora 39, which is why I ran into this. No Ubuntu version ships with 2023.*, yet.

No other changes seem to be necessary for everything to work.