### PR TITLE
Make `/serve` more consistent

### DIFF
--- a/changelog/next/bug-fixes/3885--serve-inconsistencies.md
+++ b/changelog/next/bug-fixes/3885--serve-inconsistencies.md
@@ -1,0 +1,3 @@
+The `/serve` API sometimes returned an empty string for the next continuation
+token instead of `null` when there are no further results to fetch. It now
+consistently returns `null`.

--- a/web/openapi/openapi.yaml
+++ b/web/openapi/openapi.yaml
@@ -646,7 +646,7 @@ paths:
                               schema: string
                               schema_id: string
                               events: uint64
-                  data:
+                  events:
                     type: array
                     items:
                       type: object


### PR DESCRIPTION
This fixes a bug in the `/serve` endpoint where sometimes the last continuation token was rendered as an empty string rather than null.

Fixes tenzir/issues#1509