### PR TITLE
Fix debian package installation when a vast state directory exists

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -208,6 +208,7 @@ RUN cmake -S contrib/tenzir-plugins/platform -B build-platform -G Ninja \
 
 FROM tenzir-de AS tenzir-ce
 
+COPY --from=context-plugin --chown=tenzir:tenzir /plugin/context /
 COPY --from=matcher-plugin --chown=tenzir:tenzir /plugin/matcher /
 COPY --from=netflow-plugin --chown=tenzir:tenzir /plugin/netflow /
 COPY --from=pipeline-manager-plugin --chown=tenzir:tenzir /plugin/pipeline_manager /

--- a/ansible/roles/tenzir/tenzir-node.service
+++ b/ansible/roles/tenzir/tenzir-node.service
@@ -16,6 +16,11 @@ User=tenzir
 Group=tenzir
 NoNewPrivileges=yes
 
+# Directories
+StateDirectory=tenzir
+CacheDirectory=tenzir
+LogsDirectory=tenzir
+
 # capabilities
 RestrictNamespaces=yes
 RestrictAddressFamilies=
@@ -26,11 +31,6 @@ RestrictSUIDSGID=yes
 # system access
 ExecPaths=/opt/tenzir/libexec/tenzir-df-percent.sh
 ProtectSystem=strict
-ReadWritePaths=/var/cache/tenzir
-ReadWritePaths=/var/lib/tenzir
-ReadWritePaths=/var/lib/vast
-ReadWritePaths=/var/log/tenzir
-ReadWritePaths=/var/log/vast
 ReadWritePaths=/tmp
 PrivateTmp=no
 # Allow read access to the home directory of the user so config files can be

--- a/changelog/next/bug-fixes/3705.md
+++ b/changelog/next/bug-fixes/3705.md
@@ -1,0 +1,2 @@
+The Debian package sometimes failed to install, and the bundled systemd unit
+failed to start with Tenzir v4.6.2. This issue no longer exists.

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -328,6 +328,7 @@ in {
     };
   in
     pkg.withPlugins (ps: [
+      ps.context
       ps.matcher
       ps.netflow
       ps.pipeline_manager
@@ -349,6 +350,7 @@ in {
   in
     pkg.withPlugins (ps: [
       ps.compaction
+      ps.context
       #ps.inventory
       ps.matcher
       ps.netflow

--- a/scripts/debian/postinst
+++ b/scripts/debian/postinst
@@ -3,41 +3,6 @@
 set -e
 
 if [ "$1" = "configure" ]; then
-  # Provide an opt-out mechanism for the automatic migration.
-  if ! [ -f /var/lib/vast/disable-migration ]; then
-    if getent passwd vast >/dev/null; then
-      echo "Detected previous VAST installation and enabling trace mode for the migration"
-      set -x
-    fi
-    # Migrate user and group.
-    if ! getent passwd tenzir >/dev/null; then
-      if getent passwd vast >/dev/null; then
-        usermod -l tenzir vast
-        usermod -d /var/lib/tenzir tenzir || true
-        groupmod -n tenzir vast
-      fi
-    fi
-    # Copy vast.yaml to tenzir.yaml.
-    if [ -f /opt/vast/etc/vast/vast.yaml ] && ! [ -f /opt/tenzir/etc/tenzir/tenzir.yaml ]; then
-      mkdir -p /opt/tenzir/etc/tenzir
-      cp /opt/vast/etc/vast/vast.yaml /opt/tenzir/etc/tenzir/tenzir.yaml
-    fi
-    explicit_db_dir=0
-    if grep -q '^\s\+db-directory:' /opt/vast/etc/vast/vast.yaml > /dev/null 2>&1; then
-      explicit_db_dir=1
-    fi
-    # Move db-directory if is not set explicitly.
-    if [ "$explicit_db_dir" = 0 ] && [ -d /var/lib/vast ] && ! [ -f /var/lib/vast/MOVED-TO-VAR-LIB-TENZIR ] && ! [ -d /var/lib/tenzir ]; then
-      mv /var/lib/vast /var/lib/tenzir
-      mkdir /var/lib/vast
-      touch /var/lib/vast/MOVED-TO-VAR-LIB-TENZIR
-      # Also adjust the inner /var/lib/tenzir/vast.db directory in case it exists.
-      if [ -d /var/lib/tenzir/vast.db ]; then
-        mv /var/lib/tenzir/vast.db /var/lib/tenzir/tenzir.db
-      fi
-    fi
-    set +x
-  fi
 	mkdir -p /var/lib/tenzir
     if ! getent passwd tenzir >/dev/null; then
         adduser \
@@ -58,15 +23,6 @@ if [ "$1" = "configure" ]; then
 fi
 
 if [ "$1" = "configure" ] ; then
-	# Delete all lines referencing /var/lib/vast if it doesn't exist. This works
-	# around restrictive behavior in systemd, which refuses to start the unit if
-	# a ReadWritePath does not exist.
-  if ! [ -d /var/lib/vast ]; then
-    sed -i '/\/var\/lib\/vast/d' /opt/tenzir/lib/systemd/system/tenzir-node.service
-  fi
-	if ! [ -d /var/log/vast ]; then
-		sed -i '/\/var\/log\/vast/d' /opt/tenzir/lib/systemd/system/tenzir-node.service
-	fi
   if [ -d /run/systemd/system ]; then
     # Link the service into systemd's default service directory to make
     # it known.

--- a/tenzir/services/systemd/tenzir-node.service.in
+++ b/tenzir/services/systemd/tenzir-node.service.in
@@ -16,6 +16,11 @@ User=tenzir
 Group=tenzir
 NoNewPrivileges=yes
 
+# Directories
+StateDirectory=tenzir
+CacheDirectory=tenzir
+LogsDirectory=tenzir
+
 # capabilities
 RestrictNamespaces=yes
 RestrictAddressFamilies=
@@ -26,11 +31,6 @@ RestrictSUIDSGID=yes
 # system access
 ExecPaths=@CMAKE_INSTALL_FULL_LIBEXECDIR@/tenzir-df-percent.sh
 ProtectSystem=strict
-ReadWritePaths=/var/cache/tenzir
-ReadWritePaths=/var/lib/tenzir
-ReadWritePaths=/var/lib/vast
-ReadWritePaths=/var/log/tenzir
-ReadWritePaths=/var/log/vast
 ReadWritePaths=/tmp
 PrivateTmp=no
 # Allow read access to the home directory of the user so config files can be


### PR DESCRIPTION
This PR drops the migration support from VAST. The logic to implement that did so without updating the internal state of dpkg, causing problems with the package on the next update.

We also include a commit to simplify the setup of the `cache`, `state` and `log` directories in the systemd unit.