### PR TITLE
Support concepts in more places

### DIFF
--- a/libtenzir/builtins/contexts/geoip.cpp
+++ b/libtenzir/builtins/contexts/geoip.cpp
@@ -296,8 +296,7 @@ public:
       return caf::make_error(ec::invalid_argument, "missing argument `field`");
     }
     auto field_builder = series_builder{};
-    auto column_offset
-      = caf::get<record_type>(slice.schema()).resolve_key(*field_name);
+    auto column_offset = slice.schema().resolve_key_or_concept(*field_name);
     if (not column_offset) {
       for (auto i = size_t{0}; i < slice.rows(); ++i) {
         field_builder.null();

--- a/libtenzir/builtins/contexts/lookup-table.cpp
+++ b/libtenzir/builtins/contexts/lookup-table.cpp
@@ -68,8 +68,7 @@ public:
       return caf::make_error(ec::invalid_argument, "missing argument `field`");
     }
     auto field_builder = series_builder{};
-    auto column_offset
-      = caf::get<record_type>(slice.schema()).resolve_key(*field_name);
+    auto column_offset = slice.schema().resolve_key_or_concept(*field_name);
     if (not column_offset) {
       for (auto i = size_t{0}; i < slice.rows(); ++i) {
         field_builder.null();
@@ -150,13 +149,12 @@ public:
     if (not parameters.contains("key")) {
       return caf::make_error(ec::invalid_argument, "missing 'key' parameter");
     }
-    const auto& layout = caf::get<record_type>(slice.schema());
     auto key_field = parameters["key"];
     if (not key_field) {
       return caf::make_error(ec::invalid_argument,
                              "invalid 'key' parameter; 'key' must be a string");
     }
-    auto key_column = layout.resolve_key(*key_field);
+    auto key_column = slice.schema().resolve_key_or_concept(*key_field);
     if (not key_column) {
       // If there's no key column then we cannot do much.
       return update_result{record{}};

--- a/libtenzir/builtins/operators/chart.cpp
+++ b/libtenzir/builtins/operators/chart.cpp
@@ -60,12 +60,11 @@ private:
       return caf::make_error(ec::unspecified,
                              "chart operator expects input to be a record");
     }
-    const auto& record = caf::get<record_type>(schema);
     for (auto&& attr : cfg.get_attributes()) {
       // "type" and "description" fields aren't expected to be found in the input
       if (attr.key == "type" || attr.key == "description")
         continue;
-      if (record.resolve_key(attr.value))
+      if (schema.resolve_key_or_concept(attr.value))
         continue;
       return caf::make_error(ec::unspecified,
                              fmt::format("field `{}` not found in input, "

--- a/libtenzir/builtins/operators/delay.cpp
+++ b/libtenzir/builtins/operators/delay.cpp
@@ -65,7 +65,7 @@ public:
       const auto& layout = caf::get<record_type>(slice.schema());
       auto resolved_field = resolved_fields.find(slice.schema());
       if (resolved_field == resolved_fields.end()) {
-        const auto index = layout.resolve_key(field_);
+        const auto index = slice.schema().resolve_key_or_concept(field_);
         if (not index) {
           diagnostic::warning("failed to resolve field `{}` for schema `{}`",
                               field_, slice.schema())

--- a/libtenzir/builtins/operators/drop.cpp
+++ b/libtenzir/builtins/operators/drop.cpp
@@ -79,7 +79,7 @@ public:
     };
     auto transformations = std::vector<indexed_transformation>{};
     for (const auto& field : config_.fields) {
-      if (auto index = caf::get<record_type>(schema).resolve_key(field)) {
+      if (auto index = schema.resolve_key_or_concept(field)) {
         transformations.push_back({std::move(*index), transform_fn});
       }
     }

--- a/libtenzir/builtins/operators/hash.cpp
+++ b/libtenzir/builtins/operators/hash.cpp
@@ -64,8 +64,7 @@ public:
   auto initialize(const type& schema, operator_control_plane&) const
     -> caf::expected<state_type> override {
     // Get the target field if it exists.
-    const auto& schema_rt = caf::get<record_type>(schema);
-    auto column_index = schema_rt.resolve_key(config_.field);
+    auto column_index = schema.resolve_key_or_concept(config_.field);
     if (!column_index) {
       return state_type{};
     }

--- a/libtenzir/builtins/operators/parse.cpp
+++ b/libtenzir/builtins/operators/parse.cpp
@@ -74,7 +74,7 @@ public:
       }
       auto batch = to_record_batch(slice);
       auto schema = caf::get<record_type>(slice.schema());
-      auto index = schema.resolve_key(input_.inner);
+      auto index = slice.schema().resolve_key_or_concept(input_.inner);
       if (not index) {
         diagnostic::error("could not resolve `{}` for schema `{}`",
                           input_.inner, slice.schema())

--- a/libtenzir/builtins/operators/pseudonymize.cpp
+++ b/libtenzir/builtins/operators/pseudonymize.cpp
@@ -77,7 +77,7 @@ public:
       };
     };
     for (const auto& field_name : config_.fields) {
-      if (auto index = caf::get<record_type>(schema).resolve_key(field_name)) {
+      if (auto index = schema.resolve_key_or_concept(field_name)) {
         auto index_type = caf::get<record_type>(schema).field(*index).type;
         if (!caf::holds_alternative<ip_type>(index_type)) {
           TENZIR_DEBUG("pseudonymize operator skips field '{}' of unsupported "

--- a/libtenzir/builtins/operators/put_extend_replace.cpp
+++ b/libtenzir/builtins/operators/put_extend_replace.cpp
@@ -205,7 +205,7 @@ public:
                           operator_name(Mode), extractor)));
             continue;
           }
-          if (auto index = layout.resolve_key(extractor)) {
+          if (auto index = slice.schema().resolve_key_or_concept(extractor)) {
             index_to_operand.emplace_back(std::move(*index), &*operand);
           }
           for (const auto& index : layout.resolve_type_extractor(extractor)) {

--- a/libtenzir/builtins/operators/rename.cpp
+++ b/libtenzir/builtins/operators/rename.cpp
@@ -87,8 +87,7 @@ public:
     auto field_transformations = std::vector<indexed_transformation>{};
     if (!config_.fields.empty()) {
       for (const auto& field : config_.fields) {
-        if (auto index
-            = caf::get<record_type>(schema).resolve_key(field.from)) {
+        if (auto index = schema.resolve_key_or_concept(field.from)) {
           auto transformation
             = [&](struct record_type::field old_field,
                   std::shared_ptr<arrow::Array> array) noexcept

--- a/libtenzir/builtins/operators/select.cpp
+++ b/libtenzir/builtins/operators/select.cpp
@@ -59,7 +59,7 @@ public:
     -> caf::expected<state_type> override {
     auto indices = state_type{};
     for (const auto& field : config_.fields) {
-      if (auto index = caf::get<record_type>(schema).resolve_key(field)) {
+      if (auto index = schema.resolve_key_or_concept(field)) {
         indices.push_back(std::move(*index));
       }
     }

--- a/libtenzir/builtins/operators/sort.cpp
+++ b/libtenzir/builtins/operators/sort.cpp
@@ -94,8 +94,7 @@ private:
     }
     // Set up the sorting and emit warnings at most once per schema.
     key_path = key_field_path_.emplace_hint(
-      key_field_path_.end(), schema,
-      caf::get<record_type>(schema).resolve_key(key_));
+      key_field_path_.end(), schema, schema.resolve_key_or_concept(key_));
     if (not key_path->second.has_value()) {
       ctrl.warn(caf::make_error(ec::invalid_configuration,
                                 fmt::format("sort key `{}` does not apply to "

--- a/libtenzir/builtins/operators/summarize.cpp
+++ b/libtenzir/builtins/operators/summarize.cpp
@@ -228,7 +228,7 @@ struct binding {
     result.aggregation_columns.reserve(config.aggregations.size());
     auto const& rt = caf::get<record_type>(schema);
     for (auto const& field : config.group_by_extractors) {
-      if (auto offset = rt.resolve_key(field)) {
+      if (auto offset = schema.resolve_key_or_concept(field)) {
         auto type = rt.field(*offset).type;
         result.group_by_columns.emplace_back(
           column{std::move(*offset), std::move(type)});
@@ -251,7 +251,8 @@ struct binding {
               // that `count(.)` works across multiple schemas.
               TENZIR_ASSERT(aggr.function->name() == "count");
               return {{{}, type{int64_type{}}}};
-            } else if (auto offset = rt.resolve_key(aggr.input)) {
+            } else if (auto offset
+                       = schema.resolve_key_or_concept(aggr.input)) {
               auto type = rt.field(*offset).type;
               return {{std::move(*offset), std::move(type)}};
             } else {

--- a/libtenzir/builtins/operators/timeshift.cpp
+++ b/libtenzir/builtins/operators/timeshift.cpp
@@ -45,7 +45,7 @@ public:
       const auto& layout = caf::get<record_type>(slice.schema());
       auto resolved_field = resolved_fields.find(slice.schema());
       if (resolved_field == resolved_fields.end()) {
-        const auto index = layout.resolve_key(field_);
+        const auto index = slice.schema().resolve_key_or_concept(field_);
         if (not index) {
           diagnostic::warning("failed to resolve field `{}` for schema `{}`",
                               field_, slice.schema())

--- a/libtenzir/include/tenzir/type.hpp
+++ b/libtenzir/include/tenzir/type.hpp
@@ -300,6 +300,11 @@ public:
   [[nodiscard]] std::shared_ptr<arrow::ArrayBuilder>
   make_arrow_builder(arrow::MemoryPool* pool) const noexcept;
 
+  /// Resolves a key on a schema.
+  /// @returns nullopt if the type is not a valid schema.
+  [[nodiscard]] std::optional<offset>
+  resolve_key_or_concept(std::string_view key) const noexcept;
+
   /// Enables integration with CAF's type inspection.
   template <class Inspector>
   friend auto inspect(Inspector& f, type& x) {
@@ -1269,6 +1274,13 @@ public:
 
   /// Resolves a flat index into an offset.
   [[nodiscard]] offset resolve_flat_index(size_t flat_index) const noexcept;
+
+  /// Resolves a key or a concept into an offset.
+  /// @note This only matches on full keys, so the key 'x.y'  matches 'x.y.z'
+  /// but not 'x.y_other.z' .
+  [[nodiscard]] std::optional<offset>
+  resolve_key_or_concept(std::string_view key,
+                         std::string_view schema_name) const noexcept;
 
   /// Resolves a key into an offset.
   /// @note This only matches on full keys, so the key 'x.y'  matches 'x.y.z'

--- a/libtenzir/src/table_slice.cpp
+++ b/libtenzir/src/table_slice.cpp
@@ -890,7 +890,7 @@ auto resolve_operand(const table_slice& slice, const operand& op)
       bind_value(value);
     },
     [&](const field_extractor& ex) {
-      if (auto index = layout.resolve_key(ex.field)) {
+      if (auto index = slice.schema().resolve_key_or_concept(ex.field)) {
         bind_array(*index);
         return;
       }


### PR DESCRIPTION
This change adds support for concepts in almost all operators and contexts. In particular, this affects the following contexts or operators:
- `context`
- `delay`
- `drop`
- `enrich`
- `extend`
- `geoip`
- `hash`
- `lookup`
- `lookup-table`
- `parse`
- `pseudonymize`
- `put`
- `rename`
- `replace`
- `select`
- `sort`
- `summarize`
- `timeshift`
- `lookup`

Note that `put net.src.ip` creates a field `net.src.ip`, but `select net.src.ip` keeps the original field name.