### PR TITLE
Slightly relax rules for policy enforcement

### DIFF
--- a/.github/workflows/bump-plugins-submodule.yaml
+++ b/.github/workflows/bump-plugins-submodule.yaml
@@ -48,8 +48,8 @@ jobs:
           set -x
 
           # Setup git
-          git config --global user.name 'CI Bot'
-          git config --global user.email 'tenzir-ci-app@users.noreply.github.com'
+          git config --global user.name 'tenzir-bot'
+          git config --global user.email 'engineering@tenzir.com'
           git remote set-url origin https://x-access-token:$GITHUB_APP_TOKEN@github.com/tenzir/tenzir.git
           git -C contrib/tenzir-plugins fetch -q origin main
 

--- a/.github/workflows/bump-plugins-submodule.yaml
+++ b/.github/workflows/bump-plugins-submodule.yaml
@@ -34,6 +34,11 @@ jobs:
           app-id: ${{ vars.TENZIR_AUTOBUMPER_APP_ID }}
           private-key: ${{ secrets.TENZIR_AUTOBUMPER_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+      - uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.TENZIR_BOT_GPG_SIGNING_KEY }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
       - name: Bump plugins submodule
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:

--- a/.github/workflows/tenzir.yaml
+++ b/.github/workflows/tenzir.yaml
@@ -355,7 +355,7 @@ jobs:
             $(git -C contrib/tenzir-plugins rev-parse HEAD) || \
           git -C contrib/tenzir-plugins merge-base --is-ancestor \
             $(git -C contrib/tenzir-plugins rev-parse HEAD) \
-            $(git -C contrib/tenzir-plugins rev-parse origin/main) \
+            $(git -C contrib/tenzir-plugins rev-parse origin/main)
       - name: Generate a token
         id: generate_token
         uses: actions/create-github-app-token@v1

--- a/.github/workflows/tenzir.yaml
+++ b/.github/workflows/tenzir.yaml
@@ -348,9 +348,14 @@ jobs:
         run: |
           git submodule update --init contrib/tenzir-plugins
           git -C contrib/tenzir-plugins fetch origin main
+          # Check that the plugins submodule commit is either already merged
+          # into `main` or branches off directly from current `main`.
           git -C contrib/tenzir-plugins merge-base --is-ancestor \
             $(git -C contrib/tenzir-plugins rev-parse origin/main) \
-            $(git -C contrib/tenzir-plugins rev-parse HEAD)
+            $(git -C contrib/tenzir-plugins rev-parse HEAD) || \
+          git -C contrib/tenzir-plugins merge-base --is-ancestor \
+            $(git -C contrib/tenzir-plugins rev-parse HEAD) \
+            $(git -C contrib/tenzir-plugins rev-parse origin/main) \
       - name: Generate a token
         id: generate_token
         uses: actions/create-github-app-token@v1

--- a/.github/workflows/tenzir.yaml
+++ b/.github/workflows/tenzir.yaml
@@ -349,7 +349,7 @@ jobs:
           git submodule update --init contrib/tenzir-plugins
           git -C contrib/tenzir-plugins fetch origin main
           # Check that the plugins submodule commit is either already merged
-          # into `main` or branches off directly from current `main`.
+          # into `main` or descends from current `main`.
           git -C contrib/tenzir-plugins merge-base --is-ancestor \
             $(git -C contrib/tenzir-plugins rev-parse origin/main) \
             $(git -C contrib/tenzir-plugins rev-parse HEAD) || \


### PR DESCRIPTION
As observed by @jachris , if a PR does not change the plugins, but some other PR does in the meantime, that the branch protections (of the PR that does not change plugins) do not pass. This means that all PRs have to be updated, even though they don't necessarily conflict.

This PR aims to solve this by allowing submodule commits that are either direct ancestors or direct descendants of `origin/main`.