### PR TITLE
Run functional tests when building the static binary

### DIFF
--- a/.github/workflows/nix.nu
+++ b/.github/workflows/nix.nu
@@ -130,7 +130,7 @@ export def run [
   # Run local effects by building all requested editions.
   let targets = ($cfg.editions | each {|e| $".#(attribute_name $e)" })
   print $"::notice building ($targets)"
-  nix --accept-flake-config --print-build-logs build --no-link $targets
+  nix --accept-flake-config --print-build-logs build --no-link ...$targets
   # Run remote effects by uploading packages and images.
   for e in $cfg.editions {
     let stores = (if ($e.package-stores? == null) {[]} else {$e.package-stores})

--- a/.github/workflows/tenzir.yaml
+++ b/.github/workflows/tenzir.yaml
@@ -941,7 +941,7 @@ jobs:
         run: |
           # We don't always have a bats submodule when building plugins, so we
           # get it with Nix.
-          nix --accept-flake-config develop .#integration-shell \
+          nix --accept-flake-config develop .#integration-test-shell \
             --command bash -c "cmake --build \"$BUILD_DIR\" --target integration -j 1"
       - name: Publish Integration Test Report
         uses: mikepenz/action-junit-report@v4

--- a/flake.lock
+++ b/flake.lock
@@ -101,17 +101,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1700948707,
-        "narHash": "sha256-W4TRYSGaD8Gybw0u66aJM6IVClOtjZaXsSCpkWbZMQ4=",
+        "lastModified": 1707111038,
+        "narHash": "sha256-BNY4vKMLcrkjlC4tH8/QaUGXJif0mOV+p5l8bbEhTC8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7086fd448fbe174a8c05a87a475bedd704520b68",
+        "rev": "1f5d74db169236ad4bed54028c8e147298c7cf9d",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7086fd448fbe174a8c05a87a475bedd704520b68",
+        "rev": "1f5d74db169236ad4bed54028c8e147298c7cf9d",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -83,21 +83,6 @@
         "type": "github"
       }
     },
-    "nix-filter": {
-      "locked": {
-        "lastModified": 1694857738,
-        "narHash": "sha256-bxxNyLHjhu0N8T3REINXQ2ZkJco0ABFPn6PIe2QUfqo=",
-        "owner": "numtide",
-        "repo": "nix-filter",
-        "rev": "41fd48e00c22b4ced525af521ead8792402de0ea",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "nix-filter",
-        "type": "github"
-      }
-    },
     "nix-visualize": {
       "flake": false,
       "locked": {
@@ -152,7 +137,6 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
-        "nix-filter": "nix-filter",
         "nixpkgs": "nixpkgs",
         "sbomnix": "sbomnix"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,6 @@
   inputs.flake-compat.url = "github:edolstra/flake-compat";
   inputs.flake-compat.flake = false;
   inputs.flake-utils.url = "github:numtide/flake-utils";
-  inputs.nix-filter.url = "github:numtide/nix-filter";
   inputs.sbomnix.url = "github:tiiuae/sbomnix";
   inputs.sbomnix.inputs.nixpkgs.follows = "nixpkgs";
 
@@ -102,10 +101,7 @@
             tenzir-ee = pkgs.tenzir-ee;
             tenzir-ee-static = pkgs.pkgsStatic.tenzir-ee;
             integration-test-shell = pkgs.mkShell {
-              packages = pkgs.tenzir-de;
-            };
-            integration-shell = pkgs.mkShell {
-              packages = pkgs.tenzir-integration-deps;
+              packages = pkgs.tenzir-integration-test-runner;
             };
           }
           // {

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
     ];
   };
 
-  inputs.nixpkgs.url = "github:nixos/nixpkgs/7086fd448fbe174a8c05a87a475bedd704520b68";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/1f5d74db169236ad4bed54028c8e147298c7cf9d";
   inputs.flake-compat.url = "github:edolstra/flake-compat";
   inputs.flake-compat.flake = false;
   inputs.flake-utils.url = "github:numtide/flake-utils";

--- a/flake.nix
+++ b/flake.nix
@@ -99,8 +99,6 @@
             tenzir-de-static = pkgs.pkgsStatic.tenzir-de;
             tenzir = pkgs.tenzir;
             tenzir-static = pkgs.pkgsStatic.tenzir;
