### PR TITLE
Make `getenv` and `environment()` thread-safe

### DIFF
--- a/libtenzir/include/tenzir/detail/env.hpp
+++ b/libtenzir/include/tenzir/detail/env.hpp
@@ -20,7 +20,7 @@ namespace tenzir::detail {
 /// A thread-safe wrapper around `::getenv`.
 /// @param var The environment variable.
 /// @returns The copied environment variables contents, or `std::nullopt`.
-[[nodiscard]] std::optional<std::string_view> getenv(std::string_view var);
+[[nodiscard]] std::optional<std::string> getenv(std::string_view var);
 
 /// A thread-safe wrapper around `::setenv`.
 /// @param key The environment variable key.
@@ -40,6 +40,9 @@ setenv(std::string_view key, std::string_view value, int overwrite = 1);
 /// strings, each of which has the form `key=value` by convention (per `man
 /// environ`). The results does not include variables that violate this
 /// convention.
+///
+/// The returned `string_view`s must are only valid until the returned generator
+/// is destroyed.
 generator<std::pair<std::string_view, std::string_view>> environment();
 
 } // namespace tenzir::detail

--- a/libtenzir/src/concept/printable/tenzir/json_printer_options.cpp
+++ b/libtenzir/src/concept/printable/tenzir/json_printer_options.cpp
@@ -32,7 +32,7 @@ auto no_style() -> json_style {
 
 auto default_style() -> json_style {
   // See https://no-color.org.
-  if (detail::getenv("NO_COLOR").value_or(std::string_view{}).empty()) {
+  if (detail::getenv("NO_COLOR").value_or("").empty()) {
     return no_style();
   }
   // TODO: Let the saver detect a default style, depending on

--- a/libtenzir/src/detail/env.cpp
+++ b/libtenzir/src/detail/env.cpp
@@ -28,11 +28,11 @@ auto env_mutex = std::mutex{};
 
 } // namespace
 
-std::optional<std::string_view> getenv(std::string_view var) {
+std::optional<std::string> getenv(std::string_view var) {
   auto lock = std::scoped_lock{env_mutex};
   // NOLINTNEXTLINE(concurrency-mt-unsafe)
   if (const char* result = ::getenv(var.data()))
-    return std::string_view{result};
+    return std::string{result};
   return {};
 }
 
@@ -58,6 +58,7 @@ caf::error unsetenv(std::string_view var) {
 
 generator<std::pair<std::string_view, std::string_view>> environment() {
   // Envrionment variables come as "key=value" pair strings.
+  auto lock = std::scoped_lock{env_mutex};
   for (auto env = environ; *env != nullptr; ++env) {
     auto str = std::string_view{*env};
     auto i = str.find('=');


### PR DESCRIPTION
This reverts a `std::string -> std::string_view` change of 51ce33c950f9bf769c37f3f29a168a8c383a8be8 and additionally makes the `environment()` generator thread-safe (with the requirement that the returned values must not be accessed after the generator is destroyed). This makes all functions in the `env.hpp` thread-safe, assuming that all environment modification goes through them.