### PR TITLE
Fix `export --live` and introduce `metrics`

### DIFF
--- a/changelog/next/bug-fixes/3790--export-live.md
+++ b/changelog/next/bug-fixes/3790--export-live.md
@@ -1,0 +1,2 @@
+`export --live` sometimes got stuck, failing to deliver events. This no longer
+happens.

--- a/changelog/next/features/3790--metrics-operator.md
+++ b/changelog/next/features/3790--metrics-operator.md
@@ -1,0 +1,3 @@
+The `metrics` operator returns internal metrics events generated in a Tenzir
+node. Use `metrics --live` to get a feed of metrics as they are being generated
+instead of past metrics.

--- a/changelog/next/features/3790--metrics-operator.md
+++ b/changelog/next/features/3790--metrics-operator.md
@@ -1,3 +1,2 @@
 The `metrics` operator returns internal metrics events generated in a Tenzir
-node. Use `metrics --live` to get a feed of metrics as they are being generated
-instead of past metrics.
+node. Use `metrics --live` to get a feed of metrics as they are being generated.

--- a/libtenzir/builtins/operators/export.cpp
+++ b/libtenzir/builtins/operators/export.cpp
@@ -23,8 +23,6 @@
 #include <tenzir/uuid.hpp>
 
 #include <arrow/type.h>
-#include <caf/attach_stream_sink.hpp>
-#include <caf/attach_stream_source.hpp>
 #include <caf/event_based_actor.hpp>
 #include <caf/scheduled_actor.hpp>
 #include <caf/scoped_actor.hpp>
