### PR TITLE
Remove wrong value updates for paused pipeline metrics

### DIFF
--- a/changelog/next/bug-fixes/3902--remove-wrong-values-for-paused-pipeline-metrics.md
+++ b/changelog/next/bug-fixes/3902--remove-wrong-values-for-paused-pipeline-metrics.md
@@ -1,0 +1,2 @@
+Durations in pipeline metrics now correctly exclude time that a pipeline was
+paused.

--- a/changelog/next/features/3902--remove-wrong-values-for-paused-pipeline-metrics.md
+++ b/changelog/next/features/3902--remove-wrong-values-for-paused-pipeline-metrics.md
@@ -1,0 +1,2 @@
+The new `time_paused_total` metric tracks the total duration a pipeline spent
+in the paused state.

--- a/libtenzir/include/tenzir/pipeline.hpp
+++ b/libtenzir/include/tenzir/pipeline.hpp
@@ -188,6 +188,7 @@ struct [[nodiscard]] metric {
   duration time_processing = {};
   duration time_scheduled = {};
   duration time_total = {};
+  duration time_paused_total = {};
   uint64_t num_runs = {};
   uint64_t num_runs_processing = {};
   uint64_t num_runs_processing_input = {};
@@ -206,6 +207,7 @@ struct [[nodiscard]] metric {
       f.field("time_processing", x.time_processing),
       f.field("time_scheduled", x.time_scheduled),
       f.field("time_total", x.time_total),
+      f.field("time_paused_total", x.time_paused_total),
       f.field("inbound_measurement", x.inbound_measurement),
       f.field("outbound_measurement", x.outbound_measurement),
       f.field("num_runs", x.num_runs),

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "5bae28d2ed94431c927f0ee8683e87bf9212f7ce",
+  "rev": "f31f89c953d4e9cd9d6689b7e314b76410b12711",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
This change fixes time delta calculation for paused pipelines: Dismiss any deltas in metrics for a paused pipeline and add a `time_paused_total` metric to fix further duration-based calculations.
