### PR TITLE
Implement the `geoip` context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,6 +96,7 @@ RUN apt-get update && \
       libfmt9 \
       libgrpc++1.51 \
       libhttp-parser2.9 \
+      libmaxminddb0 \
       libpcap0.8 \
       libprotobuf32 \
       librabbitmq4 \

--- a/changelog/next/features/3731--geoip-context.md
+++ b/changelog/next/features/3731--geoip-context.md
@@ -1,0 +1,2 @@
+The new `geoip` context is a built-in that reads MaxMind DB files and uses IP
+values in events to enrich them with the MaxMind DB geolocation data.

--- a/cmake/Findlibmaxminddb.cmake
+++ b/cmake/Findlibmaxminddb.cmake
@@ -1,0 +1,53 @@
+# Findlibmaxminddb
+# ---------
+#
+# Find the libmaxminddb includes and library.
+#
+# Result Variables
+# ^^^^^^^^^^^^^^^^
+#
+# This module will set the following variables in your project:
+#
+# ``libmaxminddb_INCLUDE_DIRS``
+#   where to find maxminddb.h, etc.
+# ``libmaxminddb_LIBRARIES``
+#   the libraries to link against to use the MaxMindDB library.
+# ``libmaxminddb_VERSION``
+#   the version of the MaxMindDB library found.
+# ``libmaxminddb_FOUND``
+#   true if the MaxMindDB library was found.
+#
+find_package(PkgConfig)
+if (PkgConfig_FOUND)
+  pkg_check_modules(MDDB libmaxminddb)
+
+  find_path(
+    libmaxminddb_INCLUDE_DIRS
+    NAMES maxminddb.h
+    HINTS ${MDDB_INCLUDE_DIRS})
+
+  find_library(
+    libmaxminddb_LIBRARIES
+    NAMES maxminddb
+    HINTS ${MDDB_LIBRARIES})
+
+  set(libmaxminddb_VERSION ${MDDB_VERSION})
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(
+    libmaxminddb
+    REQUIRED_VARS libmaxminddb_LIBRARIES libmaxminddb_INCLUDE_DIRS
+    VERSION_VAR libmaxminddb_VERSION)
+
+  mark_as_advanced(libmaxminddb_INCLUDE_DIRS libmaxminddb_LIBRARIES)
+
+  if (libmaxminddb_FOUND)
+    if (NOT TARGET maxminddb::maxminddb)
+      add_library(maxminddb::maxminddb INTERFACE IMPORTED GLOBAL)
+      set_target_properties(
+        maxminddb::maxminddb
+        PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${libmaxminddb_INCLUDE_DIRS}"
+                   INTERFACE_LINK_LIBRARIES "${libmaxminddb_LIBRARIES}")
+    endif ()
+  endif ()
+endif ()
+

--- a/libtenzir/CMakeLists.txt
+++ b/libtenzir/CMakeLists.txt
@@ -338,7 +338,7 @@ target_link_libraries(libtenzir PUBLIC tsl::robin_map)
 # dependency_summary("robin-map" tsl::robin_map "Dependencies")
 
 # Link against libmaxminddb.
-target_link_libraries(libtenzir PUBLIC maxminddb::maxminddb)
+target_link_libraries(libtenzir_builtins PRIVATE maxminddb::maxminddb)
 dependency_summary("libmaxminddb" maxminddb::maxminddb "Dependencies")
 
 # Link against Apache Arrow.

--- a/libtenzir/CMakeLists.txt
+++ b/libtenzir/CMakeLists.txt
@@ -101,6 +101,10 @@ find_package(Boost REQUIRED COMPONENTS headers filesystem)
 
 find_package(re2 REQUIRED)
 
