### PR TITLE
Add support for Cisco Firepower syslog messages

### DIFF
--- a/changelog/next/features/3833--syslog-years.md
+++ b/changelog/next/features/3833--syslog-years.md
@@ -1,0 +1,1 @@
+The RFC 3164 syslog parser now supports years in the message timestamp.

--- a/tenzir/functional-test/data/syslog/syslog-rfc3164.log
+++ b/tenzir/functional-test/data/syslog/syslog-rfc3164.log
@@ -9,3 +9,4 @@ Nov 21 13:09:11 mymachine/10.1.1.16 FOO: CEF:0|Cynet|Cynet 360|4.5.4.22139|0|Mem
 Dec  6 15:56:37 mymachine PROCESS[123]: foobar
 Dec  6 15:56:17 mymachine/10.1.1.16 No app name in this message
 Dec  6 15:56:27 mymachine No app name in this message, either
+<164>Jan 18 2024 11:50:03 firepower : %FTD-4-419002: Duplicate TCP SYN from outside:84.241.12.18/59821 to inside:134.40.10.168/8192 with different initial sequence number

--- a/tenzir/integration/reference/syslog-format/step_01.ref
+++ b/tenzir/integration/reference/syslog-format/step_01.ref
@@ -97,3 +97,12 @@
   "process_id": null,
   "content": "No app name in this message, either"
 }
+{
+  "facility": 20,
+  "severity": 4,
+  "timestamp": "Jan 18 2024 11:50:03",
+  "hostname": "firepower",
+  "app_name": null,
+  "process_id": null,
+  "content": "%FTD-4-419002: Duplicate TCP SYN from outside:84.241.12.18/59821 to inside:134.40.10.168/8192 with different initial sequence number"
+}


### PR DESCRIPTION
Closes https://github.com/tenzir/issues/issues/1162

The RFC 3164 syslog parser couldn't handle (non-standard) years in timestamps. Now it can.