### PR TITLE
Allow empty field names

### DIFF
--- a/changelog/next/changes/3742--empty-field-names.md
+++ b/changelog/next/changes/3742--empty-field-names.md
@@ -1,0 +1,1 @@
+Records can now have fields where the name is empty.

--- a/libtenzir/src/type.cpp
+++ b/libtenzir/src/type.cpp
@@ -61,7 +61,7 @@ constexpr size_t reserved_string_size(std::string_view str) {
   // table. It adds an extra byte because strings in FlatBuffers tables are
   // always zero-terminated, and then rounds up to a full four bytes because of
   // the included padding.
-  return str.empty() ? 0 : (((str.size() + 1 + 3) / 4) * 4);
+  return ((str.size() + 1 + 3) / 4) * 4;
 }
 
 const fbs::Type*
@@ -192,7 +192,6 @@ void construct_record_type(stateful_type_base& self, const T& begin,
     for (auto it = begin; it != end; ++it) {
       const auto& type_bytes = as_bytes(it->type);
       size += 24;
-      TENZIR_ASSERT(!it->name.empty(), "Record field names must not be empty.");
       size += reserved_string_size(it->name);
       size += type_bytes.size();
     }

--- a/libtenzir/test/table_slice.cpp
+++ b/libtenzir/test/table_slice.cpp
@@ -18,6 +18,7 @@
 #include "tenzir/expression.hpp"
 #include "tenzir/ids.hpp"
 #include "tenzir/project.hpp"
+#include "tenzir/series_builder.hpp"
 #include "tenzir/table_slice_column.hpp"
 #include "tenzir/table_slice_row.hpp"
 #include "tenzir/test/fixtures/table_slices.hpp"
@@ -621,6 +622,21 @@ TEST(unflatten - invalid field names) {
   CHECK_EQUAL(materialize(input.at(0, 1)), materialize(output.at(0, 2)));
   CHECK_EQUAL(materialize(input.at(0, 2)), materialize(output.at(0, 1)));
   CHECK_EQUAL(materialize(input.at(0, 3)), materialize(output.at(0, 3)));
+}
+
+TEST(empty record) {
+  auto b = series_builder{};
+  b.record();
+  auto x = b.finish_assert_one_slice();
+  CHECK_EQUAL(caf::get<record_type>(x.schema()).num_fields(), size_t{0});
+}
+
+TEST(record with empty field name) {
+  auto b = series_builder{};
+  b.record().field("", 42);
+  auto x = b.finish_assert_one_slice();
+  CHECK_EQUAL(caf::get<record_type>(x.schema()).num_fields(), size_t{1});
+  CHECK_EQUAL(caf::get<record_type>(x.schema()).field(0).name, "");
 }
 
 FIXTURE_SCOPE_END()


### PR DESCRIPTION
Previously, the record `{"": 42}` was not allowed. This PR removes this restriction.