### PR TITLE
Include UDOs in `show operators`

### DIFF
--- a/changelog/next/features/3723--show-udos.md
+++ b/changelog/next/features/3723--show-udos.md
@@ -1,0 +1,2 @@
+`show operators` now shows user-defined operators in addition to operators
+that ship with Tenzir or as plugins.

--- a/libtenzir/builtins/aspects/config.cpp
+++ b/libtenzir/builtins/aspects/config.cpp
@@ -34,7 +34,7 @@ public:
   }
 
   auto location() const -> operator_location override {
-    return operator_location::local;
+    return operator_location::anywhere;
   }
 
   auto show(operator_control_plane&) const -> generator<table_slice> override {

--- a/libtenzir/builtins/aspects/operators.cpp
+++ b/libtenzir/builtins/aspects/operators.cpp
@@ -8,27 +8,21 @@
 
 #include <tenzir/argument_parser.hpp>
 #include <tenzir/plugin.hpp>
-#include <tenzir/table_slice_builder.hpp>
+#include <tenzir/series_builder.hpp>
 
 namespace tenzir::plugins::operators {
 
 namespace {
 
-/// A type that represents an operator.
-auto operator_type() -> type {
-  return type{
-    "tenzir.operator",
-    record_type{
-      {"name", string_type{}},
-      {"source", bool_type{}},
-      {"transformation", bool_type{}},
-      {"sink", bool_type{}},
-    },
-  };
-}
-
 class plugin final : public virtual aspect_plugin {
 public:
+  auto initialize(const record& plugin_config, const record& global_config)
+    -> caf::error override {
+    (void)plugin_config;
+    udos_ = get_or(global_config, "tenzir.operators", udos_);
+    return {};
+  }
+
   auto name() const -> std::string override {
     return "operators";
   }
@@ -39,18 +33,51 @@ public:
 
   auto show(operator_control_plane& ctrl) const
     -> generator<table_slice> override {
-    auto builder = table_slice_builder{operator_type()};
+    auto builder = series_builder{};
+    // Add operator plugins.
     for (const auto* plugin : plugins::get<operator_parser_plugin>()) {
+      auto event = builder.record();
       auto signature = plugin->signature();
-      if (not(builder.add(plugin->name()) && builder.add(signature.source)
-              && builder.add(signature.transformation)
-              && builder.add(signature.sink))) {
-        diagnostic::error("failed to add operator").emit(ctrl.diagnostics());
-        co_return;
-      }
+      event.field("name", plugin->name());
+      event.field("definition").null();
+      event.field("source", signature.source);
+      event.field("transformation", signature.transformation);
+      event.field("sink", signature.sink);
     }
-    co_yield builder.finish();
+    // Add user-defined operators.
+    for (const auto& [udo, definition] : udos_) {
+      auto def_str = caf::get_if<std::string>(&definition);
+      if (not def_str) {
+        // Invalid UDOs are just ignored for `show operators`, as we don't care
+        // about them here.
+        continue;
+      }
+      auto op = pipeline::internal_parse(*def_str);
+      if (not op) {
+        diagnostic::warning("user-defined operator `{}` failed to parse: {}",
+                            udo, op.error())
+          .emit(ctrl.diagnostics());
+        continue;
+      }
+      auto event = builder.record();
+      event.field("name", udo);
+      event.field("definition", *def_str);
+      const auto void_output = op->infer_type<void>();
+      const auto bytes_output = op->infer_type<chunk_ptr>();
+      const auto events_output = op->infer_type<table_slice>();
+      event.field("source", static_cast<bool>(void_output));
+      event.field("transformation",
+                  (bytes_output and not bytes_output->is<void>())
+                    or (events_output and not events_output->is<void>()));
+      event.field("sink", (void_output and void_output->is<void>())
+                            or (bytes_output and bytes_output->is<void>())
+                            or (events_output and events_output->is<void>()));
+    }
+    co_yield builder.finish_assert_one_slice("tenzir.operator");
   }
+
+private:
+  record udos_ = {};
 };
 
 } // namespace

--- a/libtenzir/include/tenzir/pipeline.hpp
+++ b/libtenzir/include/tenzir/pipeline.hpp
@@ -129,6 +129,14 @@ auto inspect(auto& f, operator_location& x) {
   return detail::inspect_enum(f, x);
 }
 
+/// Describes the signature of an operator.
+/// @relates operator_parser_plugin
+struct operator_signature {
+  bool source = false;
+  bool transformation = false;
+  bool sink = false;
+};
+
 // TODO: Consider splitting this up and use alias instead.
 struct inspector
   : std::variant<std::reference_wrapper<caf::serializer>,
@@ -377,6 +385,9 @@ public:
     }
     return {};
   }
+
+  /// Infers the "signature" of a pipeline.
+  auto infer_signature() const -> operator_signature;
 
 protected:
   virtual auto infer_type_impl(operator_type input) const

--- a/libtenzir/include/tenzir/plugin.hpp
+++ b/libtenzir/include/tenzir/plugin.hpp
@@ -363,14 +363,6 @@ public:
 
 // -- operator plugin ----------------------------------------------------------
 
-/// Describes the signature of an operator.
-/// @relates operator_parser_plugin
-struct operator_signature {
-  bool source{false};
-  bool transformation{false};
-  bool sink{false};
-};
-
 /// Deriving from this plugin will add an operator with the name of this plugin
 /// to the pipeline parser. Derive from this class when you want to introduce an
 /// alias to existing operators. This plugin itself does not add a new operator,

--- a/libtenzir/src/pipeline.cpp
+++ b/libtenzir/src/pipeline.cpp
@@ -365,6 +365,20 @@ auto operator_base::to_string() const -> std::string {
   return fmt::format("{} {}", name(), s);
 }
 
+auto operator_base::infer_signature() const -> operator_signature {
+  const auto void_output = infer_type<void>();
+  const auto bytes_output = infer_type<chunk_ptr>();
+  const auto events_output = infer_type<table_slice>();
+  return {
+    .source = static_cast<bool>(void_output),
+    .transformation = (bytes_output and not bytes_output->is<void>())
+                      or (events_output and not events_output->is<void>()),
+    .sink = (void_output and void_output->is<void>())
+            or (bytes_output and bytes_output->is<void>())
+            or (events_output and events_output->is<void>()),
+  };
+}
+
 auto operator_base::infer_type_impl(operator_type input) const
   -> caf::expected<operator_type> {
   auto ctrl = local_control_plane{};


### PR DESCRIPTION
This adds user-defined operators to the output of `show operators`.