### PR TITLE
fix: change the primary color in docs for better contrast

### DIFF
--- a/web/src/css/custom.scss
+++ b/web/src/css/custom.scss
@@ -9,7 +9,7 @@
 
 /* You can override the default Infima variables here. */
 :root {
-  --ifm-color-primary: #0377ad;
+  --ifm-color-primary: #005E8A;
   --ifm-color-primary-dark: #0094d9;
   --ifm-color-primary-darker: #008bcd;
   --ifm-color-primary-darkest: #0073a9;
@@ -37,7 +37,7 @@
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
 [data-theme='dark'] {
-  --ifm-color-primary: #00a4f1;
+  --ifm-color-primary: #0EB0FB;
   --ifm-color-primary-dark: #0094d9;
   --ifm-color-primary-darker: #008bcd;
   --ifm-color-primary-darkest: #0073a9;

--- a/web/src/css/custom.scss
+++ b/web/src/css/custom.scss
@@ -9,7 +9,7 @@
 
 /* You can override the default Infima variables here. */
 :root {
-  --ifm-color-primary: #00a4f1;
+  --ifm-color-primary: #0377ad;
   --ifm-color-primary-dark: #0094d9;
   --ifm-color-primary-darker: #008bcd;
   --ifm-color-primary-darkest: #0073a9;


### PR DESCRIPTION
As I was exploring [Tenzir docs](https://docs.tenzir.com/get-started) from a design point of view,  It appears that the links in light mode are not very accessible [contrast](https://webaim.org/resources/contrastchecker/) wise. The minimum contrast ratio for large text is 4.5:1 and for normal text, it is 7:1.

## Tests

### Light Mode

![Screenshot 2024-02-15 133205](https://github.com/tenzir/tenzir/assets/81866614/c43cf784-eff1-4988-ba7e-223c4211d1e0)

### Dark Mode

![Screenshot 2024-02-15 133554](https://github.com/tenzir/tenzir/assets/81866614/69444650-84b5-45c2-b128-2482a5366b7b)

## Fix

For light mode and dark mode, I changed the primary color and improved the color contrast ratio. Now it passes AA and AAA color contrast checks

### Light Mode

![Screenshot 2024-02-15 144236](https://github.com/tenzir/tenzir/assets/81866614/ba7e9af0-79e2-469e-9a1b-e1e9e19d63d8)

### Dark Mode

![Screenshot 2024-02-15 144316](https://github.com/tenzir/tenzir/assets/81866614/f5c8a54a-4325-4a43-920a-f790d0508037)

## How will this change affect the docs?

In both the modes, the primary color will be replaced in areas where it is used, such as links or the side navigation bar.

This adjustment is only temporary and is crucial for those currently reading the documentation. Following a discussion with Dominik, I discovered that there isn't a consistent design system in place yet.