### PR TITLE
Prevent delays for blocking operators

### DIFF
--- a/.github/workflows/tenzir.yaml
+++ b/.github/workflows/tenzir.yaml
@@ -599,7 +599,10 @@ jobs:
             dependencies-script-path: scripts/macOS/install-dev-dependencies.sh
             cmake-extra-flags: -DTENZIR_ENABLE_BUNDLED_CAF:BOOL=ON
             bundled-plugins:
-              - plugins/*
+              # Parquet uses illegal instructions on macOS in Arrow version
+              # 14.0.1, so we disable it in the macOS CI. Last checked on
+              # 2023-12-16.
+              - plugins/[^(parquet)]*
               - contrib/tenzir-plugins/*
     env:
       BUILD_DIR: build

--- a/changelog/next/bug-fixes/3743--blocking-operators.md
+++ b/changelog/next/bug-fixes/3743--blocking-operators.md
@@ -1,0 +1,3 @@
+Pipeline operators blocking in their execution sometimes caused results to be
+delayed. This is no longer the case. This bug fix also reduces the time to first
+result for pipelines with many operators.

--- a/demo-node/setup.bash
+++ b/demo-node/setup.bash
@@ -9,6 +9,10 @@ coproc NODE { exec tenzir-node --print-endpoint; }
 # shellcheck disable=SC2034
 read -r -u "${NODE[0]}" DUMMY
 
+# Empirically, we sometimes fail to connect to a node if we attempt that right
+# after starting it up. So we simply wait a bit with that.
+sleep 1
+
 echo "Spawning M57 Suricata pipeline"
 m57_suricata_definition='from https://storage.googleapis.com/tenzir-datasets/M57/suricata.json.zst read suricata --no-infer\n| where #schema != \"suricata.stats\"\n| import'
 m57_suricata_id=$(tenzir -q "api /pipeline/create '{\"definition\": \"${m57_suricata_definition}\", \"name\": \"M57 Suricata\", \"autostart\": {\"created\": true}}'" | jq -re ".id")

--- a/libtenzir/builtins/operators/export.cpp
+++ b/libtenzir/builtins/operators/export.cpp
@@ -203,6 +203,7 @@ public:
             });
           if (current_error) {
             ctrl.warn(std::move(current_error));
+            co_yield {};
             continue;
           }
           if (current_slice) {

--- a/libtenzir/builtins/operators/import.cpp
+++ b/libtenzir/builtins/operators/import.cpp
@@ -64,6 +64,12 @@ public:
       ctrl.abort(std::move(err));
       co_return;
     }
+    // We empirically need this sleep here for the flushing to take any effect
+    // afterwards. I do not fully understand why, but since we're about to
+    // rewrite this operator anyways to create partitions in-band and to
+    // directly send then to the catalog we may as well leave this in here for
+    // now. –- DL, Dec 2023
+    std::this_thread::sleep_for(std::chrono::milliseconds{100});
     // We yield once to the scheduler as the stream flushing only takes effect
     // then.
     co_yield {};

--- a/libtenzir/builtins/operators/python.cpp
+++ b/libtenzir/builtins/operators/python.cpp
@@ -62,7 +62,10 @@ auto drain_pipe(bp::ipstream& pipe) -> std::string {
     return result;
   auto line = std::string{};
   while (std::getline(pipe, line)) {
-    result += line + "\n";
+    if (not result.empty()) {
+      result += '\n';
+    }
+    result += line;
   }
   return result;
 }
@@ -185,6 +188,7 @@ public:
       codepipe << detail::strip_leading_indentation(std::string{code_});
       codepipe.close();
       ::close(errpipe.pipe().native_sink());
+      co_yield {}; // signal successful startup
       for (auto&& slice : input) {
         if (slice.rows() == 0) {
           co_yield {};

--- a/libtenzir/builtins/operators/shell.cpp
+++ b/libtenzir/builtins/operators/shell.cpp
@@ -285,6 +285,11 @@ public:
     return true;
   }
 
+  auto input_independent() const -> bool override {
+    // We may produce results without receiving any further input.
+    return true;
+  }
+
   auto name() const -> std::string override {
     return "shell";
   }

--- a/libtenzir/include/tenzir/actors.hpp
+++ b/libtenzir/include/tenzir/actors.hpp
@@ -401,9 +401,9 @@ using datagram_source_actor = typed_actor_fwd<
 
 using exec_node_sink_actor = typed_actor_fwd<
   // Push events.
-  auto(atom::push, std::vector<table_slice> events)->caf::result<void>,
+  auto(atom::push, table_slice events)->caf::result<void>,
   // Push bytes.
-  auto(atom::push, std::vector<chunk_ptr> bytes)->caf::result<void>>::unwrap;
+  auto(atom::push, chunk_ptr bytes)->caf::result<void>>::unwrap;
 
 /// The interface of a EXEC NODE actor.
 using exec_node_actor = typed_actor_fwd<
@@ -411,14 +411,13 @@ using exec_node_actor = typed_actor_fwd<
   auto(atom::internal, atom::run)->caf::result<void>,
   // Start an execution node. Returns after the operator has yielded for the
   // first time.
-  auto(atom::start, std::vector<caf::actor> previous)->caf::result<void>,
+  auto(atom::start, std::vector<caf::actor> all_previous)->caf::result<void>,
   // Pause the execution node. No-op if it was already paused.
   auto(atom::pause)->caf::result<void>,
   // Resume the execution node. No-op if it was not paused.
   auto(atom::resume)->caf::result<void>,
   // Uodate demand.
-  auto(atom::pull, exec_node_sink_actor sink, uint64_t batch_size,
-       duration batch_timeout)
+  auto(atom::pull, exec_node_sink_actor sink, uint64_t batch_size)
     ->caf::result<void>>
   // Source.
   ::extend_with<exec_node_sink_actor>::unwrap;

--- a/libtenzir/include/tenzir/chunk.hpp
+++ b/libtenzir/include/tenzir/chunk.hpp
@@ -336,6 +336,12 @@ bool inspect(Inspector& f, chunk_ptr& x) {
 caf::error read(const std::filesystem::path& filename, chunk_ptr& x,
                 chunk_metadata metadata = {});
 
+auto split(const chunk_ptr& chunk, size_t partition_point)
+  -> std::pair<chunk_ptr, chunk_ptr>;
+
+auto split(std::vector<chunk_ptr> chunks, size_t partition_point)
+  -> std::pair<std::vector<chunk_ptr>, std::vector<chunk_ptr>>;
+
 } // namespace tenzir
 
 namespace fmt {

--- a/libtenzir/include/tenzir/diagnostics.hpp
+++ b/libtenzir/include/tenzir/diagnostics.hpp
@@ -37,8 +37,6 @@ public:
   virtual ~diagnostic_handler() = default;
 
   virtual void emit(diagnostic d) = 0;
-
-  virtual auto has_seen_error() const -> bool = 0;
 };
 
 enum class severity { error, warning, note };
@@ -282,26 +280,16 @@ inline auto diagnostic::modify() && -> diagnostic_builder {
 class null_diagnostic_handler final : public diagnostic_handler {
 public:
   void emit(diagnostic diag) override {
-    has_seen_error_ |= diag.severity == severity::error;
-  }
-
-  auto has_seen_error() const -> bool override {
-    return has_seen_error_;
+    (void)diag;
   }
 
 private:
-  bool has_seen_error_ = false;
 };
 
 class collecting_diagnostic_handler final : public diagnostic_handler {
 public:
   void emit(diagnostic diag) override {
-    has_seen_error_ |= diag.severity == severity::error;
     result.push_back(std::move(diag));
-  }
-
-  auto has_seen_error() const -> bool override {
-    return has_seen_error_;
   }
 
   auto collect() && -> std::vector<diagnostic> {
@@ -310,7 +298,6 @@ public:
 
 private:
   std::vector<diagnostic> result;
-  bool has_seen_error_ = false;
 };
 
 enum class color_diagnostics { no, yes };

--- a/libtenzir/include/tenzir/pipeline.hpp
+++ b/libtenzir/include/tenzir/pipeline.hpp
@@ -333,6 +333,13 @@ public:
     return false;
   }
 
+  /// Returns whether the operator can produce output independently from
+  /// receiving input. Set to true to cause operators to be polled rather than
+  /// pulled from. Operators without a source are always polled from.
+  virtual auto input_independent() const -> bool {
+    return false;
+  }
+
   /// Retrieve the output type of this operator for a given input.
   ///
   /// The default implementation will try to instantiate the operator and then
@@ -479,6 +486,10 @@ public:
 
   auto internal() const -> bool override {
     die("pipeline::internal() must not be called");
+  }
+
+  auto input_independent() const -> bool override {
+    die("pipeline::input_independent() must not be called");
   }
 
   auto instantiate(operator_input input, operator_control_plane& control) const

--- a/libtenzir/src/diagnostics.cpp
+++ b/libtenzir/src/diagnostics.cpp
@@ -106,10 +106,6 @@ public:
     }
   }
 
-  auto has_seen_error() const -> bool override {
-    return error_;
-  }
-
 private:
   static auto symbol(severity s) -> char {
     switch (s) {

--- a/libtenzir/src/error.cpp
+++ b/libtenzir/src/error.cpp
@@ -89,9 +89,6 @@ std::string render(caf::error err) {
     return "";
   std::ostringstream oss;
   auto category = err.category();
-  if (category == caf::type_id_v<tenzir::ec>
-      && static_cast<tenzir::ec>(err.code()) == ec::silent)
-    return "";
   oss << "!! ";
   switch (category) {
     default:

--- a/libtenzir/src/execution_node.cpp
+++ b/libtenzir/src/execution_node.cpp
@@ -34,44 +34,35 @@ using namespace si_literals;
 
 template <class Element = void>
 struct defaults {
-  /// Defines the lower and upper bound for the batch timeout used when
-  /// requesting a batch from the the previous execution node in the pipeline.
-  inline static constexpr duration min_batch_timeout = 10ms;
-  inline static constexpr duration max_batch_timeout = 2s;
+  /// Defines how much free capacity must be in the inbound buffer of the
+  /// execution node before it requests further data.
+  inline static constexpr uint64_t min_batch_size = 1;
+
+  /// Defines the upper bound for the inbound buffer of the execution node.
+  inline static constexpr uint64_t max_buffered = 0;
 
   /// Defines the time interval for sending metrics of the currently running
   /// pipeline operator.
-  inline static constexpr auto metrics_interval
-    = std::chrono::milliseconds{1000};
+  inline static constexpr auto metrics_interval = 1000ms;
 };
 
 template <>
 struct defaults<table_slice> : defaults<> {
-  /// Defines the upper bound for the batch size used when requesting a batch
-  /// from the the previous execution node in the pipeline.
-  inline static constexpr uint64_t max_batch_size = 64_Ki;
-
   /// Defines how much free capacity must be in the inbound buffer of the
   /// execution node before it requests further data.
   inline static constexpr uint64_t min_batch_size = 8_Ki;
 
-  /// Defines the upper bound for the inbound and outbound buffer of the
-  /// execution node.
+  /// Defines the upper bound for the inbound buffer of the execution node.
   inline static constexpr uint64_t max_buffered = 254_Ki;
 };
 
 template <>
 struct defaults<chunk_ptr> : defaults<> {
-  /// Defines the upper bound for the batch size used when requesting a batch
-  /// from the the previous execution node in the pipeline.
-  inline static constexpr uint64_t max_batch_size = 1_Mi;
-
   /// Defines how much free capacity must be in the inbound buffer of the
   /// execution node before it requests further data.
   inline static constexpr uint64_t min_batch_size = 128_Ki;
 
-  /// Defines the upper bound for the inbound and outbound buffer of the
-  /// execution node.
+  /// Defines the upper bound for the inbound buffer of the execution node.
   inline static constexpr uint64_t max_buffered = 4_Mi;
 };
 
@@ -92,31 +83,31 @@ auto make_timer_guard(Duration&... elapsed) {
 // Return an underestimate for the total number of referenced bytes for a vector
 // of table slices, excluding the schema and disregarding any overlap or custom
 // information from extension types.
-auto num_approx_bytes(const std::vector<table_slice>& events) {
-  auto result = uint64_t{};
-  for (const auto& batch : events) {
-    if (batch.rows() == 0)
-      continue;
-    auto record_batch = to_record_batch(batch);
-    TENZIR_ASSERT(record_batch);
-    // Note that this function can sometimes fail. Because we ultimately want to
-    // return an underestimate for the value of bytes, we silently fall back to
-    // a value of zero if the referenced buffer size cannot be measured.
-    //
-    // As a consequence, the result of this function can be off by a large
-    // margin. It never overestimates, but sometimes the result is a lot smaller
-    // than you would think and also a lot smaller than it should be.
-    //
-    // We opted to use the built-in Arrow solution here hoping that it will be
-    // improved upon in the future upsrream, rather than us having to roll our
-    // own.
-    //
-    // We cannot feasibly warn for failure here as that would cause a lot of
-    // noise.
-    result += detail::narrow_cast<uint64_t>(
-      arrow::util::ReferencedBufferSize(*record_batch).ValueOr(0));
-  }
-  return result;
+auto approx_bytes(const table_slice& events) -> uint64_t {
+  if (events.rows() == 0)
+    return 0;
+  auto record_batch = to_record_batch(events);
+  TENZIR_ASSERT(record_batch);
+  // Note that this function can sometimes fail. Because we ultimately want to
+  // return an underestimate for the value of bytes, we silently fall back to
+  // a value of zero if the referenced buffer size cannot be measured.
+  //
+  // As a consequence, the result of this function can be off by a large
+  // margin. It never overestimates, but sometimes the result is a lot smaller
+  // than you would think and also a lot smaller than it should be.
+  //
+  // We opted to use the built-in Arrow solution here hoping that it will be
+  // improved upon in the future upsrream, rather than us having to roll our
+  // own.
+  //
+  // We cannot feasibly warn for failure here as that would cause a lot of
+  // noise.
+  return detail::narrow_cast<uint64_t>(
+    arrow::util::ReferencedBufferSize(*record_batch).ValueOr(0));
+}
+
+auto approx_bytes(const chunk_ptr& bytes) -> uint64_t {
+  return bytes ? bytes->size() : 0;
 }
 
 template <class Input, class Output>
@@ -131,27 +122,31 @@ public:
     : self_{self}, diagnostic_handler_{std::move(diagnostic_handler)} {
   }
 
-  void emit(diagnostic d) override {
-    TENZIR_VERBOSE("emitting diagnostic: {:?}", d);
-    self_->request(diagnostic_handler_, caf::infinite, std::move(d))
-      .then([]() {},
-            [](caf::error& e) {
-              TENZIR_WARN("failed to send diagnostic: {}", e);
-            });
-    if (d.severity == severity::error and not has_seen_error_) {
-      has_seen_error_ = true;
-      self_->state.ctrl->abort(ec::silent);
+  void emit(diagnostic diag) override {
+    TENZIR_DEBUG("{} {} emits diagnostic: {:?}", *self_,
+                 self_->state.op->name(), diag);
+    if (diag.severity == severity::error) {
+      self_->state.has_seen_error = true;
+      self_->request(diagnostic_handler_, caf::infinite, std::move(diag))
+        .then(
+          [this] {
+            self_->quit(ec::silent);
+          },
+          [this](caf::error& err) {
+            self_->quit(add_context(err, "failed to emit diagnostic"));
+          });
+      return;
     }
-  }
-
-  auto has_seen_error() const -> bool override {
-    return has_seen_error_;
+    self_->request(diagnostic_handler_, caf::infinite, std::move(diag))
+      .then([] {},
+            [](const caf::error& err) {
+              TENZIR_WARN("failed to emit diagnostic: {}", err);
+            });
   }
 
 private:
   exec_node_actor::stateful_pointer<exec_node_state<Input, Output>> self_ = {};
   receiver_actor<diagnostic> diagnostic_handler_ = {};
-  bool has_seen_error_ = {};
 };
 
 template <class Input, class Output>
@@ -176,26 +171,19 @@ public:
   }
 
   auto abort(caf::error error) noexcept -> void override {
-    TENZIR_ASSERT(error != caf::none);
-    if (error != ec::silent) {
-      diagnostic::error("{}", error)
-        .note("from `{}`", state_.op->name())
-        .emit(diagnostics());
-    }
-    if (not state_.abort) {
-      TENZIR_VERBOSE("setting abort flag of `{}`", state_.op->name());
-      state_.abort = caf::make_error(ec::silent, fmt::to_string(error));
-    } else {
-      TENZIR_VERBOSE("abort flag of `{}` was already set", state_.op->name());
-    }
+    TENZIR_DEBUG("{} {} aborts: {}", *state_.self, state_.op->name(), error);
+    TENZIR_ASSERT_CHEAP(error != caf::none);
+    diagnostic::error("{}", error)
+      .note("from `{}`", state_.op->name())
+      .emit(diagnostics());
   }
 
   auto warn(caf::error error) noexcept -> void override {
-    if (error != ec::silent) {
-      diagnostic::warning("{}", error)
-        .note("from `{}`", state_.op->name())
-        .emit(diagnostics());
-    }
+    TENZIR_DEBUG("{} {} warns: {}", *state_.self, state_.op->name(), error);
+    TENZIR_ASSERT_CHEAP(error != caf::none);
+    diagnostic::warning("{}", error)
+      .note("from `{}`", state_.op->name())
+      .emit(diagnostics());
   }
 
   auto emit(table_slice) noexcept -> void override {
@@ -238,53 +226,6 @@ auto size(const chunk_ptr& chunk) -> uint64_t {
   return chunk ? chunk->size() : 0;
 }
 
-auto split(const chunk_ptr& chunk, size_t partition_point)
-  -> std::pair<chunk_ptr, chunk_ptr> {
-  if (partition_point == 0)
-    return {{}, chunk};
-  if (partition_point >= size(chunk))
-    return {chunk, {}};
-  return {
-    chunk->slice(0, partition_point),
-    chunk->slice(partition_point, size(chunk) - partition_point),
-  };
-}
-
-auto split(std::vector<chunk_ptr> chunks, uint64_t partition_point)
-  -> std::pair<std::vector<chunk_ptr>, std::vector<chunk_ptr>> {
-  auto it = chunks.begin();
-  for (; it != chunks.end(); ++it) {
-    if (partition_point == size(*it)) {
-      return {
-        {chunks.begin(), it + 1},
-        {it + 1, chunks.end()},
-      };
-    }
-    if (partition_point < size(*it)) {
-      auto lhs = std::vector<chunk_ptr>{};
-      auto rhs = std::vector<chunk_ptr>{};
-      lhs.reserve(std::distance(chunks.begin(), it + 1));
-      rhs.reserve(std::distance(it, chunks.end()));
-      lhs.insert(lhs.end(), std::make_move_iterator(chunks.begin()),
-                 std::make_move_iterator(it));
-      auto [split_lhs, split_rhs] = split(*it, partition_point);
-      lhs.push_back(std::move(split_lhs));
-      rhs.push_back(std::move(split_rhs));
-      rhs.insert(rhs.end(), std::make_move_iterator(it + 1),
-                 std::make_move_iterator(chunks.end()));
-      return {
-        std::move(lhs),
-        std::move(rhs),
-      };
-    }
-    partition_point -= size(*it);
-  }
-  return {
-    std::move(chunks),
-    {},
-  };
-}
-
 struct metrics_state {
   auto emit() -> void {
     values.time_total = std::chrono::duration_cast<duration>(
@@ -300,45 +241,8 @@ struct metrics_state {
   metric values = {};
 };
 
-template <class Input>
-struct inbound_state_mixin {
-  /// A handle to the previous execution node.
-  exec_node_actor previous = {};
-  uint64_t signaled_demand = {};
-  uint64_t fulfilled_demand = {};
-
-  std::vector<Input> inbound_buffer = {};
-  uint64_t inbound_buffer_size = {};
-};
-
-template <>
-struct inbound_state_mixin<std::monostate> {};
-
-template <class Output>
-struct outbound_state_mixin {
-  /// The outbound buffer of the operator contains elements ready to be
-  /// transported to the next operator's execution node.
-  std::vector<Output> outbound_buffer = {};
-  uint64_t outbound_buffer_size = {};
-
-  /// The currently open demand.
-  struct demand {
-    caf::typed_response_promise<void> rp = {};
-    exec_node_sink_actor sink = {};
-    const uint64_t batch_size = {};
-    const std::chrono::steady_clock::time_point batch_timeout = {};
-    bool ongoing = {};
-  };
-  std::optional<demand> current_demand = {};
-  bool reject_demand = {};
-};
-
-template <>
-struct outbound_state_mixin<std::monostate> {};
-
 template <class Input, class Output>
-struct exec_node_state : inbound_state_mixin<Input>,
-                         outbound_state_mixin<Output> {
+struct exec_node_state {
   static constexpr auto name = "exec-node";
 
   /// A pointer to the parent actor.
@@ -354,15 +258,29 @@ struct exec_node_state : inbound_state_mixin<Input>,
   };
   std::optional<resumable_generator> instance = {};
 
+  /// Whether the diagnostics handler has emitted an error.
+  bool has_seen_error = false;
+
   /// State required for keeping and sending metrics. Stored in a separate
   /// shared pointer to allow safe usage from an attached functor to send out
   /// metrics after this actor has quit.
   std::shared_ptr<metrics_state> metrics = {};
 
-  // Indicates whether the operator input has stalled, i.e., the generator
-  // should not be advanced.
-  bool input_stalled = {};
-  duration batch_timeout = defaults<>::min_batch_timeout;
+  /// A handle to the previous execution node.
+  exec_node_actor previous = {};
+
+  /// The inbound buffer.
+  std::vector<Input> inbound_buffer = {};
+  uint64_t inbound_buffer_size = {};
+
+  /// The currently open demand.
+  struct demand {
+    caf::typed_response_promise<void> rp = {};
+    exec_node_sink_actor sink = {};
+    uint64_t remaining = {};
+  };
+  std::optional<struct demand> demand = {};
+  bool issue_demand_inflight = {};
 
   /// A pointer to te operator control plane passed to this operator during
   /// execution, which acts as an escape hatch to this actor.
@@ -375,16 +293,24 @@ struct exec_node_state : inbound_state_mixin<Input>,
   /// already been scheduled.
   bool run_scheduled = {};
 
+  /// Tracks whether the current run has produced an output and consumed an
+  /// input, respectively.
+  bool consumed_input = false;
+  bool produced_output = false;
+
   /// Whether this execution node is paused.
   bool paused = {};
 
-  /// Set by `ctrl.abort(...)`, to be checked by `start()` and `run()`.
-  caf::error abort;
+  ~exec_node_state() noexcept {
+    TENZIR_DEBUG("{} {} shut down", *self, op->name());
+    metrics->emit();
+    if (demand and demand->rp.pending()) {
+      demand->rp.deliver();
+    }
+  }
 
-  auto start(std::vector<caf::actor> previous) -> caf::result<void> {
-    auto time_starting_guard = make_timer_guard(metrics->values.time_scheduled,
-                                                metrics->values.time_starting);
-    TENZIR_DEBUG("{} received start request for `{}`", *self, op->name());
+  auto start(std::vector<caf::actor> all_previous) -> caf::result<void> {
+    TENZIR_DEBUG("{} {} received start request", *self, op->name());
     detail::weak_run_delayed_loop(self, defaults<>::metrics_interval, [this] {
       auto time_scheduled_guard
         = make_timer_guard(metrics->values.time_scheduled);
@@ -395,7 +321,7 @@ struct exec_node_state : inbound_state_mixin<Input>,
                              fmt::format("{} was already started", *self));
     }
     if constexpr (std::is_same_v<Input, std::monostate>) {
-      if (not previous.empty()) {
+      if (not all_previous.empty()) {
         return caf::make_error(ec::logic_error,
                                fmt::format("{} runs a source operator and must "
                                            "not have a previous exec-node",
@@ -403,49 +329,39 @@ struct exec_node_state : inbound_state_mixin<Input>,
       }
     } else {
       // The previous exec-node must be set when the operator is not a source.
-      if (previous.empty()) {
+      if (all_previous.empty()) {
         return caf::make_error(
           ec::logic_error, fmt::format("{} runs a transformation/sink operator "
                                        "and must have a previous exec-node",
                                        *self));
       }
-      this->previous
-        = caf::actor_cast<exec_node_actor>(std::move(previous.back()));
-      previous.pop_back();
-      self->monitor(this->previous);
-      self->set_exit_handler([this](const caf::exit_msg& msg) {
-        TENZIR_DEBUG("{} emitting last metrics before exiting", op->name());
+      previous
+        = caf::actor_cast<exec_node_actor>(std::move(all_previous.back()));
+      all_previous.pop_back();
+      self->monitor<caf::message_priority::normal>(previous);
+      self->set_down_handler([this, addr = previous.address()](
+                               const caf::down_msg& msg) {
         auto time_scheduled_guard
           = make_timer_guard(metrics->values.time_scheduled);
-        metrics->emit();
-        self->quit(msg.reason);
-      });
-      self->set_down_handler([this](const caf::down_msg& msg) {
-        auto time_scheduled_guard
-          = make_timer_guard(metrics->values.time_scheduled);
-        if (msg.source != this->previous.address()) {
-          TENZIR_DEBUG("ignores down msg `{}` from unknown source: {}",
-                       msg.reason, msg.source);
+        if (msg.source != addr) [[unlikely]] {
+          TENZIR_DEBUG("{} {} ignores down message `{}` from unknown source: "
+                       "{}",
+                       *self, op->name(), msg.reason, msg.source);
           return;
         }
-        TENZIR_DEBUG("{} got down from previous execution node: {}", op->name(),
-                     msg.reason);
-        this->previous = nullptr;
-        // We empirically noticed that sometimes, we get a down message from a
-        // previous execution node in a different actor system, but do not get
-        // an error response to our demand request. To be able to shutdown
-        // correctly, we must set `signaled_demand` to false as a workaround.
-        this->signaled_demand = 0;
-        this->fulfilled_demand = 0;
-        batch_timeout = defaults<>::min_batch_timeout;
+        TENZIR_DEBUG("{} {} got down message from previous execution node: {}",
+                     *self, op->name(), msg.reason);
+        previous = nullptr;
         schedule_run();
         if (msg.reason) {
-          auto category
-            = msg.reason == ec::silent ? ec::silent : ec::unspecified;
-          ctrl->abort(caf::make_error(
-            category, fmt::format("{} shuts down because of irregular "
-                                  "exit of previous operator: {}",
-                                  op->name(), msg.reason)));
+          if (msg.reason != ec::silent) {
+            diagnostic::error("{}", msg.reason)
+              .note("`{}` shuts down because of an irregular exit of the "
+                    "previous operator",
+                    op->name())
+              .emit(ctrl->diagnostics());
+          }
+          self->quit(ec::silent);
         }
       });
     }
@@ -455,10 +371,11 @@ struct exec_node_state : inbound_state_mixin<Input>,
         = make_timer_guard(metrics->values.time_processing);
       auto output_generator = op->instantiate(make_input_adapter(), *ctrl);
       if (not output_generator) {
-        TENZIR_VERBOSE("{} could not instantiate operator: {}", *self,
-                       output_generator.error());
+        TENZIR_DEBUG("{} {} failed to instantiate operator: {}", *self,
+                     op->name(), output_generator.error());
         return add_context(output_generator.error(),
-                           "{} failed to instantiate operator", *self);
+                           "{} {} failed to instantiate operator", *self,
+                           op->name());
       }
       if (not std::holds_alternative<generator<Output>>(*output_generator)) {
         return caf::make_error(
@@ -468,139 +385,149 @@ struct exec_node_state : inbound_state_mixin<Input>,
       }
       instance.emplace();
       instance->gen = std::get<generator<Output>>(std::move(*output_generator));
-      TENZIR_TRACE("{} calls begin on instantiated operator", *self);
       instance->it = instance->gen.begin();
-      if (abort) {
-        TENZIR_DEBUG("{} was aborted during begin: {}", *self, op->name(),
-                     abort);
-        return abort;
+      if (has_seen_error) {
+        return {};
+      }
+      // Emit metrics once to get started.
+      metrics->emit();
+      if (instance->it == instance->gen.end()) {
+        TENZIR_DEBUG("{} {} finished without yielding", *self, op->name());
+        self->quit();
+        return {};
       }
     }
     if constexpr (std::is_same_v<Output, std::monostate>) {
-      TENZIR_TRACE("{} is the sink and requests start from {}", *self,
-                   this->previous);
       auto rp = self->make_response_promise<void>();
       self
-        ->request(this->previous, caf::infinite, atom::start_v,
-                  std::move(previous))
+        ->request(previous, caf::infinite, atom::start_v,
+                  std::move(all_previous))
         .then(
           [this, rp]() mutable {
             auto time_starting_guard = make_timer_guard(
               metrics->values.time_scheduled, metrics->values.time_starting);
-            TENZIR_DEBUG("{} schedules run of sink after successful startup",
-                         *self);
+            TENZIR_DEBUG("{} {} schedules run after successful startup of all "
+                         "operators",
+                         *self, op->name());
             schedule_run();
             rp.deliver();
           },
           [this, rp](caf::error& error) mutable {
             auto time_starting_guard = make_timer_guard(
               metrics->values.time_scheduled, metrics->values.time_starting);
-            TENZIR_DEBUG("{} forwards error during startup: {}", *self, error);
+            TENZIR_DEBUG("{} {} forwards error during startup: {}", *self,
+                         op->name(), error);
             rp.deliver(std::move(error));
           });
       return rp;
     }
     if constexpr (not std::is_same_v<Input, std::monostate>) {
-      TENZIR_DEBUG("{} delegates start to {}", *self, this->previous);
-      return self->delegate(this->previous, atom::start_v, std::move(previous));
+      TENZIR_DEBUG("{} {} delegates start to {}", *self, op->name(), previous);
+      return self->delegate(previous, atom::start_v, std::move(all_previous));
     }
     return {};
   }
 
   auto pause() -> caf::result<void> {
-    auto time_scheduled_guard
-      = make_timer_guard(metrics->values.time_scheduled);
+    TENZIR_DEBUG("{} {} pauses execution", *self, op->name());
     paused = true;
     return {};
   }
 
   auto resume() -> caf::result<void> {
-    auto time_scheduled_guard
-      = make_timer_guard(metrics->values.time_scheduled);
+    TENZIR_DEBUG("{} {} resumes execution", *self, op->name());
     paused = false;
-    batch_timeout = defaults<>::min_batch_timeout;
     schedule_run();
     return {};
   }
 
-  auto request_more_input() -> void
-    requires(not std::is_same_v<Input, std::monostate>)
-  {
-    // There are a few reasons why we would not be able to request more input:
-    // 1. The space in our inbound buffer is below the minimum batch size.
-    // 2. The previous execution node is down.
-    // 3. We already have an open request for more input.
-    TENZIR_ASSERT(this->inbound_buffer_size <= defaults<Input>::max_buffered);
-    const auto batch_size
-      = std::min(defaults<Input>::max_buffered - this->inbound_buffer_size,
-                 defaults<Input>::max_batch_size);
-    if (not this->previous or this->signaled_demand > 0
-        or batch_size < defaults<Input>::min_batch_size) {
-      return;
-    }
-    /// Issue the actual request. If the inbound buffer is empty, we await the
-    /// response, causing this actor to be suspended until the events have
-    /// arrived.
-    auto handle_result_or_error = [this]() {
-      auto time_scheduled_guard
-        = make_timer_guard(metrics->values.time_scheduled);
-      if (this->signaled_demand > this->fulfilled_demand) {
-        batch_timeout
-          = std::min(batch_timeout * 2, defaults<>::max_batch_timeout);
-      } else {
-        batch_timeout = defaults<>::min_batch_timeout;
-      }
-      this->signaled_demand = 0;
-      this->fulfilled_demand = 0;
-      schedule_run();
-    };
-    auto handle_error = [handle_result_or_error, this](caf::error& error) {
-      handle_result_or_error();
-      // TODO: We currently have to use `caf::exit_reason::kill` in
-      // `pipeline_executor.cpp` to work around a CAF bug. However, this implies
-      // that we might receive a `caf::sec::broken_promise` error here.
-      if (error == caf::sec::request_receiver_down
-          || error == caf::sec::broken_promise) {
-        this->previous = nullptr;
+  auto advance_generator() -> void {
+    auto time_processing_guard
+      = make_timer_guard(metrics->values.time_processing);
+    if constexpr (std::is_same_v<Output, std::monostate>) {
+      // We never issue demand to the sink, so we cannot be at the end of the
+      // generator here.
+      TENZIR_ASSERT_CHEAP(instance->it != instance->gen.end());
+      TENZIR_DEBUG("{} {} processes", *self, op->name());
+      ++instance->it;
+      if (has_seen_error) {
         return;
       }
-      // We failed to get results from the previous; let's emit a diagnostic
-      // instead.
-      if (this->previous) {
-        diagnostic::warning("{}", error)
-          .note("`{}` failed to pull from previous execution node", op->name())
-          .emit(ctrl->diagnostics());
+      if (instance->it == instance->gen.end()) {
+        TENZIR_DEBUG("{} {} completes processing", *self, op->name());
+        self->quit();
       }
-    };
-    this->signaled_demand = batch_size;
-    TENZIR_TRACE("sending pull from {}", op->name());
-    auto response_handle
-      = self->request(this->previous, caf::infinite, atom::pull_v,
-                      static_cast<exec_node_sink_actor>(self), batch_size,
-                      batch_timeout);
-    std::move(response_handle)
-      .then(std::move(handle_result_or_error), std::move(handle_error));
-  }
-
-  auto advance_generator() -> bool {
-    auto time_running_guard = make_timer_guard(metrics->values.time_processing);
-    TENZIR_ASSERT(instance);
-    TENZIR_ASSERT(instance->it != instance->gen.end());
-    if constexpr (not std::is_same_v<Output, std::monostate>) {
-      if (this->outbound_buffer_size >= defaults<Output>::max_buffered) {
-        return false;
-      }
-      auto next = std::move(*instance->it);
-      ++instance->it;
-      if (size(next) == 0) {
-        return this->current_demand.has_value();
-      }
-      this->outbound_buffer_size += size(next);
-      this->outbound_buffer.push_back(std::move(next));
+      return;
     } else {
+      if (not demand or instance->it == instance->gen.end()) {
+        return;
+      }
+      TENZIR_ASSERT_CHEAP(instance);
+      TENZIR_DEBUG("{} {} processes", *self, op->name());
+      auto output = std::move(*instance->it);
+      const auto output_size = size(output);
       ++instance->it;
+      if (has_seen_error) {
+        return;
+      }
+      const auto should_quit = instance->it == instance->gen.end();
+      if (output_size == 0) {
+        if (should_quit) {
+          self->quit();
+        } else {
+          schedule_run();
+        }
+        return;
+      }
+      produced_output = true;
+      metrics->values.outbound_measurement.num_elements += output_size;
+      metrics->values.outbound_measurement.num_batches += 1;
+      metrics->values.outbound_measurement.num_approx_bytes
+        += approx_bytes(output);
+      self
+        ->request(demand->sink, caf::infinite, atom::push_v, std::move(output))
+        .then(
+          [this, output_size, should_quit]() {
+            auto time_scheduled_guard
+              = make_timer_guard(metrics->values.time_scheduled);
+            TENZIR_DEBUG("{} {} produced {} elements", *self, op->name(),
+                         output_size);
+            if (demand) {
+              if (demand->remaining <= output_size) {
+                demand->rp.deliver();
+                demand.reset();
+              } else {
+                // TODO: Should we make demand->remaining available in the
+                // operator control plane?
+                demand->remaining -= output_size;
+              }
+            }
+            if (should_quit) {
+              TENZIR_DEBUG("{} {} completes processing", *self, op->name());
+              if (demand and demand->rp.pending()) {
+                demand->rp.deliver();
+              }
+              self->quit();
+              return;
+            }
+            schedule_run();
+          },
+          [this](const caf::error& err) {
+            auto time_scheduled_guard
+              = make_timer_guard(metrics->values.time_scheduled);
+            if (err == caf::sec::request_receiver_down) {
+              if (demand and demand->rp.pending()) {
+                demand->rp.deliver();
+              }
+              self->quit();
+              return;
+            }
+            diagnostic::error("{}", err)
+              .note("{} {} failed to push to next execution node", *self,
+                    op->name())
+              .emit(ctrl->diagnostics());
+          });
     }
-    return true;
   }
 
   auto make_input_adapter() -> std::monostate
@@ -612,43 +539,27 @@ struct exec_node_state : inbound_state_mixin<Input>,
   auto make_input_adapter() -> generator<Input>
     requires(not std::is_same_v<Input, std::monostate>)
   {
-    auto stall_guard = caf::detail::make_scope_guard([this] {
-      TENZIR_TRACE("{} exhausted input", op->name());
-      input_stalled = false;
-      schedule_run();
-    });
-    while (this->previous or this->inbound_buffer_size > 0
-           or this->signaled_demand) {
-      if (this->inbound_buffer_size == 0) {
-        TENZIR_ASSERT(this->inbound_buffer.empty());
-        // TODO: Some operators (most notably `shell`) may produce events from
-        // side effects, which means that their input can never be consider
-        // stalled. We need to add an option to the operator API that controls
-        // whether the operator can ever be considered stalled.
-        input_stalled = true;
+    while (previous or not inbound_buffer.empty()) {
+      if (inbound_buffer.empty()) {
         co_yield {};
         continue;
       }
-      while (not this->inbound_buffer.empty()) {
-        auto next = std::move(this->inbound_buffer.front());
-        TENZIR_ASSERT(size(next) != 0);
-        this->inbound_buffer_size -= size(next);
-        this->inbound_buffer.erase(this->inbound_buffer.begin());
-        input_stalled = false;
-        co_yield std::move(next);
-      }
+      consumed_input = true;
+      auto input = std::move(inbound_buffer.front());
+      inbound_buffer.erase(inbound_buffer.begin());
+      const auto input_size = size(input);
+      inbound_buffer_size -= input_size;
+      TENZIR_DEBUG("{} {} uses {} elements", *self, op->name(), input_size);
+      co_yield std::move(input);
     }
+    TENZIR_DEBUG("{} {} reached end of input", *self, op->name());
   }
 
   auto schedule_run() -> void {
     // Check whether we're already scheduled to run, or are no longer allowed to
     // rum.
-    // TODO: We can make pausing more efficient by pausing execution nodes from
-    // left-to-right, and only pausing the next one after the current one's
-    // outbound buffer has emptied. However, that's a lot of code to write
-    // compared to this single check, so let's stick has an issue with a paused
-    // pipeline's memory usage.
-    if (paused or run_scheduled or not instance) {
+    TENZIR_DEBUG("{} {} schedules run", *self, op->name());
+    if (run_scheduled) {
       return;
     }
     run_scheduled = true;
@@ -656,220 +567,111 @@ struct exec_node_state : inbound_state_mixin<Input>,
   }
 
   auto internal_run() -> caf::result<void> {
-    auto time_scheduled_guard
-      = make_timer_guard(metrics->values.time_scheduled);
     run_scheduled = false;
     run();
     return {};
   }
 
-  auto deliver_batches(std::chrono::steady_clock::time_point now, bool force)
-    -> void
-    requires(not std::is_same_v<Output, std::monostate>)
-  {
-    if (not this->current_demand or this->current_demand->ongoing) {
+  auto issue_demand() -> void {
+    if (not previous
+        or inbound_buffer_size + defaults<Input>::min_batch_size
+             > defaults<Input>::max_buffered
+        or issue_demand_inflight) {
       return;
     }
-    TENZIR_ASSERT(instance);
-    if (not force
-        and ((instance->it == instance->gen.end()
-              or this->outbound_buffer_size < this->current_demand->batch_size)
-             and (this->current_demand->batch_timeout > now))) {
-      return;
-    }
-    this->current_demand->ongoing = true;
-    const auto capped_demand
-      = std::min(this->outbound_buffer_size, this->current_demand->batch_size);
-    if (capped_demand == 0) {
-      TENZIR_DEBUG("{} short-circuits delivery of zero batches", op->name());
-      this->current_demand->rp.deliver();
-      this->current_demand.reset();
-      schedule_run();
-      return;
-    }
-    auto [lhs, _] = split(this->outbound_buffer, capped_demand);
-    auto handle_result = [this, capped_demand]() {
-      auto time_scheduled_guard
-        = make_timer_guard(metrics->values.time_scheduled);
-      TENZIR_TRACE("{} pushed successfully", op->name());
-      metrics->values.outbound_measurement.num_elements += capped_demand;
-      auto [lhs, rhs] = split(this->outbound_buffer, capped_demand);
-      metrics->values.outbound_measurement.num_batches += lhs.size();
-      if constexpr (std::is_same_v<Output, chunk_ptr>) {
-        metrics->values.outbound_measurement.num_approx_bytes
-          = metrics->values.outbound_measurement.num_elements;
-      } else {
-        metrics->values.outbound_measurement.num_approx_bytes
-          += num_approx_bytes(lhs);
-      }
-      this->outbound_buffer = std::move(rhs);
-      this->outbound_buffer_size
-        = std::transform_reduce(this->outbound_buffer.begin(),
-                                this->outbound_buffer.end(), uint64_t{},
-                                std::plus{}, [](const Output& x) {
-                                  return size(x);
-                                });
-      this->current_demand->rp.deliver();
-      this->current_demand.reset();
-      schedule_run();
-    };
-    auto handle_error = [this](caf::error& error) {
-      auto time_scheduled_guard
-        = make_timer_guard(metrics->values.time_scheduled);
-      TENZIR_DEBUG("{} failed to push", op->name());
-      this->current_demand->rp.deliver(std::move(error));
-      this->current_demand.reset();
-      schedule_run();
-    };
-    auto response_handle = self->request(
-      this->current_demand->sink, caf::infinite, atom::push_v, std::move(lhs));
-    if (force or this->outbound_buffer_size >= defaults<Output>::max_buffered) {
-      TENZIR_TRACE("{} pushes {}/{} buffered elements and suspends execution",
-                   op->name(), capped_demand, this->outbound_buffer_size);
-      std::move(response_handle)
-        .await(std::move(handle_result), std::move(handle_error));
-    } else {
-      TENZIR_TRACE("{} pushes {}/{} buffered elements", op->name(),
-                   capped_demand, this->outbound_buffer_size);
-      std::move(response_handle)
-        .then(std::move(handle_result), std::move(handle_error));
-    }
-  };
-
-  auto run() -> void {
-    TENZIR_TRACE("{} enters run loop", op->name());
-    TENZIR_ASSERT(instance);
-    const auto now = std::chrono::steady_clock::now();
-    // Check if we're done.
-    if (instance->it == instance->gen.end()) {
-      TENZIR_DEBUG("{} is at the end of its generator", op->name());
-      // Shut down the previous execution node immediately if we're done.
-      // We send an unreachable error here slightly before this execution
-      // node shuts down. This is merely an optimization; we call self->quit
-      // a tiny bit later anyways, which would send the same exit reason
-      // upstream implicitly. However, doing this early is nice because we
-      // can prevent the upstream operators from running unnecessarily.
-      if constexpr (not std::is_same_v<Input, std::monostate>) {
-        if (this->previous) {
-          TENZIR_DEBUG("{} shuts down previous operator", op->name());
-          self->send_exit(this->previous, caf::exit_reason::normal);
-        }
-      }
-      // When we're done, we must make sure that we have delivered all results
-      // to the next operator. This has the following pre-requisites:
-      // - The generator must be completed (already checked here).
-      // - There must not be any outstanding demand.
-      // - There must not be anything remaining in the buffer.
-      if constexpr (not std::is_same_v<Output, std::monostate>) {
-        if (this->current_demand and this->outbound_buffer_size == 0) {
-          TENZIR_DEBUG("{} rejects further demand from next operator",
-                       op->name());
-          this->reject_demand = true;
-        }
-        if (this->current_demand or this->outbound_buffer_size > 0) {
-          TENZIR_DEBUG("{} forcibly delivers batches", op->name());
-          deliver_batches(now, true);
-          return;
-        }
-        TENZIR_ASSERT(not this->current_demand);
-        TENZIR_ASSERT(this->outbound_buffer_size == 0);
-      }
-      TENZIR_VERBOSE("{} is done", op->name());
-      metrics->emit();
-      self->quit();
-      return;
-    }
-    // Try to deliver.
-    if constexpr (not std::is_same_v<Output, std::monostate>) {
-      deliver_batches(now, false);
-    }
-    // Request more input if there's more to be retrieved.
-    if constexpr (not std::is_same_v<Input, std::monostate>) {
-      request_more_input();
-    }
-    // Produce more output if there's more to be produced, then schedule the
-    // next run. For sinks, this happens delayed when there is no input. For
-    // everything else, it needs to happen only when there's enough space in the
-    // outbound buffer.
-    const auto output_stalled = not advance_generator();
-    // Check if we need to quit.
-    if (abort) {
-      self->quit(abort);
-    }
-    // Check whether we should eagerly schedule the operator again. We usually
-    // consider this the case when neither the input nor the output have
-    // stalled, i.e., when there is more input to be consumed and room for
-    // output to be produced or further output desired.
-    if (not input_stalled or not output_stalled) {
-      schedule_run();
-    }
-    // Adjust performance counters for this run.
-    metrics->values.num_runs += 1;
-    metrics->values.num_runs_processing
-      += input_stalled and output_stalled ? 0 : 1;
-    metrics->values.num_runs_processing_input += input_stalled ? 0 : 1;
-    metrics->values.num_runs_processing_output += output_stalled ? 0 : 1;
+    const auto demand = defaults<Input>::max_buffered - inbound_buffer_size;
+    TENZIR_DEBUG("{} {} issues demand for up to {} elements", *self, op->name(),
+                 demand);
+    issue_demand_inflight = true;
+    self
+      ->request(previous, caf::infinite, atom::pull_v,
+                static_cast<exec_node_sink_actor>(self),
+                detail::narrow_cast<uint64_t>(demand))
+      .then(
+        [this] {
+          auto time_scheduled_guard
+            = make_timer_guard(metrics->values.time_scheduled);
+          TENZIR_DEBUG("{} {} had its demand fulfilled", *self, op->name());
+          issue_demand_inflight = false;
+        },
+        [this](const caf::error& err) {
+          auto time_scheduled_guard
+            = make_timer_guard(metrics->values.time_scheduled);
+          TENZIR_DEBUG("{} {} failed to get its demand fulfilled: {}", *self,
+                       op->name(), err);
+          issue_demand_inflight = false;
+          if (err != caf::sec::request_receiver_down) {
+            diagnostic::error("{}", err)
+              .note("{} {} failed to pull from previous execution node", *self,
+                    op->name())
+              .emit(ctrl->diagnostics());
+          }
+        });
   }
 
-  auto
-  pull(exec_node_sink_actor sink, uint64_t batch_size, duration batch_timeout)
-    -> caf::result<void>
+  auto run() -> void {
+    if (paused or not instance or has_seen_error) {
+      return;
+    }
+    TENZIR_DEBUG("{} {} enters run loop", *self, op->name());
+    // If the inbound buffer is below its capacity, we must issue demand
+    // upstream.
+    issue_demand();
+    // Advance the operator's generator.
+    advance_generator();
+    // We can continue execution under the following circumstances:
+    // 1. The operator's generator is not yet completed.
+    // 2. The operator has one of the three following reasons to do work:
+    //   a. The upstream operator has completed.
+    //   b. The operator has issued demand that is not yet answered.
+    //   c. The operator can produce output independently from receiving input.
+    //   d. The operator has input it can consume.
+    const auto should_continue = instance->it != instance->gen.end()  // (1)
+                                 and (not previous                    // (2a)
+                                      or issue_demand_inflight        // (2b)
+                                      or op->input_independent()      // (2c)
+                                      or not inbound_buffer.empty()); // (2d)
+    if (should_continue) {
+      schedule_run();
+    } else {
+      TENZIR_DEBUG("{} {} idles", *self, op->name());
+    }
+    metrics->values.num_runs += 1;
+    metrics->values.num_runs_processing
+      += consumed_input or produced_output ? 1 : 0;
+    metrics->values.num_runs_processing_input += consumed_input ? 1 : 0;
+    metrics->values.num_runs_processing_output += produced_output ? 1 : 0;
+    consumed_input = false;
+    produced_output = false;
+  }
+
+  auto pull(exec_node_sink_actor sink, uint64_t batch_size) -> caf::result<void>
     requires(not std::is_same_v<Output, std::monostate>)
   {
-    auto time_scheduled_guard
-      = make_timer_guard(metrics->values.time_scheduled);
-    if (this->reject_demand) {
-      auto rp = self->make_response_promise<void>();
-      detail::weak_run_delayed(self, batch_timeout, [rp]() mutable {
-        rp.deliver();
-      });
+    TENZIR_DEBUG("{} {} received downstream demand", *self, op->name());
+    if (demand) {
+      demand->rp.deliver();
+    }
+    if (instance->it == instance->gen.end()) {
       return {};
     }
     schedule_run();
-    if (this->current_demand) {
-      return caf::make_error(ec::logic_error, "concurrent pull");
-    }
-    auto& pr = this->current_demand.emplace(
-      self->make_response_promise<void>(), std::move(sink), batch_size,
-      std::chrono::steady_clock::now() + batch_timeout);
+    auto& pr = demand.emplace(self->make_response_promise<void>(),
+                              std::move(sink), batch_size);
     return pr.rp;
   }
 
-  auto push(std::vector<Input> input) -> caf::result<void>
+  auto push(Input input) -> caf::result<void>
     requires(not std::is_same_v<Input, std::monostate>)
   {
-    if (this->signaled_demand == 0) {
-      return caf::make_error(ec::logic_error,
-                             "received batches without demand");
-    }
-    auto time_scheduled_guard
-      = make_timer_guard(metrics->values.time_scheduled);
-    schedule_run();
-    const auto input_size = std::transform_reduce(
-      input.begin(), input.end(), uint64_t{}, std::plus{}, [](const Input& x) {
-        return size(x);
-      });
-    metrics->values.inbound_measurement.num_batches += input.size();
-    if (input_size == 0) {
-      return caf::make_error(ec::logic_error, "received empty batch");
-    }
-    this->fulfilled_demand = input_size;
-    if (this->inbound_buffer_size + input_size
-        > defaults<Input>::max_buffered) {
-      return caf::make_error(ec::logic_error, "inbound buffer full");
-    }
-    this->inbound_buffer_size += input_size;
+    const auto input_size = size(input);
+    TENZIR_DEBUG("{} {} received {} elements from upstream", *self, op->name(),
+                 input_size);
     metrics->values.inbound_measurement.num_elements += input_size;
-    if constexpr (std::is_same_v<Input, chunk_ptr>) {
-      metrics->values.inbound_measurement.num_approx_bytes
-        = metrics->values.inbound_measurement.num_elements;
-    } else {
-      metrics->values.inbound_measurement.num_approx_bytes
-        += num_approx_bytes(input);
-    }
-    this->inbound_buffer.insert(this->inbound_buffer.end(),
-                                std::make_move_iterator(input.begin()),
-                                std::make_move_iterator(input.end()));
+    metrics->values.inbound_measurement.num_batches += 1;
+    metrics->values.inbound_measurement.num_approx_bytes += approx_bytes(input);
+    inbound_buffer_size += input_size;
+    inbound_buffer.push_back(std::move(input));
     schedule_run();
     return {};
   }
@@ -911,26 +713,32 @@ auto exec_node(
     return exec_node_actor::behavior_type::make_empty_behavior();
   }
   self->state.weak_node = node;
-  self->attach_functor(
-    [name = self->state.op->name(), metrics = self->state.metrics] {
-      TENZIR_DEBUG("exec-node for {} shut down", name);
-      metrics->emit();
-    });
   return {
     [self](atom::internal, atom::run) -> caf::result<void> {
+      auto time_scheduled_guard
+        = make_timer_guard(self->state.metrics->values.time_scheduled);
       return self->state.internal_run();
     },
     [self](atom::start,
-           std::vector<caf::actor>& previous) -> caf::result<void> {
-      return self->state.start(std::move(previous));
+           std::vector<caf::actor>& all_previous) -> caf::result<void> {
+      auto time_scheduled_guard
+        = make_timer_guard(self->state.metrics->values.time_scheduled,
+                           self->state.metrics->values.time_starting);
+      return self->state.start(std::move(all_previous));
     },
     [self](atom::pause) -> caf::result<void> {
+      auto time_scheduled_guard
+        = make_timer_guard(self->state.metrics->values.time_scheduled);
       return self->state.pause();
     },
     [self](atom::resume) -> caf::result<void> {
+      auto time_scheduled_guard
+        = make_timer_guard(self->state.metrics->values.time_scheduled);
       return self->state.resume();
     },
-    [self](atom::push, std::vector<table_slice>& events) -> caf::result<void> {
+    [self](atom::push, table_slice& events) -> caf::result<void> {
+      auto time_scheduled_guard
+        = make_timer_guard(self->state.metrics->values.time_scheduled);
       if constexpr (std::is_same_v<Input, table_slice>) {
         return self->state.push(std::move(events));
       } else {
@@ -939,7 +747,9 @@ auto exec_node(
                                            *self));
       }
     },
-    [self](atom::push, std::vector<chunk_ptr>& bytes) -> caf::result<void> {
+    [self](atom::push, chunk_ptr& bytes) -> caf::result<void> {
+      auto time_scheduled_guard
+        = make_timer_guard(self->state.metrics->values.time_scheduled);
       if constexpr (std::is_same_v<Input, chunk_ptr>) {
         return self->state.push(std::move(bytes));
       } else {
@@ -948,10 +758,12 @@ auto exec_node(
                                            *self));
       }
     },
-    [self](atom::pull, exec_node_sink_actor& sink, uint64_t batch_size,
-           duration batch_timeout) -> caf::result<void> {
+    [self](atom::pull, exec_node_sink_actor& sink,
+           uint64_t batch_size) -> caf::result<void> {
+      auto time_scheduled_guard
+        = make_timer_guard(self->state.metrics->values.time_scheduled);
       if constexpr (not std::is_same_v<Output, std::monostate>) {
-        return self->state.pull(std::move(sink), batch_size, batch_timeout);
+        return self->state.pull(std::move(sink), batch_size);
       } else {
         return caf::make_error(
           ec::logic_error,

--- a/libtenzir/src/module.cpp
+++ b/libtenzir/src/module.cpp
@@ -254,9 +254,6 @@ auto load_taxonomies(const caf::actor_system_config& cfg)
         return caf::make_error(ec::parse_error,
                                "failed to extract concepts from file",
                                file.string(), err.context());
-      for (auto& [name, definition] : concepts)
-        TENZIR_DEBUG("extracted concept {} with {} fields", name,
-                     definition.fields.size());
     }
   }
   return tenzir::taxonomies{std::move(concepts)};

--- a/libtenzir/src/pipeline.cpp
+++ b/libtenzir/src/pipeline.cpp
@@ -59,15 +59,7 @@ public:
     public:
       void emit(diagnostic d) override {
         TENZIR_WARN("got diagnostic: {:?}", d);
-        error_ |= d.severity == severity::error;
       }
-
-      auto has_seen_error() const -> bool override {
-        return error_;
-      }
-
-    private:
-      bool error_ = false;
     };
     static auto diag = handler{};
     return diag;

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "f8f8b06c8f5b3eb1df52fba0af8accca33427fd0",
+  "rev": "93a72fe7d1d3a85e6f3c80554f415d14a8bb4c97",
   "submodules": true,
   "shallow": true
 }

--- a/tenzir/functional-test/reference/python/test_empty_output_throws/step_00.ref
+++ b/tenzir/functional-test/reference/python/test_empty_output_throws/step_00.ref
@@ -1,3 +1,2 @@
-[1m[31merror[39m: !! logic_error: python error: Empty output not allowed
-[0m
+[1m[31merror[39m: !! logic_error: python error: Empty output not allowed[0m
  [1m[34m=[39m note:[0m from `python`


### PR DESCRIPTION
This change removes the outbound buffer of execution nodes, changing them to fulfill demand incrementally by immediately sending out partial results. This reduces latency, and avoids a problem with operators that block during execution, which sometimes held up already buffered partial results at the execution node instead.