-            tenzir-cm = pkgs.tenzir-cm;
-            tenzir-cm-static = pkgs.pkgsStatic.tenzir-cm;
             tenzir-ee = pkgs.tenzir-ee;
             tenzir-ee-static = pkgs.pkgsStatic.tenzir-ee;
             integration-test-shell = pkgs.mkShell {
@@ -117,8 +115,6 @@
             vast-static = self.packages.${system}.tenzir-de-static;
             vast-ce = self.packages.${system}.tenzir;
             vast-ce-static = self.packages.${system}.tenzir-static;
-            vast-cm = self.packages.${system}.tenzir-cm;
-            vast-cm-static = self.packages.${system}.tenzir-cm-static;
             vast-ee = self.packages.${system}.tenzir-ee;
             vast-ee-static = self.packages.${system}.tenzir-ee-static;
             vast-integration-test-shell = self.packages.${system}.integration-test-shell;

--- a/libtenzir/CMakeLists.txt
+++ b/libtenzir/CMakeLists.txt
@@ -222,12 +222,13 @@ dependency_summary("OpenSSL" OpenSSL::SSL "Dependencies")
 
 # Link against yaml-cpp.
 find_package(yaml-cpp 0.6.2 REQUIRED)
-string(APPEND TENZIR_FIND_DEPENDENCY_LIST "\nfind_package(yaml-cpp REQUIRED)")
 if (yaml-cpp_VERSION VERSION_GREATER_EQUAL 0.8)
-  target_link_libraries(libtenzir PUBLIC yaml-cpp::yaml-cpp)
+  target_link_libraries(libtenzir PRIVATE yaml-cpp::yaml-cpp)
+  target_link_libraries(libtenzir_builtins PRIVATE yaml-cpp::yaml-cpp)
   dependency_summary("yaml-cpp" yaml-cpp::yaml-cpp "Dependencies")
 else ()
-  target_link_libraries(libtenzir PUBLIC yaml-cpp)
+  target_link_libraries(libtenzir PRIVATE yaml-cpp)
+  target_link_libraries(libtenzir_builtins PRIVATE yaml-cpp)
   dependency_summary("yaml-cpp" yaml-cpp "Dependencies")
 endif ()
 

--- a/libtenzir/CMakeLists.txt
+++ b/libtenzir/CMakeLists.txt
@@ -254,10 +254,22 @@ endif ()
 # Link against curl.
 # The FindCURL module from CMake doesn't expose the link dependencies of libcurl.a
 # correctly, so we use pkg-config instead.
-pkg_check_modules(PC_CURL REQUIRED QUIET IMPORTED_TARGET libcurl)
+pkg_check_modules(PC_CURL REQUIRED IMPORTED_TARGET libcurl)
 string(APPEND TENZIR_FIND_DEPENDENCY_LIST
        "\npkg_check_modules(PC_CURL REQUIRED QUIET IMPORTED_TARGET libcurl)")
 target_link_libraries(libtenzir PUBLIC PkgConfig::PC_CURL)
+# The static curl library we use on macOS depends on SystemConfiguration, but
+# that dependency is missing from the pkg-config file, so we insert it here as a
+# work around.
+if (CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND PC_CURL_CFLAGS MATCHES ".*CURL_STATICLIB.*")
+  find_library(SystemConfiguration SystemConfiguration REQUIRED)
+  mark_as_advanced(SystemConfiguration)
+  string(APPEND TENZIR_FIND_DEPENDENCY_LIST
+         "\nfind_library(SystemConfiguration SystemConfiguration REQUIRED)")
+  string(APPEND TENZIR_FIND_DEPENDENCY_LIST
+         "\nmark_as_advanced(SystemConfiguration)")
+  target_link_libraries(libtenzir PUBLIC ${SystemConfiguration})
+endif ()
 dependency_summary("CURL" PkgConfig::PC_CURL "Dependencies")
 
 # Link against fmt.

--- a/nix/fix-fluent-bit-install.patch
+++ b/nix/fix-fluent-bit-install.patch
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2da792d53..2f2d076c6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1118,17 +1118,10 @@ configure_file(
+ 
+ # Installation Directories
+ # ========================
+-if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+-  set(FLB_INSTALL_BINDIR "bin")
+-  set(FLB_INSTALL_LIBDIR "lib")
+-  set(FLB_INSTALL_CONFDIR "conf")
+-  set(FLB_INSTALL_INCLUDEDIR "include")
+-else()
+-  set(FLB_INSTALL_BINDIR ${CMAKE_INSTALL_FULL_BINDIR})
+-  set(FLB_INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}/${FLB_OUT_NAME}")
+-  set(FLB_INSTALL_CONFDIR "${CMAKE_INSTALL_SYSCONFDIR}/${FLB_OUT_NAME}/")
+-  set(FLB_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_PREFIX}/include")
+-endif()
++set(FLB_INSTALL_BINDIR "${CMAKE_INSTALL_BINDIR}")
++set(FLB_INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}")
++set(FLB_INSTALL_CONFDIR "${CMAKE_INSTALL_SYSCONFDIR}/${FLB_OUT_NAME}/")
++set(FLB_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_PREFIX}/include")
+ 
+ # Instruct CMake to build the Fluent Bit Core
+ add_subdirectory(include)

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -38,15 +38,36 @@ in {
             })
           ];
       });
