### PR TITLE
Fix a rare crash in the index on startup

### DIFF
--- a/libtenzir/src/index.cpp
+++ b/libtenzir/src/index.cpp
@@ -43,6 +43,7 @@
 #include "tenzir/io/read.hpp"
 #include "tenzir/io/save.hpp"
 #include "tenzir/logger.hpp"
+#include "tenzir/modules.hpp"
 #include "tenzir/partition_synopsis.hpp"
 #include "tenzir/partition_transformer.hpp"
 #include "tenzir/passive_partition.hpp"
@@ -1204,20 +1205,8 @@ index(index_actor::stateful_pointer<index_state> self,
   self->state.accountant = std::move(accountant);
   self->state.filesystem = std::move(filesystem);
   self->state.catalog = std::move(catalog);
-  self
-    ->request(self->state.catalog, caf::infinite, atom::get_v,
-              atom::taxonomies_v)
-    .await(
-      [self](tenzir::taxonomies& taxonomies) {
-        self->state.taxonomies
-          = std::make_shared<tenzir::taxonomies>(std::move(taxonomies));
-      },
-      [](caf::error& err) {
-        TENZIR_WARN("catalog failed to load taxonomy "
-                    "definitions: {}",
-                    std::move(err));
-        // TODO: Shutdown when failing?
-      });
+  self->state.taxonomies = std::make_shared<tenzir::taxonomies>();
+  self->state.taxonomies->concepts = modules::concepts();
   self->state.dir = dir;
   self->state.synopsisdir = catalog_dir;
   self->state.markersdir = dir / "markers";


### PR DESCRIPTION
This fixes a very rare crash in the index on startup where taxonomies were not yet retrieved from the catalog but already attempted to access.

This crash was introduced a few months back when we backported a bug fix for our CAF fork that allowed system messages to be scheduled while another requests's response was awaited. The index uses the (rightfully) deprecated CAF streaming, which uses system messages under the hood. This means that awaiting the taxonomies on startup of the index did no longer ensure that they couldn't be used from CAF streaming handlers already.

Luckily, all this was rather easy to fix as we made taxonomies available globally rather than just in the catalog actor quite a while ago. It looks like we just forgot to update the logic of the index here.