### PR TITLE
"URI" -> "URL" in docs and loader_saver_resolver.cpp

### DIFF
--- a/changelog/next/features/3608--uri-loader.md
+++ b/changelog/next/features/3608--uri-loader.md
@@ -1,4 +1,4 @@
-The operators `from`, `to`, `load`, and `save` support using URIs and file paths
+The operators `from`, `to`, `load`, and `save` support using URLs and file paths
 directly as their argument. For example, `load https://example.com` means
 `load https https://example.com`, and `save local-file.json` means
 `save file local-file.json`.

--- a/changelog/next/features/3653--file-extension-loader.md
+++ b/changelog/next/features/3653--file-extension-loader.md
@@ -1,4 +1,4 @@
-When using `from <URI>` and `to <URI>` without specifying the format explicitly
+When using `from <URL>` and `to <URL>` without specifying the format explicitly
 using a `read`/`write` argument, the default format is determined by the file
 extension for all loaders and savers, if possible. Previously, that was only
 done when using the `file` loader/saver. Additionally, if the file name would

--- a/web/docs/connectors.md
+++ b/web/docs/connectors.md
@@ -23,19 +23,19 @@ to <connector> [write <format>]
 If the format is omitted, the default depends on the connector.
 
 Alternatively, instead of a connector, the `from` and `to` operators
-can take a URI or a filesystem path directly:
+can take a URL or a filesystem path directly:
 
 ```
-from <uri> [read <format>]
+from <url> [read <format>]
 from <path> [read <format>]
 
-to <uri> [write <format>]
+to <url> [write <format>]
 to <path> [write <format>]
 ```
 
-When given a URI, the scheme is used to determine the connector to use.
-For example, if the URI scheme is `http`, the [`http`](connectors/http.md) connector is used.
-The [`gcs`](connectors/gcs.md) connector is an exception, as it will get used if the URI scheme is `gs`.
+When given a URL, the scheme is used to determine the connector to use.
+For example, if the URL scheme is `http`, the [`http`](connectors/http.md) connector is used.
+The [`gcs`](connectors/gcs.md) connector is an exception, as it will get used if the URL scheme is `gs`.
 
 ```
 from https://example.com/foo.json

--- a/web/docs/connectors/gcs.md
+++ b/web/docs/connectors/gcs.md
@@ -44,7 +44,7 @@ credentials.
 ## Examples
 
 Read JSON from an object `log.json` in the folder `logs` in `bucket`.
-Note how the `gcs` loader is used automatically, when the URI scheme is `gs://`.
+Note how the `gcs` loader is used automatically, when the URL scheme is `gs://`.
 
 ```
 from gcs gs://bucket/logs/log.json

--- a/web/docs/operators/sources/from.md
+++ b/web/docs/operators/sources/from.md
@@ -5,7 +5,7 @@ Produces events by combining a [connector][connectors] and a [format][formats].
 ## Synopsis
 
 ```
-from <uri> [read <format>]
+from <url> [read <format>]
 from <path> [read <format>]
 from <connector> [read <format>]
 ```
@@ -70,8 +70,8 @@ from file path/to/eve.json
 from file path/to/eve.json read suricata
 ```
 
-Read bytes from the URI `https://example.com/data.json` over HTTPS and parse them as JSON.
-Note that when `from` is passed a URI directly, the `https` connector is automatically used.
+Read bytes from the URL `https://example.com/data.json` over HTTPS and parse them as JSON.
+Note that when `from` is passed a URL directly, the `https` connector is automatically used.
 
 ```
 from https://example.com/data.json read json

--- a/web/docs/operators/sources/load.md
+++ b/web/docs/operators/sources/load.md
@@ -10,7 +10,7 @@ operator. Only use this if you need to operate on raw bytes.
 ## Synopsis
 
 ```
-load <uri>
+load <url>
 load <path>
 load <connector>
 ```
@@ -38,7 +38,7 @@ Read bytes from stdin:
 load stdin
 ```
 
-Read bytes from the URI `https://example.com/file.json`:
+Read bytes from the URL `https://example.com/file.json`:
 
 ```
 load https://example.com/file.json


### PR DESCRIPTION
Related discussion https://github.com/tenzir/tenzir/pull/3675#discussion_r1410691025

The `s3` connector still uses the term "URI", both in the docs, and in the implementation, even though "URL" would be more precise. I left that out of this drive-by fix, since they have been there for longer than this newfangled URL-connector stuff.