### PR TITLE
Add more details to OpenWEC section

### DIFF
--- a/web/docs/integrations/windows-event-logs.md
+++ b/web/docs/integrations/windows-event-logs.md
@@ -560,7 +560,7 @@ For the new subscription, configure JSON over TCP as
 [output](https://github.com/cea-sec/openwec/blob/main/doc/outputs.md):
 
 ```bash
-openwec subscriptions edit DC_SUBSCRIPTION outputs add --format json tcp localhost 1514
+openwec subscriptions edit DC_SUBSCRIPTION outputs add --format json tcp 10.0.0.1 1514
 ```
 
 Finally, enable the subscription:
@@ -570,7 +570,7 @@ openwec subscriptions enable DC_SUBSCRIPTION
 ```
 
 That's it! You should now be able read the Windows event logs in JSON format by
-spinning up a server that listens at `tcp://localhost:1514`.
+spinning up a server that listens at `tcp://10.0.0.1:1514`.
 
 ### Run a Tenzir pipeline
 

--- a/web/docs/integrations/windows-event-logs.md
+++ b/web/docs/integrations/windows-event-logs.md
@@ -459,38 +459,27 @@ setup instructions.
 For running OpenWEC on non-Windows machines that are likely not joined to a
 Windows domain, it is most useful to configure TLS client authentication. The
 OpenWEC documentation (see above) recommends to use [a script collection from
-NXLog](https://gitlab.com/nxlog-public/contrib/-/tree/master/windows-event-forwarding)
-that  creates keys/certificates that can immediately be used to configure both
-Windows clients and the OpenWEC collector. Make sure to pay attention to
-specifying the correct hostnames for the sending and receiving machines!
+NXLog][nxlog-scripts] that creates keys/certificates that can immediately be
+used to configure both Windows clients and the OpenWEC collector. Make sure to
+pay attention to specifying the correct hostnames for the sending and receiving
+machines.
 
+[nxlog-scripts]: https://gitlab.com/nxlog-public/contrib/-/tree/master/windows-event-forwarding
+
+```bash
+git clone https://gitlab.com/nxlog-public/contrib
+cd contrib/windows-event-forwarding
+./genca.sh myca
+./gencert-client.sh myclient.domain.com
+./gencert-server.sh openwec.domain.com
 ```
-$ git clone https://gitlab.com/nxlog-public/contrib
-...
-$ cd contrib/windows-event-forwarding
-$ ./genca.sh myca
-.........+..+.......+...+...+..+...+.........+..................+.......+..+.+..+......+.+...+..+.+........+......+.+.................+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*..............+....+..+.............+......+......+......+..+...+.............+......+.....+.+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*.......+...............+......+..+...+.........+......+....+...........+..........+.........+............+.....+.+...+.....+....+...+..+.+..+.............+............+.....+.........+.+..+.......+.....+....+..+...+.+...........+.........+....+..............+.......+........+................+..+....+......+...+.....+.......+..+..........+..+...+.......+...+...+...+..+.........+....+......+.....+....+.........+......+..............+.......+......+.....+....+........+...+..........+..............+.+.....+............+.............+...+.........+..+.+........+......+................+..................+..+........................+......+...+.+...+............+.........+.....+.+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-..+....+.....+.+..+..........+..+......+..........+.................+......+.+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*....+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*...+...........+...+.......+.........+......+.....+...+.+............+..+...+..........+........+.......+...+..+...+......+..........+..................+......+.....+....+.....+......+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
------
-$ ./gencert-client.sh myclient.domain.com
-..+.....+.+.........+...........+............+.......+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*..+......+......+...+..+....+..............+...+..........+..+.+......+......+..+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*.....+.+...+.....+.......+...+..+............+.............+...+.....+.+...+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-.+......+....+...+..+...+...+..........+.........+.....+.+..+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*...........+...................+...........+.+...+...+.....+..........+...+.....+......+.+..+......+.+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*........+..........+..+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
------
-Certificate request self-signature ok
-subject=CN = myclient.domain.com, O = nxlog.org, C = HU, ST = state, L = location
-Enter Export Password: <pwd>
-Verifying - Enter Export Password: <pwd>
-$ ./gencert-server.sh openwec.domain.com
-.+..+..........+...+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*...+......+.......+...+...+.........+........+..........+...+..+...+......+..........+......+........+....+.....+...+....+...+..+...............+...+...+............+.+.....+....+...+.....+.........+...+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*......+....+......+............+..+................+..............+.......+.....+...+.......+.....+......+....+..............+.+..............+....+...+..+.+..+....+...+..+....+..+..........+...+.........+..+.........+......+.+........+....+...........+..........+..+..........+.....+....+.....+....+..............+.+..+...+......+...................+...........+...+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-...+....+..+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*....+...+..+......+....+..+.+.........+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*.+....+........+...+....+......+..+.......+...+......+...........+.+..+............+.............+...+...+.....+................+...+.....+.......+........................+.....+...................+..+......+...+.+...+...+.....+..........+...+..+....+.....+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
------
-Certificate request self-signature ok
-subject=CN = openwec.domain.com, O = nxlog.org, C = HU, ST = state, L = location
-##################################################################################
 
 Use the following for the Subscription Manager string:
+
+```
 Server=HTTPS://openwec.domain.com:5985/wsman/,Refresh=14400,IssuerCA=6605742C5400141B76A747E19EA585E29B09F017
 ```
+
 The string in the last line can be used to configure the Windows Event
 Forwarding subscription manager on the sending side as described in the section
 above ("Change local group policy settings"). While you're at it, also import
@@ -501,8 +490,7 @@ Then, configure the OpenWEC server as follows (assuming the output files are in
 `/etc`, the directory `/var/db/openwec` exists and it is writable by the current
 user):
 
-```
-$ cat openwec.conf.toml
+```toml title="openwec.conf.toml"
 [server]
 
 [logging]
@@ -523,14 +511,19 @@ server_certificate = "/etc/server-cert.pem"
 server_private_key = "/etc/server-key.pem"
 ```
 
-Create the database (only needed to be done once):
-```
-$ openwec -c openwec.conf.toml db init
+Create the database (only needs to be done once):
+
+```bash
+openwec -c openwec.conf.toml db init
 ```
 
 Start the server:
+
+```bash
+openwecd -c openwec.conf.toml
 ```
-$ openwecd -c openwec.conf.toml
+
+```
 2024-01-30T13:59:26.295792509+01:00 INFO server - Server settings: Server { db_sync_interval: None, flush_heartbeats_interval: None, heartbeats_queue_size: None, node_name: None, keytab: None, tcp_keepalive_time: None, tcp_keepalive_intvl: None, tcp_keepalive_probes: None }
 2024-01-30T13:59:26.295947557+01:00 INFO server::subscription - reload_subscriptions task started
 2024-01-30T13:59:26.296046314+01:00 INFO server::heartbeat - Heartbeat task started
@@ -538,14 +531,15 @@ $ openwecd -c openwec.conf.toml
 2024-01-30T13:59:26.306151854+01:00 INFO server::tls - Loaded TLS configuration with server certificate /etc/server-cert.pem
 2024-01-30T13:59:26.309876793+01:00 INFO server - Server listenning on 0.0.0.0:5985
 ```
+
 It might make sense to ensure that the server is started and kept up via some
 automated means, like systemd.
 
 Then, while the server is running, create a subscription in OpenWEC for the
 desired channels. For example, to match the subscription from the example above,
-create an XML file like this (say, `subscription.xml`):
+create an XML file like this:
 
-```xml
+```xml title="subscription.xml"
 <QueryList>
     <Query Id="0">
         <Select Path="Application">*</Select>
@@ -555,21 +549,28 @@ create an XML file like this (say, `subscription.xml`):
 </QueryList>
 ```
 
-Create a named subscription (e.g. with name `DC_SUBSCRIPTION`) using the `openwec` CLI tool:
-```
-$ openwec subscriptions new DC_SUBSCRIPTION subscription.xml
+Pass this file to `openwec` to create a subscription, e.g., with name
+`DC_SUBSCRIPTION`:
+
+```bash
+openwec subscriptions new DC_SUBSCRIPTION subscription.xml
 ```
 
-Configure JSON over TCP as
+For the new subscription, configure JSON over TCP as
 [output](https://github.com/cea-sec/openwec/blob/main/doc/outputs.md):
-```
-$ openwec subscriptions edit DC_SUBSCRIPTION outputs add --format json tcp localhost 1514
+
+```bash
+openwec subscriptions edit DC_SUBSCRIPTION outputs add --format json tcp localhost 1514
 ```
 
-Enable the subscription:
+Finally, enable the subscription:
+
+```bash
+openwec subscriptions enable DC_SUBSCRIPTION
 ```
-$ openwec subscriptions enable DC_SUBSCRIPTION
-```
+
+That's it! You should now be able read the Windows event logs in JSON format by
+spinning up a server that listens at `tcp://localhost:1514`.
 
 ### Run a Tenzir pipeline
 

--- a/web/docs/integrations/windows-event-logs.md
+++ b/web/docs/integrations/windows-event-logs.md
@@ -58,7 +58,7 @@ output.elasticsearch:
 
 #### Start Winlogbeat as a service
 
-After you've competed your configuration, start the Winlogbeat service:
+After completing your configuration, start the Winlogbeat service:
 
 ```
 C:\Program Files\Winlogbeat> Start-Service winlogbeat
@@ -276,7 +276,7 @@ instructions.
 
 ### Setup the Window Event Collector (WEC)
 
-We begin with setting up the WEC priot to connecting the client to it.
+We begin with setting up the WEC prior to connecting the client to it.
 
 #### Setup Windows Remote Management (WinRM)
 


### PR DESCRIPTION
This PR adds some more details about setting up an OpenWEC server to ingest Windows events into Tenzir. It distills the most important steps down so they can be concisely shown within the integration documentation.
There are also small typographical fixes.