### PR TITLE
Support execution of *.bats files in subdirectories

### DIFF
--- a/cmake/TenzirRegisterPlugin.cmake
+++ b/cmake/TenzirRegisterPlugin.cmake
@@ -743,7 +743,7 @@ function (TenzirRegisterPlugin)
       COMMAND
         ${CMAKE_COMMAND} -E env
         PATH="${TENZIR_PATH}:\$\$PATH:${TENZIR_PATH}/../share/tenzir/functional-test/lib/bats/bin"
-        bats "-T" "${CMAKE_CURRENT_SOURCE_DIR}/functional-test/tests"
+        bats "-r" "-T" "${CMAKE_CURRENT_SOURCE_DIR}/functional-test/tests"
       COMMENT "Executing ${PLUGIN_TARGET} functional tests..."
       USES_TERMINAL)
     unset(TENZIR_PATH)

--- a/tenzir/CMakeLists.txt
+++ b/tenzir/CMakeLists.txt
@@ -124,7 +124,7 @@ add_custom_target(
   COMMAND
     ${CMAKE_COMMAND} -E env
     PATH="$<TARGET_FILE_DIR:tenzir::tenzir>:\$\$PATH:${CMAKE_CURRENT_SOURCE_DIR}/functional-test/lib/bats/bin"
-    bats "-T" "${CMAKE_CURRENT_SOURCE_DIR}/functional-test/tests"
+    bats "-r" "-T" "${CMAKE_CURRENT_SOURCE_DIR}/functional-test/tests"
   COMMENT "Executing functional tests..."
   USES_TERMINAL)
 

--- a/tenzir/functional-test/tests/setup_suite.bash
+++ b/tenzir/functional-test/tests/setup_suite.bash
@@ -7,7 +7,7 @@ setup_suite() {
   export_default_node_config
 }
 
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 export BATS_LIB_PATH=${BATS_LIB_PATH:+${BATS_LIB_PATH}:}${SCRIPT_DIR}/../lib
 
 # Normalize the environment unless `BATS_TENZIR_KEEP_ENVIRONMENT` is set.
@@ -22,9 +22,9 @@ fi
 
 # TODO: Should the datadir definitions move into the bats-tenzir library,
 # so that files in there automatically available for plugins integration tests?
-export BATS_TENZIR_DATADIR="$(dirname ${BATS_TEST_DIRNAME})/data"
+BATS_TEST_DATADIR="$(realpath $(dirname ${BATS_TEST_DIRNAME}))"
+export BATS_TENZIR_DATADIR="${BATS_TEST_DATADIR%%/functional-test/*}/data"
 
 export INPUTSDIR="${BATS_TENZIR_DATADIR}/inputs"
 export QUERYDIR="${BATS_TENZIR_DATADIR}/queries"
 export MISCDIR="${BATS_TENZIR_DATADIR}/misc"
-


### PR DESCRIPTION
I stumbled upon this when trying to group our test suites with a directory structure: We just picked up tests in `<dir>/tests/*.bats` instead of `<dir>/tests/**/*.bats`, with tests in subdirectories being silently ignored.
