### PR TITLE
Improve handling of open file descriptors

### DIFF
--- a/ansible/roles/tenzir/tenzir-node.service
+++ b/ansible/roles/tenzir/tenzir-node.service
@@ -28,6 +28,9 @@ CapabilityBoundingSet=
 AmbientCapabilities=
 RestrictSUIDSGID=yes
 
+# limits
+LimitNOFILE=65535
+
 # system access
 ExecPaths=/opt/tenzir/libexec/tenzir-df-percent.sh
 ProtectSystem=strict

--- a/changelog/next/features/3784--open-fds.md
+++ b/changelog/next/features/3784--open-fds.md
@@ -1,0 +1,3 @@
+On linux systems, the process metrics now have an additional
+value `open_fds` showing the number of file descriptors
+opened by the node.

--- a/changelog/next/features/3784--open-fds.md
+++ b/changelog/next/features/3784--open-fds.md
@@ -1,3 +1,3 @@
-On linux systems, the process metrics now have an additional
+On Linux systems, the process metrics now have an additional
 value `open_fds` showing the number of file descriptors
 opened by the node.

--- a/libtenzir/builtins/health-metrics/process.cpp
+++ b/libtenzir/builtins/health-metrics/process.cpp
@@ -6,7 +6,7 @@
 // SPDX-FileCopyrightText: (c) 2023 The Tenzir Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#include <tenzir/detail/process.hpp>
+#include <tenzir/os.hpp>
 #include <tenzir/plugin.hpp>
 #include <tenzir/type.hpp>
 
@@ -20,12 +20,20 @@ namespace {
 
 auto get_process_statistics() -> caf::expected<record> {
   auto result = record{};
-  auto status = detail::get_status();
-  // Change dashes to underscores for consistency.
-  for (auto [key, value] : status) {
-    std::replace(key.begin(), key.end(), '-', '_');
-    result[key] = std::move(value);
-  }
+  auto os = os::make();
+  if (!os)
+    return caf::make_error(ec::system_error, "failed to create os");
+  auto process = os->current_process();
+  auto assign_optional = [&result](std::string_view key, auto value) {
+    if (value)
+      result[key] = *value;
+    else
+      result[key] = caf::none;
+  };
+  assign_optional("swap_space_usage", process.swap);
+  assign_optional("open_fds", process.open_fds);
+  assign_optional("peak_memory_usage", process.peak_mem);
+  assign_optional("current_memory_usage", process.rsize);
   return result;
 }
 
@@ -45,16 +53,10 @@ public:
 
   auto metric_layout() const -> record_type override {
     return record_type{{
-#if TENZIR_LINUX
       {"swap_space_usage", uint64_type{}},
       {"open_fds", uint64_type{}},
-#endif
-#if TENZIR_LINUX || TENZIR_MACOS
       {"current_memory_usage", uint64_type{}},
-#endif
-#if TENZIR_POSIX
       {"peak_memory_usage", uint64_type{}},
-#endif
     }};
   }
 };