+# -- libmaxminddb -------------------------------------------------------------
+
+find_package(libmaxminddb REQUIRED)
+
 # -- libsystemd ----------------------------------------------------------------
 
 option(TENZIR_ENABLE_JOURNALD_LOGGING
@@ -332,6 +336,10 @@ string(APPEND TENZIR_FIND_DEPENDENCY_LIST "\nfind_package(simdjson REQUIRED)")
 target_link_libraries(libtenzir PUBLIC tsl::robin_map)
 # This is broken for the bundled robin-map, so we special-case it above.
 # dependency_summary("robin-map" tsl::robin_map "Dependencies")
+
+# Link against libmaxminddb.
+target_link_libraries(libtenzir PUBLIC maxminddb::maxminddb)
+dependency_summary("libmaxminddb" maxminddb::maxminddb "Dependencies")
 
 # Link against Apache Arrow.
 target_link_libraries(libtenzir PUBLIC ${ARROW_LIBRARY})

--- a/libtenzir/CMakeLists.txt
+++ b/libtenzir/CMakeLists.txt
@@ -104,6 +104,7 @@ find_package(re2 REQUIRED)
 # -- libmaxminddb -------------------------------------------------------------
 
 find_package(libmaxminddb REQUIRED)
+provide_find_module(libmaxminddb)
 
 # -- libsystemd ----------------------------------------------------------------
 
@@ -338,7 +339,9 @@ target_link_libraries(libtenzir PUBLIC tsl::robin_map)
 # dependency_summary("robin-map" tsl::robin_map "Dependencies")
 
 # Link against libmaxminddb.
-target_link_libraries(libtenzir_builtins PRIVATE maxminddb::maxminddb)
+target_link_libraries(libtenzir PUBLIC maxminddb::maxminddb)
+string(APPEND TENZIR_FIND_DEPENDENCY_LIST
+       "\nfind_package(libmaxminddb)")
 dependency_summary("libmaxminddb" maxminddb::maxminddb "Dependencies")
 
 # Link against Apache Arrow.

--- a/libtenzir/aux/README.md
+++ b/libtenzir/aux/README.md
@@ -8,6 +8,8 @@ This directory contains the third-party software Tenzir uses. We manage it via
 ### submodules
 
 - [CAF](https://github.com/actor-framework/actor-framework) https://github.com/actor-framework/actor-framework
+- [fast_float](https://github.com/fastfloat/fast_float) https://github.com/fastfloat/fast_float
+- [simdjson](https://github.com/simdjson/simdjson) https://github.com/simdjson/simdjson
 
 ### subtrees
 

--- a/libtenzir/builtins/contexts/geoip.cpp
+++ b/libtenzir/builtins/contexts/geoip.cpp
@@ -317,20 +317,21 @@ public:
       return field_builder.finish();
     }
     for (const auto& value : values(slice_type, *slice_array)) {
-      auto gai_error = 0;
+      auto address_info_error = 0;
       auto ip_string = fmt::to_string(value);
       if (slice_type == type{string_type{}}) {
         // Unquote IP strings.
         ip_string.erase(0, 1);
         ip_string.erase(ip_string.size() - 1);
       }
-      auto result
-        = MMDB_lookup_string(&mmdb, ip_string.data(), &gai_error, &status);
-      if (gai_error != MMDB_SUCCESS) {
+      auto result = MMDB_lookup_string(&mmdb, ip_string.data(),
+                                       &address_info_error, &status);
+      if (address_info_error != MMDB_SUCCESS) {
         return caf::make_error(
-          ec::lookup_error, fmt::format("error looking up IP address '{}' in "
-                                        "GeoIP database: {}",
-                                        ip_string, gai_strerror(gai_error)));
+          ec::lookup_error,
+          fmt::format("error looking up IP address '{}' in "
+                      "GeoIP database: {}",
+                      ip_string, gai_strerror(address_info_error)));
       }
       if (status != MMDB_SUCCESS) {
         return caf::make_error(

--- a/libtenzir/builtins/contexts/geoip.cpp
+++ b/libtenzir/builtins/contexts/geoip.cpp
@@ -66,8 +66,8 @@ public:
   }
 
   ~ctx() override {
-    if (mmdb) {
-      MMDB_close(&*mmdb);
+    if (mmdb_) {
+      MMDB_close(&*mmdb_);
     }
   }
 
@@ -317,7 +317,7 @@ public:
         ip_string.erase(0, 1);
         ip_string.erase(ip_string.size() - 1);
       }
-      auto result = MMDB_lookup_string(&*mmdb, ip_string.data(),
+      auto result = MMDB_lookup_string(&*mmdb_, ip_string.data(),
                                        &address_info_error, &status);
       if (address_info_error != MMDB_SUCCESS) {
         return caf::make_error(
@@ -389,12 +389,12 @@ public:
     if (parameters.contains(path_key) and parameters.at(path_key)) {
       db_path_ = *parameters[path_key];
     }
-    if (mmdb) {
-      MMDB_close(&*mmdb);
+    if (mmdb_) {
+      MMDB_close(&*mmdb_);
     } else {
-      mmdb = MMDB_s{};
+      mmdb_ = MMDB_s{};
     }
-    auto status = MMDB_open(db_path_.c_str(), MMDB_MODE_MMAP, &*mmdb);
+    auto status = MMDB_open(db_path_.c_str(), MMDB_MODE_MMAP, &*mmdb_);
     if (status != MMDB_SUCCESS) {
       return caf::make_error(ec::filesystem_error,
                              fmt::format("error opening IP database at path "
@@ -426,8 +426,8 @@ public:
 
 private:
   std::string db_path_;
-  record r;
-  std::optional<MMDB_s> mmdb;
+  record r_;
+  std::optional<MMDB_s> mmdb_;
 };
 
 class plugin : public virtual context_plugin {

--- a/libtenzir/builtins/contexts/geoip.cpp
+++ b/libtenzir/builtins/contexts/geoip.cpp
@@ -356,7 +356,7 @@ public:
                                           ip_string, MMDB_strerror(status)));
         }
         auto r = field_builder.record();
-        r.field("key", value);
+        r.field("address", value);
         r.field("context", output);
         r.field("timestamp", std::chrono::system_clock::now());
       } else {

--- a/libtenzir/builtins/contexts/geoip.cpp
+++ b/libtenzir/builtins/contexts/geoip.cpp
@@ -6,41 +6,24 @@
 // SPDX-FileCopyrightText: (c) 2023 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#include "tenzir/error.hpp"
-#include "tenzir/view.hpp"
-
 #include <tenzir/arrow_table_slice.hpp>
-#include <tenzir/concept/parseable/numeric/bool.hpp>
 #include <tenzir/data.hpp>
-#include <tenzir/detail/range_map.hpp>
+#include <tenzir/error.hpp>
 #include <tenzir/fbs/data.hpp>
 #include <tenzir/flatbuffer.hpp>
 #include <tenzir/fwd.hpp>
 #include <tenzir/plugin.hpp>
-#include <tenzir/project.hpp>
 #include <tenzir/series_builder.hpp>
-#include <tenzir/table_slice.hpp>
-#include <tenzir/table_slice_builder.hpp>
 #include <tenzir/type.hpp>
-#include <tenzir/typed_array.hpp>
+#include <tenzir/view.hpp>
 
-#include <arrow/array.h>
-#include <arrow/array/array_base.h>
-#include <arrow/array/builder_primitive.h>
-#include <arrow/type.h>
-#include <boost/config/detail/suffix.hpp>
-#include <caf/callback.hpp>
-#include <caf/config_value.hpp>
-#include <caf/sum_type.hpp>
 #include <fmt/format.h>
-#include <tsl/robin_map.h>
 
 #include <chrono>
 #include <cstdint>
 #include <maxminddb.h>
 #include <memory>
 #include <string>
-#include <string_view>
 
 namespace tenzir::plugins::geoip {
 

--- a/libtenzir/builtins/contexts/geoip.cpp
+++ b/libtenzir/builtins/contexts/geoip.cpp
@@ -1,0 +1,501 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2023 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "tenzir/error.hpp"
+#include "tenzir/view.hpp"
+
+#include <tenzir/arrow_table_slice.hpp>
+#include <tenzir/concept/parseable/numeric/bool.hpp>
+#include <tenzir/data.hpp>
+#include <tenzir/detail/range_map.hpp>
+#include <tenzir/fbs/data.hpp>
+#include <tenzir/flatbuffer.hpp>
+#include <tenzir/fwd.hpp>
+#include <tenzir/plugin.hpp>
+#include <tenzir/project.hpp>
+#include <tenzir/series_builder.hpp>
+#include <tenzir/table_slice.hpp>
+#include <tenzir/table_slice_builder.hpp>
+#include <tenzir/type.hpp>
+#include <tenzir/typed_array.hpp>
+
+#include <arrow/array.h>
+#include <arrow/array/array_base.h>
+#include <arrow/array/builder_primitive.h>
+#include <arrow/type.h>
+#include <boost/config/detail/suffix.hpp>
+#include <caf/callback.hpp>
+#include <caf/config_value.hpp>
+#include <caf/sum_type.hpp>
+#include <fmt/format.h>
+#include <tsl/robin_map.h>
+
+#include <chrono>
+#include <cstdint>
+#include <maxminddb.h>
+#include <memory>
+#include <string>
+#include <string_view>
+
+namespace tenzir::plugins::geoip {
+
+namespace {
+
+auto constexpr path_key = "db_path";
+
+#if MMDB_UINT128_IS_BYTE_ARRAY
+auto cast_128_bit_unsigned_to_64_bit(uint8_t uint128[16]) -> uint64_t {
+  auto low = uint64_t{};
+  auto high = uint64_t{};
+  std::memcpy(&low, uint128, 8);
+  std::memcpy(&high, uint128 + 8, 8);
+  if (high != 0) {
+    TENZIR_WARN("casting MDDB 128-bit to 64-bit unsigned will be lossy for "
+                "value [{},{}]",
+                high, low);
+  }
+  return low;
+}
+#else
+auto cast_128_bit_unsigned_to_64_bit(mmdb_uint128_t uint128) -> uint64_t {
+  auto high = static_cast<uint64_t>(uint128 >> 64);
+  auto low = static_cast<uint64_t>(uint128);
+  if (high != 0) {
+    TENZIR_WARN("casting MDDB 128-bit to 64-bit unsigned will be lossy for "
+                "value [{},{}]",
+                high, low);
+  }
+  return low;
+}
+#endif
+
+class ctx final : public virtual context {
+public:
+  ctx() noexcept = default;
+
+  explicit ctx(context::parameter_map parameters) noexcept {
+    update(std::move(parameters));
+  }
+
+  auto entry_data_list_to_list(MMDB_entry_data_list_s* entry_data_list,
+                               int* status, list& l) const
+    -> MMDB_entry_data_list_s* {
+    switch (entry_data_list->entry_data.type) {
+      case MMDB_DATA_TYPE_MAP: {
+        auto size = entry_data_list->entry_data.data_size;
+        auto sub_r = record{};
+        for (entry_data_list = entry_data_list->next; size && entry_data_list;
+             size--) {
+          if (MMDB_DATA_TYPE_UTF8_STRING != entry_data_list->entry_data.type) {
+            *status = MMDB_INVALID_DATA_ERROR;
+            return entry_data_list;
+          }
+          auto sub_record_key
+            = std::string{entry_data_list->entry_data.utf8_string,
+                          entry_data_list->entry_data.data_size};
+
+          entry_data_list = entry_data_list->next;
+          entry_data_list = entry_data_list_to_record(entry_data_list, status,
+                                                      sub_r, sub_record_key);
+          if (*status != MMDB_SUCCESS) {
+            return entry_data_list;
+          }
+        }
+        l.emplace_back(sub_r);
+        break;
+      }
+      case MMDB_DATA_TYPE_ARRAY: {
+        auto sub_l = list{};
+        auto size = entry_data_list->entry_data.data_size;
+        for (entry_data_list = entry_data_list->next; size && entry_data_list;
+             size--) {
+          entry_data_list
+            = entry_data_list_to_list(entry_data_list, status, sub_l);
+          if (*status != MMDB_SUCCESS) {
+            return entry_data_list;
+          }
+        }
+        l.emplace_back(sub_l);
+        break;
+      }
+      case MMDB_DATA_TYPE_UTF8_STRING: {
+        auto str = std::string{entry_data_list->entry_data.utf8_string,
+                               entry_data_list->entry_data.data_size};
+        l.emplace_back(str);
+        entry_data_list = entry_data_list->next;
+        break;
+      }
+      case MMDB_DATA_TYPE_BYTES: {
+        auto bytes = blob{
+          reinterpret_cast<const std::byte*>(entry_data_list->entry_data.bytes),
+          entry_data_list->entry_data.data_size};
+        l.emplace_back(std::move(bytes));
+        entry_data_list = entry_data_list->next;
+        break;
+      }
+      case MMDB_DATA_TYPE_DOUBLE:
+        l.emplace_back(entry_data_list->entry_data.double_value);
+        entry_data_list = entry_data_list->next;
+        break;
+      case MMDB_DATA_TYPE_FLOAT:
+        l.emplace_back(entry_data_list->entry_data.float_value);
+        entry_data_list = entry_data_list->next;
+        break;
+      case MMDB_DATA_TYPE_UINT16:
+        l.emplace_back(entry_data_list->entry_data.uint16);
+        entry_data_list = entry_data_list->next;
+        break;
+      case MMDB_DATA_TYPE_UINT32:
+        l.emplace_back(entry_data_list->entry_data.uint32);
+        entry_data_list = entry_data_list->next;
+        break;
+      case MMDB_DATA_TYPE_BOOLEAN:
+        l.emplace_back(entry_data_list->entry_data.boolean);
+        entry_data_list = entry_data_list->next;
+        break;
+      case MMDB_DATA_TYPE_UINT64:
+        l.emplace_back(entry_data_list->entry_data.uint64);
+        entry_data_list = entry_data_list->next;
+        break;
+      case MMDB_DATA_TYPE_UINT128:
+        l.emplace_back(
+          cast_128_bit_unsigned_to_64_bit(entry_data_list->entry_data.uint128));
+        entry_data_list = entry_data_list->next;
+        break;
+      case MMDB_DATA_TYPE_INT32:
+        l.emplace_back(int64_t{entry_data_list->entry_data.int32});
+        entry_data_list = entry_data_list->next;
+        break;
+      default:
+        *status = MMDB_INVALID_DATA_ERROR;
+        return entry_data_list;
+    }
+    *status = MMDB_SUCCESS;
+    return entry_data_list;
+  }
+
+  auto
+  entry_data_list_to_record(MMDB_entry_data_list_s* entry_data_list,
+                            int* status, record& r, std::string key = {}) const
+    -> MMDB_entry_data_list_s* {
+    switch (entry_data_list->entry_data.type) {
+      case MMDB_DATA_TYPE_MAP: {
+        auto size = entry_data_list->entry_data.data_size;
+
+        for (entry_data_list = entry_data_list->next; size && entry_data_list;
+             size--) {
+          if (MMDB_DATA_TYPE_UTF8_STRING != entry_data_list->entry_data.type) {
+            *status = MMDB_INVALID_DATA_ERROR;
+            return entry_data_list;
+          }
+          auto sub_record_key
+            = std::string{entry_data_list->entry_data.utf8_string,
+                          entry_data_list->entry_data.data_size};
+          auto sub_r = record{};
+          entry_data_list = entry_data_list->next;
+          entry_data_list = entry_data_list_to_record(entry_data_list, status,
+                                                      sub_r, sub_record_key);
+          if (*status != MMDB_SUCCESS) {
+            return entry_data_list;
+          }
+          if (sub_r.size() == 1) {
+            // Fuse values of sub-records that belong to the parent record with
+            // the parent record. MMDB recursive map iteration idiosyncracy.
+            r[sub_record_key] = sub_r.begin()->second;
+          } else if (not sub_r.empty()) {
+            r[sub_record_key] = sub_r;
+          }
+        }
+        break;
+      }
+      case MMDB_DATA_TYPE_ARRAY: {
+        auto l = list{};
+        auto size = entry_data_list->entry_data.data_size;
+        auto sub_r = record{};
+        for (entry_data_list = entry_data_list->next; size && entry_data_list;
+             size--) {
+          entry_data_list = entry_data_list_to_list(entry_data_list, status, l);
+          if (*status != MMDB_SUCCESS) {
+            return entry_data_list;
+          }
+        }
+        r[key] = l;
+        break;
+      }
+      case MMDB_DATA_TYPE_UTF8_STRING: {
+        auto str = std::string{entry_data_list->entry_data.utf8_string,
+                               entry_data_list->entry_data.data_size};
+        r[key] = str;
+        entry_data_list = entry_data_list->next;
+        break;
+      }
+      case MMDB_DATA_TYPE_BYTES: {
+        auto bytes = blob{
+          reinterpret_cast<const std::byte*>(entry_data_list->entry_data.bytes),
+          entry_data_list->entry_data.data_size};
+        r[key] = std::move(bytes);
+        entry_data_list = entry_data_list->next;
+        break;
+      }
+      case MMDB_DATA_TYPE_DOUBLE:
+        r[key] = entry_data_list->entry_data.double_value;
+        entry_data_list = entry_data_list->next;
+        break;
+      case MMDB_DATA_TYPE_FLOAT:
+        r[key] = entry_data_list->entry_data.float_value;
+        entry_data_list = entry_data_list->next;
+        break;
+      case MMDB_DATA_TYPE_UINT16:
+        r[key] = entry_data_list->entry_data.uint16;
+        entry_data_list = entry_data_list->next;
+        break;
+      case MMDB_DATA_TYPE_UINT32:
+        r[key] = entry_data_list->entry_data.uint32;
+        entry_data_list = entry_data_list->next;
+        break;
+      case MMDB_DATA_TYPE_BOOLEAN:
+        r[key] = entry_data_list->entry_data.boolean;
+        entry_data_list = entry_data_list->next;
+        break;
+      case MMDB_DATA_TYPE_UINT64:
+        r[key] = entry_data_list->entry_data.uint64;
+        entry_data_list = entry_data_list->next;
+        break;
+      case MMDB_DATA_TYPE_UINT128:
+        r[key] = cast_128_bit_unsigned_to_64_bit(
+          entry_data_list->entry_data.uint128);
+        break;
+      case MMDB_DATA_TYPE_INT32:
+        r[key] = int64_t{entry_data_list->entry_data.int32};
+        entry_data_list = entry_data_list->next;
+        break;
+      default:
+        *status = MMDB_INVALID_DATA_ERROR;
+        return entry_data_list;
+    }
+    *status = MMDB_SUCCESS;
+    return entry_data_list;
+  }
+
+  /// Emits context information for every event in `slice` in order.
+  auto apply(table_slice slice, context::parameter_map parameters) const
+    -> caf::expected<std::vector<typed_array>> override {
+    auto mmdb = MMDB_s{};
+    auto status = MMDB_open(db_path_.c_str(), MMDB_MODE_MMAP, &mmdb);
+    if (status != MMDB_SUCCESS) {
+      return caf::make_error(ec::filesystem_error,
+                             fmt::format("error opening IP database at path "
+                                         "'{}': {}",
+                                         db_path_, MMDB_strerror(status)));
+    }
+    MMDB_entry_data_list_s* entry_data_list = nullptr;
+    auto close_mmdb = caf::detail::make_scope_guard([&] {
+      if (entry_data_list) {
+        MMDB_free_entry_data_list(entry_data_list);
+      }
+      MMDB_close(&mmdb);
+    });
+    auto resolved_slice = resolve_enumerations(slice);
+    auto field_name = std::optional<std::string>{};
+    for (const auto& [key, value] : parameters) {
+      if (key == "field") {
+        if (not value) {
+          return caf::make_error(ec::invalid_argument,
+                                 "invalid argument type for `field`: expected "
+                                 "a string");
+        }
+        field_name = *value;
+        continue;
+      }
+      return caf::make_error(ec::invalid_argument,
+                             fmt::format("invalid argument `{}`", key));
+    }
+    if (not field_name) {
+      return caf::make_error(ec::invalid_argument, "missing argument `field`");
+    }
+    auto field_builder = series_builder{};
+    auto column_offset
+      = caf::get<record_type>(slice.schema()).resolve_key(*field_name);
+    if (not column_offset) {
+      for (auto i = size_t{0}; i < slice.rows(); ++i) {
+        field_builder.null();
+      }
+      return field_builder.finish();
+    }
+    auto [slice_type, slice_array] = column_offset->get(resolved_slice);
+    if (slice_type != type{ip_type{}} and slice_type != type{string_type{}}) {
+      // No ip type = no enrichment.
+      field_builder.null();
+      return field_builder.finish();
+    }
+    for (const auto& value : values(slice_type, *slice_array)) {
+      auto gai_error = 0;
+      auto ip_string = fmt::to_string(value);
+      if (slice_type == type{string_type{}}) {
+        // Unquote IP strings.
+        ip_string.erase(0, 1);
+        ip_string.erase(ip_string.size() - 1);
+      }
+      auto result
+        = MMDB_lookup_string(&mmdb, ip_string.data(), &gai_error, &status);
+      if (gai_error != MMDB_SUCCESS) {
+        return caf::make_error(
+          ec::lookup_error, fmt::format("error looking up IP address '{}' in "
+                                        "GeoIP database: {}",
+                                        ip_string, gai_strerror(gai_error)));
+      }
+      if (status != MMDB_SUCCESS) {
+        return caf::make_error(
+          ec::lookup_error, fmt::format("error looking up IP address '{}' in "
+                                        "GeoIP database: {}",
+                                        ip_string, MMDB_strerror(status)));
+      }
+      if (result.found_entry) {
+        status = MMDB_get_entry_data_list(&result.entry, &entry_data_list);
+        if (status != MMDB_SUCCESS) {
+          return caf::make_error(
+            ec::lookup_error, fmt::format("error looking up IP address '{}' in "
+                                          "GeoIP database: {}",
+                                          ip_string, MMDB_strerror(status)));
+        }
+        auto* entry_data_list_it = entry_data_list;
+        auto output = record{};
+        entry_data_list_it
+          = entry_data_list_to_record(entry_data_list_it, &status, output);
+        if (status != MMDB_SUCCESS) {
+          return caf::make_error(
+            ec::lookup_error, fmt::format("error looking up IP address '{}' in "
+                                          "GeoIP database: {}",
+                                          ip_string, MMDB_strerror(status)));
+        }
+        auto r = field_builder.record();
+        r.field("key", value);
+        r.field("context", output);
+        r.field("timestamp", std::chrono::system_clock::now());
+      } else {
+        field_builder.null();
+      }
+    }
+    return field_builder.finish();
+  }
+
+  /// Inspects the context.
+  auto show() const -> record override {
+    return record{{path_key, db_path_}};
+  }
+
+  /// Updates the context.
+  auto update(table_slice, context::parameter_map)
+    -> caf::expected<record> override {
+    return caf::make_error(ec::unimplemented,
+                           "geoip context can not be updated with events");
+  }
+
+  auto update(chunk_ptr, context::parameter_map)
+    -> caf::expected<record> override {
+    return caf::make_error(ec::unimplemented, "geoip context can not be "
+                                              "updated with bytes");
+  }
+
+  auto update(context::parameter_map parameters)
+    -> caf::expected<record> override {
+    if (parameters.contains(path_key) and parameters.at(path_key)) {
+      db_path_ = *parameters[path_key];
+    }
+    return show();
+  }
+
+  auto save() const -> caf::expected<chunk_ptr> override {
+    // We save the context by formatting into a record of this format:
+    // {path: string}
+    auto builder = flatbuffers::FlatBufferBuilder{};
+    const auto key_key_offset = builder.CreateSharedString(path_key);
+    const auto key_value_offset = pack(builder, data{db_path_});
+    auto field_offsets
+      = std::vector<flatbuffers::Offset<fbs::data::RecordField>>{};
+    field_offsets.reserve(1);
+    const auto record_offset
+      = fbs::data::CreateRecordField(builder, key_key_offset, key_value_offset);
+    field_offsets.emplace_back(record_offset);
+    const auto value_offset
+      = fbs::data::CreateRecordDirect(builder, &field_offsets);
+    const auto data_offset
+      = fbs::CreateData(builder, fbs::data::Data::record, value_offset.Union());
+    fbs::FinishDataBuffer(builder, data_offset);
+    return chunk::make(builder.Release());
+  }
+
+private:
+  std::string db_path_;
+  record r;
+};
+
+class plugin : public virtual context_plugin {
+  auto initialize(const record&, const record&) -> caf::error override {
+    return caf::none;
+  }
+
+  auto name() const -> std::string override {
+    return "geoip";
+  }
+
+  auto make_context(context::parameter_map parameters) const
+    -> caf::expected<std::unique_ptr<context>> override {
+    return std::make_unique<ctx>(std::move(parameters));
+  }
+
+  auto load_context(chunk_ptr serialized) const
+    -> caf::expected<std::unique_ptr<context>> override {
+    auto fb = flatbuffer<fbs::Data>::make(std::move(serialized));
+    if (not fb) {
+      return caf::make_error(ec::serialization_error,
+                             fmt::format("failed to deserialize geoip "
+                                         "context: {}",
+                                         fb.error()));
+    }
+    const auto* record = fb.value()->data_as_record();
+    if (not record) {
+      return caf::make_error(ec::serialization_error,
+                             "failed to deserialize geoip "
+                             "context: invalid type for "
+                             "context entry, entry must be a record");
+    }
+    if (not record->fields() or record->fields()->size() != 1) {
+      return caf::make_error(ec::serialization_error,
+                             "failed to deserialize geoip "
+                             "context: invalid or missing value for "
+                             "context entry, entry must be a record {key, "
+                             "value}");
+    }
+    data value;
+    context::parameter_map params;
+    if (record->fields()->Get(0)->name()->str() != path_key) {
+      return caf::make_error(
+        ec::serialization_error,
+        fmt::format("failed to deserialize geoip context"
+                    ": invalid key '{}' ",
+                    record->fields()->Get(0)->name()->str()));
+    }
+    auto err = unpack(*record->fields()->Get(0)->data(), value);
+    if (err) {
+      return caf::make_error(ec::serialization_error,
+                             fmt::format("failed to deserialize geoip"
+                                         "context: invalid value for key '{}': "
+                                         "{}",
+                                         path_key, err));
+    }
+    params[path_key] = caf::get<std::string>(value);
+    return std::make_unique<ctx>(std::move(params));
+  }
+};
+
+} // namespace
+
+} // namespace tenzir::plugins::geoip
+
+TENZIR_REGISTER_PLUGIN(tenzir::plugins::geoip::plugin)

--- a/libtenzir/builtins/contexts/geoip.cpp
+++ b/libtenzir/builtins/contexts/geoip.cpp
@@ -29,7 +29,7 @@ namespace tenzir::plugins::geoip {
 
 namespace {
 
-auto constexpr path_key = "db_path";
+auto constexpr path_key = "db-path";
 
 #if MMDB_UINT128_IS_BYTE_ARRAY
 auto cast_128_bit_unsigned_to_64_bit(uint8_t uint128[16]) -> uint64_t {

--- a/libtenzir/builtins/contexts/lookup-table.cpp
+++ b/libtenzir/builtins/contexts/lookup-table.cpp
@@ -79,7 +79,7 @@ public:
     for (const auto& value : values(type, *slice_array)) {
       if (auto it = context_entries.find(value); it != context_entries.end()) {
         auto r = field_builder.record();
-        r.field("key", it->first);
+        r.field("address", it->first);
         r.field("context", it->second);
         r.field("timestamp", std::chrono::system_clock::now());
       } else {

--- a/libtenzir/builtins/contexts/lookup-table.cpp
+++ b/libtenzir/builtins/contexts/lookup-table.cpp
@@ -79,7 +79,7 @@ public:
     for (const auto& value : values(type, *slice_array)) {
       if (auto it = context_entries.find(value); it != context_entries.end()) {
         auto r = field_builder.record();
-        r.field("address", it->first);
+        r.field("key", it->first);
         r.field("context", it->second);
         r.field("timestamp", std::chrono::system_clock::now());
       } else {

--- a/libtenzir/fbs/geoip.fbs
+++ b/libtenzir/fbs/geoip.fbs
@@ -1,0 +1,8 @@
+namespace tenzir.fbs.context.geoip;
+
+table GeoIPData {
+  url: string (required);
+}
+
+root_type GeoIPData;
+file_identifier "vGEO";

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -168,6 +168,9 @@ in {
     prev.writeShellScriptBin name ''
       echo "stub-${name}: $@" >&2
     '';
+  libmaxminddb = overrideAttrsIf isStatic prev.libmaxminddb (orig: {
+    nativeBuildInputs = (orig.nativeBuildInputs or []) ++ [prev.buildPackages.cmake];
+  });
   fluent-bit = let
     fluent-bit' =
       overrideAttrsIf isDarwin prev.fluent-bit

--- a/nix/tenzir/default.nix
+++ b/nix/tenzir/default.nix
@@ -32,6 +32,7 @@
     yara,
     rdkafka,
     cppzmq,
+    libmaxminddb,
     re2,
     tenzir-functional-test-deps,
     tenzir-integration-test-deps,
@@ -114,6 +115,7 @@
           libpcap
           libunwind
           libyamlcpp
+          libmaxminddb
           protobuf
           rabbitmq-c
           rdkafka

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "0000000000000000000000000000000000000000",
+  "rev": "19ec5bdeefc0f4f1b9f0d1c1dd563e425ceaa4bd",
   "submodules": true,
   "shallow": true
 }

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "19ec5bdeefc0f4f1b9f0d1c1dd563e425ceaa4bd",
+  "rev": "4c36cdbb32991b6cc6262348fade03b5e2138846",
   "submodules": true,
   "shallow": true
 }

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "4c36cdbb32991b6cc6262348fade03b5e2138846",
+  "rev": "6d20fe57efead2aa2251cee5a4fc54de3c98b8c5",
   "submodules": true,
   "shallow": true
 }

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "93a72fe7d1d3a85e6f3c80554f415d14a8bb4c97",
+  "rev": "19ec5bdeefc0f4f1b9f0d1c1dd563e425ceaa4bd",
   "submodules": true,
   "shallow": true
 }

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "19ec5bdeefc0f4f1b9f0d1c1dd563e425ceaa4bd",
+  "rev": "0000000000000000000000000000000000000000",
   "submodules": true,
   "shallow": true
 }

--- a/scripts/debian/install-dev-dependencies.sh
+++ b/scripts/debian/install-dev-dependencies.sh
@@ -24,6 +24,7 @@ apt-get -y --no-install-recommends install \
     libfmt-dev \
     libgrpc-dev \
     libhttp-parser-dev \
+    libmaxminddb-dev \
     libpcap-dev tcpdump \
     libprotobuf-dev \
     librabbitmq-dev \

--- a/scripts/macOS/install-dev-dependencies.sh
+++ b/scripts/macOS/install-dev-dependencies.sh
@@ -16,6 +16,7 @@ brew install --overwrite \
     gnu-sed \
     grpc \
     http-parser \
+    libmaxminddb \
     libpcap \
     librdkafka \
     libunwind-headers \

--- a/web/docs/contexts/geoip.md
+++ b/web/docs/contexts/geoip.md
@@ -1,15 +1,12 @@
 # GeoIP
 
-A [MaxMind](https://www.maxmind.com/en/home)-based IP address lookup that
-enriches events with geographical data related to a specified IP address.
+A context for enriching IP addresses with geographical data.
 
 ## Synopsis
 
 ```
-context create <name> geoip
-context create <name> geoip --db-path <mmdb file path>
-context update <name>
-context update <name> --db-path <mmdb file path>
+context create <name> geoip [--db-path <mmdb>]
+context update <name> [--db-path <mmdb>]
 context delete <name>
 enrich <name> --field <field>
 lookup <name> --field <field>
@@ -17,18 +14,22 @@ lookup <name> --field <field>
 
 ## Description
 
-The following options are currently supported for the `geoip` context:
+The `geoip` context uses a [MaxMind](https://www.maxmind.com/) database
+to perform IP address lookups.
 
-### `--db-path <mmdb file path>`
+Run `context update <name> --db-path <mmdb>` to initialize the database at path
+`<mmdb>`. Omitting `--db-path` causes a reload of a previously initialized
+database file.
 
-The path to the MaxMind DB file.
+### `--db-path <mmdb>`
 
-Updating the `db-path` will load the file content.
+The path to the MaxMind database file.
 
-Writing `context update <name>` without the path will force the context to
-reload the DB file content.
+You can provide any database in [MMDB
+format](https://maxmind.github.io/MaxMind-DB/).
 
 ### `--field <field>`
 
-The name of the field to use as IP address lookup. Only IP and string values
-will work with this context.
+The name of the field to use as IP address lookup.
+
+Only IP addresses and strings work with this context.

--- a/web/docs/contexts/geoip.md
+++ b/web/docs/contexts/geoip.md
@@ -1,0 +1,34 @@
+# GeoIP
+
+A [MaxMind](https://www.maxmind.com/en/home)-based IP address lookup that
+enriches events with geographical data related to a specified IP address.
+
+## Synopsis
+
+```
+context create <name> geoip
+context create <name> geoip --db-path <mmdb file path>
+context update <name>
+context update <name> --db-path <mmdb file path>
+context delete <name>
+enrich <name> --field <field>
+lookup <name> --field <field>
+```
+
+## Description
+
+The following options are currently supported for the `geoip` context:
+
+### `--db-path <mmdb file path>`
+
+The path to the MaxMind DB file.
+
+Updating the `db-path` will load the file content.
+
+Writing `context update <name>` without the path will force the context to
+reload the DB file content.
+
+### `--field <field>`
+
+The name of the field to use as IP address lookup. Only IP and string values
+will work with this context.

--- a/web/docs/developer-guides/build-from-source.md
+++ b/web/docs/developer-guides/build-from-source.md
@@ -59,7 +59,6 @@ Every [release](https://github.com/tenzir/tenzir/releases) of Tenzir includes an
 ||[bash](https://www.gnu.org/software/bash/)|>= 4.0.0|Required to run the functional tests.|
 ||[bats](https://bats-core.readthedocs.io)|>= 1.8.0|Required to run the functional tests.|
 
-
 The minimum specified versions reflect those versions that we use in CI and
 manual testing. Older versions may still work in select cases.
 

--- a/web/docs/developer-guides/build-from-source.md
+++ b/web/docs/developer-guides/build-from-source.md
@@ -43,6 +43,7 @@ Every [release](https://github.com/tenzir/tenzir/releases) of Tenzir includes an
 |✓|[xxHash](https://github.com/Cyan4973/xxHash)|>= 0.8.0|Required for computing fast hash digests.|
 |✓|[robin-map](https://github.com/Tessil/robin-map)|>= 0.6.3|Fast hash map and hash set using robin hood hashing. (Bundled as subtree.)|
 |✓|[fast_float](https://github.com/FastFloat/fast_float)|>= 3.2.0|Required for parsing floating point numbers. (Bundled as submodule.)|
+|✓|[libmaxminddb](https://github.com/maxmind/libmaxminddb)|>= 1.8.0|Required for the `geoip` context.|
 ||[libpcap](https://www.tcpdump.org)||Required for building the `pcap` plugin.|
 ||[librdkafka](https://github.com/confluentinc/librdkafka)||Required for building the `kafka` plugin.|
 ||[http-parser](https://github.com/nodejs/http-parser)||Required for building the `web` plugin.|
@@ -57,6 +58,7 @@ Every [release](https://github.com/tenzir/tenzir/releases) of Tenzir includes an
 ||[Pandoc](https://github.com/jgm/pandoc)||Required to build the manpage for Tenzir.|
 ||[bash](https://www.gnu.org/software/bash/)|>= 4.0.0|Required to run the functional tests.|
 ||[bats](https://bats-core.readthedocs.io)|>= 1.8.0|Required to run the functional tests.|
+
 
 The minimum specified versions reflect those versions that we use in CI and
 manual testing. Older versions may still work in select cases.


### PR DESCRIPTION
This change implements the `geoip` context - a built-in that reads MaxMind DB files and uses IP values in events to enrich them with the MaxMind DB geolocation data.
