### PR TITLE
Make FlatBuffers easier to use

### DIFF
--- a/.cmake-format
+++ b/.cmake-format
@@ -29,6 +29,7 @@ with section("parse"):
                 "INCLUDE_DIRECTORIES": "*",
                 "DEPENDENCIES": "*",
                 "BUILTINS": "*",
+                "FLATBUFFERS": "*",
             },
         },
         "tenzirnormalizeinstalldirs": {

--- a/libtenzir/include/tenzir/diagnostics.hpp
+++ b/libtenzir/include/tenzir/diagnostics.hpp
@@ -289,6 +289,10 @@ public:
     return std::move(result_);
   }
 
+  auto to_error() && -> caf::error {
+    return std::move(*this).done().to_error();
+  }
+
   void emit(diagnostic_handler& diag) && {
     diag.emit(std::move(result_));
   }

--- a/libtenzir/include/tenzir/flatbuffer.hpp
+++ b/libtenzir/include/tenzir/flatbuffer.hpp
@@ -128,6 +128,9 @@ public:
 
   /// Constructs a ref-counted FlatBuffers root table that shares the
   /// lifetime with the chunk it's constructed from.
+  /// @note This verifies the FlatBuffers table recursively, potentially
+  /// loading memory in the chunk, which can be expensive. Use `make_unsafe`
+  /// instead to skip this verification.
   /// @pre *chunk* must hold a valid *Table*.
   [[nodiscard]] static auto make(chunk_ptr&& chunk) noexcept
     -> caf::expected<flatbuffer>
@@ -162,16 +165,6 @@ public:
   /// Constructs a ref-counted FlatBuffers root table.
   /// @pre *buffer* must hold a valid *Table*.
   [[nodiscard]] static auto make(flatbuffers::DetachedBuffer&& buffer) noexcept
