### PR TITLE
Print Zeek TSV metadata when schema changes

### DIFF
--- a/changelog/next/bug-fixes/3836--zeek-tsv-metadata.md
+++ b/changelog/next/bug-fixes/3836--zeek-tsv-metadata.md
@@ -1,0 +1,2 @@
+The `zeek-tsv` printer incorrectly emitted metadata too frequently. It now only
+writes opening and closing tags when it encounters a new schema.

--- a/libtenzir/src/table_slice.cpp
+++ b/libtenzir/src/table_slice.cpp
@@ -775,6 +775,9 @@ uint64_t count_matching(const table_slice& slice, const expression& expr,
 }
 
 table_slice resolve_enumerations(table_slice slice) {
+  if (slice.rows() == 0) {
+    return slice;
+  }
   auto type = caf::get<record_type>(slice.schema());
   // Resolve enumeration types, if there are any.
   auto transformations = std::vector<indexed_transformation>{};

--- a/tenzir/integration/reference/zeek-tsv-pipeline-format/step_11.ref
+++ b/tenzir/integration/reference/zeek-tsv-pipeline-format/step_11.ref
@@ -9,13 +9,6 @@
 2009-11-18T08:08:00.237253	nkCxlvNN8pi	192.168.1.103	137	192.168.1.255	137	udp	dns	3.78s	350	0	S0	-	-	0	D	7	546	0	0	(empty)	-	-
 2009-11-18T08:08:13.816224	9VdICMMnxQ7	192.168.1.102	137	192.168.1.255	137	udp	dns	3.75s	350	0	S0	-	-	0	D	7	546	0	0	(empty)	-	-
 2009-11-18T08:07:15.800932	bEgBnkI31Vf	192.168.1.103	138	192.168.1.255	138	udp	-	46.73s	560	0	S0	-	-	0	D	3	644	0	0	(empty)	-	-
-#separator \x09
-#set_separator	,
-#empty_field	(empty)
-#unset_field	-
-#path	zeek.conn
-#fields	ts	uid	id.orig_h	id.orig_p	id.resp_h	id.resp_p	proto	service	duration	orig_bytes	resp_bytes	conn_state	local_orig	local_resp	missed_bytes	history	orig_pkts	orig_ip_bytes	resp_pkts	resp_ip_bytes	tunnel_parents	community_id	_write_ts
-#types	time	string	addr	port	addr	port	string	string	interval	count	count	string	bool	bool	count	string	count	count	count	count	vector[string]	string	time
 2009-11-18T08:00:21.486539	Pii6cUUq1v4	192.168.1.102	68	192.168.1.1	67	udp	-	163.82ms	301	300	SF	-	-	0	Dd	1	329	1	328	(empty)	-	-
 2009-11-18T08:08:00.237253	nkCxlvNN8pi	192.168.1.103	137	192.168.1.255	137	udp	dns	3.78s	350	0	S0	-	-	0	D	7	546	0	0	(empty)	-	-
 2009-11-18T08:08:13.816224	9VdICMMnxQ7	192.168.1.102	137	192.168.1.255	137	udp	dns	3.75s	350	0	S0	-	-	0	D	7	546	0	0	(empty)	-	-


### PR DESCRIPTION
Fixes tenzir/issues#587

This addresses two issues in the `zeek-tsv` printer:
1. Previously, the printer returned opening and closing tags once per batch rather than when the schema changes. That is not technically incorrect, but bloated the generated file sizes by a lot for small batches.
2. The printer was incorrectly marked as not allowing joining the output. Zeek TSV can be printer interleaved, so things like `to stdout write zeek-tsv` should not be forbidden.