### PR TITLE
Fix handling of escapes in detail::split_escaped, attempt 2

### DIFF
--- a/libtenzir/src/detail/string.cpp
+++ b/libtenzir/src/detail/string.cpp
@@ -137,7 +137,7 @@ split_escaped(std::string_view str, std::string_view sep, std::string_view esc,
   auto it = str.begin();
   std::string current{};
   size_t splits = 0;
-  while (it != str.end()) {
+  while (it != str.end() && splits != max_splits) {
     auto next_sep = std::ranges::search(std::string_view{it, str.end()}, sep);
     if (std::distance(it, next_sep.begin()) >= std::ssize(esc)) {
       // Possibly escaped separator
@@ -150,14 +150,13 @@ split_escaped(std::string_view str, std::string_view sep, std::string_view esc,
         continue;
       }
     }
-    if (splits++ == max_splits)
-      break;
     current.append(std::string_view{it, next_sep.begin()});
     out.emplace_back(std::move(current));
     current = {};
     it = next_sep.end();
     if (!next_sep.empty() && it == str.end())
       out.emplace_back("");
+    ++splits;
   }
   if (it != str.end())
     current.append(std::string_view{it, str.end()});

--- a/libtenzir/test/http.cpp
+++ b/libtenzir/test/http.cpp
@@ -48,7 +48,7 @@ TEST(parse HTTP request item) {
     item = http::request_item::parse(str);
     REQUIRE(item);
     CHECK_EQUAL(item->key, "foo");
-    auto value = fmt::format("bar{}", sep);
+    auto value = fmt::format("bar\\{}", sep);
     CHECK_EQUAL(item->value, value);
   }
 }

--- a/libtenzir/test/string.cpp
+++ b/libtenzir/test/string.cpp
@@ -290,7 +290,7 @@ TEST(escaped splitting) {
   CHECK_EQUAL(s[0], "a,b");
   CHECK_EQUAL(s[1], "c");
   CHECK_EQUAL(s[2], "");
-  // Regression found in the HTTP request item parser.
+  MESSAGE("escaped split with trailing, possibly escaped separators");
   str = "foo:=@bar";
   s = split_escaped(str, ":=@", "\\", 1);
   REQUIRE_EQUAL(s.size(), 2ull);
@@ -305,7 +305,49 @@ TEST(escaped splitting) {
   s = split_escaped(str, ":=@", "\\", 1);
   REQUIRE_EQUAL(s.size(), 2ull);
   CHECK_EQUAL(s[0], "foo");
+  CHECK_EQUAL(s[1], "bar\\:=@");
+  str = "foo:=@bar:=@:=@";
+  s = split_escaped(str, ":=@", "\\", 1);
+  REQUIRE_EQUAL(s.size(), 2ull);
+  CHECK_EQUAL(s[0], "foo");
+  CHECK_EQUAL(s[1], "bar:=@:=@");
+  str = "foo:=@bar\\:=@:=@";
+  s = split_escaped(str, ":=@", "\\", 1);
+  REQUIRE_EQUAL(s.size(), 2ull);
+  CHECK_EQUAL(s[0], "foo");
+  CHECK_EQUAL(s[1], "bar\\:=@:=@");
+  str = "foo:=@bar:=@\\:=@";
+  s = split_escaped(str, ":=@", "\\", 1);
+  REQUIRE_EQUAL(s.size(), 2ull);
+  CHECK_EQUAL(s[0], "foo");
+  CHECK_EQUAL(s[1], "bar:=@\\:=@");
+  str = "foo:=@bar\\:=@\\:=@";
+  s = split_escaped(str, ":=@", "\\", 1);
+  REQUIRE_EQUAL(s.size(), 2ull);
+  CHECK_EQUAL(s[0], "foo");
+  CHECK_EQUAL(s[1], "bar\\:=@\\:=@");
+  str = "foo:=@bar\\:=@\\:=@baz";
+  s = split_escaped(str, ":=@", "\\", 1);
+  REQUIRE_EQUAL(s.size(), 2ull);
+  CHECK_EQUAL(s[0], "foo");
+  CHECK_EQUAL(s[1], "bar\\:=@\\:=@baz");
+  str = "foo\\:=@bar:=@baz\\:=@\\:=@quux";
+  s = split_escaped(str, ":=@", "\\", 1);
+  REQUIRE_EQUAL(s.size(), 2ull);
+  CHECK_EQUAL(s[0], "foo:=@bar");
+  CHECK_EQUAL(s[1], "baz\\:=@\\:=@quux");
+  str = "foo:=@bar\\:=@:=@";
+  s = split_escaped(str, ":=@", "\\", 2);
+  REQUIRE_EQUAL(s.size(), 3ull);
+  CHECK_EQUAL(s[0], "foo");
   CHECK_EQUAL(s[1], "bar:=@");
+  CHECK_EQUAL(s[2], "");
+  str = "foo:=@bar\\:=@:=@baz";
+  s = split_escaped(str, ":=@", "\\", 2);
+  REQUIRE_EQUAL(s.size(), 3ull);
+  CHECK_EQUAL(s[0], "foo");
+  CHECK_EQUAL(s[1], "bar:=@");
+  CHECK_EQUAL(s[2], "baz");
 }
 
 TEST(join) {


### PR DESCRIPTION
Closes https://github.com/tenzir/issues/issues/1128, old PR https://github.com/tenzir/tenzir/pull/3791

```cpp
// Before:
// Only first separator after `max_splits` was reached
// had its escape sequence removed in the output
auto ret = detail::split_escaped("abc\\==def==ghi\\==jkl\\==mno", "==", "\\", 1);
// ret == ["abc==def", "ghi==jkl\\==mno"]

// After:
// Escape sequences not removed after `max_splits` is reached
auto ret = detail::split_escaped("abc\\==def==ghi\\==jkl\\==mno", "==", "\\", 1);
// ret == ["abc==def", "ghi\\==jkl\\==mno"]
```

TODO: sign commits