-    -> caf::expected<flatbuffer>
-    requires(Type != flatbuffer_type::child)
-  {
-    return make(chunk::make(std::move(buffer)));
-  }
-
-  /// Constructs a ref-counted FlatBuffers root table.
-  /// @pre *buffer* must hold a valid *Table*.
-  [[nodiscard]] static auto
-  make_unsafe(flatbuffers::DetachedBuffer&& buffer) noexcept
     -> caf::expected<flatbuffer>
     requires(Type != flatbuffer_type::child)
   {

--- a/libtenzir/include/tenzir/fwd.hpp
+++ b/libtenzir/include/tenzir/fwd.hpp
@@ -65,8 +65,9 @@ class RandomAccessFile;
 
 namespace flatbuffers {
 
-#if FLATBUFFERS_VERSION_MAJOR >= 23 && FLATBUFFERS_VERSION_MINOR >= 5          \
-  && FLATBUFFERS_VERSION_REVISION >= 9
+#if (FLATBUFFERS_VERSION_REVISION + (FLATBUFFERS_VERSION_MINOR * 100)          \
+     + (FLATBUFFERS_VERSION_MAJOR * 10000))                                    \
+  >= 230509
 
 template <bool>
 class FlatBufferBuilderImpl;

--- a/libtenzir/include/tenzir/type.hpp
+++ b/libtenzir/include/tenzir/type.hpp
@@ -13,6 +13,7 @@
 #include "tenzir/aliases.hpp"
 #include "tenzir/chunk.hpp"
 #include "tenzir/detail/type_traits.hpp"
+#include "tenzir/flatbuffer.hpp"
 #include "tenzir/generator.hpp"
 #include "tenzir/hash/hash.hpp"
 #include "tenzir/offset.hpp"
@@ -170,6 +171,12 @@ public:
   /// @note The table offsets are verified only when assertions are enabled.
   /// @pre `table != nullptr`
   explicit type(chunk_ptr&& table) noexcept;
+
+  /// Constructs a type from a FlatBuffers root table.
+  /// @param fb The FlatBuffers root table.
+  /// @note The table offsets are verified only when assertions are enabled.
+  /// @pre `fb != nullptr`
+  explicit type(flatbuffer<fbs::Type>&& fb) noexcept;
 
   /// Explicitly construct a type from a basic concrete type.
   template <basic_type T>

--- a/libtenzir/src/catalog.cpp
+++ b/libtenzir/src/catalog.cpp
@@ -537,7 +537,8 @@ caf::error catalog_state::load_type_registry_from_disk() {
       if (!buffer)
         return buffer.error();
       auto maybe_flatbuffer
-        = flatbuffer<fbs::TypeRegistry>::make(chunk::make(std::move(*buffer)));
+        = flatbuffer<fbs::TypeRegistry, fbs::TypeRegistryIdentifier>::make(
+          chunk::make(std::move(*buffer)));
       if (!maybe_flatbuffer)
         return maybe_flatbuffer.error();
       const auto flatbuffer = std::move(*maybe_flatbuffer);

--- a/libtenzir/src/type.cpp
+++ b/libtenzir/src/type.cpp
@@ -377,6 +377,10 @@ type::type(chunk_ptr&& table) noexcept {
   table_ = std::move(table);
 }
 
+type::type(flatbuffer<fbs::Type>&& fb) noexcept : type(std::move(fb).chunk()) {
+  // nop
+}
+
 type::type(std::string_view name, const type& nested,
            std::vector<attribute_view>&& attributes) noexcept {
   if (name.empty() && attributes.empty()) {

--- a/plugins/amqp/CMakeLists.txt
+++ b/plugins/amqp/CMakeLists.txt
@@ -9,13 +9,10 @@ include(CTest)
 
 find_package(Tenzir REQUIRED)
 
-file(GLOB_RECURSE rabbitmq_sources CONFIGURE_DEPENDS
-     "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
-
 TenzirRegisterPlugin(
   TARGET amqp
   ENTRYPOINT src/plugin.cpp
-  SOURCES ${rabbitmq_sources}
+  SOURCES GLOB "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp"
   INCLUDE_DIRECTORIES include)
 
 find_package(rabbitmq-c REQUIRED)

--- a/plugins/kafka/CMakeLists.txt
+++ b/plugins/kafka/CMakeLists.txt
@@ -9,13 +9,10 @@ include(CTest)
 
 find_package(Tenzir REQUIRED)
 
-file(GLOB_RECURSE kafka_sources CONFIGURE_DEPENDS
-     "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
-
 TenzirRegisterPlugin(
   TARGET kafka
   ENTRYPOINT src/plugin.cpp
-  SOURCES ${kafka_sources}
+  SOURCES GLOB "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp"
   INCLUDE_DIRECTORIES include)
 
 find_package(RdKafka QUIET)

--- a/plugins/sigma/CMakeLists.txt
+++ b/plugins/sigma/CMakeLists.txt
@@ -7,17 +7,11 @@ project(
 
 include(CTest)
 
-file(GLOB_RECURSE sigma_sources CONFIGURE_DEPENDS
-     "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp"
-     "${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp")
-
-file(GLOB_RECURSE sigma_tests CONFIGURE_DEPENDS
-     "${CMAKE_CURRENT_SOURCE_DIR}/tests/*.cpp")
-
 find_package(Tenzir REQUIRED)
 TenzirRegisterPlugin(
   TARGET sigma
   ENTRYPOINT src/plugin.cpp
-  SOURCES ${sigma_sources}
-  TEST_SOURCES ${sigma_tests}
+  SOURCES GLOB "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp"
+          "${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp"
+  TEST_SOURCES GLOB "${CMAKE_CURRENT_SOURCE_DIR}/tests/*.cpp"
   INCLUDE_DIRECTORIES include)

--- a/plugins/velociraptor/CMakeLists.txt
+++ b/plugins/velociraptor/CMakeLists.txt
@@ -9,13 +9,10 @@ include(CTest)
 
 find_package(Tenzir REQUIRED)
 
-file(GLOB_RECURSE velociraptor_sources CONFIGURE_DEPENDS
-     "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
-
 TenzirRegisterPlugin(
   TARGET velociraptor
   ENTRYPOINT src/plugin.cpp
-  SOURCES ${velociraptor_sources})
+  SOURCES GLOB "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
 
 find_package(protobuf CONFIG)
 if (NOT protobuf_FOUND)

--- a/plugins/web/CMakeLists.txt
+++ b/plugins/web/CMakeLists.txt
@@ -8,20 +8,15 @@ project(
 include(FeatureSummary)
 include(CTest)
 
-file(GLOB_RECURSE web_sources CONFIGURE_DEPENDS
-     "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp"
-     "${CMAKE_CURRENT_SOURCE_DIR}/include/web/*.hpp")
-
-file(GLOB_RECURSE web_tests CONFIGURE_DEPENDS
-     "${CMAKE_CURRENT_SOURCE_DIR}/tests/*.cpp")
-
 find_package(Tenzir REQUIRED)
 
 TenzirRegisterPlugin(
   TARGET web
   ENTRYPOINT src/plugin.cpp
-  SOURCES ${web_sources}
-  TEST_SOURCES ${web_tests}
+  SOURCES GLOB "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp"
+          "${CMAKE_CURRENT_SOURCE_DIR}/include/web/*.hpp"
+  TEST_SOURCES GLOB "${CMAKE_CURRENT_SOURCE_DIR}/tests/*.cpp"
+  FLATBUFFERS GLOB "${CMAKE_CURRENT_SOURCE_DIR}/src/fbs/*.fbs"
   INCLUDE_DIRECTORIES include)
 
 find_package(OpenSSL REQUIRED)
@@ -46,14 +41,3 @@ else ()
 endif ()
 dependency_summary("restinio" restinio::restinio "Dependencies")
 target_link_libraries(web PRIVATE restinio::restinio)
-
-# Compile the web FlatBuffers schemas.
-file(GLOB flatbuffers_schemas CONFIGURE_DEPENDS
-     "${CMAKE_CURRENT_SOURCE_DIR}/src/fbs/*.fbs")
-
-TenzirCompileFlatBuffers(
-  TARGET web-fbs
-  SCHEMAS ${flatbuffers_schemas}
-  INCLUDE_DIRECTORY "web/fbs")
-
-target_link_libraries(web PUBLIC web-fbs)

--- a/plugins/web/src/authenticator.cpp
+++ b/plugins/web/src/authenticator.cpp
@@ -21,8 +21,8 @@ namespace tenzir::plugins::web {
 caf::error authenticator_state::initialize_from(chunk_ptr chunk) {
   // We always verify here since most fields are required, so we
   // can just assert there presence below.
-  auto fb = flatbuffer<fbs::ServerState>::make(
-    std::move(chunk), flatbuffer<fbs::ServerState>::verify::yes);
+  auto fb = flatbuffer<fbs::ServerState, fbs::ServerStateIdentifier>::make(
+    std::move(chunk));
   if (!fb)
     return fb.error();
   if ((*fb)->server_state_type() != fbs::server_state::ServerState::v0)

--- a/plugins/zmq/CMakeLists.txt
+++ b/plugins/zmq/CMakeLists.txt
@@ -9,13 +9,10 @@ include(CTest)
 
 find_package(Tenzir REQUIRED)
 
-file(GLOB_RECURSE zmq_sources CONFIGURE_DEPENDS
-     "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
-
 TenzirRegisterPlugin(
   TARGET zmq
   ENTRYPOINT src/plugin.cpp
-  SOURCES ${zmq_sources}
+  SOURCES GLOB "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp"
   INCLUDE_DIRECTORIES include)
 
 find_package(cppzmq QUIET)


### PR DESCRIPTION
This set of changes improves the developer experience when working with FlatBuffers tables in Tenzir. I've made them out of frustration when working with FlatBuffers for another plugin, and for an improved reviewability I split them out into a separate pull request.

This PR
1. Fixes the version comparison to detect FlatBuffers versions without an opt-in to 64-bit offsets,
2. adds a convenience parameter for compiling, linking, and including FlatBuffers table in plugins,
3. makes globbing for files in plugins easier,
4. adds support for setting and checking the file identifier of a FlatBuffers root table, and
5. introduces support for size-prefixed FlatBuffers root tables.

None of this is user-facing, so no changelog entry required. The plugin scaffolding changes are also entirely backwards-compatible.