### PR TITLE
Improve the `/serve` API docs

### DIFF
--- a/libtenzir/builtins/operators/serve.cpp
+++ b/libtenzir/builtins/operators/serve.cpp
@@ -81,7 +81,7 @@ constexpr auto SPEC_V0 = R"_(
 /serve:
   post:
     summary: Return data from a pipeline
-    description: Returns events from an existing pipeline. The pipeline definition must include a serve operator.
+    description: "Returns events from an existing pipeline. The pipeline definition must include a serve operator. By default, the endpoint performs long polling (`timeout: 2s`) and returns events as soon as they are available (`min_events: 1`)."
     requestBody:
       description: Body for the serve endpoint
       required: true

--- a/web/docs/operators/sinks/serve.md
+++ b/web/docs/operators/sinks/serve.md
@@ -12,7 +12,7 @@ serve [--buffer-size <buffer-size>] <serve-id>
 ## Description
 
 The `serve` operator bridges between pipelines and the corresponding `/serve`
-REST API endpoint:
+[REST API endpoint](/api#/paths/~1serve/post):
 
 ![Serve Operator](serve.excalidraw.svg)
 

--- a/web/openapi/openapi.yaml
+++ b/web/openapi/openapi.yaml
@@ -585,7 +585,7 @@ paths:
   /serve:
     post:
       summary: Return data from a pipeline
-      description: Returns events from an existing pipeline. The pipeline definition must include a serve operator.
+      description: "Returns events from an existing pipeline. The pipeline definition must include a serve operator. By default, the endpoint performs long polling (`timeout: 2s`) and returns events as soon as they are available (`min_events: 1`)."
       requestBody:
         description: Body for the serve endpoint
         required: true


### PR DESCRIPTION
I got a litle bit confused by the behavior of the new `min_events` and its default value of 1. I think a bit more docs about the semantics of the endpoint would help a bit.