### PR TITLE
Downtone push behavior of pipelines

### DIFF
--- a/changelog/next/bug-fixes/3758--hang-fix.md
+++ b/changelog/next/bug-fixes/3758--hang-fix.md
@@ -1,0 +1,4 @@
+We fixed a bug that caused operators that caused an increased memory usage for
+pipelines with slow operators immediately after a faster operator.
+
+We fixed a bug that caused short-running pipelines to sometimes hang.

--- a/libtenzir/src/pipeline_executor.cpp
+++ b/libtenzir/src/pipeline_executor.cpp
@@ -285,6 +285,8 @@ auto pipeline_executor(
                     [&](auto& exec_node) {
                       if (exec_node) {
                         self->unlink_from(exec_node);
+                        self->send_exit(exec_node,
+                                        caf::exit_reason::user_shutdown);
                         exec_node = nullptr;
                       }
                     });


### PR DESCRIPTION
This PR fixes two bugs:
1. This reduces memory usage for fast operators right in front of very slow operators. Previously, the fast operator overfulfilled the demand of the slow operator, causing the inbound buffer of the slow operator to overfill. This no longer happens as drastically, and is limited to at most one batch.
2. This fixes a potential hang on shutdown due to a bug in CAF by sending an explicit exit message to operators preceding an operator that itself down early (e.g., `head`). I accidentally dropped this fix as part of the blocking operators fix.
