### PR TITLE
Disable regression tests for v4.6.0 and v4.6.1

### DIFF
--- a/.github/workflows/tenzir.yaml
+++ b/.github/workflows/tenzir.yaml
@@ -110,7 +110,7 @@ jobs:
           if git rev-parse "${limit_version}" --; then
             dated_versions=$(git for-each-ref --format="%(creatordate:format:%s)#%(refname:short)" "refs/tags/v[1-9]*" | grep -v '\-rc[0-9]\+$')
             dated_limit_version=$(printf "$dated_versions" | grep $limit_version)
-            filtered_versions=$(printf "$dated_versions" | awk '-F#' '{if($0>="'$dated_limit_version'")print$2}')
+            filtered_versions=$(printf "$dated_versions" | awk '-F#' '{if($0>="'$dated_limit_version'")print$2}' | grep -v 'v4.6.[0-1]')
             version_matrix="$(printf "$filtered_versions\nlatest\n" | jq -R | jq -sc 'map({version: .})')"
           else
             version_matrix="$(printf "latest\n" | jq -R | jq -sc 'map({version: .})')"


### PR DESCRIPTION
These were bad releases that did not upload correctly in CI, so the regression tests fail for them.