### PR TITLE
Force braces around statements with clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -43,6 +43,7 @@ IndentPPDirectives: AfterHash
 IndentRequires: true
 IndentWidth: 2
 IndentWrappedFunctionNames: false
+InsertBraces: true
 KeepEmptyLinesAtTheStartOfBlocks: false
 Language: Cpp
 MacroBlockBegin: "CAF_BEGIN_TYPE_ID_BLOCK"


### PR DESCRIPTION
We've changed our coding style to always using braces almost two years ago now, and it turns out that there's actually a clang-format option to automatically rewrite code to have statements around braces for improved legibility.