### PR TITLE
Add 'min_events' parameters to /serve endpoint

### DIFF
--- a/changelog/next/features/3666--serve-latency.md
+++ b/changelog/next/features/3666--serve-latency.md
@@ -1,0 +1,5 @@
+We optimized the behavior of the 'serve' operator to respond
+quicker and cause less system load for pipelines that take a
+long time to generate the first result. The new `min_events`
+parameter can be used to implement long-polling behavior for
+clients of `/serve`.

--- a/libtenzir/builtins/operators/serve.cpp
+++ b/libtenzir/builtins/operators/serve.cpp
@@ -101,16 +101,18 @@ constexpr auto SPEC_V0 = R"_(
                 description: The continuation token that was returned with the last response. For the initial request this is null.
               max_events:
                 type: integer
-                example: 50
-                description: The maximum number of events returned. If unset, the number is unlimited.
+                example: 1024
+                default: 1024
+                description: The maximum number of events returned.
               min_events:
                 type: integer
-                example: 50
-                description: Wait for this number of events before returning. If unset, the number is unlimited.
+                example: 1
+                default: 1
+                description: Wait for this number of events before returning.
               timeout:
                 type: string
-                example: "100ms"
-                default: "100ms"
+                example: "2000ms"
+                default: "2000ms"
                 description: The maximum amount of time spent on the request. Hitting the timeout is not an error. The timeout must not be greater than 5 seconds.
     responses:
       200:

--- a/libtenzir/include/tenzir/defaults.hpp
+++ b/libtenzir/include/tenzir/defaults.hpp
@@ -172,12 +172,16 @@ namespace serve {
 /// is kept available after being fetched for the first time.
 inline constexpr std::chrono::seconds retention_time = std::chrono::minutes{1};
 
-/// Number of events returned.
-inline constexpr uint64_t max_events = 64;
+/// Threshold number of events to wait for .
+inline constexpr uint64_t min_events = 1;
 
-/// The amount of time to wait for additional events.
+/// Number of events returned.
+inline constexpr uint64_t max_events = 1024;
+
+/// The maximum amount of time to wait for additional having at least
+/// `min_events`.
 inline constexpr std::chrono::milliseconds timeout
-  = std::chrono::milliseconds{100};
+  = std::chrono::milliseconds{2000};
 
 /// The maximum timeout that can be requested by the client.
 inline constexpr std::chrono::seconds max_timeout = std::chrono::seconds{5};

--- a/web/docs/operators/sinks/serve.md
+++ b/web/docs/operators/sinks/serve.md
@@ -34,7 +34,7 @@ operator errors when receiving a duplicate serve id.
 
 ## Examples
 
-Read a Zeek conn.log, 100 events at a time:
+### Read a Zeek conn.log, 100 events at a time:
 
 ```bash
 tenzir 'from file path/to/conn.log read zeek-tsv | serve zeek-conn-logs'
@@ -54,3 +54,22 @@ expired.
 Subsequent results for further events must specify a continuation token. The
 token is included in the response under `next_continuation_token` if there are
 further events to be retrieved from the endpoint.
+
+### Wait for an initial event
+
+This pipeline will produce 10 events after 3 seconds of doing nothing.
+
+```bash
+tenzir "shell \"sleep 3; jq --null-input '{foo: 1}'\" | read json | repeat 10 | serve slow-events"
+```
+
+```bash
+curl \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"serve_id": "slow-events", "continuation_token": null, "timeout": "5s", "min_events": 1}' \
+  http://localhost:5160/api/v0/serve
+```
+
+The call to `/serve` will wait up to 5 seconds for the first event from the pipeline arriving at the serve operator,
+and return immediately once the first event arrives.

--- a/web/openapi/openapi.yaml
+++ b/web/openapi/openapi.yaml
@@ -606,12 +606,18 @@ paths:
                   description: The continuation token that was returned with the last response. For the initial request this is null.
                 max_events:
                   type: integer
-                  example: 50
-                  description: The maximum number of events returned. If unset, the number is unlimited.
+                  example: 1024
+                  default: 1024
+                  description: The maximum number of events returned.
+                min_events:
+                  type: integer
+                  example: 1
+                  default: 1
+                  description: Wait for this number of events before returning.
                 timeout:
                   type: string
-                  example: 100.0ms
-                  default: 100.0ms
+                  example: 2.0s
+                  default: 2.0s
                   description: The maximum amount of time spent on the request. Hitting the timeout is not an error. The timeout must not be greater than 5 seconds.
       responses:
         200:


### PR DESCRIPTION
This adds a new parameter 'min_events' to the `/serve` endpoint, with the semantics that the endpoint will return a result as soon as `min_events` events have arrived, regardless of the configured `timeout` and `max_events`.

The idea is to allow long polling, by specifying a long timeout and a low value for `min_events`. The defaults for the endpoint are adjusted accordingly.
