### PR TITLE
Test debian package install in the build job

### DIFF
--- a/.github/workflows/nix.nu
+++ b/.github/workflows/nix.nu
@@ -48,18 +48,18 @@ def upload_packages [
       do $run "tarball" $tgzs
     }
   }
+  print $"::notice copying artifacts to /packages/{debian,tarball}"
+  mkdir ./packages/debian ./packages/tarball
+  for deb in $debs {
+    cp -v $deb ./packages/debian
+  }
+  for pkg in $pkgs {
+    cp -v $pkg ./packages/macOS
+  }
+  for tgz in $tgzs {
+    cp -v $tgz ./packages/tarball
+  }
   if $copy {
-    print $"::notice copying artifacts to /packages/{debian,tarball}"
-    mkdir ./packages/debian ./packages/tarball
-    for deb in $debs {
-      cp -v $deb ./packages/debian
-    }
-    for pkg in $pkgs {
-      cp -v $pkg ./packages/macOS
-    }
-    for tgz in $tgzs {
-      cp -v $tgz ./packages/tarball
-    }
     if $git_tag != null {
       let os = (uname -s)
       if $os == "Linux" {

--- a/.github/workflows/nix.nu
+++ b/.github/workflows/nix.nu
@@ -49,7 +49,7 @@ def upload_packages [
     }
   }
   print $"::notice copying artifacts to /packages/{debian,tarball}"
-  mkdir ./packages/debian ./packages/tarball
+  mkdir ./packages/debian ./packages/tarball ./packages/macOS
   for deb in $debs {
     cp -v $deb ./packages/debian
   }

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build:
-    name: Build
+    name: Build & Install
     runs-on: ${{ fromJSON(inputs.config).editions[0].gha-runner-labels }}
     steps:
       - name: Prevent pushing protected editions to public repos
@@ -118,49 +118,41 @@ jobs:
             nixpkgs#skopeo \
             -c .github/workflows/nix.nu '${{ inputs.config }}'
       - name: Upload Tarball to Github
-        if: steps.cfg.outputs.upload-to-github == 'true'
+        if: >-
+          runner.os == 'Linux' &&
+          steps.cfg.outputs.upload-to-github == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: tarball
           path: "./packages/tarball/*.tar.gz"
           if-no-files-found: ignore
       - name: Upload Debian Package to Github
-        if: steps.cfg.outputs.upload-to-github == 'true'
+        if: >-
+          runner.os == 'Linux' &&
+          steps.cfg.outputs.upload-to-github == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: debian
           path: "./packages/debian/*.deb"
           if-no-files-found: ignore
       - name: Upload macOS Package to Github
-        if: steps.cfg.outputs.upload-to-github == 'true'
+        if: >-
+          runner.os == 'macOS' &&
+          steps.cfg.outputs.upload-to-github == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: macOS
           path: "./packages/macOS/*.pkg"
           if-no-files-found: ignore
-
-  install:
-    needs:
-      - build
-    if: ${{ contains(fromJSON(inputs.config).editions[0].gha-runner-labels, 'ubuntu-latest') }}
-    name: Install
-    runs-on: "ubuntu-latest"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Download Tenzir artifact
-        id: download
-        uses: actions/download-artifact@v4
-        with:
-          name: "debian"
-      - name: Install
+      - name: Test Installation
+        if: runner.os == 'Linux'
         run: |
-          deb_file="$(basename ${{steps.download.outputs.download-path}}/tenzir*.deb)"
+          deb_file="$(basename ./packages/debian/tenzir*.deb)"
           docker build docker/systemd-test -t installer-test
           docker run -d --name installer-test \
                  --privileged \
                  --volume=.:/src/tenzir:ro \
-                 --volume="${{steps.download.outputs.download-path}}":/tmp/packages:ro \
+                 --volume="./packages/debian":/tmp/packages:ro \
                  --volume=/sys/fs/cgroup:/sys/fs/cgroup:rw \
                  --cgroupns=host \
                  installer-test

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -125,7 +125,7 @@ jobs:
         with:
           name: tarball
           path: "./packages/tarball/*.tar.gz"
-          if-no-files-found: ignore
+          if-no-files-found: error
       - name: Upload Debian Package to Github
         if: >-
           runner.os == 'Linux' &&
@@ -134,7 +134,7 @@ jobs:
         with:
           name: debian
           path: "./packages/debian/*.deb"
-          if-no-files-found: ignore
+          if-no-files-found: error
       - name: Upload macOS Package to Github
         if: >-
           runner.os == 'macOS' &&
@@ -143,7 +143,7 @@ jobs:
         with:
           name: macOS
           path: "./packages/macOS/*.pkg"
-          if-no-files-found: ignore
+          if-no-files-found: error
       - name: Test Installation
         if: runner.os == 'Linux'
         run: |


### PR DESCRIPTION
Before this change the enterprise edition install job actually used the community edition build. This sometimes led to a failure in case the latter was not uploaded yet.

We fix both problems by merging both into a joint "Build & Install" job.