--- a/libtenzir/builtins/health-metrics/process.cpp
+++ b/libtenzir/builtins/health-metrics/process.cpp
@@ -47,6 +47,7 @@ public:
     return record_type{{
 #if TENZIR_LINUX
       {"swap_space_usage", uint64_type{}},
+      {"open_fds", uint64_type{}},
 #endif
 #if TENZIR_LINUX || TENZIR_MACOS
       {"current_memory_usage", uint64_type{}},

--- a/libtenzir/include/tenzir/detail/process.hpp
+++ b/libtenzir/include/tenzir/detail/process.hpp
@@ -32,8 +32,6 @@ caf::expected<std::filesystem::path> objectpath(const void* addr = nullptr);
 ///     This metric is only available on Mac and Linux systems.
 ///   * The maximum swap space usage is stored in the key 'swap-space-usage'.
 ///     This metric is only available on Linux systems.
-///   * The number of currently opened file descriptors is stored in the
-///     key 'open-fds'. This metric is only available on Linux systems.
 record get_status();
 
 /// Forks a process to execute the given comand and returns its output

--- a/libtenzir/include/tenzir/detail/process.hpp
+++ b/libtenzir/include/tenzir/detail/process.hpp
@@ -32,6 +32,8 @@ caf::expected<std::filesystem::path> objectpath(const void* addr = nullptr);
 ///     This metric is only available on Mac and Linux systems.
 ///   * The maximum swap space usage is stored in the key 'swap-space-usage'.
 ///     This metric is only available on Linux systems.
+///   * The number of currently opened file descriptors is stored in the
+///     key 'open-fds'. This metric is only available on Linux systems.
 record get_status();
 
 /// Forks a process to execute the given comand and returns its output

--- a/libtenzir/include/tenzir/os.hpp
+++ b/libtenzir/include/tenzir/os.hpp
@@ -94,7 +94,7 @@ public:
   ~linux_os() final;
 
   auto current_pid() -> int final;
-  auto fetch_processes(std::optional<int> pid_filter)
+  auto fetch_processes(std::optional<int> pid_filterstd = std::nullopt)
     -> std::vector<process> final;
   auto fetch_sockets() -> std::vector<socket> final;
 
@@ -115,7 +115,7 @@ public:
   ~darwin_os() final;
 
   auto current_pid() -> int final;
-  auto fetch_processes(std::optional<int> pid_filter)
+  auto fetch_processes(std::optional<int> pid_filter = std::nullopt)
     -> std::vector<process> final;
   auto fetch_sockets() -> std::vector<socket> final;
 

--- a/libtenzir/include/tenzir/os.hpp
+++ b/libtenzir/include/tenzir/os.hpp
@@ -35,6 +35,9 @@ struct process {
   time startup;
   std::optional<uint64_t> vsize;
   std::optional<uint64_t> rsize;
+  std::optional<uint64_t> peak_mem;
+  std::optional<uint64_t> swap;
+  std::optional<uint64_t> open_fds;
   std::optional<duration> utime;
   std::optional<duration> stime;
 };
@@ -64,6 +67,9 @@ public:
 
   virtual ~os() = default;
 
+  /// Provides information about the current process.
+  auto current_process() -> process;
+
   /// Provides a snapshot of all currently running processes.
   auto processes() -> table_slice;
 
@@ -71,7 +77,10 @@ public:
   auto sockets() -> table_slice;
 
 protected:
-  virtual auto fetch_processes() -> std::vector<process> = 0;
+  virtual auto current_pid() -> int = 0;
+  virtual auto fetch_processes(std::optional<int> pid_filter = std::nullopt)
+    -> std::vector<process>
+    = 0;
   virtual auto fetch_sockets() -> std::vector<socket> = 0;
 };
 
@@ -84,7 +93,9 @@ public:
 
   ~linux_os() final;
 
-  auto fetch_processes() -> std::vector<process> final;
+  auto current_pid() -> int final;
+  auto fetch_processes(std::optional<int> pid_filter)
+    -> std::vector<process> final;
   auto fetch_sockets() -> std::vector<socket> final;
 
 private:
@@ -103,7 +114,9 @@ public:
 
   ~darwin_os() final;
 
-  auto fetch_processes() -> std::vector<process> final;
+  auto current_pid() -> int final;
+  auto fetch_processes(std::optional<int> pid_filter)
+    -> std::vector<process> final;
   auto fetch_sockets() -> std::vector<socket> final;
 
 private:

--- a/libtenzir/src/detail/process.cpp
+++ b/libtenzir/src/detail/process.cpp
@@ -75,18 +75,6 @@ static record get_status_proc() {
   return result;
 }
 
-static int64_t get_process_fds() {
-  auto path = "/proc/self/fd";
-  try {
-    // Empirically this uses about 1 syscall per 1500 directory entries.
-    auto begin = std::filesystem::directory_iterator(path);
-    auto end = std::filesystem::directory_iterator{};
-    return std::distance(begin, end);
-  } catch (const std::filesystem::filesystem_error& e) {
-    return -1;
-  }
-}
-
 } // namespace tenzir::detail
 #endif
 
