### PR TITLE
Replace `tenzir.db-directory` with `tenzir.state-directory`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ ENV PREFIX="/opt/tenzir" \
 # When changing these, make sure to also update the corresponding entries in the
 # flake.nix file.
 ENV TENZIR_CACHE_DIRECTORY="/var/cache/tenzir" \
-    TENZIR_DB_DIRECTORY="/var/lib/tenzir" \
+    TENZIR_STATE_DIRECTORY="/var/lib/tenzir" \
     TENZIR_LOG_FILE="/var/log/tenzir/server.log" \
     TENZIR_ENDPOINT="0.0.0.0"
 
@@ -83,7 +83,7 @@ FROM debian:bookworm-slim AS tenzir-de
 ENV PREFIX="/opt/tenzir" \
     PATH="/opt/tenzir/bin:${PATH}" \
     TENZIR_CACHE_DIRECTORY="/var/cache/tenzir" \
-    TENZIR_DB_DIRECTORY="/var/lib/tenzir" \
+    TENZIR_STATE_DIRECTORY="/var/lib/tenzir" \
     TENZIR_LOG_FILE="/var/log/tenzir/server.log" \
     TENZIR_ENDPOINT="0.0.0.0"
 

--- a/changelog/next/changes/3889--state-directory.md
+++ b/changelog/next/changes/3889--state-directory.md
@@ -1,0 +1,2 @@
+The option `tenzir.db-directory` is deprecated in favor of the
+`tenzir.state-directory` option and will be removed in the future.

--- a/flake.nix
+++ b/flake.nix
@@ -77,7 +77,7 @@
               Env = [
                 # When changing these, make sure to also update the
                 # corresponding entries in the Dockerfile.
-                "TENZIR_DB_DIRECTORY=${tenzir-dir}"
+                "TENZIR_STATE_DIRECTORY=${tenzir-dir}"
                 "TENZIR_CACHE_DIRECTORY=/var/cache/tenzir"
                 "TENZIR_LOG_FILE=/var/log/tenzir/server.log"
                 "TENZIR_ENDPOINT=0.0.0.0"

--- a/libtenzir/builtins/health-metrics/disk.cpp
+++ b/libtenzir/builtins/health-metrics/disk.cpp
@@ -35,7 +35,8 @@ class plugin final : public virtual health_metrics_plugin {
 public:
   auto initialize(const record& config, const record& /*plugin_config*/)
     -> caf::error override {
-    dbdir_ = get_or(config, "tenzir.db-directory", defaults::db_directory);
+    state_directory_
+      = get_or(config, "tenzir.state-directory", defaults::state_directory);
     return {};
   }
 
@@ -48,8 +49,8 @@ public:
   }
 
   auto make_collector() const -> caf::expected<collector> override {
-    return [dbdir = dbdir_]() {
-      return get_diskspace_info(dbdir);
+    return [state_directory = state_directory_]() {
+      return get_diskspace_info(state_directory);
     };
   }
 
@@ -63,7 +64,7 @@ public:
   }
 
 private:
-  std::string dbdir_ = {};
+  std::string state_directory_ = {};
 };
 
 } // namespace

--- a/libtenzir/include/tenzir/defaults.hpp
+++ b/libtenzir/include/tenzir/defaults.hpp
@@ -207,7 +207,7 @@ inline constexpr uint16_t endpoint_port = 5158;
 inline constexpr std::string_view node_id = "node";
 
 /// Path to persistent state.
-inline constexpr std::string_view db_directory = "tenzir.db";
+inline constexpr std::string_view state_directory = "tenzir.db";
 
 /// Interval between two aging cycles.
 inline constexpr caf::timespan aging_frequency = std::chrono::hours{24};

--- a/libtenzir/include/tenzir/disk_monitor.hpp
+++ b/libtenzir/include/tenzir/disk_monitor.hpp
@@ -56,7 +56,7 @@ struct disk_monitor_state {
   };
 
   /// The path to the database directory.
-  std::filesystem::path dbdir;
+  std::filesystem::path state_directory;
 
   /// The user-configurable behavior.
   disk_monitor_config config;

