### PR TITLE
Fix a logic bug in the Zeek TSV printer

### DIFF
--- a/libtenzir/builtins/formats/zeek_tsv.cpp
+++ b/libtenzir/builtins/formats/zeek_tsv.cpp
@@ -802,8 +802,7 @@ public:
                                 args_.unset_field.value_or("-"),
                                 args_.disable_timestamp_tags};
     auto last_schema = std::make_shared<type>();
-    return printer_instance::make([last_schema = last_schema,
-                                   printer = std::move(printer)](
+    return printer_instance::make([last_schema, printer = std::move(printer)](
                                     table_slice slice) -> generator<chunk_ptr> {
       if (slice.rows() == 0) {
         co_yield {};
@@ -817,9 +816,8 @@ public:
       auto array
         = to_record_batch(resolved_slice)->ToStructArray().ValueOrDie();
       auto first = true;
-      auto is_first_schema = static_cast<bool>(*last_schema);
-      auto did_schema_change
-        = *last_schema != input_schema and not is_first_schema;
+      auto is_first_schema = not *last_schema;
+      auto did_schema_change = *last_schema != input_schema;
       *last_schema = input_schema;
       for (const auto& row : values(input_type, *array)) {
         TENZIR_ASSERT_CHEAP(row);


### PR DESCRIPTION
This fixes a bug I accidentally introduced in #3836 that caused the Zeek TSV printer to not print schema information when no empty batch arrived before the first batch containing a result. This is a rare case, but it can actually happen depending on timing and the operators preceding `write zeek-tsv`.