### PR TITLE
Introduce the shared diagnostics handler

### DIFF
--- a/libtenzir/builtins/operators/shell.cpp
+++ b/libtenzir/builtins/operators/shell.cpp
@@ -206,14 +206,15 @@ public:
     // queue such that to this coroutine can yield them.
     auto chunks = std::queue<chunk_ptr>{};
     auto chunks_mutex = std::mutex{};
-    auto thread = std::thread([&child, &chunks, &chunks_mutex, &ctrl] {
+    auto thread = std::thread([&child, &chunks, &chunks_mutex,
+                               diagnostics = ctrl.shared_diagnostics()]() {
       auto buffer = std::vector<char>(block_size);
       while (true) {
         auto bytes_read = child->read(as_writeable_bytes(buffer));
         if (not bytes_read) {
           diagnostic::error(add_context(bytes_read.error(),
                                         "failed to read from child process"))
-            .emit(ctrl.diagnostics());
+            .emit(diagnostics);
           return;
         }
         if (*bytes_read == 0) {

--- a/libtenzir/include/tenzir/actors.hpp
+++ b/libtenzir/include/tenzir/actors.hpp
@@ -420,6 +420,8 @@ using exec_node_actor = typed_actor_fwd<
   auto(atom::pause)->caf::result<void>,
   // Resume the execution node. No-op if it was not paused.
   auto(atom::resume)->caf::result<void>,
+  // Emit a diagnostic through the exec node.
+  auto(diagnostic diag)->caf::result<void>,
   // Uodate demand.
   auto(atom::pull, exec_node_sink_actor sink, uint64_t batch_size)
     ->caf::result<void>>

--- a/libtenzir/include/tenzir/detail/weak_handle.hpp
+++ b/libtenzir/include/tenzir/detail/weak_handle.hpp
@@ -45,6 +45,12 @@ struct weak_handle : caf::weak_actor_ptr {
     return caf::actor_cast<Handle>(weak_ptr_.lock());
   }
 
+  friend auto inspect(auto& f, weak_handle& x) -> bool {
+    return f.object(x)
+      .pretty_name("tenzir.detail.weak_handle")
+      .fields(f.field("weak_ptr", x.weak_ptr_));
+  }
+
 private:
   caf::weak_actor_ptr weak_ptr_ = {};
 };

--- a/libtenzir/include/tenzir/diagnostics.hpp
+++ b/libtenzir/include/tenzir/diagnostics.hpp
@@ -293,6 +293,8 @@ public:
     diag.emit(std::move(result_));
   }
 
+  void emit(const shared_diagnostic_handler& diag) &&;
+
   [[noreturn]] void throw_() && {
     throw std::move(result_);
   }

--- a/libtenzir/include/tenzir/fwd.hpp
+++ b/libtenzir/include/tenzir/fwd.hpp
@@ -165,6 +165,7 @@ class plugin;
 class port;
 class record_type;
 class segment;
+class shared_diagnostic_handler;
 class string_type;
 class subnet_type;
 class subnet;
@@ -441,6 +442,7 @@ CAF_BEGIN_TYPE_ID_BLOCK(tenzir_types, first_tenzir_type_id)
   TENZIR_ADD_TYPE_ID((tenzir::relational_operator))
   TENZIR_ADD_TYPE_ID((tenzir::rest_endpoint))
   TENZIR_ADD_TYPE_ID((tenzir::rest_response))
+  TENZIR_ADD_TYPE_ID((tenzir::shared_diagnostic_handler))
   TENZIR_ADD_TYPE_ID((tenzir::subnet))
   TENZIR_ADD_TYPE_ID((tenzir::table_slice))
   TENZIR_ADD_TYPE_ID((tenzir::table_slice_column))

--- a/libtenzir/include/tenzir/operator_control_plane.hpp
+++ b/libtenzir/include/tenzir/operator_control_plane.hpp
@@ -12,9 +12,7 @@
 
 #include "tenzir/actors.hpp"
 #include "tenzir/diagnostics.hpp"
-#include "tenzir/die.hpp"
-#include "tenzir/taxonomies.hpp"
-#include "tenzir/type.hpp"
+#include "tenzir/shared_diagnostic_handler.hpp"
 
 #include <caf/typed_actor.hpp>
 
@@ -28,10 +26,10 @@ struct operator_control_plane {
   virtual ~operator_control_plane() noexcept = default;
 
   /// Returns the hosting actor.
-  [[nodiscard]] virtual auto self() noexcept -> exec_node_actor::base& = 0;
+  virtual auto self() noexcept -> exec_node_actor::base& = 0;
 
   /// Returns the node actor, if the operator location is remote.
-  [[nodiscard]] virtual auto node() noexcept -> node_actor = 0;
+  virtual auto node() noexcept -> node_actor = 0;
 
   /// Returns the pipeline's diagnostic handler.
   virtual auto diagnostics() noexcept -> diagnostic_handler& = 0;
@@ -41,6 +39,14 @@ struct operator_control_plane {
 
   /// Returns true if the operator is hosted by process that has a terminal.
   virtual auto has_terminal() const noexcept -> bool = 0;
+
+  /// Return a version of the diagnostic handler that may be passed to other
+  /// threads. NOTE: Unlike for the regular diagnostic handler, emitting an
+  /// erorr via the shared diagnostic handler does not shut down the operator
+  /// immediately.
+  inline auto shared_diagnostics() noexcept -> shared_diagnostic_handler {
+    return shared_diagnostic_handler{exec_node_actor{&(self())}};
+  }
 };
 
 } // namespace tenzir

--- a/libtenzir/include/tenzir/shared_diagnostic_handler.hpp
+++ b/libtenzir/include/tenzir/shared_diagnostic_handler.hpp
@@ -36,9 +36,7 @@ public:
   ~shared_diagnostic_handler() noexcept override = default;
 
   inline auto emit(diagnostic diag) -> void override {
-    if (auto exec_node = weak_exec_node_.lock()) {
-      caf::anon_send<caf::message_priority::high>(exec_node, std::move(diag));
-    }
+    std::as_const(*this).emit(std::move(diag));
   }
 
   inline auto emit(diagnostic diag) const -> void {

--- a/libtenzir/include/tenzir/shared_diagnostic_handler.hpp
+++ b/libtenzir/include/tenzir/shared_diagnostic_handler.hpp
@@ -1,0 +1,60 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2024 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "tenzir/fwd.hpp"
+
+#include "tenzir/actors.hpp"
+#include "tenzir/detail/weak_handle.hpp"
+#include "tenzir/diagnostics.hpp"
+
+#include <caf/typed_event_based_actor.hpp>
+
+namespace tenzir {
+
+/// A diagnostic handler that may be passed to other threads from an operator.
+class shared_diagnostic_handler final : public diagnostic_handler {
+public:
+  shared_diagnostic_handler() noexcept = default;
+  shared_diagnostic_handler(const shared_diagnostic_handler&) = default;
+  shared_diagnostic_handler& operator=(const shared_diagnostic_handler&)
+    = default;
+  shared_diagnostic_handler(shared_diagnostic_handler&&) noexcept = default;
+  shared_diagnostic_handler& operator=(shared_diagnostic_handler&&) noexcept
+    = default;
+
+  inline shared_diagnostic_handler(const exec_node_actor& exec_node) noexcept
+    : weak_exec_node_{exec_node} {
+  }
+
+  ~shared_diagnostic_handler() noexcept override = default;
+
+  inline auto emit(diagnostic diag) -> void override {
+    if (auto exec_node = weak_exec_node_.lock()) {
+      caf::anon_send<caf::message_priority::high>(exec_node, std::move(diag));
+    }
+  }
+
+  inline auto emit(diagnostic diag) const -> void {
+    if (auto exec_node = weak_exec_node_.lock()) {
+      caf::anon_send<caf::message_priority::high>(exec_node, std::move(diag));
+    }
+  }
+
+  friend auto inspect(auto& f, shared_diagnostic_handler& x) -> bool {
+    return f.object(x)
+      .pretty_name("tenzir.shared_diagnostic_handler")
+      .fields(f.field("weak_exec_node", x.weak_exec_node_));
+  }
+
+private:
+  detail::weak_handle<exec_node_actor> weak_exec_node_ = {};
+};
+
+} // namespace tenzir

--- a/libtenzir/src/detail/add_message_types.cpp
+++ b/libtenzir/src/detail/add_message_types.cpp
@@ -39,6 +39,7 @@
 #include "tenzir/query_status.hpp"
 #include "tenzir/report.hpp"
 #include "tenzir/resource.hpp"
+#include "tenzir/shared_diagnostic_handler.hpp"
 #include "tenzir/status.hpp"
 #include "tenzir/subnet.hpp"
 #include "tenzir/table_slice.hpp"

--- a/libtenzir/src/diagnostics.cpp
+++ b/libtenzir/src/diagnostics.cpp
@@ -10,6 +10,7 @@
 
 #include "tenzir/detail/string.hpp"
 #include "tenzir/logger.hpp"
+#include "tenzir/shared_diagnostic_handler.hpp"
 
 #include <boost/algorithm/string.hpp>
 #include <caf/message_handler.hpp>
@@ -231,6 +232,10 @@ auto diagnostic::builder(enum severity s, caf::error err)
     b = std::move(b).note("{}", *as_string(i - 1));
   }
   return b;
+}
+
+void diagnostic_builder::emit(const shared_diagnostic_handler& diag) && {
+  return diag.emit(std::move(result_));
 }
 
 } // namespace tenzir

--- a/libtenzir/src/execution_node.cpp
+++ b/libtenzir/src/execution_node.cpp
@@ -747,6 +747,12 @@ auto exec_node(
         = make_timer_guard(self->state.metrics->values.time_scheduled);
       return self->state.resume();
     },
+    [self](diagnostic& diag) -> caf::result<void> {
+      auto time_scheduled_guard
+        = make_timer_guard(self->state.metrics->values.time_scheduled);
+      self->state.ctrl->diagnostics().emit(std::move(diag));
+      return {};
+    },
     [self](atom::push, table_slice& events) -> caf::result<void> {
       auto time_scheduled_guard
         = make_timer_guard(self->state.metrics->values.time_scheduled);


### PR DESCRIPTION
This introduces a diagnostics handler that is safe to use from other threads, allowing operators, connectors, and formats that spawn threads through third-party libraries or other actors to emit diagnostics.

To create a shared diagnostics handler, call `ctrl.shared_diagnostics()` instead of `ctrl.diagnostics()` on the operator's control plane.

Unlike for the regular diagnostics handler, errors emitted through the shared handler do not shut down the operator's execution node immediately. Diagnostics sent through the shared diagnostics handler may arrive out of order.

This is a first step towards being able to emit errors in the context API. For the `shell` transformation operator, this fixes an unsafe use of the regular diagnostic handler from another thread.

Fixes tenzir/issues#1073