### PR TITLE
Build Fluent Bit as part of the Docker image

### DIFF
--- a/.github/workflows/tenzir.yaml
+++ b/.github/workflows/tenzir.yaml
@@ -659,8 +659,14 @@ jobs:
           git submodule update --init --recursive libtenzir
           git submodule update --init --recursive plugins
           git submodule update --init --recursive tenzir
-      - name: Install Dependencies
-        run: ./${{ matrix.tenzir.dependencies-script-path }}
+      - name: Install Dependencies (Debian)
+        if: ${{ matrix.tenzir.name == 'Debian' }}
+        run: |
+          ./scripts/debian/install-dev-dependencies.sh
+          ./scripts/debian/install-fluent-bit.sh
+      - name: Install Dependencies (macOS)
+        if: ${{ matrix.tenzir.name == 'macOS' }}
+        run: ./scripts/macOS/install-dev-dependencies.sh
       - name: Setup Python
         if: ${{ matrix.tenzir.name == 'macOS' }}
         uses: actions/setup-python@v5
@@ -897,6 +903,7 @@ jobs:
             apt-transport-https \
             curl
           ./scripts/debian/install-dev-dependencies.sh
+          ./scripts/debian/install-fluent-bit.sh
       - name: Determine Tenzir Package Name
         id: configure
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -127,7 +127,7 @@ RUN apt-get update && \
     apt-get -y --no-install-recommends install \
       ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
     apt-get update && \
-    apt-get -y --no-install-recommends install libarrow1300 libparquet1300 && \
+    apt-get -y --no-install-recommends install libarrow1500 libparquet1500 && \
     wget "https://storage.googleapis.com/tenzir-public-data/fluent-bit-packages/debian/bookworm/fluent-bit_2.1.10_amd64.deb" && \
     apt-get -y --no-install-recommends install ./fluent-bit_2.1.10_amd64.deb && \
     rm ./fluent-bit_2.1.10_amd64.deb && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ WORKDIR /tmp/tenzir
 
 COPY scripts ./scripts
 
