### PR TITLE
Allow using `put` as a source

### DIFF
--- a/changelog/next/features/3669--put-as-asource.md
+++ b/changelog/next/features/3669--put-as-asource.md
@@ -1,0 +1,2 @@
+The `put` operator is now a source operator as well, which allows for
+introducing one event into a pipeline with known values.

--- a/libtenzir/include/tenzir/concept/parseable/tenzir/data.hpp
+++ b/libtenzir/include/tenzir/concept/parseable/tenzir/data.hpp
@@ -71,11 +71,11 @@ private:
     // with named fields. Allowing a mixture of both would mean we'd
     // have to deal with ambiguous inputs.
     auto record_parser =
-        '<' >> ~as<record>(named_field % ',') >> trailing_comma >> '>'
+        '{' >> ~as<record>(named_field % ',') >> trailing_comma >> '}'
         // Creating a record with repeated field names technically violates
         // the consistency of the underlying stable_map. We live with that
         // until record is refactored into a proper type (FIXME).
-      | ('<' >> (unnamed_field % ',') >> trailing_comma >> '>')
+      | ('{' >> (unnamed_field % ',') >> trailing_comma >> '}')
         ->* [](record::vector_type&& xs) {
           return record::make_unsafe(std::move(xs));
         };

--- a/libtenzir/include/tenzir/concept/printable/tenzir/data.hpp
+++ b/libtenzir/include/tenzir/concept/printable/tenzir/data.hpp
@@ -98,7 +98,7 @@ struct record_printer : printer_base<record_printer> {
   template <class Iterator>
   bool print(Iterator& out, const record& xs) const {
     auto kvp = printers::str << ": " << printers::data;
-    auto p = '<' << (kvp % ", ") << '>';
+    auto p = '{' << (kvp % ", ") << '}';
     return p.print(out, xs);
   }
 };

--- a/web/docs/operators/transformations/put.md
+++ b/web/docs/operators/transformations/put.md
@@ -16,6 +16,11 @@ All other fields are removed from the input.
 The difference between `put` and [`extend`](extend.md) is that `put` drops all
 fields not explicitly specified, whereas `extend` only appends fields.
 
+:::info Put can also be used as a source
+The `put` operator can also be used as a source operator to inject an event into
+a pipeline.
+:::
+
 ### `<field[=operand]>`
 
 The `field` describes the name of the field to select. The extended form with an


### PR DESCRIPTION
This changes `put` so that it can be used to inject a static event into a pipeline.