### PR TITLE
Fix `shell` categorization in docs sidebar

### DIFF
--- a/web/docs/formats/grok.md
+++ b/web/docs/formats/grok.md
@@ -4,7 +4,7 @@ sidebar_custom_props:
     parser: true
 ---
 
-# `grok`
+# grok
 
 Parses a string using a `grok`-pattern, backed by regular expressions.
 

--- a/web/docs/operators/shell.md
+++ b/web/docs/operators/shell.md
@@ -3,7 +3,6 @@ sidebar_custom_props:
   operator:
     source: true
     transformation: true
-    sink: true
 ---
 
 # shell


### PR DESCRIPTION
It's not a sink.