### PR TITLE
Fix implicit discovery of named capture groups in Grok

### DIFF
--- a/libtenzir/builtins/operators/grok.cpp
+++ b/libtenzir/builtins/operators/grok.cpp
@@ -185,7 +185,7 @@ void pattern::resolve(const pattern_store& patterns, bool allow_recursion) {
   // Thus, we need to maintain a list of named captures ourselves.
   {
     static const auto expr
-      = re2::RE2("(\\(\\?(?:P?<(.+?)>|'(.+?)'))", re2::RE2::Quiet);
+      = re2::RE2(R"((\(\?(?:P?<(\w+)>|'(\w+)')))", re2::RE2::Quiet);
     TENZIR_ASSERT(expr.ok());
     re2::StringPiece str_re2{raw_pattern.data(), raw_pattern.size()};
     re2::StringPiece capture{}, name{};

--- a/tenzir/integration/reference/parse-with-grok/step_09.ref
+++ b/tenzir/integration/reference/parse-with-grok/step_09.ref
@@ -1,0 +1,9 @@
+{
+  "line": {
+    "client": "55.3.244.1",
+    "method": "GET",
+    "request": "/index.html",
+    "bytes": "15824",
+    "duration": "0.043"
+  }
+}

--- a/tenzir/integration/tests.yaml
+++ b/tenzir/integration/tests.yaml
@@ -1240,6 +1240,7 @@ tests:
           exec 'read lines | parse line grok --include-unnamed "(<%{NONNEGINT:priority}>\s*)?%{SYSLOGTIMESTAMP:timestamp} (%{HOSTNAME:hostname}/%{IPV4:hostip}|%{WORD:host}) %{SYSLOGPROG}:%{GREEDYDATA:message}"'
         input: data/syslog/syslog-rfc3164.log
       - command: exec 'show version | put version="v4.5.0-71-gae887a0ca3-dirty" | parse version grok "%{TIMESTAMP_ISO8601}"'
+      - command: exec 'show version | put line="55.3.244.1 GET /index.html 15824 0.043" | parse line grok "%{IP:client} %{WORD:method} %{URIPATHPARAM:request} %{NUMBER:bytes} %{NUMBER:duration}"'
 
   CSV with comments:
     tags: [pipelines, csv]


### PR DESCRIPTION
In regular expressions, named capture groups don't match the pattern `\(\?<.+?>`, but `\(\?<\w+>`. The former would erroneously match `(?<=` and `(?<!`, which mean lookbehind. This manifested as regex lookbehind directives being included as named capture groups.