--- a/libtenzir/src/application.cpp
+++ b/libtenzir/src/application.cpp
@@ -44,9 +44,6 @@ void add_root_opts(command& cmd) {
     "disable user and system configuration, schema and plugin "
     "directories lookup and static and dynamic plugin "
     "autoloading (this may only be used on the command line)");
-  cmd.options.add<bool>("?tenzir", "detach-components",
-                        "create dedicated threads for some "
-                        "components");
   cmd.options.add<bool>(
     "?tenzir", "allow-unsafe-pipelines",
     "allow unsafe location overrides for pipelines with the "
@@ -60,8 +57,12 @@ void add_root_opts(command& cmd) {
                                "console");
   cmd.options.add<caf::config_value::list>("?tenzir", "schema-dirs",
                                            module_desc);
-  cmd.options.add<std::string>("?tenzir", "db-directory,d",
+  cmd.options.add<std::string>("?tenzir", "db-directory",
+                               "deprecated; use state-directory instead");
+  cmd.options.add<std::string>("?tenzir", "state-directory,d",
                                "directory for persistent state");
+  cmd.options.add<std::string>("?tenzir", "cache-directory",
+                               "directory for runtime state");
   cmd.options.add<std::string>("?tenzir", "log-file", "log filename");
   cmd.options.add<std::string>("?tenzir", "client-log-file",
                                "client log file (default: "

--- a/libtenzir/src/configuration.cpp
+++ b/libtenzir/src/configuration.cpp
@@ -447,10 +447,13 @@ caf::error configuration::parse(int argc, char** argv) {
   // Fallback handling for system default paths that may be provided by the
   // runtime system and should win over the build-time defaults but loose if set
   // via any other method.
-  if (!config->contains("tenzir.db-directory")) {
+  if (!config->contains("tenzir.state-directory")) {
+    if (config->contains("tenzir.db-directory")) {
+      (*config)["tenzir.state-directory"] = (*config)["tenzir.db-directory"];
+    }
     // Provided by systemd when StateDirectory= is set in the unit.
-    if (auto state_directory = detail::getenv("STATE_DIRECTORY")) {
-      (*config)["tenzir.db-directory"] = std::string{*state_directory};
+    else if (auto state_directory = detail::getenv("STATE_DIRECTORY")) {
+      (*config)["tenzir.state-directory"] = std::string{*state_directory};
     }
   }
   if (!config->contains("tenzir.log-directory")) {

--- a/libtenzir/src/logger.cpp
+++ b/libtenzir/src/logger.cpp
@@ -162,7 +162,7 @@ bool setup_spdlog(bool is_server, const tenzir::invocation& cmd_invocation,
     if (log_file == defaults::logger::log_file
         && tenzir_file_verbosity != TENZIR_LOG_LEVEL_QUIET) {
       std::filesystem::path log_dir = caf::get_or(
-        cfg_file, "tenzir.db-directory", defaults::db_directory.data());
+        cfg_file, "tenzir.state-directory", defaults::state_directory.data());
       std::error_code err{};
       if (!std::filesystem::exists(log_dir, err)) {
         const auto created_log_dir
@@ -178,7 +178,7 @@ bool setup_spdlog(bool is_server, const tenzir::invocation& cmd_invocation,
       log_file = (log_dir / log_file).string();
     }
   } else {
-    // Please note, client file does not go to db_directory!
+    // Please note, client file does not go to state_directory!
     auto client_log_file
       = caf::get_if<std::string>(&cfg_cmd, "tenzir.client-log-file");
     if (!client_log_file)

--- a/libtenzir/src/plugin.cpp
+++ b/libtenzir/src/plugin.cpp
@@ -417,8 +417,8 @@ store_plugin::make_store_builder(accountant_actor accountant,
   if (!store)
     return store.error();
   auto db_dir = std::filesystem::path{
-    caf::get_or(content(fs->home_system().config()), "tenzir.db-directory",
-                defaults::db_directory.data())};
+    caf::get_or(content(fs->home_system().config()), "tenzir.state-directory",
+                defaults::state_directory.data())};
   std::error_code err{};
   const auto abs_dir = std::filesystem::absolute(db_dir, err);
   auto path = abs_dir / "archive" / fmt::format("{}.{}", id, name());
@@ -440,8 +440,8 @@ store_plugin::make_store(accountant_actor accountant, filesystem_actor fs,
                                                  "single uuid");
   const auto id = uuid{header.subspan<0, uuid::num_bytes>()};
   auto db_dir = std::filesystem::path{
-    caf::get_or(content(fs->home_system().config()), "tenzir.db-directory",
-                defaults::db_directory.data())};
+    caf::get_or(content(fs->home_system().config()), "tenzir.state-directory",
+                defaults::state_directory.data())};
   std::error_code err{};
   const auto abs_dir = std::filesystem::absolute(db_dir, err);
   auto path = abs_dir / "archive" / fmt::format("{}.{}", id, name());

--- a/libtenzir/src/spawn_disk_monitor.cpp
+++ b/libtenzir/src/spawn_disk_monitor.cpp
@@ -66,8 +66,8 @@ spawn_disk_monitor(node_actor::stateful_pointer<node_state> self,
         "not be spawned");
     return ec::no_error;
   }
-  const auto db_dir
-    = caf::get_or(opts, "tenzir.db-directory", defaults::db_directory.data());
+  const auto db_dir = caf::get_or(opts, "tenzir.state-directory",
+                                  defaults::state_directory.data());
   const auto db_dir_path = std::filesystem::path{db_dir};
   std::error_code err{};
   const auto db_dir_abs = std::filesystem::absolute(db_dir_path, err);

--- a/libtenzir/src/spawn_node.cpp
+++ b/libtenzir/src/spawn_node.cpp
@@ -35,7 +35,7 @@ spawn_node(caf::scoped_actor& self, const caf::settings& opts) {
   // Fetch values from config.
   auto id = get_or(opts, "tenzir.node-id", defaults::node_id.data());
   auto db_dir
-    = get_or(opts, "tenzir.db-directory", defaults::db_directory.data());
+    = get_or(opts, "tenzir.state-directory", defaults::state_directory.data());
   auto detach_components = caf::get_or(opts, "tenzir.detach-components",
                                        defaults::detach_components);
   std::error_code err{};
@@ -43,21 +43,22 @@ spawn_node(caf::scoped_actor& self, const caf::settings& opts) {
   if (err)
     return caf::make_error(ec::filesystem_error,
                            fmt::format("failed to get absolute path to "
-                                       "db-directory {}: {}",
+                                       "state-directory {}: {}",
                                        db_dir, err.message()));
   const auto dir_exists = std::filesystem::exists(abs_dir, err);
   if (!dir_exists) {
     if (auto created_dir = std::filesystem::create_directories(abs_dir, err);
         !created_dir)
       return caf::make_error(ec::filesystem_error,
-                             fmt::format("unable to create db-directory {}: {}",
+                             fmt::format("unable to create state-directory {}: "
+                                         "{}",
                                          abs_dir, err.message()));
   }
   if (const auto is_writable = ::access(abs_dir.c_str(), W_OK) == 0;
       !is_writable)
     return caf::make_error(
       ec::filesystem_error,
-      "unable to write to db-directory:", abs_dir.string());
+      "unable to write to state-directory:", abs_dir.string());
   // Acquire PID lock.
   auto pid_file = abs_dir / "pid.lock";
   TENZIR_DEBUG("node acquires PID lock {}", pid_file.string());

--- a/libtenzir/test/feather.cpp
+++ b/libtenzir/test/feather.cpp
@@ -442,9 +442,9 @@ TEST(active feather store status) {
   run();
   r.receive(
     [uuid, this](record& status) {
-      auto db_dir = std::filesystem::path{
-        caf::get_or(content(self->home_system().config()),
-                    "tenzir.db-directory", defaults::db_directory.data())};
+      auto db_dir = std::filesystem::path{caf::get_or(
+        content(self->home_system().config()), "tenzir.state-directory",
+        defaults::state_directory.data())};
       std::error_code err{};
       const auto abs_dir = std::filesystem::absolute(db_dir, err);
       auto path = abs_dir / "archive" / fmt::format("{}.feather", uuid);

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -65,7 +65,7 @@ in {
                   default = ["all"];
                   description = "The names of plugins to enable";
                 };
-                db-directory = mkOption {
+                state-directory = mkOption {
                   type = lib.types.path;
                   default = "/var/lib/tenzir";
                   description = ''
@@ -108,7 +108,7 @@ in {
         ExecStart = "${cfg.package}/bin/tenzir-node --config=${configFile}";
         DynamicUser = true;
         NoNewPrivileges = true;
-        PIDFile = "${cfg.settings.tenzir.db-directory}/pid.lock";
+        PIDFile = "${cfg.settings.tenzir.state-directory}/pid.lock";
         ProtectKernelTunables = true;
         ProtectControlGroups = true;
         ProtectKernelModules = true;

--- a/plugins/parquet/tests/parquet.cpp
+++ b/plugins/parquet/tests/parquet.cpp
@@ -470,9 +470,9 @@ TEST(active parquet store status) {
   run();
   r.receive(
     [uuid, this](record& status) {
-      auto db_dir = std::filesystem::path{
-        caf::get_or(content(self->home_system().config()),
-                    "tenzir.db-directory", defaults::db_directory.data())};
+      auto db_dir = std::filesystem::path{caf::get_or(
+        content(self->home_system().config()), "tenzir.state-directory",
+        defaults::state_directory.data())};
       std::error_code err{};
       const auto abs_dir = std::filesystem::absolute(db_dir, err);
       auto path = abs_dir / "archive" / fmt::format("{}.parquet", uuid);

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -20,7 +20,16 @@ tenzir:
   # available:
   #   - $STATE_DIRECTORY
   #   - $PWD/tenzir.db
-  #db-directory:
+  #state-directory:
+
+  # The file system path used for persistent state.
+  # Defaults to one of the following paths, selecting the first that is
+  # available:
+  #   - $CACHE_DIRECTORY
+  #   - $XDG_CACHE_HOME/tenzir
+  #   - $HOME/.cache/tenzir (Linux)
+  #   - $HOME/Library/Caches/tenzir (macOS)
+  #cache-directory:
 
   # The file system path used for persistent state.
   # Defaults to one of the following paths, selecting the first that is
@@ -38,7 +47,7 @@ tenzir:
   # Defaults to one of the following paths, selecting the first that is
   # available:
   #   - $LOGS_DIRECTORY/server.log
-  #   - <db-directory>/server.log
+  #   - <state-directory>/server.log
   #log-file:
 
   # The file system path used for client log files relative to the current
@@ -147,14 +156,6 @@ tenzir:
 
   # The amount of queries that can be executed in parallel.
   max-queries: 10
-
-  # The directory to use for the partition synopses of the catalog.
-  #catalog-dir: <dbdir>/index
-
-  # Whether to run some components in dedicated threads, in particular
-  # the filesystem and catalog actors. It is usually a good idea to
-  # enable this setting for significantly better performance.
-  detach-components: true
 
   # The store backend to use. Can be 'feather', or the name of a user-provided
   # store plugin.

--- a/tenzir/functional-test/data/misc/scripts/break-sizelimit.sh
+++ b/tenzir/functional-test/data/misc/scripts/break-sizelimit.sh
@@ -2,5 +2,5 @@
 
 set -eu
 
-partition="$(find "${TENZIR_DB_DIRECTORY}/index/" -name '*.mdx' | head -1)"
+partition="$(find "${TENZIR_STATE_DIRECTORY}/index/" -name '*.mdx' | head -1)"
 dd if=/dev/zero bs=1G seek=3 count=0 of="${partition}"

--- a/tenzir/functional-test/lib/bats-tenzir/src/fixtures.bash
+++ b/tenzir/functional-test/lib/bats-tenzir/src/fixtures.bash
@@ -3,7 +3,7 @@
 
 
 export_default_node_config() {
-  export TENZIR_DB_DIRECTORY="${BATS_TEST_TMPDIR}/db"
+  export TENZIR_STATE_DIRECTORY="${BATS_TEST_TMPDIR}/db"
   export TENZIR_BARE_MODE=true
   export TENZIR_PLUGINS=""
   export TENZIR_ENDPOINT=":0"

--- a/tenzir/functional-test/tests/database.bats
+++ b/tenzir/functional-test/tests/database.bats
@@ -14,7 +14,7 @@ setup() {
   export TENZIR_METRICS__SELF_SINK__ENABLE=false
   export TENZIR_METRICS__FILE_SINK__ENABLE=true
   export TENZIR_METRICS__FILE_SINK__REAL_TIME=true
-  export TENZIR_METRICS__FILE_SINK__PATH=${TENZIR_DB_DIRECTORY}/metrics.log
+  export TENZIR_METRICS__FILE_SINK__PATH=${TENZIR_STATE_DIRECTORY}/metrics.log
   setup_node_raw
 }
 

--- a/tenzir/functional-test/tests/vast_server.bats
+++ b/tenzir/functional-test/tests/vast_server.bats
@@ -322,7 +322,7 @@ teardown() {
   TENZIR_EXAMPLE_YAML="$(dirname "$BATS_TEST_DIRNAME")/../../tenzir.yaml.example"
 
   check tenzir "from file ${TENZIR_EXAMPLE_YAML} read yaml | put plugins=tenzir.plugins, commands=tenzir.start.commands"
-  check tenzir 'show config | drop tenzir.config | drop tenzir.cache-directory | drop tenzir.metrics | drop tenzir.db-directory | write yaml'
+  check tenzir 'show config | drop tenzir.config | drop tenzir.cache-directory | drop tenzir.metrics | drop tenzir.state-directory | write yaml'
   check tenzir "from file ${INPUTSDIR}/zeek/zeek.json read zeek-json | head 5 | write yaml"
   check tenzir 'show plugins | where name == "yaml" | repeat 10 | write yaml | read yaml'
 }

--- a/tenzir/integration/integration.py
+++ b/tenzir/integration/integration.py
@@ -263,7 +263,7 @@ def run_step(
             if step.transformation:
                 LOGGER.debug(f"transforming output with `{step.transformation}`")
                 env = os.environ.copy()
-                env["TENZIR_INTEGRATION_DB_DIRECTORY"] = db_dir
+                env["TENZIR_INTEGRATION_STATE_DIRECTORY"] = db_dir
                 try:
                     out = subprocess.run(
                         [step.transformation],

--- a/tenzir/tenzir.cpp
+++ b/tenzir/tenzir.cpp
@@ -123,6 +123,13 @@ int main(int argc, char** argv) {
     TENZIR_ERROR("failed to initialize plugins: {}", err);
     return EXIT_FAILURE;
   }
+  // Warn when we used the fallback path from db-directory to state-directory.
+  // We cannot emit this warning when we override the option, as we do not have
+  // the logger initialized at that time.
+  if (caf::get_if<std::string>(&cfg, "tenzir.db-directory")) {
+    TENZIR_WARN("the option 'tenzir.db-directory' is deprecated; use "
+                "'tenzir.state-directory' instead");
+  }
   // Eagerly verify that the Arrow libraries we're using have Zstd support so
   // we can assert this works when serializing record batches.
   {


### PR DESCRIPTION
The option `tenzir.db-directory` is quite old, and comes from a time when Tenzir wasn't all about pipelines, but rather mostly about its storage engine VAST. Nowadays, we store lots of state in this directory that is not part of a "database" in the classical sense. As such, the option is now called `tenzir.state-directory`, with the old option name still being supported for the foreseeable future in a backwards-comaptible way.

Additionally, this change makes it possible to set the `tenzir.cache-directory` on the command line when starting the node.

Fixes tenzir/issues#1109