### PR TITLE
Randomize pipeline ids

### DIFF
--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "5ce59f1bd3b5d73e2cd797340c691e5e08d70d8f",
+  "rev": "dc1a7e5a6b7aecf640d879c486bfa041428bbc0f",
   "submodules": true,
   "shallow": true
 }

--- a/web/docs/operators/metrics.md
+++ b/web/docs/operators/metrics.md
@@ -224,17 +224,17 @@ metrics
 
 ```json
 {
-  "pipeline_id": "13",
+  "pipeline_id": "70a25089-b16c-448d-9492-af5566789b99",
   "operator_id": 0,
   "events": 391008694
 }
 {
-  "pipeline_id": "12",
+  "pipeline_id": "7842733c-06d6-4713-9b80-e20944927207",
   "operator_id": 0,
   "events": 246914949
 }
 {
-  "pipeline_id": "0",
+  "pipeline_id": "6df003be-0841-45ad-8be0-56ff4b7c19ef",
   "operator_id": 1,
   "events": 83013294
 }

--- a/web/openapi/openapi.yaml
+++ b/web/openapi/openapi.yaml
@@ -371,7 +371,7 @@ paths:
               properties:
                 id:
                   type: string
-                  example: 7
+                  example: 4c7f2b11-6169-4d1b-89b4-4fc0a68b3d4a
                   description: The id of the pipeline to be deleted.
       responses:
         200:
@@ -438,7 +438,7 @@ paths:
                       $ref: "#/components/schemas/PipelineInfo"
                 example:
                   pipelines:
-                    - id: 7
+                    - id: 4c7f2b11-6169-4d1b-89b4-4fc0a68b3d4a
                       name: user-assigned-name
                       definition: export | where foo | publish /bar
                       created_at: 1706180157837037485
@@ -453,7 +453,7 @@ paths:
                             {}
                           out:
                             {}
-                    - id: 8
+                    - id: 08446737-da9b-4787-8599-97d85c48c3bb
                       name: wrong-pipeline
                       definition: export asdf
                       state: failed
@@ -547,7 +547,7 @@ paths:
               properties:
                 id:
                   type: string
-                  example: 7
+                  example: 08446737-da9b-4787-8599-97d85c48c3bb
                   description: The id of the pipeline to be updated.
                 action:
                   type: string


### PR DESCRIPTION
Why? Because of two very simple reasons:
1. Our integration tests should be order-independent. Having truly random pipeline ids forces us to write them without relying on the ids being incremental.
2. When using the `metrics` and `diagnostics` operators, it was rather easy to make the mistake `where pipeline_id == 42` when it should've been `where pipeline_id == "42"`. This won't happen anymore now that the id is obviously not a number anymore.

This change should not be user-visible, as we never made any guarantees about the format of the pipeline ids.

Additionally, this fixes a small oversight in the recent addition of the `created_at` and `last_modified` fields in managed pipelines, which were not rendered as `time` values when using `show pipelines`.