### PR TITLE
Replace non-breaking spaces with normal ones

### DIFF
--- a/libtenzir/builtins/operators/api.cpp
+++ b/libtenzir/builtins/operators/api.cpp
@@ -39,7 +39,7 @@ public:
           response = std::move(value);
         },
         [&](const caf::error& error) {
-          diagnostic::error("internal server error: {}", error)
+          diagnostic::error("internal server error: {}", error)
             .note("endpoint: {}", endpoint_)
             .note("request body: {}", request_body_)
             .docs("https://docs.tenzir.com/operators/api")

--- a/libtenzir/include/tenzir/pipeline.hpp
+++ b/libtenzir/include/tenzir/pipeline.hpp
@@ -282,19 +282,19 @@ public:
   /// if opt.order == ordered:
   ///   OPT = opt.replacement
   /// elif opt.order == schema:
-  ///   OPT = interleave | opt.replacement
+  ///   OPT = interleave | opt.replacement
   /// elif opt.order == unordered:
-  ///   OPT = shuffle | opt.replacement
+  ///   OPT = shuffle | opt.replacement
   /// ~~~
   ///
   /// The implementation must promise that the following equivalences hold:
   /// ~~~
   /// if opt.filter:
-  ///   this | where filter | sink
-  ///   <=> where opt.filter | OPT | sink
+  ///   this | where filter | sink
+  ///   <=> where opt.filter | OPT | sink
   /// else:
-  ///   this | where filter | sink
-  ///   <=> OPT | where filter | sink
+  ///   this | where filter | sink
+  ///   <=> OPT | where filter | sink
   /// ~~~
   ///
   /// Now, let us assume that operator is not `events -> events`. If the output
@@ -309,9 +309,9 @@ public:
   ///
   /// The `where expr` operator returns `opt.filter = expr && filter`,
   /// `opt.order = order` and `opt.replacement == nullptr`. Thus we want to show
-  /// `where expr | where filter | sink <=> where expr && filter | OPT | sink`,
-  /// which is implied by `sink <=> OPT | sink`. If `order = schema`, this
-  /// resolves to `sink <=> interleave | pass | sink`, which follows from what
+  /// `where expr | where filter | sink <=> where expr && filter | OPT | sink`,
+  /// which is implied by `sink <=> OPT | sink`. If `order = schema`, this
+  /// resolves to `sink <=> interleave | pass | sink`, which follows from what
   /// we may assume about `sink`.
   virtual auto optimize(expression const& filter, event_order order) const
     -> optimize_result
@@ -431,7 +431,7 @@ public:
   auto operator=(pipeline&& other) noexcept -> pipeline& = default;
 
   /// Constructs a pipeline from a sequence of operators. Flattens nested
-  /// pipelines, for example `(a | b) | c` becomes `a | b | c`.
+  /// pipelines, for example `(a | b) | c` becomes `a | b | c`.
   explicit pipeline(std::vector<operator_ptr> operators);
 
   /// TODO

--- a/libtenzir/include/tenzir/plugin.hpp
+++ b/libtenzir/include/tenzir/plugin.hpp
@@ -275,7 +275,7 @@ public:
     -> bool
     = 0;
 
-  /// @post `!x || x->name() == name()`
+  /// @post `!x || x->name() == name()`
   virtual void deserialize(deserializer f, std::unique_ptr<Base>& x) const = 0;
 };
 

--- a/libtenzir/src/argument_parser.cpp
+++ b/libtenzir/src/argument_parser.cpp
@@ -32,7 +32,7 @@ void argument_parser::parse(parser_interface& p) {
 }
 
 void argument_parser::parse_impl(parser_interface& p) const {
-  // We resolve the ambiguity between `[sort] -x` and `[file] -f` by
+  // We resolve the ambiguity between `[sort] -x` and `[file] -f` by
   // not allowing short options if there is a positional expression.
   auto has_positional_expression = std::any_of(
     positional_.begin(), positional_.end(), [](const positional_t& p) {

--- a/libtenzir/src/pipeline.cpp
+++ b/libtenzir/src/pipeline.cpp
@@ -79,10 +79,10 @@ private:
 
 auto do_not_optimize(const operator_base& op) -> optimize_result {
   // This default implementation is always correct because it effectively
-  // promises `op | where filter | sink <=> op | where filter | sink`, which is
+  // promises `op | where filter | sink <=> op | where filter | sink`, which is
   // trivial. Note that forwarding `order` is not always valid. To see this,
   // assume `op == head` and `order == unordered`. We would have to show that
-  // `head | where filter | sink <=> shuffle | head | where filter | sink`, but
+  // `head | where filter | sink <=> shuffle | head | where filter | sink`, but
   // this is clearly not the case.
   return optimize_result{std::nullopt, event_order::ordered, op.copy()};
 }

--- a/libtenzir/src/series_builder.cpp
+++ b/libtenzir/src/series_builder.cpp
@@ -66,7 +66,7 @@
 ///                                     |              ^
 ///                                builder_base        ^
 ///                               /     |      \       ^
-///                            (is)    (is)    (is)    ^            
+///                            (is)    (is)    (is)    ^
 ///                            /        |        \     ^
 ///      typed_builder<int64_type>     ...      typed_builder<record_type>
 ///

--- a/web/blog/tenzir-v4.7/index.md
+++ b/web/blog/tenzir-v4.7/index.md
@@ -35,7 +35,7 @@ export
 | enrich src_country=country --field src_ip
 | enrich dest_country=country --field dest_ip
 /* Use just the country's isocode, and discard the rest of the information */
-| replace src_country=src_country.context.country.iso_code, 
+| replace src_country=src_country.context.country.iso_code,
           dest_country=dest_country.context.country.iso_code
 ```
 
@@ -111,7 +111,7 @@ Extract space-separated `key=value` pairs with `kv`:
 
 ```json {0} title="Example input"
 {
-  "message": "foo=1 bar=2    baz=3 qux=4"
+  "message": "foo=1 bar=2 baz=3 qux=4"
 }
 ```
 

--- a/web/docs/formats/kv.md
+++ b/web/docs/formats/kv.md
@@ -51,7 +51,7 @@ The regular expression used to separate a key from its value.
 
 ## Examples
 
-Extract comma-separated key-value pairs from `foo:1, bar:2    , baz:3 ,  qux:4`:
+Extract comma-separated key-value pairs from `foo:1, bar:2,baz:3 , qux:4`:
 
 ```
 kv "\s*,\s*" ":"

--- a/web/docs/user-guides/run-a-pipeline/README.md
+++ b/web/docs/user-guides/run-a-pipeline/README.md
@@ -30,7 +30,7 @@ definition of the pipeline.
 
 If the pipeline expects events as its input, an implicit `load - | read json`
 will be prepended. If it expects bytes instead, only `load -` is prepended.
-Likewise, if the pipeline outputs events, an implicit `write json | save -` will
+Likewise, if the pipeline outputs events, an implicit `write json | save -` will
 be appended. If it outputs bytes instead, only `save -` is appended.
 
 The diagram below illustrates these mechanics:


### PR DESCRIPTION
Some new-year cleanup. These probably found their way in due to the bad option+space default keybind on macOS.