-RUN ./scripts/debian/install-dev-dependencies.sh && rm -rf /var/lib/apt/lists/*
+RUN ./scripts/debian/install-dev-dependencies.sh && \
+    ./scripts/debian/build-fluent-bit.sh && \
+    rm -rf /var/lib/apt/lists/*
 
 # Tenzir
 COPY changelog ./changelog
@@ -91,6 +93,7 @@ COPY --from=development --chown=tenzir:tenzir $PREFIX/ $PREFIX/
 COPY --from=development --chown=tenzir:tenzir /var/cache/tenzir/ /var/cache/tenzir
 COPY --from=development --chown=tenzir:tenzir /var/lib/tenzir/ /var/lib/tenzir
 COPY --from=development --chown=tenzir:tenzir /var/log/tenzir/ /var/log/tenzir
+COPY --from=development /tmp/fluent-bit/build/*.deb /root
 
 RUN apt-get update && \
     apt-get -y --no-install-recommends install \
@@ -128,9 +131,8 @@ RUN apt-get update && \
       ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
     apt-get update && \
     apt-get -y --no-install-recommends install libarrow1500 libparquet1500 && \
-    wget "https://storage.googleapis.com/tenzir-public-data/fluent-bit-packages/debian/bookworm/fluent-bit_2.1.10_amd64.deb" && \
-    apt-get -y --no-install-recommends install ./fluent-bit_2.1.10_amd64.deb && \
-    rm ./fluent-bit_2.1.10_amd64.deb && \
+    apt-get -y --no-install-recommends install /root/fluent-bit_*.deb && \
+    rm /root/fluent-bit_*.deb && \
     rm -rf /var/lib/apt/lists/*
 
 USER tenzir:tenzir

--- a/scripts/debian/build-fluent-bit.sh
+++ b/scripts/debian/build-fluent-bit.sh
@@ -4,17 +4,34 @@ set -euo pipefail
 
 apt-get -qq update
 apt-get install --no-install-recommends -y \
-  curl ca-certificates build-essential \
-  cmake make wget unzip dh-make libminizip-dev \
-  libsystemd-dev zlib1g-dev flex bison \
-  libssl-dev libsasl2-dev libyaml-dev pkg-config && \
-  apt-get install -y --reinstall lsb-base lsb-release
+  bison \
+  build-essential \
+  ca-certificates \
+  cmake \
+  curl \
+  dh-make \
+  flex \
+  libminizip-dev \
+  libsasl2-dev \
+  libssl-dev \
+  libsystemd-dev \
+  libyaml-dev \
+  make \
+  pkg-config \
+  unzip \
+  wget \
+  zlib1g-dev
+apt-get install -y --reinstall \
+  lsb-base \
+  lsb-release
 
-mkdir -p /tmp/fluent-bit
-cd /tmp/fluent-bit
+mkdir -p source
+pushd source
 curl -L 'https://github.com/fluent/fluent-bit/archive/refs/tags/v2.2.2.tar.gz' | tar -xz --strip-components=1
 cmake -B build -S . -DFLB_RELEASE=ON -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_SYSCONFDIR=/etc
-cmake --build build
-cmake --install build
+cmake --build build --parallel "$(nproc --all)"
 cd build
-cpack -G DEB
+cpack -G DEB -D CPACK_STRIP_FILES=ON
+mv fluent-bit_*.deb /root
+popd
+rm -rf source

--- a/scripts/debian/build-fluent-bit.sh
+++ b/scripts/debian/build-fluent-bit.sh
@@ -1,0 +1,20 @@
+#! /usr/bin/env bash
+
+set -euo pipefail
+
+apt-get -qq update
+apt-get install --no-install-recommends -y \
+  curl ca-certificates build-essential \
+  cmake make wget unzip dh-make libminizip-dev \
+  libsystemd-dev zlib1g-dev flex bison \
+  libssl-dev libsasl2-dev libyaml-dev pkg-config && \
+  apt-get install -y --reinstall lsb-base lsb-release
+
+mkdir -p /tmp/fluent-bit
+cd /tmp/fluent-bit
+curl -L 'https://github.com/fluent/fluent-bit/archive/refs/tags/v2.2.2.tar.gz' | tar -xz --strip-components=1
+cmake -B build -S . -DFLB_RELEASE=ON -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_SYSCONFDIR=/etc
+cmake --build build
+cmake --install build
+cd build
+cpack -G DEB

--- a/scripts/debian/install-dev-dependencies.sh
+++ b/scripts/debian/install-dev-dependencies.sh
@@ -63,7 +63,7 @@ codename="$(lsb_release --codename --short)"
 wget "https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-${codename}.deb"
 apt-get -y --no-install-recommends install ./"apache-arrow-apt-source-latest-${codename}.deb"
 apt-get update
-apt-get -y --no-install-recommends install libarrow-dev=13.0.0-1 libprotobuf-dev libparquet-dev=13.0.0-1
+apt-get -y --no-install-recommends install libarrow-dev libprotobuf-dev libparquet-dev
 rm ./"apache-arrow-apt-source-latest-${codename}.deb"
 
 # Fluent-bit

--- a/scripts/debian/install-dev-dependencies.sh
+++ b/scripts/debian/install-dev-dependencies.sh
@@ -64,7 +64,12 @@ codename="$(lsb_release --codename --short)"
 wget "https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-${codename}.deb"
 apt-get -y --no-install-recommends install ./"apache-arrow-apt-source-latest-${codename}.deb"
 apt-get update
-apt-get -y --no-install-recommends install libarrow-dev libprotobuf-dev libparquet-dev
+# The apt download sometimes fails with a 403. We employ a similar workaround as
+# arrow itself: https://github.com/apache/arrow/pull/36836.
+# See also: https://github.com/apache/arrow/issues/35292.
+apt-get -y --no-install-recommends install libarrow-dev libprotobuf-dev libparquet-dev || \
+  apt-get -y --no-install-recommends install libarrow-dev libprotobuf-dev libparquet-dev || \
+  apt-get -y --no-install-recommends install libarrow-dev libprotobuf-dev libparquet-dev
 rm ./"apache-arrow-apt-source-latest-${codename}.deb"
 
 # Node 18.x and Yarn

--- a/scripts/debian/install-dev-dependencies.sh
+++ b/scripts/debian/install-dev-dependencies.sh
@@ -23,6 +23,7 @@ apt-get -y --no-install-recommends install \
     libflatbuffers-dev \
     libfmt-dev \
     libgrpc-dev \
+    libgrpc++-dev \
     libhttp-parser-dev \
     libmaxminddb-dev \
     libpcap-dev tcpdump \
@@ -65,22 +66,6 @@ apt-get -y --no-install-recommends install ./"apache-arrow-apt-source-latest-${c
 apt-get update
 apt-get -y --no-install-recommends install libarrow-dev libprotobuf-dev libparquet-dev
 rm ./"apache-arrow-apt-source-latest-${codename}.deb"
-
-# Fluent-bit
-# TODO: The official package contains a conflicting static build of jemalloc.
-# https://github.com/fluent/fluent-bit/pull/8005 attempts to clean that up.
-#wget -O - 'https://packages.fluentbit.io/fluentbit.key' | tee /usr/share/keyrings/fluentbit.asc >/dev/null
-#echo "deb [signed-by=/usr/share/keyrings/fluentbit.asc] https://packages.fluentbit.io/debian/${codename} ${codename} main" | tee /etc/apt/sources.list.d/fluentbit.list
-#apt-get update
-#apt-get -y install fluent-bit
-# A custom package generated from git tag with
-# ```
-# cd packaging
-# FLB_JEMALLOC=OFF ./build.sh -d debian/bookworm
-# ```
-wget https://storage.googleapis.com/tenzir-public-data/fluent-bit-packages/debian/bookworm/fluent-bit_2.1.10_amd64.deb
-apt-get -y --no-install-recommends install ./fluent-bit_2.1.10_amd64.deb
-rm ./fluent-bit_2.1.10_amd64.deb
 
 # Node 18.x and Yarn
 NODE_MAJOR=18

--- a/scripts/debian/install-fluent-bit.sh
+++ b/scripts/debian/install-fluent-bit.sh
@@ -1,0 +1,21 @@
+#! /usr/bin/env bash
+
+set -euo pipefail
+
+codename="$(lsb_release --codename --short)"
+
+# Fluent-bit
+# TODO: The official package contains a conflicting static build of jemalloc.
+# https://github.com/fluent/fluent-bit/pull/8005 attempts to clean that up.
+#wget -O - 'https://packages.fluentbit.io/fluentbit.key' | tee /usr/share/keyrings/fluentbit.asc >/dev/null
+#echo "deb [signed-by=/usr/share/keyrings/fluentbit.asc] https://packages.fluentbit.io/debian/${codename} ${codename} main" | tee /etc/apt/sources.list.d/fluentbit.list
+#apt-get update
+#apt-get -y install fluent-bit
+# A custom package generated from git tag with
+# ```
+# cd packaging
+# FLB_JEMALLOC=OFF ./build.sh -d debian/bookworm
+# ```
+wget https://storage.googleapis.com/tenzir-public-data/fluent-bit-packages/debian/${codename}/fluent-bit_2.2.2_amd64.deb
+apt-get -y --no-install-recommends install ./fluent-bit_2.2.2_amd64.deb
+rm ./fluent-bit_2.2.2_amd64.deb


### PR DESCRIPTION
The docker image is currently broken on `arm64`, because we install a custom `amd64` fluent-bit package without checking for the platform. This PR changes the docker setup to build fluent-bit as part of the `dependencies` target.
The regular Debian CI build is still using the prebuilt fluent-bit package to avoid increasing the runtime of the slowest job.
