### PR TITLE
Prepare repository for Tenzir v4.6.2

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tenzir"
-version = "4.6.1"
+version = "4.6.2"
 description = "A security telemetry engine for detection and response"
 authors = ["Tenzir <engineering@tenzir.com>"]
 maintainers = ["Tenzir <engineering@tenzir.com>"]

--- a/version.json
+++ b/version.json
@@ -4,14 +4,14 @@
     "annotated git tag without the leading 'v'.",
     "This value gets updated automatically by `scripts/prepare-release`."
   ],
-  "tenzir-version-fallback": "4.6.1",
+  "tenzir-version-fallback": "4.6.2",
   "tenzir-version-rev-count_COMMENT": [
     "This value stores the ancestor count of the tagged commit, calculated",
     "with `git rev-list --count HEAD`, then incremented by 1. This operates",
     "under the assumption that the release-preparing PR contains exactly one",
     "commit and is rebased before merging."
   ],
-  "tenzir-version-rev-count": 18880,
+  "tenzir-version-rev-count": 18883,
   "tenzir-partition-version_COMMENT": [
     "The partition version. This number must be bumped alongside the release",
     "version for releases that contain major format changes to the on-disk",


### PR DESCRIPTION
This commit is was created with /scripts/prepare-release.

Here is a high-level summary of the changes:

* Updated `/version.json` to v4.6.2 and the expected rev-count of the merge commit to 18883.
* Generated a new entry in the docs version selector list.
* Removed the docs for the previous release candidate.
* Updated the python bindings version in `/python/pyproject.toml` to v4.6.2.