### PR TITLE
Revert "Simplify builtins setup"

### DIFF
--- a/cmake/TenzirRegisterPlugin.cmake
+++ b/cmake/TenzirRegisterPlugin.cmake
@@ -702,6 +702,8 @@ function (TenzirRegisterPlugin)
                                                         tenzir::internal)
     TenzirTargetLinkWholeArchive(${PLUGIN_TARGET}-test PRIVATE
                                  ${PLUGIN_TARGET}-static)
+    TenzirTargetLinkWholeArchive(${PLUGIN_TARGET}-test PRIVATE
+                                 tenzir::libtenzir_builtins)
     add_test(NAME build-${PLUGIN_TARGET}-test
              COMMAND "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" --config
                      "$<CONFIG>" --target ${PLUGIN_TARGET}-test)

--- a/libtenzir/CMakeLists.txt
+++ b/libtenzir/CMakeLists.txt
@@ -165,19 +165,29 @@ endif ()
 # library, but always loaded when linking against the libtenzir_builtins library.
 file(GLOB_RECURSE libtenzir_builtins_sources CONFIGURE_DEPENDS
      "${CMAKE_CURRENT_SOURCE_DIR}/builtins/*.cpp")
-set_source_files_properties(
-  ${libtenzir_builtins_sources} PROPERTIES COMPILE_DEFINITIONS
-                                           TENZIR_ENABLE_BUILTINS=1)
+foreach (source IN LISTS libtenzir_builtins_sources)
+  file(READ "${source}" lines)
+  if (NOT "${lines}" MATCHES "\n *TENZIR_REGISTER_PLUGIN *\\(.+\\) *[\n$]")
+    message(FATAL_ERROR "builtin ${source} does not register as a plugin")
+  endif ()
+endforeach ()
 
 file(GLOB_RECURSE libtenzir_sources CONFIGURE_DEPENDS
-     "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp" ${libtenzir_builtins_sources}
+     "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp"
      "${CMAKE_CURRENT_SOURCE_DIR}/include/tenzir/*.hpp")
 
 add_library(libtenzir ${libtenzir_sources})
 TenzirTargetEnableTooling(libtenzir)
 add_library(tenzir::libtenzir ALIAS libtenzir)
 
+add_library(libtenzir_builtins STATIC ${libtenzir_builtins_sources})
+TenzirTargetEnableTooling(libtenzir_builtins)
+target_compile_definitions(libtenzir_builtins PRIVATE TENZIR_ENABLE_BUILTINS)
+set_target_properties(libtenzir_builtins PROPERTIES OUTPUT_NAME tenzir_builtins)
+add_library(tenzir::libtenzir_builtins ALIAS libtenzir_builtins)
+
 target_link_libraries(libtenzir PRIVATE libtenzir_internal)
+target_link_libraries(libtenzir_builtins PRIVATE libtenzir libtenzir_internal)
 
 # Set the libtenzir SOVERSION to '<256 * (major + 7) + minor>.<patch>' to indicate
 # that libtenzir is considered to have an unstable API and ABI. The +7 is a
@@ -375,15 +385,18 @@ target_link_libraries(libtenzir PRIVATE FastFloat::fast_float)
 
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
   option(TENZIR_ENABLE_BUNDLED_PFS "Use the pfs submodule" OFF)
-  add_feature_info("TENZIR_ENABLE_BUNDLED_PFS" TENZIR_ENABLE_BUNDLED_PFS
-                   "use the pfs submodule.")
+  add_feature_info(
+    "TENZIR_ENABLE_BUNDLED_PFS" TENZIR_ENABLE_BUNDLED_PFS
+    "use the pfs submodule.")
   if (NOT TENZIR_ENABLE_BUNDLED_PFS)
     find_package(pfs CONFIG)
   endif ()
   if (NOT pfs_FOUND)
     if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/aux/pfs/CMakeLists.txt")
-      message(FATAL_ERROR "pfs library not found, either use -pfs_DIR=... or"
-                          " initialize the libtenzir/aux/pfs submodule")
+      message(
+        FATAL_ERROR
+          "pfs library not found, either use -pfs_DIR=... or"
+          " initialize the libtenzir/aux/pfs submodule")
     endif ()
     add_subdirectory(aux/pfs)
     export(
@@ -396,7 +409,7 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     dependency_summary("pfs" pfs "Dependencies")
   endif ()
   target_link_libraries(libtenzir PRIVATE pfs)
-endif ()
+endif()
 
 # Link against a backtrace library.
 option(TENZIR_ENABLE_BACKTRACE "Print a backtrace on unexpected termination" ON)
@@ -497,7 +510,7 @@ endif ()
 # install the static libtenzir_builtins archive for development targets because
 # the plugin unit test binaries need to be able to link against it.
 install(
-  TARGETS libtenzir ${_tenzir_bundled_simdjson}
+  TARGETS libtenzir libtenzir_builtins ${_tenzir_bundled_simdjson}
   EXPORT TenzirTargets
   ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT Development
   LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT Runtime

--- a/libtenzir/test/CMakeLists.txt
+++ b/libtenzir/test/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(tenzir-test ${test_sources} ${test_headers})
 TenzirTargetEnableTooling(tenzir-test)
 target_link_libraries(tenzir-test PRIVATE tenzir::test tenzir::libtenzir tenzir::internal
                                         ${CMAKE_THREAD_LIBS_INIT})
+TenzirTargetLinkWholeArchive(tenzir-test PRIVATE tenzir::libtenzir_builtins)
 
 add_test(NAME build-tenzir-test
          COMMAND "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" --config

--- a/tenzir/CMakeLists.txt
+++ b/tenzir/CMakeLists.txt
@@ -4,6 +4,7 @@ target_link_libraries(tenzir PRIVATE tenzir::internal tenzir::libtenzir)
 if (TENZIR_ENABLE_JEMALLOC)
   target_link_libraries(tenzir PRIVATE jemalloc::jemalloc_)
 endif ()
+TenzirTargetLinkWholeArchive(tenzir PRIVATE tenzir::libtenzir_builtins)
 add_executable(tenzir::tenzir ALIAS tenzir)
 
 # Install tenzir in PREFIX/lib and headers in PREFIX/include/tenzir.


### PR DESCRIPTION
This reverts commit b7791a0312af60f34504db3ba4c4b644e2b29f68.

The commit broke builtins in the static binary build.
```
      _____ _____ _   _ ________ ____       
     |_   _| ____| \ | |__  /_ _|  _ \      
       | | |  _| |  \| | / / | || |_) |     
       | | | |___| |\  |/ /_ | ||  _ <      
       |_| |_____|_| \_/____|___|_| \_\     

           v4.7.1-18-g21bf4c89a8            
Visit https://app.tenzir.com to get started.

[20:50:21.790] loaded configuration file: /home/tobim/.config/tenzir/tenzir.yaml
[20:50:21.791] loaded plugin configuration file: /home/tobim/.config/tenzir/plugin/platform.yaml
[20:50:21.802] !! invalid_configuration: could not find store plugin 'feather'
[20:50:21.803] node terminates after DOWN from index with reason !! invalid_configuration: could not find store plugin 'feather'
[20:50:21.803] failed to connect analyzer matcher to the importer: !! caf::sec::invalid_argument
[20:50:21.803] authenticator failed to load server state: !! caf::sec::invalid_argument
```