### PR TITLE
Drop a noisy trace log from the tcp connector

### DIFF
--- a/libtenzir/builtins/connectors/tcp.cpp
+++ b/libtenzir/builtins/connectors/tcp.cpp
@@ -343,8 +343,6 @@ public:
             .request(tcp_bridge, caf::infinite, atom::read_v, uint64_t{65536})
             .await(
               [&](chunk_ptr& chunk) {
-                TENZIR_DEBUG("tcp operator produces {} bytes of data",
-                             chunk->size());
                 result = std::move(chunk);
               },
               [&](const caf::error& err) {


### PR DESCRIPTION
Writing a log message for every successful read on a socket floods the `server.log` file.
