### PR TITLE
Improve submodule bump workflow

### DIFF
--- a/.github/workflows/bump-plugins-submodule.yaml
+++ b/.github/workflows/bump-plugins-submodule.yaml
@@ -46,7 +46,7 @@ jobs:
           git config --global user.name 'CI Bot'
           git config --global user.email 'tenzir-ci-app@users.noreply.github.com'
           git remote set-url origin https://x-access-token:$GITHUB_APP_TOKEN@github.com/tenzir/tenzir.git
-          git -C contrib/tenzir-plugins fetch origin main
+          git -C contrib/tenzir-plugins fetch -q origin main
 
           plugins_sha=$(git -C contrib/tenzir-plugins rev-parse HEAD)
           plugins_sha_short=$(git -C contrib/tenzir-plugins rev-parse --short HEAD)

--- a/.github/workflows/bump-plugins-submodule.yaml
+++ b/.github/workflows/bump-plugins-submodule.yaml
@@ -31,8 +31,8 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ vars.TENZIR_TESTAPP_APP_ID }}
-          private-key: ${{ secrets.TENZIR_TESTAPP_PRIVATE_KEY }}
+          app-id: ${{ vars.TENZIR_AUTOBUMPER_APP_ID }}
+          private-key: ${{ secrets.TENZIR_AUTOBUMPER_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Bump plugins submodule
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -57,12 +57,10 @@ jobs:
             # Auto-merge the plugins PR and update 'tenzir-plugins/main'.
             # gh pr --repo tenzir/tenzir-plugins list
             pr_number=$(gh pr --repo tenzir/tenzir-plugins list --search $plugins_sha --json number -q .[0].number)
-            echo $pr_number
             [ $pr_number ] # Assert the pr number was non-empty
             gh pr --repo tenzir/tenzir-plugins merge $pr_number --merge --match-head-commit ${plugins_sha}
 
             # Create a new commit for the updated submodule.
-            git checkout main # TODO: Is this necessary or are we already on main?
             git -C contrib/tenzir-plugins checkout main
             new_plugins_main_sha=$(git -C contrib/tenzir-plugins rev-parse --short origin/main)
             nix/update-plugins.sh

--- a/.github/workflows/bump-plugins-submodule.yaml
+++ b/.github/workflows/bump-plugins-submodule.yaml
@@ -60,8 +60,10 @@ jobs:
             [ $pr_number ] # Assert the pr number was non-empty
             gh pr --repo tenzir/tenzir-plugins merge $pr_number --merge --match-head-commit ${plugins_sha}
 
+            # Fetch and checkout the newly created merge commit
+            git -C contrib/tenzir-plugins pull -q origin main
+
             # Create a new commit for the updated submodule.
-            git -C contrib/tenzir-plugins checkout main
             new_plugins_main_sha=$(git -C contrib/tenzir-plugins rev-parse --short origin/main)
             nix/update-plugins.sh
             git add contrib/tenzir-plugins

--- a/.github/workflows/tenzir.yaml
+++ b/.github/workflows/tenzir.yaml
@@ -349,8 +349,24 @@ jobs:
           git submodule update --init contrib/tenzir-plugins
           git -C contrib/tenzir-plugins fetch origin main
           git -C contrib/tenzir-plugins merge-base --is-ancestor \
-            $(git -C contrib/tenzir-plugins rev-parse origin/main) \
-            $(git -C contrib/tenzir-plugins rev-parse HEAD)
+            $(git -C contrib/tenzir-plugins rev-parse HEAD) \
+            $(git -C contrib/tenzir-plugins rev-parse origin/main)
+      - name: Generate a token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.TENZIR_AUTOBUMPER_APP_ID }}
+          private-key: ${{ secrets.TENZIR_AUTOBUMPER_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - name: Require an open PR for the submodule bump
+        run: |
+          plugins_sha=$(git -C contrib/tenzir-plugins rev-parse HEAD)
+          plugins_main_sha=$(git -C contrib/tenzir-plugins rev-parse origin/main)
+
+          if [ "$plugins_sha" != "$plugins_main_sha" ]; then
+            pr_number=$(gh pr --repo tenzir/tenzir-plugins list --search $plugins_sha --json number -q .[0].number)
+            [ $pr_number ] # Assert the pr number was non-empty
+          fi
       - name: Install Nix
         uses: cachix/install-nix-action@v25
         with:

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "517fb8e82e7dd717f88dd9dbd33c3fcd20513832",
+  "rev": "7b7884a686f652a415cfebb5dc95745612b5dfee",
   "submodules": true,
   "shallow": true
 }


### PR DESCRIPTION
* Require an open PR for any changes to the plugins submodule
* Remove some leftover debug code
* Rename the used secrets away from `TESTAPP`
* Fix a bug where the submodule would be bumped to an incorrect state.