### PR TITLE
Simplify CMake of proprietary plugins

### DIFF
--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "45fb19770ceda4ebfc981b551296604be90f187d",
+  "rev": "e09b0acd2aae07fb27e48cdd72a35e597fc2dfd5",
   "submodules": true,
   "shallow": true
 }


### PR DESCRIPTION
This makes use of the new simplified globbing and FlatBuffers setup in all of our proprietary plugins. There are no functional changes in this.