### PR TITLE
Add 'area' chart type

### DIFF
--- a/changelog/next/features/3866--chart-operator.md
+++ b/changelog/next/features/3866--chart-operator.md
@@ -1,2 +1,2 @@
 The `chart` operator adds metadata to the schema of the input events,
-enabling rendering events as bar, line, or donut charts on app.tenzir.com.
+enabling rendering events as bar, area, line, or donut charts on app.tenzir.com.

--- a/libtenzir/builtins/operators/chart.cpp
+++ b/libtenzir/builtins/operators/chart.cpp
@@ -325,6 +325,13 @@ chart_definition chart_definitions[] = {
    = {{.attr = "x", .flag = "-x,--x-axis", .type = flag_type::field_name, .default_ = nth_field{0}},
       {.attr = "y", .flag = "-y,--y-axis", .type = flag_type::field_name, .default_ = nth_field{1}},
       {.attr = "title", .flag = "--title", .type = flag_type::attribute_value, .default_ = schema_name{}},}},
+  // `area` is equivalent to `line`
+  {.type = "area",
+   .required_flags = {},
+   .optional_flags
+   = {{.attr = "x", .flag = "-x,--x-axis", .type = flag_type::field_name, .default_ = nth_field{0}},
+      {.attr = "y", .flag = "-y,--y-axis", .type = flag_type::field_name, .default_ = nth_field{1}},
+      {.attr = "title", .flag = "--title", .type = flag_type::attribute_value, .default_ = schema_name{}},}},
   // `bar` is equivalent to `line`
   {.type = "bar",
    .required_flags = {},

--- a/libtenzir/src/type.cpp
+++ b/libtenzir/src/type.cpp
@@ -910,12 +910,9 @@ data type::to_definition(bool expand) const noexcept {
 
 auto type::to_definition2(std::optional<std::string> field_name,
                           offset parent_path) const noexcept -> record {
-  auto attributes = list{};
+  auto attributes = record{};
   for (const auto& [key, value] : this->attributes()) {
-    attributes.push_back(record{
-      {"key", std::string{key}},
-      {"value", value.empty() ? data{std::string{value}} : data{}},
-    });
+    attributes.emplace(key, value.empty() ? data{} : data{std::string{value}});
   }
   auto path = list{};
   for (const auto& index : parent_path) {

--- a/tenzir/integration/data/reference/pipelines_local/test_chart_attributes/step_06.ref
+++ b/tenzir/integration/data/reference/pipelines_local/test_chart_attributes/step_06.ref
@@ -4,5 +4,5 @@ error: invalid chart type
 1 | from stdin read json | chart donuttt --value b
   |                              ^^^^^^^ 
   |
-  = hint: valid chart types are: line, bar, donut
+  = hint: valid chart types are: line, area, bar, donut
   = docs: https://docs.tenzir/operators/chart

--- a/web/docs/operators/chart.md
+++ b/web/docs/operators/chart.md
@@ -12,6 +12,7 @@ Add metadata to a schema, necessary for rendering as a chart.
 
 ```
 chart line   [--title <title>] [-x|--x-axis <field>] [-y|--y-axis <field>]
+chart area   [--title <title>] [-x|--x-axis <field>] [-y|--y-axis <field>]
 chart bar    [--title <title>] [-x|--x-axis <field>] [-y|--y-axis <field>]
 chart donut  [--title <title>] [--name <field>] [--value <field>]
 ```
@@ -26,11 +27,11 @@ The operator does no rendering itself.
 
 Set the chart title. Defaults to the schema name.
 
-### `-x|--x-axis <field>` (`line` and `bar` charts only)
+### `-x|--x-axis <field>` (`line`, `area`, and `bar` charts only)
 
 Set the field used for the X-axis. Defaults to the first field in the schema.
 
-### `-y|--y-axis <field>` (`line` and `bar` charts only)
+### `-y|--y-axis <field>` (`line`, `area`, and `bar` charts only)
 
 Set the field used for the Y-axis. Defaults to the second field in the schema.
 


### PR DESCRIPTION
The frontend already has the capability to handle `area` charts. This PR simply adds the type to the operator.