@@ -175,9 +163,7 @@ caf::expected<std::filesystem::path> objectpath(const void* addr) {
 
 record get_status() {
 #if TENZIR_LINUX
-  auto result = get_status_proc();
-  result["open-fds"] = get_process_fds();
-  return result;
+  return get_status_proc();
 #elif TENZIR_MACOS
   auto result = get_status_rusage();
   merge(get_settings_mach(), result, policy::merge_lists::no);

--- a/libtenzir/src/os.cpp
+++ b/libtenzir/src/os.cpp
@@ -203,7 +203,6 @@ auto linux_os::fetch_processes(std::optional<int> pid_filter)
           .open_fds = open_fds,
           .utime = std::chrono::seconds{stat.utime / state_->clock_tick},
           .stime = std::chrono::seconds{stat.stime / state_->clock_tick},
-
         };
         result.push_back(std::move(proc));
       } catch (std::system_error&) {
@@ -452,7 +451,7 @@ auto socket_state_to_string(auto proto, auto state) -> std::string_view {
 
 auto darwin_os::fetch_sockets() -> std::vector<socket> {
   auto result = std::vector<socket>{};
-  for (const auto& proc : fetch_processes(std::nullopt)) {
+  for (const auto& proc : fetch_processes()) {
     auto pid = detail::narrow_cast<uint32_t>(proc.pid);
     auto sockets = sockets_for(pid);
     result.insert(result.end(), std::make_move_iterator(sockets.begin()),

--- a/libtenzir/src/os.cpp
+++ b/libtenzir/src/os.cpp
@@ -452,7 +452,7 @@ auto socket_state_to_string(auto proto, auto state) -> std::string_view {
 
 auto darwin_os::fetch_sockets() -> std::vector<socket> {
   auto result = std::vector<socket>{};
-  for (const auto& proc : fetch_processes()) {
+  for (const auto& proc : fetch_processes(std::nullopt)) {
     auto pid = detail::narrow_cast<uint32_t>(proc.pid);
     auto sockets = sockets_for(pid);
     result.insert(result.end(), std::make_move_iterator(sockets.begin()),

--- a/libtenzir/src/os.cpp
+++ b/libtenzir/src/os.cpp
@@ -388,11 +388,11 @@ auto darwin_os::fetch_processes(std::optional<int> pid_filter)
       .startup = time{runtime},
       .vsize = {},
       .rsize = {},
-      .utime = {},
-      .stime = {},
       .peak_mem = {},
       .swap = {},
       .open_fds = {},
+      .utime = {},
+      .stime = {},
     };
     if (n < 0) {
       p.vsize = task.pti_virtual_size;

--- a/tenzir/services/systemd/tenzir-node.service.in
+++ b/tenzir/services/systemd/tenzir-node.service.in
@@ -28,6 +28,9 @@ CapabilityBoundingSet=
 AmbientCapabilities=
 RestrictSUIDSGID=yes
 
+# limits
+LimitNOFILE=65535
+
 # system access
 ExecPaths=@CMAKE_INSTALL_FULL_LIBEXECDIR@/tenzir-df-percent.sh
 ProtectSystem=strict

--- a/web/docs/metrics.md
+++ b/web/docs/metrics.md
@@ -454,6 +454,7 @@ Contains a measurement of the amount of memory used by the `tenzir-node` process
 |`current_memory_usage`|`uint64`|The memory currently used by this process|
 |`peak_memory_usage`|`uint64`|The peak amount of memory, in bytes|
 |`swap_space_usage`|`uint64`|The amount of swap space, in bytes. Only available on Linux systemsm.|
+|`open_fds`|`uint64`|The number of opened file descriptors. Only available on Linux systemsm.|
 
 ### Examples
 


### PR DESCRIPTION
Attempt to improve the behavior of nodes that are running into the maximum number of open files:

  * Increase the upper limit imposed by our systemd unit files to 64Ki
  * Add monitoring of open file descriptors as a health metric so that leaks can be detected by looking at the rate of change over time.
