### PR TITLE
Fix various bugs in the `lookup` operator

### DIFF
--- a/libtenzir/builtins/operators/enrich.cpp
+++ b/libtenzir/builtins/operators/enrich.cpp
@@ -29,7 +29,7 @@ public:
   };
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
-    const auto token = located<std::string>{"apply", location::unknown};
+    const auto token = located<std::string>{"enrich", location::unknown};
     auto context_pi = prepend_token{token, p};
     const auto* context_plugin = plugins::find_operator("context");
     if (not context_plugin) {

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "8ee286e2066e628a12a142f0c66705f3dbbb170e",
+  "rev": "5a5447b85d98bc611527bc7163f3ed94855c46fe",
   "submodules": true,
   "shallow": true
 }


### PR DESCRIPTION
This fixes a few bugs in the `lookup` operator:
- Deleting a context did previously not shut down `lookup` operators making use of the context.
- Unrecognized actions for the `context` operator, e.g., `context remove`, did not trigger an erorr but rather did nothing silently.