### PR TITLE
Add support for commas in seconds in the time data parser

### DIFF
--- a/changelog/next/bug-fixes/3903--time-comma.md
+++ b/changelog/next/bug-fixes/3903--time-comma.md
@@ -1,0 +1,2 @@
+Commas are now allowed as subsecond separators in timestamps in TQL.
+Previously, only dots were allowed, but ISO 8601 allows for both.

--- a/libtenzir/include/tenzir/concept/parseable/tenzir/time.hpp
+++ b/libtenzir/include/tenzir/concept/parseable/tenzir/time.hpp
@@ -168,7 +168,7 @@ struct ymdhms_parser : tenzir::parser_base<ymdhms_parser> {
       [](auto x) { return x >= 0 && x <= 23; });
     auto min = integral_parser<int, 2, 2>{}.with(
       [](auto x) { return x >= 0 && x <= 59; });
-    auto sec = parsers::real.with([](auto x) {
+    auto sec = parsers::real_detect_sep.with([](auto x) {
       return x >= 0.0 && x <= 60.0;
     });
     auto time_divider = '+'_p | 'T' | ' ';

--- a/libtenzir/src/concept/parseable/numeric/real.cpp
+++ b/libtenzir/src/concept/parseable/numeric/real.cpp
@@ -12,47 +12,75 @@
 
 #include <fast_float/fast_float.h>
 
+#include <memory>
 #include <string>
 
 namespace tenzir {
 
+template <char Separator>
 template <class Iterator>
-bool double_parser::parse(Iterator& f, const Iterator& l, unused_type) const {
+bool double_parser<Separator>::parse(Iterator& f, const Iterator& l,
+                                     unused_type) const {
   double result;
-  auto answer = fast_float::from_chars(&*f, &*l, result,
-                                       fast_float::chars_format::general);
-  auto success = answer.ec == std::errc();
-  if (success)
-    f += answer.ptr - &*f;
+  fast_float::parse_options options{fast_float::chars_format::general,
+                                    Separator};
+  const auto [ptr, ec] = fast_float::from_chars_advanced(
+    std::to_address(f), std::to_address(l), result, options);
+  const auto success = ec == std::errc();
+  if (success) {
+    f += std::ranges::distance(std::to_address(f), ptr);
+  }
   return success;
 }
 
+template <char Separator>
 template <class Iterator>
-bool double_parser::parse(Iterator& f, const Iterator& l, double& a) const {
-  auto answer
-    = fast_float::from_chars(&*f, &*l, a, fast_float::chars_format::general);
-  auto success = answer.ec == std::errc();
-  if (success)
-    f += answer.ptr - &*f;
+bool double_parser<Separator>::parse(Iterator& f, const Iterator& l,
+                                     double& a) const {
+  fast_float::parse_options options{fast_float::chars_format::general,
+                                    Separator};
+  const auto [ptr, ec] = fast_float::from_chars_advanced(
+    std::to_address(f), std::to_address(l), a, options);
+  const auto success = ec == std::errc();
+  if (success) {
+    f += std::ranges::distance(std::to_address(f), ptr);
+  }
   return success;
 }
 
 template bool
-double_parser::parse(std::string::iterator&, const std::string::iterator&,
-                     unused_type) const;
-template bool double_parser::parse(std::string::iterator&,
-                                   const std::string::iterator&, double&) const;
+double_parser<'.'>::parse(std::string::iterator&, const std::string::iterator&,
+                          unused_type) const;
+template bool
+double_parser<'.'>::parse(std::string::iterator&, const std::string::iterator&,
+                          double&) const;
+template bool
+double_parser<','>::parse(std::string::iterator&, const std::string::iterator&,
+                          unused_type) const;
+template bool
+double_parser<','>::parse(std::string::iterator&, const std::string::iterator&,
+                          double&) const;
+
+template bool double_parser<'.'>::parse(std::string::const_iterator&,
+                                        const std::string::const_iterator&,
+                                        unused_type) const;
+template bool
+double_parser<'.'>::parse(std::string::const_iterator&,
+                          const std::string::const_iterator&, double&) const;
+template bool double_parser<','>::parse(std::string::const_iterator&,
+                                        const std::string::const_iterator&,
+                                        unused_type) const;
+template bool
+double_parser<','>::parse(std::string::const_iterator&,
+                          const std::string::const_iterator&, double&) const;
 
 template bool
-double_parser::parse(std::string::const_iterator&,
-                     const std::string::const_iterator&, unused_type) const;
+double_parser<'.'>::parse(char const*&, char const* const&, unused_type) const;
 template bool
-double_parser::parse(std::string::const_iterator&,
-                     const std::string::const_iterator&, double&) const;
-
+double_parser<'.'>::parse(char const*&, char const* const&, double&) const;
 template bool
-double_parser::parse(char const*&, char const* const&, unused_type) const;
+double_parser<','>::parse(char const*&, char const* const&, unused_type) const;
 template bool
-double_parser::parse(char const*&, char const* const&, double&) const;
+double_parser<','>::parse(char const*&, char const* const&, double&) const;
 
 } // namespace tenzir

--- a/tenzir/integration/tests/vast.bats
+++ b/tenzir/integration/tests/vast.bats
@@ -188,14 +188,12 @@ teardown() {
     if [ ! command -v gdate ]; then
       skip "this test requires coreutils to be installed on macOS"
     fi
-    NOW=$(gdate -Ins | tr ',' '.')
+    # We need subsecond precision here because `date` rounds down otherwise.
+    NOW=$(gdate -Ins)
   else
-    NOW=$(date -Ins | tr ',' '.')
+    NOW=$(date -Ins)
   fi
 
-  # We need subsecond precision here because `date` rounds down otherwise. Also,
-  # we need `tr` because `date` uses a comma for subsecond precision by default
-  # but tenzir requires a dot. (ISO 8601 allows both)
   check tenzir "export | where #import_time > ${NOW}"
   check tenzir "export | where #import_time <= ${NOW} | sort timestamp"
   check tenzir "export | where #import_time > now"


### PR DESCRIPTION
Closes https://github.com/tenzir/issues/issues/1520

Makes `double_parser` a template, that accepts the expected radix separator as a parameter. `parsers::real` is `double_parser<'.'>`, and the new `parsers::real_comma` is `double_parser<','>`.

`parsers::real_detect_sep` is also added, that tries both `real` and `real_comma`, and yields whichever matched more characters. The seconds parser in `parsers::time` is changed to use that.

The end result is, that both dots and commas are accepted as separators for subsecond values in `parsers::time`, as specified by ISO 8601. I'm not 100% happy with the implementation, but it works.