### PR TITLE
Update the manual static build workflow

### DIFF
--- a/.github/workflows/nix-manual.yaml
+++ b/.github/workflows/nix-manual.yaml
@@ -63,6 +63,7 @@ jobs:
               if ${{ inputs.build-de }} then
                 {
                   "name": "tenzir",
+                  "gha-runner-labels": ["ubuntu-latest"],
                   "static": true,
                   "upload-package-to-github": ${{ inputs.upload-de-package-to-github }},
                   "package-stores": [
@@ -79,6 +80,7 @@ jobs:
               if ${{ inputs.build-ce }} then
                 {
                   "name": "tenzir-ce",
+                  "gha-runner-labels": ["ubuntu-latest"],
                   "static": true,
                   "upload-package-to-github": false,
                   "package-stores": [
@@ -94,6 +96,7 @@ jobs:
               if ${{ inputs.build-ee }} then
                 {
                   "name": "tenzir-ee",
+                  "gha-runner-labels": ["ubuntu-latest"],
                   "static": true,
                   "upload-package-to-github": false,
                   "package-stores": [


### PR DESCRIPTION
The actual builder workflow now takes an additional parameter named "gha-runner-labels". The workflow broke when we added support for building on darwin.
