### PR TITLE
Enable CAF assertions alongside our own assertions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -721,7 +721,9 @@ endif ()
 # CAF::openssl needs OpenSSL, but CAFConfig.cmake does not pull it in.
 find_package(OpenSSL REQUIRED)
 
-# TODO: Require CAF to be installed.
+set(TENZIR_CAF_LOG_LEVEL
+    "WARNING"
+    CACHE STRING "")
 
 if (TENZIR_ENABLE_DEVELOPER_MODE
     AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/libtenzir/aux/caf/CMakeLists.txt"
@@ -759,11 +761,14 @@ else ()
         libtenzir/aux/caf submodule")
   else ()
     set(TENZIR_ENABLE_BUNDLED_CAF ON)
-    set(CAF_LOG_LEVEL ${TENZIR_CAF_LOG_LEVEL})
-    set(CAF_ENABLE_EXAMPLES OFF)
-    set(CAF_ENABLE_TESTING OFF)
-    set(CAF_ENABLE_TOOLS OFF)
-    set(CAF_ENABLE_OPENSSL ON)
+    set(CAF_LOG_LEVEL "${TENZIR_CAF_LOG_LEVEL}" CACHE STRING "")
+    set(CAF_ENABLE_EXAMPLES OFF CACHE BOOL "")
+    set(CAF_ENABLE_TESTING OFF CACHE BOOL "")
+    set(CAF_ENABLE_TOOLS OFF CACHE BOOL "")
+    set(CAF_ENABLE_OPENSSL ON CACHE BOOL "")
+    if (TENZIR_ENABLE_ASSERTIONS)
+      set(CAF_ENABLE_RUNTIME_CHECKS ON CACHE BOOL "")
+    endif ()
     # add_subdirectory libtenzir/aux/caf checks if compiler supports the c++ 17. This check fails and the workaround
     # can be removed once CAF cmake changes to use set(CMAKE_CXX_STANDARD) instead of it's own check
     set(ORIGINAL_CXX_STANDARD ${CMAKE_CXX_STANDARD})

--- a/libtenzir/CMakeLists.txt
+++ b/libtenzir/CMakeLists.txt
@@ -141,10 +141,6 @@ elseif (NOT TENZIR_LOG_LEVEL STREQUAL "$CACHE{TENZIR_LOG_LEVEL}")
       CACHE STRING "${TENZIR_LOG_LEVEL_DOC}" FORCE)
 endif ()
 
-set(TENZIR_CAF_LOG_LEVEL
-    "WARNING"
-    CACHE STRING ${TENZIR_LOG_LEVEL_DOC})
-
 # Raise an error for invalid log levels.
 set(validLogLevels
     QUIET

--- a/nix/caf/source.json
+++ b/nix/caf/source.json
@@ -1,7 +1,7 @@
 {
   "owner": "tenzir",
   "repo": "actor-framework",
-  "rev": "e1d910282298d3a5ac81b3d53d7beffad9643f49",
-  "sha256": "B88kwUtVogsOoRCSvLa1HOhP1eGVELfbdtVjvt5+kzM=",
+  "rev": "4ff66bf218dec0514829230af6f41fb8ed09aa5c",
+  "sha256": "s7CdmQ64whJ7o7KiIxKLrZSR4RRJnNzcgGuqGKcxCzI=",
   "version": "0.18.7"
 }


### PR DESCRIPTION
Fixes tenzir/issues#1157

This makes it so that `CAF_ASSERT` is always enabled alongside `TENZIR_ASSERT_EXPENSIVE`. This is the default behavior in debug builds.