### PR TITLE
Make the schema definition easier to parse programmatically

### DIFF
--- a/libtenzir/builtins/operators/serve.cpp
+++ b/libtenzir/builtins/operators/serve.cpp
@@ -714,8 +714,7 @@ struct serve_handler_state {
       first = false;
       out_iter = fmt::format_to(out_iter, R"("schema_id":"{}","definition":)",
                                 schema.make_fingerprint());
-      const auto ok
-        = printer.print(out_iter, schema.to_definition(/*expand*/ false));
+      const auto ok = printer.print(out_iter, schema.to_definition2());
       TENZIR_ASSERT_CHEAP(ok);
     }
     out_iter = fmt::format_to(out_iter, R"(}}]}}{})", '\n');

--- a/libtenzir/builtins/operators/serve.cpp
+++ b/libtenzir/builtins/operators/serve.cpp
@@ -720,7 +720,7 @@ struct serve_handler_state {
     }
     // Write schemas
     if (seen_schemas.empty()) {
-      out_iter = fmt::format_to(out_iter, R"(}}],"schemas":[]}}{})", '\n');
+      out_iter = fmt::format_to(out_iter, R"(],"schemas":[]}}{})", '\n');
       return result;
     }
     out_iter = fmt::format_to(out_iter, R"(}}],"schemas":[)");

--- a/libtenzir/builtins/operators/serve.cpp
+++ b/libtenzir/builtins/operators/serve.cpp
@@ -113,6 +113,11 @@ constexpr auto SPEC_V0 = R"_(
                 example: "2000ms"
                 default: "2000ms"
                 description: The maximum amount of time spent on the request. Hitting the timeout is not an error. The timeout must not be greater than 5 seconds.
+              use_simple_format:
+                type: bool
+                example: true
+                default: false
+                description: Use an experimental, more simple format for the contained schema.
     responses:
       200:
         description: Success.
@@ -211,6 +216,7 @@ struct request_limits {
 struct serve_request {
   std::string serve_id = {};
   std::string continuation_token = {};
+  bool use_simple_format = {};
   request_limits limits = {};
 };
 
@@ -661,12 +667,24 @@ struct serve_handler_state {
       }
       result.limits.timeout = **timeout;
     }