+  # The arrow package overrides aws-sdk-cpp in a let binding to specify
+  # the exact apis that are needed for arrow. We need to extend the list
+  # of APIs for our own purpose, so we "decorate" the override function.
+  aws-sdk-cpp-tenzir = let
+    self = final.aws-sdk-cpp.override {
+      apis = [
+        # arrow-cpp apis; must be kept in sync with nixpkgs.
+        "cognito-identity"
+        "config"
+        "identity-management"
+        "s3"
+        "sts"
+        "transfer"
+        # Additional apis used by tenzir.
+        "sqs"
+      ];
+    };
+  in
+    (self // {override = _: self;});
   arrow-cpp = let
-    arrow-cpp' = prev.arrow-cpp.overrideAttrs (orig: {
+    arrow-cpp' = (prev.arrow-cpp.overrideAttrs (orig: {
       buildInputs = orig.buildInputs ++ [final.bzip2];
       cmakeFlags =
         orig.cmakeFlags
         ++ [
           "-DARROW_WITH_BZ2=ON"
         ];
-    });
+      })).override {
+        aws-sdk-cpp = final.aws-sdk-cpp-tenzir;
+      };
   in
     overrideAttrsIf isStatic
     (
@@ -78,10 +99,6 @@ in {
       cmakeFlags =
         orig.cmakeFlags
         ++ [
-          # Needed for correct dependency resolution, should be the default...
-          "-DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON"
-          # Backtrace doesn't build in static mode, need to investigate.
-          "-DARROW_WITH_BACKTRACE=OFF"
           "-DARROW_BUILD_TESTS=OFF"
         ];
       doCheck = false;

--- a/nix/pfs/default.nix
+++ b/nix/pfs/default.nix
@@ -7,17 +7,18 @@
 in
   stdenv.mkDerivation (finalAttrs: {
     pname = "pfs";
-    version = "0.6.1";
+    version = "0.8.0";
 
     src = fetchFromGitHub {
       owner = "dtrugman";
       repo = "pfs";
       rev = "v${finalAttrs.version}";
-      sha256 = "sha256-T1VGXhWw6zC6xkfmnI4sPE3y0XXqTsZvvubcLwnjyKg=";
+      sha256 = "sha256-TeSdON2MXUZ8LDiIFfh8cjyP361SE7cE1c8oDXQL3OU=";
     };
 
     cmakeFlags = lib.optionals stdenv.hostPlatform.isStatic [
       "-Dpfs_BUILD_TESTS=OFF"
+      "-Dpfs_BUILD_SAMPLES=OFF"
     ];
     nativeBuildInputs = [cmake];
 

--- a/nix/tenzir/check.nix
+++ b/nix/tenzir/check.nix
@@ -3,7 +3,7 @@
   stdenvNoCC,
   src,
   tenzir-integration-test-deps,
-  pkgsBuildHost,
+  pkgsBuildBuild,
 }:
 # The untested tenzir edition build.
 unchecked:
@@ -19,6 +19,9 @@ stdenvNoCC.mkDerivation {
   nativeCheckInputs = tenzir-integration-test-deps;
   checkPhase =
     let
+      py3 = pkgsBuildBuild.python3.withPackages (ps: [
+        ps.requests
+      ]);
       template = path: ''
         if [ -d "${path}/integration/tests" ]; then
           echo "running ${path} tests"
@@ -28,8 +31,9 @@ stdenvNoCC.mkDerivation {
     in
     ''
       patchShebangs tenzir/integration/data/misc/scripts
-      export PATH=''${PATH:+$PATH:}${lib.getBin unchecked}/bin:${lib.getBin pkgsBuildHost.toybox}/bin
+      export PATH=''${PATH:+$PATH:}${lib.getBin unchecked}/bin:${lib.getBin pkgsBuildBuild.toybox}/bin
       export BATS_LIB_PATH=''${BATS_LIB_PATH:+''${BATS_LIB_PATH}:}$PWD/tenzir/integration
+      export PYTHONPATH=''${PYTHONPATH:+''${PYTHONPATH}:}${py3}/${py3.sitePackages}
       mkdir -p cache
       export XDG_CACHE_HOME=$PWD/cache
       ${template "tenzir"}

--- a/nix/tenzir/check.nix
+++ b/nix/tenzir/check.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenvNoCC,
+  src,
+  tenzir-integration-test-deps,
+  pkgsBuildHost,
+}:
+# The untested tenzir edition build.
+unchecked:
+
+stdenvNoCC.mkDerivation {
+  inherit (unchecked) pname version meta;
+  inherit src;
+
+  dontBuild = true;
+  strictDeps = true;
+
+  doCheck = true;
+  nativeCheckInputs = tenzir-integration-test-deps;
+  checkPhase =
+    let
+      template = path: ''
+        if [ -d "${path}/integration/tests" ]; then
+          echo "running ${path} tests"
+          bats -T -j $(nproc) "${path}/integration/tests"
+        fi
+      '';
+    in
+    ''
+      patchShebangs tenzir/integration/data/misc/scripts
+      export PATH=''${PATH:+$PATH:}${lib.getBin unchecked}/bin:${lib.getBin pkgsBuildHost.toybox}/bin
+      export BATS_LIB_PATH=''${BATS_LIB_PATH:+''${BATS_LIB_PATH}:}$PWD/tenzir/integration
+      mkdir -p cache
+      export XDG_CACHE_HOME=$PWD/cache
+      ${template "tenzir"}
+      ${lib.concatMapStrings template unchecked.plugins}
+    '';
+
+  # We just symlink all outputs of the unchecked derivation.
+  inherit (unchecked) outputs;
+  installPhase = ''
+    runHook preInstall;
+    ${lib.concatMapStrings (o: "ln -s ${unchecked.${o}} ${"$"}${o}; ") unchecked.outputs}
+    runHook postInstall;
+  '';
+  dontFixup = true;
+  passthru = unchecked.passthru // {
+    inherit unchecked;
+  };
+}

--- a/nix/tenzir/default.nix
+++ b/nix/tenzir/default.nix
@@ -87,6 +87,7 @@
     in
       p.withPackages (ps:
         with ps; [
+          aiohttp
           dynaconf
           pandas
           pyarrow

--- a/nix/tenzir/default.nix
+++ b/nix/tenzir/default.nix
@@ -16,6 +16,7 @@
     curl,
     libpcap,
     arrow-cpp,
+    aws-sdk-cpp-tenzir,
     fast_float,
     flatbuffers,
     fluent-bit,
@@ -122,6 +123,7 @@
         ];
         propagatedNativeBuildInputs = [pkg-config];
         buildInputs = [
+          aws-sdk-cpp-tenzir
           fast_float
           fluent-bit
           grpc

--- a/nix/tenzir/default.nix
+++ b/nix/tenzir/default.nix
@@ -34,8 +34,6 @@
     cppzmq,
     libmaxminddb,
     re2,
-    tenzir-integration-deps,
-    tenzir-integration-test-deps,
     dpkg,
     restinio,
     pfs,
@@ -43,11 +41,11 @@
     versionShortOverride ? null,
     extraPlugins ? [],
     symlinkJoin,
-    runCommand,
-    makeWrapper,
     extraCmakeFlags ? [],
-    disableTests ? true,
+    python3,
     pkgsBuildHost,
+    runCommand,
+    makeBinaryWrapper,
   }: let
     inherit (stdenv.hostPlatform) isMusl isStatic;
 
@@ -81,10 +79,22 @@
       # building protobufc.
       ++ lib.optionals (!(stdenv.isDarwin && isStatic)) [
         "plugins/yara"
-      ]
-      ++ extraPlugins';
+      ];
+    py3 = let
+      p = if stdenv.buildPlatform.canExecute stdenv.hostPlatform
+        then pkgsBuildHost.python3
+        else python3;
+    in
+      p.withPackages (ps:
+        with ps; [
+          dynaconf
+          pandas
+          pyarrow
+          python-box
+          pip
+        ]);
   in
-    stdenv.mkDerivation ({
+    stdenv.mkDerivation (finalAttrs: ({
         inherit pname;
         version = versionLong;
         src = tenzir-source;
@@ -105,6 +115,7 @@
           dpkg
           protobuf
           poetry
+          makeBinaryWrapper
         ] ++ lib.optionals stdenv.isDarwin [
           lld
         ];
@@ -116,7 +127,6 @@
           libpcap
           libunwind
           libyamlcpp
-          libmaxminddb
           protobuf
           rabbitmq-c
           rdkafka
@@ -134,6 +144,7 @@
           caf
           curl
           flatbuffers
+          libmaxminddb
           robin-map
           simdjson
           spdlog
@@ -156,9 +167,12 @@
             "-DTENZIR_ENABLE_MANPAGES=OFF"
             "-DTENZIR_ENABLE_BUNDLED_AND_PATCHED_RESTINIO=OFF"
             "-DTENZIR_ENABLE_FLUENT_BIT_SO_WORKAROUNDS=OFF"
-            "-DTENZIR_PLUGINS=${lib.concatStringsSep ";" bundledPlugins}"
-          ]
-          ++ lib.optionals isStatic [
+            "-DTENZIR_PLUGINS=${lib.concatStringsSep ";" (bundledPlugins ++ extraPlugins')}"
+            # Disabled for now, takes long to compile and integration tests give
+            # reasonable coverage.
+            "-DTENZIR_ENABLE_UNIT_TESTS=OFF"
+            "-DTENZIR_ENABLE_BATS_TENZIR_INSTALLATION=OFF"
+          ] ++ lib.optionals isStatic [
             "-DBUILD_SHARED_LIBS:BOOL=OFF"
             #"-DCMAKE_INTERPROCEDURAL_OPTIMIZATION:BOOL=ON"
             "-DCPACK_GENERATOR=${if stdenv.isDarwin then "productbuild" else "TGZ;DEB"}"
@@ -200,9 +214,6 @@
             # builder in the Nix context, and that doesn't make sense.
             "-DTENZIR_ENABLE_INIT_SYSTEM_INTEGRATION=OFF"
           ])
-          ++ lib.optionals disableTests [
-            "-DTENZIR_ENABLE_UNIT_TESTS=OFF"
-          ]
           ++ extraCmakeFlags;
 
         # TODO: Fix LTO on darwin by passing these commands by their original
@@ -227,25 +238,23 @@
           rm -rf $out/nix-support
         '';
 
+        # Checking is done in a dedicated derivation, see check.nix.
         doCheck = false;
-        checkTarget = "test";
+        doInstallCheck = false;
 
         dontStrip = true;
 
-        doInstallCheck = false;
-        installCheckInputs = tenzir-integration-deps ++ tenzir-integration-test-deps;
-        # TODO: Investigate why the disk monitor test fails in the build sandbox.
-        installCheckPhase = ''
-          PATH="${placeholder "out"}/bin:$PATH" bats -T -j $NIX_BUILD_CORES ../tenzir/integration
-          python ../tenzir/integration/integration.py \
-            --app ${placeholder "out"}/bin/tenzir-ctl \
-            --disable "Disk Monitor"
+        postInstall = ''
+          wrapProgram $out/bin/tenzir \
+            --prefix PATH : ${lib.makeBinPath [ py3 ]} \
+            --suffix PYTHONPATH : ${py3}/${py3.sitePackages}
         '';
 
-        passthru = rec {
-          plugins = callPackage ./plugins {tenzir = self;};
-          withPlugins = plugins': let
-            actualPlugins = plugins' plugins;
+        passthru = {
+          plugins = bundledPlugins ++ extraPlugins;
+          withPlugins = selection: let
+            allPlugins = callPackage ./plugins {tenzir = self;};
+            actualPlugins = selection allPlugins;
           in
             if isStatic
             then
@@ -254,8 +263,8 @@
               }
             else
               symlinkJoin {
-                name = "tenzir";
-                paths = [self actualPlugins];
+                inherit (self) passthru meta pname version name;
+                paths = [ self ] ++ actualPlugins;
               };
         };
 
@@ -269,15 +278,16 @@
           maintainers = with maintainers; [tobim];
         };
       }
-      # allowedRequisites does not work on darwin.
+      # disallowedReferences does not work on darwin.
       // lib.optionalAttrs (isStatic && stdenv.isLinux) {
-        allowedRequisites = ["out"];
+        #disallowedReferences = [ tenzir-source ] ++ extraPlugins;
       }
       // lib.optionalAttrs isStatic {
         __noChroot = stdenv.isDarwin;
 
         installPhase = ''
           runHook preInstall
+          # TODO: Check if we need this and comment if yes.
           PATH=$PATH:/usr/bin
           cmake --install . --component Runtime
           cmakeFlagsArray+=(
@@ -300,7 +310,7 @@
           install -m 644 -Dt $package package/*
           runHook postInstall
         '';
-      });
-  self = callPackage pkgFun ({self = self;} // args);
+      }));
+  self' = callPackage pkgFun ({self = self';} // args);
 in
-  self
+  self'

--- a/plugins/fluent-bit/CMakeLists.txt
+++ b/plugins/fluent-bit/CMakeLists.txt
@@ -26,7 +26,6 @@ if (NOT fluentbit_FOUND)
 endif ()
 
 get_filename_component(FLUENT_BIT_PREFIX ${FLUENT_BIT_LOCATION} PATH)
-get_filename_component(FLUENT_BIT_PREFIX ${FLUENT_BIT_PREFIX} PATH)
 dependency_summary("fluent-bit" ${FLUENT_BIT_PREFIX} "Dependencies")
 target_link_libraries(fluent-bit PRIVATE fluentbit::fluentbit)
 

--- a/plugins/web/integration/tests/rest.bats
+++ b/plugins/web/integration/tests/rest.bats
@@ -18,36 +18,37 @@ teardown() {
   teardown_node
 }
 
-wait_for_http() {
-  timeout 10 bash -c 'until echo > /dev/tcp/127.0.0.1/42025; do sleep 0.2; done'
+wait_for_tcp() {
+  port=$1
+  timeout $BATS_TEST_TIMEOUT bash -c "until echo > /dev/tcp/127.0.0.1/$port; do sleep 0.2; done"
 }
 
 @test "status endpoint" {
   TENZIR_START__COMMANDS="web server --mode=dev --port=42025"
   setup_node_with_plugins web
-  wait_for_http
+  wait_for_tcp 42025
 
   check curl -XPOST http://127.0.0.1:42025/api/v0/status?component=filesystem
   check ! curl --fail-with-body -XPOST http://127.0.0.1:42025/api/v0/status?verbosity=!~asdf
 }
 
 @test "authenticated endpoints" {
-  TENZIR_START__COMMANDS="web server --mode=upstream --port=42025"
+  TENZIR_START__COMMANDS="web server --mode=upstream --port=42026"
   setup_node_with_plugins web
-  wait_for_http
+  wait_for_tcp 42026
 
-  check curl -XPOST http://127.0.0.1:42025/api/v0/status
+  check curl -XPOST http://127.0.0.1:42026/api/v0/status
   token="$(tenzir-ctl web generate-token)"
-  check curl -H "X-Tenzir-Token: ${token}" -XPOST http://127.0.0.1:42025/api/v0/status?component=filesystem
+  check curl -H "X-Tenzir-Token: ${token}" -XPOST http://127.0.0.1:42026/api/v0/status?component=filesystem
 }
 
 @test "TLS endpoints" {
-  TENZIR_START__COMMANDS="web server --mode=server --certfile=${DATADIR}/server.pem --keyfile=${DATADIR}/server.key --port=42025"
+  TENZIR_START__COMMANDS="web server --mode=server --certfile=${DATADIR}/server.pem --keyfile=${DATADIR}/server.key --port=42027"
   setup_node_with_plugins web
-  wait_for_http
+  wait_for_tcp 42027
 
-  check ! curl --fail-with-body -XPOST http://127.0.0.1:42025/api/v0/status
-  check ! curl --fail-with-body --cacert "${DATADIR}/client.pem" -XPOST https://127.0.0.1:42025/api/v0/status?component=filesystem
+  check ! curl --fail-with-body -XPOST http://127.0.0.1:42027/api/v0/status
+  check ! curl --fail-with-body --cacert "${DATADIR}/client.pem" -XPOST https://127.0.0.1:42027/api/v0/status?component=filesystem
   token="$(tenzir-ctl web generate-token)"
-  check curl -H "X-Tenzir-Token: ${token}" --cacert "${DATADIR}/client.pem" -XPOST https://127.0.0.1:42025/api/v0/status?component=filesystem
+  check curl -H "X-Tenzir-Token: ${token}" --cacert "${DATADIR}/client.pem" -XPOST https://127.0.0.1:42027/api/v0/status?component=filesystem
 }

--- a/shell.nix
+++ b/shell.nix
@@ -13,6 +13,7 @@ pkgs.mkShell.override { stdenv = pkgs.gcc13Stdenv; } (
         pkgs.ccache
         pkgs.clang-tools_16
         pkgs.cmake-format
+        pkgs.shfmt
         pkgs.speeve
         pkgs.poetry
         pkgs.python3Packages.spdx-tools

--- a/shell.nix
+++ b/shell.nix
@@ -1,40 +1,42 @@
-{pkgs}: let
+{ pkgs }:
+let
   inherit (pkgs) lib;
   inherit (pkgs.stdenv.hostPlatform) isStatic;
 in
-  pkgs.mkShell.override {stdenv = pkgs.gcc13Stdenv;} ({
-      name = "tenzir-dev";
-      hardeningDisable = ["fortify"] ++ lib.optional isStatic "pic";
-      inputsFrom = [pkgs.tenzir-de];
-      nativeBuildInputs =
-        [
-          pkgs.ccache
-          pkgs.clang-tools_16
-          pkgs.cmake-format
-          pkgs.speeve
-          pkgs.poetry
-          pkgs.python3Packages.spdx-tools
-        ] ++ pkgs.tenzir-integration-deps
-          ++ pkgs.tenzir-integration-test-deps
-          ++ lib.optionals (!(pkgs.stdenv.hostPlatform.useLLVM or false)) [
-          # Make clang available as alternative compiler when it isn't the default.
-          pkgs.clang_16
-          # Bintools come with a wrapped lld for faster linking.
-          pkgs.llvmPackages_16.bintools
-        ] # Temporarily only on Linux.
-          ++ lib.optionals pkgs.stdenv.isLinux [
-          pkgs.pandoc
-        ];
-      # To build libcaf_openssl with bundled CAF.
-      buildInputs = [pkgs.openssl];
-      shellHook = ''
-        # Use editable mode for python code part of the python operator. This
-        # makes changes to the python code observable in the python operator
-        # without needing to rebuild the wheel.
-        export TENZIR_PLUGINS__PYTHON__IMPLICIT_REQUIREMENTS="-e $PWD/python"
-      '';
-    }
-    // lib.optionalAttrs isStatic {
-      # Signal static build mode to CMake via the environment.
-      env.TENZIR_ENABLE_STATIC_EXECUTABLE = "ON";
-    })
+pkgs.mkShell.override { stdenv = pkgs.gcc13Stdenv; } (
+  {
+    name = "tenzir-dev";
+    hardeningDisable = [ "fortify" ] ++ lib.optional isStatic "pic";
+    inputsFrom = [ pkgs.tenzir-de.unchecked ];
+    nativeBuildInputs =
+      [
+        pkgs.ccache
+        pkgs.clang-tools_16
+        pkgs.cmake-format
+        pkgs.speeve
+        pkgs.poetry
+        pkgs.python3Packages.spdx-tools
+      ]
+      ++ pkgs.tenzir-integration-test-deps
+      ++ lib.optionals (!(pkgs.stdenv.hostPlatform.useLLVM or false)) [
+        # Make clang available as alternative compiler when it isn't the default.
+        pkgs.clang_16
+        # Bintools come with a wrapped lld for faster linking.
+        pkgs.llvmPackages_16.bintools
+      ]
+      # Temporarily only on Linux.
+      ++ lib.optionals pkgs.stdenv.isLinux [ pkgs.pandoc ];
+    # To build libcaf_openssl with bundled CAF.
+    buildInputs = [ pkgs.openssl ];
+    shellHook = ''
+      # Use editable mode for python code part of the python operator. This
+      # makes changes to the python code observable in the python operator
+      # without needing to rebuild the wheel.
+      export TENZIR_PLUGINS__PYTHON__IMPLICIT_REQUIREMENTS="-e $PWD/python"
+    '';
+  }
+  // lib.optionalAttrs isStatic {
+    # Signal static build mode to CMake via the environment.
+    env.TENZIR_ENABLE_STATIC_EXECUTABLE = "ON";
+  }
+)

--- a/tenzir/CMakeLists.txt
+++ b/tenzir/CMakeLists.txt
@@ -69,7 +69,7 @@ option(TENZIR_ENABLE_INIT_SYSTEM_INTEGRATION
        "Integrate with init systems when installing" ON)
 add_feature_info(
   "TENZIR_ENABLE_INIT_SYSTEM_INTEGRATION" TENZIR_ENABLE_INIT_SYSTEM_INTEGRATION
-  "integrate with init systems when installing")
+  "integrate with init systems when installing.")
 
 if (TENZIR_ENABLE_INIT_SYSTEM_INTEGRATION)
   if (${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
@@ -146,10 +146,16 @@ add_dependencies(tenzir link-integration)
 # We only install the tenzir extension library, users need to provide bats,
 # bats-common and bats-assert themselves when building plugins against an
 # install tree.
-install(
-  DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/integration/lib/bats-tenzir"
-  COMPONENT Development
-  DESTINATION "${CMAKE_INSTALL_DATADIR}/tenzir/integration/lib")
+option(TENZIR_ENABLE_BATS_TENZIR_INSTALLATION "Install bats-tenzir" ON)
+add_feature_info("TENZIR_ENABLE_BATS_TENZIR_INSTALLATION"
+                 TENZIR_ENABLE_BATS_TENZIR_INSTALLATION "install bats-tenzir.")
+
+if (TENZIR_ENABLE_BATS_TENZIR_INSTALLATION)
+  install(
+    DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/integration/lib/bats-tenzir"
+    COMPONENT Development
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/tenzir/integration")
+endif ()
 
 # -- add plugins ---------------------------------------------------------------
 

--- a/tenzir/integration/tests/setup_suite.bash
+++ b/tenzir/integration/tests/setup_suite.bash
@@ -13,7 +13,7 @@ teardown_suite() {
   : # Nothing to do
 }
 
-if ! which tenzir; then
+if ! command -v tenzir; then
   echo "tenzir binaries must be on $PATH"
   return 1
 fi

--- a/tenzir/integration/tests/tcp.bats
+++ b/tenzir/integration/tests/tcp.bats
@@ -1,4 +1,4 @@
-: "${BATS_TEST_TIMEOUT:=3}"
+: "${BATS_TEST_TIMEOUT:=10}"
 
 setup() {
   bats_load_library bats-support


### PR DESCRIPTION
The Nix package expression is refactored into 2 derivations. The first
builds the binary and package as before, and the newly introduced second
derivation runs the functional tests. This allows us to iterate on the
tests without having to rebuild c++ code with every change.

The untested binary can still be accessed with the the `unchecked`
attribute, e.g. `...#tenzir-static.unchecked`, `...#tenzir-de.unchecked`
and so on.