@@ -37,45 +35,36 @@
 namespace tenzir::plugins::export_ {
 
 struct bridge_state {
-  std::queue<table_slice> buffer;
-  caf::typed_response_promise<table_slice> rp;
+  std::queue<table_slice> buffer = {};
+  caf::typed_response_promise<table_slice> rp = {};
+  expression expr = {};
 };
 
-caf::behavior
-make_bridge(caf::stateful_actor<bridge_state>* self, importer_actor importer) {
+caf::behavior make_bridge(caf::stateful_actor<bridge_state>* self,
+                          importer_actor importer, expression expr) {
+  self->state.expr = std::move(expr);
   self
-    ->request(importer, caf::infinite,
-              caf::actor_cast<stream_sink_actor<table_slice>>(self))
-    .then([](caf::outbound_stream_slot<table_slice>) {},
-          [self](caf::error err) {
-            self->quit(err);
+    ->request(importer, caf::infinite, atom::subscribe_v,
+              caf::actor_cast<receiver_actor<table_slice>>(self))
+    .then([]() {},
+          [self](const caf::error& err) {
+            self->quit(add_context(err, "failed to subscribe to importer"));
           });
-
   return {
-    [self](
-      caf::stream<table_slice> in) -> caf::inbound_stream_slot<table_slice> {
-      return caf::attach_stream_sink(
-               self, in,
-               [](caf::unit_t&) {
-                 // nop
-               },
-               [=](caf::unit_t&, table_slice slice) {
-                 if (self->state.rp.pending())
-                   self->state.rp.deliver(std::move(slice));
-                 else
-                   self->state.buffer.push(std::move(slice));
-               },
-               [=](caf::unit_t&, const caf::error& err) {
-                 if (err)
-                   TENZIR_ERROR("{} got error during streaming: {}", *self,
-                                err);
-               })
-        .inbound_slot();
+    [self](table_slice slice) {
+      auto filtered = filter(std::move(slice), self->state.expr);
+      if (not filtered)
+        return;
+      if (self->state.rp.pending()) {
+        self->state.rp.deliver(std::move(*filtered));
+      } else {
+        self->state.buffer.push(std::move(*filtered));
+      }
     },
     [self](atom::get) -> caf::result<table_slice> {
       if (self->state.rp.pending()) {
         return caf::make_error(ec::logic_error,
-                               "live exporter bride promise out of sync.");
+                               "live exporter bridge promise out of sync");
       }
       if (self->state.buffer.empty()) {
         self->state.rp = self->make_response_promise<table_slice>();
@@ -109,9 +98,9 @@ public:
     }
     co_yield {};
     auto [importer] = std::move(*components);
-    auto bridge = ctrl.self().spawn(make_bridge, importer);
+    auto bridge = ctrl.self().spawn(make_bridge, importer, expr_);
+    auto next = table_slice{};
     while (true) {
-      auto next = table_slice{};
       ctrl.self()
         .request(bridge, caf::infinite, atom::get_v)
         .await(
@@ -121,13 +110,7 @@ public:
           [&ctrl](caf::error e) {
             diagnostic::error("{}", e).emit(ctrl.diagnostics());
           });
-      if (next.rows() == 0) {
-        co_yield {};
-        continue;
-      }
-      for (auto&& out : select(next, expr_, ids{})) {
-        co_yield std::move(out);
-      }
+      co_yield std::move(next);
     }
   }
 

--- a/libtenzir/builtins/operators/metrics.cpp
+++ b/libtenzir/builtins/operators/metrics.cpp
@@ -3,7 +3,7 @@
 //   | |/ / __ |_\ \  / /          Across
 //   |___/_/ |_/___/ /_/       Space and Time
 //
-// SPDX-FileCopyrightText: (c) 2023 The Tenzir Contributors
+// SPDX-FileCopyrightText: (c) 2024 The Tenzir Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include <tenzir/argument_parser.hpp>

--- a/libtenzir/builtins/operators/metrics.cpp
+++ b/libtenzir/builtins/operators/metrics.cpp
@@ -1,0 +1,51 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2023 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <tenzir/argument_parser.hpp>
+#include <tenzir/pipeline.hpp>
+#include <tenzir/plugin.hpp>
+
+namespace tenzir::plugins::metrics {
+
+namespace {
+
+class plugin final : public virtual operator_parser_plugin {
+public:
+  auto name() const -> std::string override {
+    return "metrics";
+  };
+
+  auto signature() const -> operator_signature override {
+    return {.transformation = true};
+  }
+
+  auto parse_operator(parser_interface& p) const -> operator_ptr override {
+    auto parser = argument_parser{"metrics", "https://docs.tenzir.com/next/"
+                                             "operators/metrics"};
+    bool live = false;
+    parser.add("--live", live);
+    parser.parse(p);
+    const auto definition
+      = fmt::format("export --internal {}| where #schema == /tenzir.metrics.*/",
+                    live ? " --live" : "");
+    auto result = pipeline::internal_parse_as_operator(definition);
+    if (not result) {
+      diagnostic::error("failed to transform `metrics` operator into `{}`",
+                        definition)
+        .hint("{}", result.error())
+        .throw_();
+    }
+    return std::move(*result);
+  }
+};
+
+} // namespace
+
+} // namespace tenzir::plugins::metrics
+
+TENZIR_REGISTER_PLUGIN(tenzir::plugins::metrics::plugin)

--- a/libtenzir/include/tenzir/actors.hpp
+++ b/libtenzir/include/tenzir/actors.hpp
@@ -238,6 +238,8 @@ using importer_actor = typed_actor_fwd<
     ->caf::result<caf::outbound_stream_slot<table_slice>>,
   // Register a FLUSH LISTENER actor.
   auto(atom::subscribe, atom::flush, flush_listener_actor)->caf::result<void>,
+  // Register a subscriber for table slices.
+  auto(atom::subscribe, receiver_actor<table_slice>)->caf::result<void>,
   // Push buffered slices downstream to make the data available.
   auto(atom::flush)->caf::result<void>>
   // Conform to the protocol of the STREAM SINK actor for table slices.
@@ -509,6 +511,7 @@ CAF_BEGIN_TYPE_ID_BLOCK(tenzir_actors, caf::id_block::tenzir_atoms::end)
   TENZIR_ADD_TYPE_ID((tenzir::receiver_actor<tenzir::atom::done>))
   TENZIR_ADD_TYPE_ID((tenzir::receiver_actor<tenzir::diagnostic>))
   TENZIR_ADD_TYPE_ID((tenzir::receiver_actor<tenzir::metric>))
+  TENZIR_ADD_TYPE_ID((tenzir::receiver_actor<tenzir::table_slice>))
   TENZIR_ADD_TYPE_ID((tenzir::rest_handler_actor))
   TENZIR_ADD_TYPE_ID((tenzir::status_client_actor))
   TENZIR_ADD_TYPE_ID((tenzir::stream_sink_actor<tenzir::table_slice>))

--- a/libtenzir/include/tenzir/importer.hpp
+++ b/libtenzir/include/tenzir/importer.hpp
@@ -85,6 +85,9 @@ struct importer_state {
 
   accountant_actor accountant;
 
+  /// A list of subscribers for incoming events.
+  std::vector<receiver_actor<table_slice>> subscribers = {};
+
   /// Name of this actor in log events.
   static inline const char* name = "importer";
 };

--- a/web/docs/metrics.md
+++ b/web/docs/metrics.md
@@ -7,7 +7,7 @@ legacy metrics system is available [here](metrics/legacy_metrics.md).
 :::
 
 Metrics are stored as internal events in the database. To access these events,
-use `export --internal` followed by `where #schema == "<name>"`, where `<name>`
+use `metrics` followed by `where #schema == "<name>"`, where `<name>`
 is one of the following:
 
 ## `tenzir.metrics.operator`
@@ -42,18 +42,18 @@ The records `input` and `output` have the following schema:
 Show the total pipeline ingress in bytes for every day over the last week,
 excluding pipelines are only run for the explorer:
 
-~~~c
-export --internal |
-where #schema == "tenzir.metrics.operator" |
-where timestamp > 1 week ago |
-where hidden == false && source == true  |
-summarize bytes=sum(output.approx_bytes) by timestamp resolution 1 day
-~~~
+```c
+metrics
+| where #schema == "tenzir.metrics.operator"
+| where timestamp > 1 week ago
+| where hidden == false && source == true
+| summarize bytes=sum(output.approx_bytes) by timestamp resolution 1 day
+```
 
 <details>
 <summary>Output</summary>
 
-~~~json
+```json
 {
   "timestamp": "2023-11-08T00:00:00.000000",
   "bytes": 79927223
@@ -82,25 +82,26 @@ summarize bytes=sum(output.approx_bytes) by timestamp resolution 1 day
   "timestamp": "2023-11-14T00:00:00.000000",
   "bytes": 68643200
 }
-~~~
+```
+
 </details>
 
 Show the three operator instantiations that produced the most events in total
 and their pipeline:
 
-~~~c
-export --internal |
-where #schema == "tenzir.metrics.operator" |
-where output.unit == "events" |
-summarize events=max(output.elements) by pipeline_id, operator_id |
-sort events desc |
-head 3
-~~~
+```c
+metrics
+| where #schema == "tenzir.metrics.operator"
+| where output.unit == "events"
+| summarize events=max(output.elements) by pipeline_id, operator_id
+| sort events desc
+| head 3
+```
 
 <details>
 <summary>Output</summary>
 
-~~~json
+```json
 {
   "pipeline_id": "13",
   "operator_id": 0,
@@ -116,5 +117,5 @@ head 3
   "operator_id": 1,
   "events": 83013294
 }
-~~~
+```
 </details>

--- a/web/docs/operators/metrics.md
+++ b/web/docs/operators/metrics.md
@@ -1,0 +1,41 @@
+---
+sidebar_custom_props:
+  operator:
+    source: true
+---
+
+# export
+
+Retrieves metrics events from a Tenzir node.
+
+## Synopsis
+
+```
+metrics [--live]
+```
+
+## Description
+
+The `metrics` operator retrieves metrics events from a Tenzir node.
+
+### `--live`
+
+Work on all metrics events as they are generated in real-time instead of on
+metrics events persisted at a Tenzir node.
+
+## Examples
+
+View all metrics generated in the past five minutes.
+
+```
+metrics
+| where #import_time > 5 minutes ago
+```
+
+Show the total runtime of all pipelines by their ID.
+
+```
+metrics
+| where #schema == "tenzir.metrics.operator" && sink == true
+| summarize runtime=sum(duration) by pipeline_id
+```


### PR DESCRIPTION
The `metrics [--live]` source operator is a short-hand notation for accessing all metrics events via `export --internal`.

Additionally, this PR fixes `export --live`, which was broken in many ways.