### PR TITLE
Support setting a single `TENZIR_TOKEN` for platform auth

### DIFF
--- a/libtenzir/src/application.cpp
+++ b/libtenzir/src/application.cpp
@@ -69,6 +69,8 @@ void add_root_opts(command& cmd) {
   cmd.options.add<int64_t>("?tenzir", "log-queue-size",
                            "the queue size for the logger");
   cmd.options.add<std::string>("?tenzir", "endpoint,e", "node endpoint");
+  cmd.options.add<std::string>(
+    "?tenzir", "token", "platform auth token (requires platform plugin)");
   cmd.options.add<std::string>("?tenzir", "node-id,i",
                                "the unique ID of this node");
   cmd.options.add<bool>("?tenzir", "node,N",

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "a0829e1bb563c57f9224d0924bba57f8dd412dcd",
+  "rev": "45245f1b657122265cbf8488bb3d4b2bbc2ca0ed",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -7,6 +7,10 @@ tenzir:
   # The host and port to listen at and connect to.
   endpoint: "localhost:5158"
 
+  # The platform auth token for app.tenzir.com. This is an alternative to
+  # the dedicated platform.yaml file. The key has the following format:
+  #token: <tenant-id>:<api-key>[:<control-endpoint>]
+
   # The timeout for connecting to a Tenzir server. Set to 0 seconds to wait
   # indefinitely.
   connection-timeout: 5m


### PR DESCRIPTION
The new `tenzir.token` option has the format
`<tenant-id>:<api-key>[:<control-endpoint>]`, and has a higher precedence than the existing variables.