### PR TITLE
Explain how the S3 connector uses AWS configuration files

### DIFF
--- a/web/docs/connectors/s3.md
+++ b/web/docs/connectors/s3.md
@@ -38,8 +38,8 @@ Make sure to configure AWS credentials for the same user account that runs
 current user under `~/.aws`, which can only be read by the same user account.
 
 The `tenzir-node` systemd unit by default creates a `tenzir` user and runs as
-that user, meaning that it the AWS credentials must also be configured for that
-user account. `~/.aws` must be readable for the `tenzir` user in this setup.
+that user, meaning that the AWS credentials must also be configured for that
+user. The directory `~/.aws` must be readable for the `tenzir` user.
 :::
 
 ### `<uri>` (Loader, Saver)

--- a/web/docs/connectors/s3.md
+++ b/web/docs/connectors/s3.md
@@ -7,7 +7,7 @@ sidebar_custom_props:
 
 # s3
 
-Loads bytes from an Amazon S3 object. Saves bytes to an Amazon S3 object.
+Loads from and saves to an Amazon S3 object.
 
 ## Synopsis
 
@@ -31,6 +31,16 @@ object. The `s3` saver writes bytes to an S3 object in an S3 bucket.
 The connector tries to retrieve the appropriate credentials using AWS's
 [default credentials provider
 chain](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html).
+
+:::info
+Make sure to configure AWS credentials for the same user account that runs
+`tenzir` and `tenzir-node`. The AWS CLI creates configuration files for the
+current user under `~/.aws`, which can only be read by the same user account.
+
+The `tenzir-node` systemd unit by default creates a `tenzir` user and runs as
+that user, meaning that it the AWS credentials must also be configured for that
+user account. `~/.aws` must be readable for the `tenzir` user in this setup.
+:::
 
 ### `<uri>` (Loader, Saver)
 


### PR DESCRIPTION
This adds a note to the documentation of the S3 connector explaining a pitfall that a user ran into: They configured access to S3 for the wrong user account, and were then not able to access it using Tenzir.

Fixes tenzir/issues#1102