### PR TITLE
Use `--no-infer` for demo nodes

### DIFF
--- a/demo-node/setup.bash
+++ b/demo-node/setup.bash
@@ -10,14 +10,14 @@ coproc NODE { exec tenzir-node --print-endpoint; }
 read -r -u "${NODE[0]}" DUMMY
 
 echo "Spawnng M57 Suricata pipeline"
-m57_suricata_definition='load https https://storage.googleapis.com/tenzir-datasets/M57/suricata.json.zst\n| decompress zstd\n| read suricata\n| where #schema != \"suricata.stats\"\n| import'
+m57_suricata_definition='from https://storage.googleapis.com/tenzir-datasets/M57/suricata.json.zst read suricata --no-infer\n| where #schema != \"suricata.stats\"\n| import'
 m57_suricata_id=$(tenzir -q "api /pipeline/create '{\"definition\": \"${m57_suricata_definition}\", \"name\": \"M57 Suricata\", \"autostart\": {\"created\": true}}'" | jq -re ".id")
 echo "Setting labels for M57 Suricata pipeline"
 m57_suricata_labels='[{"text": "suricata", "color": "#0086e5"}, {"text": "import", "color": "#2f00cc"}]'
 tenzir -q "api /pipeline/update '{\"id\": \"${m57_suricata_id}\", \"labels\": ${m57_suricata_labels}}'" | jq -er '"id = \(.pipeline.id)"'
 
 echo "Spawnng M57 Zeek pipeline"
-m57_zeek_definition='load https https://storage.googleapis.com/tenzir-datasets/M57/zeek-all.log.zst\n| decompress zstd\n| read zeek-tsv\n| import'
+m57_zeek_definition='from https://storage.googleapis.com/tenzir-datasets/M57/zeek-all.log.zst read zeek-tsv\n| import'
 m57_zeek_id=$(tenzir -q "api /pipeline/create '{\"definition\": \"${m57_zeek_definition}\", \"name\": \"M57 Zeek\", \"autostart\": {\"created\": true}}'" | jq -re ".id")
 echo "Setting labels for M57 Zeek pipeline"
 m57_zeek_labels='[{"text": "zeek", "color": "#e89400"}, {"text": "import", "color": "#2f00cc"}]'


### PR DESCRIPTION
This vastly improves the batch sizes for Suricata events, since type inference combined with null fields missing by default causes performance issues otherwise.

Additionally, this also rewrites the pipelines with the new `from <url>` notation for improved readability.

To test locally, have `tenzir` and `tenzir-node` in your `$PATH`, wipe your `$PWD/tenzir.db`, and run `demo-node/setup.bash`. Afterwards, start your node, and it should behave just like a demo node.
