### PR TITLE
Use Inter and JetBrains Mono fonts on docs site

### DIFF
--- a/web/src/css/custom.scss
+++ b/web/src/css/custom.scss
@@ -4,6 +4,9 @@
  * work well for content-centric websites.
  */
 
+/* Load fonts from Bunny Fonts */
+@import url(https://fonts.bunny.net/css?family=inter:100,200,300,400,500,600,700,800,900|jetbrains-mono:100,200,300,400,500,600,700,800);
+
 /* You can override the default Infima variables here. */
 :root {
   --ifm-color-primary: #00a4f1;
@@ -23,6 +26,13 @@
   --docsearch-searchbox-background: transparent !important;
   --docsearch-searchbox-focus-background: var(--ifm-color-white);
   --docsearch-searchbox-shadow: transparent !important;
+
+  /* Font families matching our design system */
+  --ifm-font-family-base: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI",
+    Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --ifm-font-family-monospace: "JetBrains Mono", SFMono-Regular, Menlo, Monaco,
+    Consolas, "Liberation Mono", "Courier New", monospace;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */


### PR DESCRIPTION
<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made in the pull request description in a way that
   is consumable by everyone, not just developers who know the context of the
   change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://docs.tenzir.com/next/contribute/changelog
3. Provide instructions for the reviewer.
4. Remove this comment so it doesn't show up in the merge commit.
-->

Closes tenzir/issues#1080.

Docusaurus and Infima does a lot of CSS abstractions that don't map one-on-one to Tailwind (and thus our design system on the app and the site). For example, Tailwind sets line-height for each of `text-base, text-lg` etc, while docusaurus just uses a base and a header line-height variables. Docusaurus also conditionally changes the font-size for small screens - which will apply when the iframe width (the main motivation for this PR) is small, but not always.

Having considered all of these, I think we should just pluck the low-hanging fruit of changing the font-families on the docs site.