### PR TITLE
Bump the partition version

### DIFF
--- a/version.json
+++ b/version.json
@@ -17,5 +17,5 @@
     "version for releases that contain major format changes to the on-disk",
     "layout of Tenzir's partitions."
   ],
-  "tenzir-partition-version": 2
+  "tenzir-partition-version": 3
 }


### PR DESCRIPTION
With the v4.5 release, we dropped dense indexes and enabled more sparse indexes by default. In order to make existing deployments take advantage of these improvements, we should've bumped the partition version—but we didn't. So this makes it so that as of the next release existing deployments will take care of upgrading partitions so that we can be sure that no more dense indexes exist after some time.