### PR TITLE
Add file data to show partitions

### DIFF
--- a/changelog/next/features/3675--disk-usage-for-show-partitions.md
+++ b/changelog/next/features/3675--disk-usage-for-show-partitions.md
@@ -1,0 +1,2 @@
+`show partitions` now contains location and size of the `store`, `index`, and
+`sketch` files of a partition, as well the aggregate size at `diskusage`.

--- a/libtenzir/include/tenzir/active_partition.hpp
+++ b/libtenzir/include/tenzir/active_partition.hpp
@@ -148,6 +148,9 @@ struct active_partition_state {
   /// The store builder.
   store_builder_actor store_builder = {};
 
+  /// Access info for the finished store.
+  std::optional<resource> store_file = {};
+
   /// Temporary storage for the serialized indexers of this partition, before
   /// they get written into the flatbuffer.
   std::map<caf::actor_id, tenzir::chunk_ptr> chunks = {};

--- a/libtenzir/include/tenzir/actors.hpp
+++ b/libtenzir/include/tenzir/actors.hpp
@@ -118,7 +118,10 @@ using default_passive_store_actor = typed_actor_fwd<
   ::extend_with<store_actor>::unwrap;
 
 /// The STORE BUILDER actor interface.
-using store_builder_actor = typed_actor_fwd<>::extend_with<store_actor>
+using store_builder_actor
+  = typed_actor_fwd<auto(atom::persist)->caf::result<resource>>
+  // Conform to the protocol of the STORE actor.
+  ::extend_with<store_actor>
   // Conform to the protocol of the STREAM SINK actor for table slices.
   ::extend_with<stream_sink_actor<table_slice>>
   // Conform to the protocol of the STATUS CLIENT actor.

--- a/libtenzir/include/tenzir/fwd.hpp
+++ b/libtenzir/include/tenzir/fwd.hpp
@@ -238,6 +238,7 @@ struct query_context;
 struct query_cursor;
 struct query_status;
 struct report;
+struct resource;
 struct rest_endpoint;
 struct rest_response;
 struct schema_statistics;
@@ -465,6 +466,7 @@ CAF_BEGIN_TYPE_ID_BLOCK(tenzir_types, first_tenzir_type_id)
   TENZIR_ADD_TYPE_ID((tenzir::query_cursor))
   TENZIR_ADD_TYPE_ID((tenzir::query_status))
   TENZIR_ADD_TYPE_ID((tenzir::report))
+  TENZIR_ADD_TYPE_ID((tenzir::resource))
   TENZIR_ADD_TYPE_ID((tenzir::keep_original_partition))
   TENZIR_ADD_TYPE_ID((tenzir::status_verbosity))
   TENZIR_ADD_TYPE_ID((tenzir::catalog_lookup_result))

--- a/libtenzir/include/tenzir/partition_synopsis.hpp
+++ b/libtenzir/include/tenzir/partition_synopsis.hpp
@@ -12,6 +12,7 @@
 #include "tenzir/fbs/partition_synopsis.hpp"
 #include "tenzir/index_config.hpp"
 #include "tenzir/qualified_record_field.hpp"
+#include "tenzir/resource.hpp"
 #include "tenzir/synopsis.hpp"
 #include "tenzir/table_slice.hpp"
 #include "tenzir/uuid.hpp"
@@ -50,6 +51,15 @@ struct partition_synopsis final : public caf::ref_counted {
   /// @returns A best-effort estimate of the amount of memory used by this
   ///          synopsis.
   size_t memusage() const;
+
+  // Information about the raw data storage.
+  resource store_file = {};
+
+  // Information about the dense indexes.
+  resource indexes_file = {};
+
+  // Information about the sparse indexes.
+  resource sketches_file = {};
 
   // Number of events in the partition.
   uint64_t events = 0;

--- a/libtenzir/include/tenzir/resource.hpp
+++ b/libtenzir/include/tenzir/resource.hpp
@@ -1,0 +1,28 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2023 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace tenzir {
+
+struct resource {
+  std::string url;
+  uint64_t size;
+
+  template <class Inspector>
+  friend auto inspect(Inspector& f, resource& x) {
+    return f.object(x)
+      .pretty_name("tenzir.resource")
+      .fields(f.field("url", x.url), f.field("size", x.size));
+  }
+};
+
+} // namespace tenzir

--- a/libtenzir/include/tenzir/store.hpp
+++ b/libtenzir/include/tenzir/store.hpp
@@ -12,10 +12,13 @@
 
 #include "tenzir/actors.hpp"
 #include "tenzir/generator.hpp"
+#include "tenzir/resource.hpp"
 #include "tenzir/table_slice.hpp"
 #include "tenzir/uuid.hpp"
 
 #include <caf/typed_event_based_actor.hpp>
+
+#include <variant>
 
 namespace tenzir {
 
@@ -129,6 +132,8 @@ default_passive_store_actor::behavior_type default_passive_store(
 struct default_active_store_state {
   static constexpr auto name = "active-store";
 
+  std::variant<std::monostate, resource, caf::typed_response_promise<resource>>
+    file = {};
   default_active_store_actor::pointer self = {};
   filesystem_actor filesystem = {};
   accountant_actor accountant = {};

--- a/libtenzir/src/detail/add_message_types.cpp
+++ b/libtenzir/src/detail/add_message_types.cpp
@@ -38,6 +38,7 @@
 #include "tenzir/query_options.hpp"
 #include "tenzir/query_status.hpp"
 #include "tenzir/report.hpp"
+#include "tenzir/resource.hpp"
 #include "tenzir/status.hpp"
 #include "tenzir/subnet.hpp"
 #include "tenzir/table_slice.hpp"

--- a/libtenzir/src/plugin.cpp
+++ b/libtenzir/src/plugin.cpp
@@ -439,8 +439,12 @@ store_plugin::make_store(accountant_actor accountant, filesystem_actor fs,
     return caf::make_error(ec::invalid_argument, "header must have size of "
                                                  "single uuid");
   const auto id = uuid{header.subspan<0, uuid::num_bytes>()};
-  auto path
-    = std::filesystem::path{"archive"} / fmt::format("{}.{}", id, name());
+  auto db_dir = std::filesystem::path{
+    caf::get_or(content(fs->home_system().config()), "tenzir.db-directory",
+                defaults::db_directory.data())};
+  std::error_code err{};
+  const auto abs_dir = std::filesystem::absolute(db_dir, err);
+  auto path = abs_dir / "archive" / fmt::format("{}.{}", id, name());
   return fs->home_system().spawn<caf::lazy_init>(default_passive_store,
                                                  std::move(*store), fs,
                                                  std::move(accountant),

--- a/libtenzir/src/plugin.cpp
+++ b/libtenzir/src/plugin.cpp
@@ -416,8 +416,12 @@ store_plugin::make_store_builder(accountant_actor accountant,
   auto store = make_active_store();
   if (!store)
     return store.error();
-  auto path
-    = std::filesystem::path{"archive"} / fmt::format("{}.{}", id, name());
+  auto db_dir = std::filesystem::path{
+    caf::get_or(content(fs->home_system().config()), "tenzir.db-directory",
+                defaults::db_directory.data())};
+  std::error_code err{};
+  const auto abs_dir = std::filesystem::absolute(db_dir, err);
+  auto path = abs_dir / "archive" / fmt::format("{}.{}", id, name());
   auto store_builder = fs->home_system().spawn<caf::lazy_init>(
     default_active_store, std::move(*store), fs, std::move(accountant),
     std::move(path), name());

--- a/libtenzir/test/active_partition.cpp
+++ b/libtenzir/test/active_partition.cpp
@@ -88,6 +88,9 @@ dummy_store(std::reference_wrapper<std::vector<tenzir::query_context>>
        const tenzir::ids&) -> caf::result<uint64_t> {
       return 0u;
     },
+    [](const tenzir::atom::persist&) -> caf::result<tenzir::resource> {
+      return {};
+    },
     [](caf::stream<tenzir::table_slice>)
       -> caf::result<caf::inbound_stream_slot<tenzir::table_slice>> {
       return tenzir::ec::no_error;

--- a/libtenzir/test/feather.cpp
+++ b/libtenzir/test/feather.cpp
@@ -441,11 +441,16 @@ TEST(active feather store status) {
                          std::chrono::duration_cast<tenzir::duration>(timeout));
   run();
   r.receive(
-    [uuid](record& status) {
+    [uuid, this](record& status) {
+      auto db_dir = std::filesystem::path{
+        caf::get_or(content(self->home_system().config()),
+                    "tenzir.db-directory", defaults::db_directory.data())};
+      std::error_code err{};
+      const auto abs_dir = std::filesystem::absolute(db_dir, err);
+      auto path = abs_dir / "archive" / fmt::format("{}.feather", uuid);
       const auto expected = record{
         {"events", 4_c},
-        {"path",
-         std::filesystem::path{"archive"} / fmt::format("{}.feather", uuid)},
+        {"path", path},
         {"store-type", "feather"},
       };
       CHECK_EQUAL(expected, status);

--- a/plugins/parquet/tests/parquet.cpp
+++ b/plugins/parquet/tests/parquet.cpp
@@ -469,11 +469,16 @@ TEST(active parquet store status) {
                          std::chrono::duration_cast<tenzir::duration>(timeout));
   run();
   r.receive(
-    [uuid](record& status) {
+    [uuid, this](record& status) {
+      auto db_dir = std::filesystem::path{
+        caf::get_or(content(self->home_system().config()),
+                    "tenzir.db-directory", defaults::db_directory.data())};
+      std::error_code err{};
+      const auto abs_dir = std::filesystem::absolute(db_dir, err);
+      auto path = abs_dir / "archive" / fmt::format("{}.parquet", uuid);
       const auto expected = record{
         {"events", 4_c},
-        {"path",
-         std::filesystem::path{"archive"} / fmt::format("{}.parquet", uuid)},
+        {"path", path},
         {"store-type", "parquet"},
       };
       CHECK_EQUAL(expected, status);


### PR DESCRIPTION
The partitions aspect is enhanced by the urls and file sizes of all persisted files.
Here is a sample:
```json
{
  "uuid": "9b6f3896-580d-461e-a930-59f784b3b59a",
  "memusage": 520,
  "events": 1,
  "min_import_time": "2023-11-27T16:59:28.946264",
  "max_import_time": "2023-11-27T16:59:28.946264",
  "version": 2,
  "schema": "suricata.http",
  "schema_id": "4e0aca2cf6a30f52",
  "store": {
    "url": "file:///home/tobim/t/tenzir/store-size-in-partition-metadata/tenzir.db/archive/9b6f3896-580d-461e-a930-59f784b3b59a.feather",
    "size": 7554
  },
  "bitmaps": {
    "url": "file:///home/tobim/t/tenzir/store-size-in-partition-metadata/tenzir.db/index/9b6f3896-580d-461e-a930-59f784b3b59a",
    "size": 17080
  },
  "sketches": {
    "url": "file:///home/tobim/t/tenzir/store-size-in-partition-metadata/tenzir.db/index/9b6f3896-580d-461e-a930-59f784b3b59a.mdx",
    "size": 4808
  }
}
```

The catalog now tracks this data directly to make this possible, which opens the door for a few improvements down the road.