+
+    auto use_simple_format = try_get<bool>(params, "use_simple_format");
+    if (not use_simple_format) {
+      return parse_error{
+        .message = "failed to read use_simple_format",
+        .detail = caf::make_error(ec::invalid_argument,
+                                  fmt::format("parameter: {}; got params {}",
+                                              max_events.error(), params))};
+    }
+    if (*use_simple_format) {
+      result.use_simple_format = **use_simple_format;
+    }
     return result;
   }
 
   static auto create_response(const std::string& next_continuation_token,
-                              const std::vector<table_slice>& results)
-    -> std::string {
+                              const std::vector<table_slice>& results,
+                              bool use_simple_format) -> std::string {
     auto printer = json_printer{{
       .indentation = 0,
       .oneline = true,
@@ -702,7 +720,7 @@ struct serve_handler_state {
     }
     // Write schemas
     if (seen_schemas.empty()) {
-      out_iter = fmt::format_to(out_iter, R"(],"schemas":[]}}{})", '\n');
+      out_iter = fmt::format_to(out_iter, R"(}}],"schemas":[]}}{})", '\n');
       return result;
     }
     out_iter = fmt::format_to(out_iter, R"(}}],"schemas":[)");
@@ -714,7 +732,9 @@ struct serve_handler_state {
       first = false;
       out_iter = fmt::format_to(out_iter, R"("schema_id":"{}","definition":)",
                                 schema.make_fingerprint());
-      const auto ok = printer.print(out_iter, schema.to_definition2());
+      const auto ok
+        = printer.print(out_iter, use_simple_format ? schema.to_definition2()
+                                                    : schema.to_definition());
       TENZIR_ASSERT_CHEAP(ok);
     }
     out_iter = fmt::format_to(out_iter, R"(}}]}}{})", '\n');
@@ -742,10 +762,11 @@ struct serve_handler_state {
                 request.continuation_token, request.limits.min_events,
                 request.limits.timeout, request.limits.max_events)
       .then(
-        [rp](const std::tuple<std::string, std::vector<table_slice>>&
-               result) mutable {
-          rp.deliver(rest_response::from_json_string(
-            create_response(std::get<0>(result), std::get<1>(result))));
+        [rp, use_simple_format = request.use_simple_format](
+          const std::tuple<std::string, std::vector<table_slice>>&
+            result) mutable {
+          rp.deliver(rest_response::from_json_string(create_response(
+            std::get<0>(result), std::get<1>(result), use_simple_format)));
         },
         [rp](caf::error& err) mutable {
           // TODO: Use a struct with distinct fields for user-facing
@@ -984,6 +1005,7 @@ public:
           {"max_events", uint64_type{}},
           {"min_events", uint64_type{}},
           {"timeout", duration_type{}},
+          {"use_simple_format", bool_type{}},
         },
         .version = api_version::v0,
         .content_type = http_content_type::json,

--- a/libtenzir/include/tenzir/type.hpp
+++ b/libtenzir/include/tenzir/type.hpp
@@ -275,7 +275,10 @@ public:
   /// Converts the type into its type definition.
   /// @param expand Render the definition in its expanded form.
   /// @pre *this
-  [[nodiscard]] data to_definition(bool expand = false) const noexcept;
+  [[nodiscard]] auto to_definition(bool expand = false) const noexcept -> data;
+  [[nodiscard]] auto to_definition2(std::optional<std::string> field_name = {},
+                                    offset parent_path = {}) const noexcept
+    -> record;
 
   /// Creates a type from an Arrow DataType, Field, or Schema.
   [[nodiscard]] static type from_arrow(const arrow::DataType& other) noexcept;

--- a/libtenzir/src/type.cpp
+++ b/libtenzir/src/type.cpp
@@ -926,7 +926,8 @@ auto type::to_definition2(std::optional<std::string> field_name,
       auto result = record{};
       result.emplace("name", field_name.value_or(std::string{name()}));
       result.emplace("kind", std::string{to_string(kind())});
-      result.emplace("type", fmt::to_string(*this));
+      result.emplace("type", name().empty() ? std::string{to_string(kind())}
+                                            : std::string{name()});
       result.emplace("attributes", std::move(attributes));
       result.emplace("path", std::move(path));
       result.emplace("fields", list{});
@@ -939,7 +940,10 @@ auto type::to_definition2(std::optional<std::string> field_name,
       parent_path.push_back(-1);
       auto result = self.value_type().to_definition2(
         field_name.value_or(std::string{name()}), parent_path);
-      result.emplace("type", fmt::to_string(*this));
+      result.emplace(
+        "kind", fmt::format("list<{}>", caf::get<std::string>(result["kind"])));
+      result.emplace(
+        "type", fmt::format("list<{}>", caf::get<std::string>(result["type"])));
       return result;
     },
     [&](const record_type& self) noexcept -> record {
@@ -952,8 +956,8 @@ auto type::to_definition2(std::optional<std::string> field_name,
       }
       auto result = record{};
       result.emplace("name", field_name.value_or(std::string{name()}));
-      result.emplace("kind", std::string{to_string(kind())});
-      result.emplace("type", fmt::to_string(*this));
+      result.emplace("kind", "record");
+      result.emplace("type", name().empty() ? "record" : std::string{name()});
       result.emplace("attributes", std::move(attributes));
       result.emplace("path", std::move(path));
       result.emplace("fields", std::move(fields));

--- a/libtenzir/src/type.cpp
+++ b/libtenzir/src/type.cpp
@@ -940,10 +940,12 @@ auto type::to_definition2(std::optional<std::string> field_name,
       parent_path.push_back(-1);
       auto result = self.value_type().to_definition2(
         field_name.value_or(std::string{name()}), parent_path);
-      result.emplace(
-        "kind", fmt::format("list<{}>", caf::get<std::string>(result["kind"])));
-      result.emplace(
-        "type", fmt::format("list<{}>", caf::get<std::string>(result["type"])));
+      result["kind"]
+        = fmt::format("list<{}>", caf::get<std::string>(result["kind"]));
+      result["type"]
+        = name().empty()
+            ? fmt::format("list<{}>", caf::get<std::string>(result["type"]))
+            : std::string{name()};
       return result;
     },
     [&](const record_type& self) noexcept -> record {

--- a/libtenzir/src/version.cpp
+++ b/libtenzir/src/version.cpp
@@ -88,6 +88,8 @@ auto tenzir_features() -> std::vector<std::string> {
     // The `chart` operator is supported, so that the frontend can conditionally
     // render results as charts.
     "chart_operator",
+    // The `/serve` endpoint supports the new `use_simple_format: bool` option.
+    "serve_use_simple_format_option",
   };
 }
 

--- a/web/openapi/openapi.yaml
+++ b/web/openapi/openapi.yaml
@@ -624,6 +624,11 @@ paths:
                   example: 2.0s
                   default: 2.0s
                   description: The maximum amount of time spent on the request. Hitting the timeout is not an error. The timeout must not be greater than 5 seconds.
+                use_simple_format:
+                  type: bool
+                  example: true
+                  default: false
+                  description: Use an experimental, more simple format for the contained schema.
       responses:
         200:
           description: Success.


### PR DESCRIPTION
This is an experimental branch for @dit7ya to play with: It changes the schema definition included with the response in `/serve` to a simpler to parse format for the app hosted at app.tenzir.com.