### PR TITLE
Fix the `tenzir/tenzir:latest-slim` image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,11 @@ FROM dependencies AS development
 ENV PREFIX="/opt/tenzir" \
     PATH="/opt/tenzir/bin:${PATH}" \
     CC="gcc-12" \
-    CXX="g++-12" \
-    TENZIR_CACHE_DIRECTORY="/var/cache/tenzir" \
+    CXX="g++-12"
+
+# When changing these, make sure to also update the corresponding entries in the
+# flake.nix file.
+ENV TENZIR_CACHE_DIRECTORY="/var/cache/tenzir" \
     TENZIR_DB_DIRECTORY="/var/lib/tenzir" \
     TENZIR_LOG_FILE="/var/log/tenzir/server.log" \
     TENZIR_ENDPOINT="0.0.0.0"

--- a/changelog/next/bug-fixes/3764--slim-image.md
+++ b/changelog/next/bug-fixes/3764--slim-image.md
@@ -1,0 +1,2 @@
+The `tenzir/tenzir:latest-slim` Docker image now sets a default
+`TENZIR_CACHE_DIRECTORY` automatically.

--- a/flake.nix
+++ b/flake.nix
@@ -75,11 +75,12 @@
               Entrypoint = ["${pkgs.lib.getBin pkg}/bin/${entrypoint}"];
               CMD = ["--help"];
               Env = [
-                # When changing these, make sure to also update the entries in the
-                # Dockerfile.
-                "TENZIR_ENDPOINT=0.0.0.0"
+                # When changing these, make sure to also update the
+                # corresponding entries in the Dockerfile.
                 "TENZIR_DB_DIRECTORY=${tenzir-dir}"
+                "TENZIR_CACHE_DIRECTORY=/var/cache/tenzir"
                 "TENZIR_LOG_FILE=/var/log/tenzir/server.log"
+                "TENZIR_ENDPOINT=0.0.0.0"
               ];
               ExposedPorts = {
                 "5158/tcp" = {};


### PR DESCRIPTION
This was missing the `TENZIR_CACHE_DIRECTORY`, causing the slim variant to fail on startup.