### PR TITLE
Enable redundant move warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,7 +322,6 @@ target_compile_options(
             # Never treat deprecation warnings as errors.
             -Wno-error=deprecated
             -Wno-error=deprecated-declarations>
-            $<$<CXX_COMPILER_ID:GNU>:-Wno-redundant-move>
             $<$<CXX_COMPILER_ID:GNU>:-Wno-error=bool-compare>)
 
 # -- build id ------------------------------------------------------------------

--- a/libtenzir/include/tenzir/cast.hpp
+++ b/libtenzir/include/tenzir/cast.hpp
@@ -889,7 +889,7 @@ struct cast_helper<enumeration_type, enumeration_type> {
     if (can) {
       return value;
     }
-    return std::move(can.error());
+    return can.error();
   }
 
   static auto

--- a/libtenzir/include/tenzir/concept/parseable/tenzir/schema.hpp
+++ b/libtenzir/include/tenzir/concept/parseable/tenzir/schema.hpp
@@ -47,7 +47,7 @@ struct symbol_resolver {
 
   template <class Type>
   caf::expected<legacy_type> operator()(Type x) {
-    return std::move(x);
+    return x;
   }
 
   caf::expected<legacy_type> operator()(const legacy_none_type& x) {
@@ -63,7 +63,7 @@ struct symbol_resolver {
     if (!y)
       return y.error();
     x.value_type = *y;
-    return std::move(x);
+    return x;
   }
 
   caf::expected<legacy_type> operator()(legacy_list_type x) {
@@ -81,7 +81,7 @@ struct symbol_resolver {
     if (caf::holds_alternative<legacy_record_type>(x.value_type)
         && !has_skip_attribute(x))
       x.update_attributes({{"skip", caf::none}});
-    return std::move(x);
+    return x;
   }
 
   caf::expected<legacy_type> operator()(legacy_map_type x) {
@@ -93,7 +93,7 @@ struct symbol_resolver {
     if (!z)
       return z.error();
     x.key_type = *z;
-    return std::move(x);
+    return x;
   }
 
   caf::expected<legacy_type> operator()(legacy_record_type x) {
@@ -154,7 +154,7 @@ struct symbol_resolver {
         TENZIR_ASSERT(!field.name.empty());
       return acc.name(x.name());
     }
-    return std::move(x);
+    return x;
   }
 
   caf::expected<legacy_type> resolve(symbol_map::iterator next) {

--- a/libtenzir/src/detail/posix.cpp
+++ b/libtenzir/src/detail/posix.cpp
@@ -146,7 +146,7 @@ uds_datagram_sender::make(const std::string& path) {
   result.dst.sun_family = AF_UNIX;
   std::strncpy(result.dst.sun_path, path.data(),
                sizeof(result.dst.sun_path) - 1);
-  return std::move(result);
+  return result;
 }
 
 caf::error uds_datagram_sender::send(std::span<char> data, int timeout_usec) {

--- a/libtenzir/src/format/arrow.cpp
+++ b/libtenzir/src/format/arrow.cpp
@@ -106,7 +106,7 @@ arrow_istream_wrapper::Read(int64_t nbytes) {
                         Read(nbytes, buffer->mutable_data()));
   ARROW_RETURN_NOT_OK(buffer->Resize(bytes_read, false));
   buffer->ZeroPadding();
-  return std::move(buffer);
+  return buffer;
 }
 
 arrow_fd_wrapper::arrow_fd_wrapper(int fd) : fd_{fd} {
@@ -145,7 +145,7 @@ auto arrow_fd_wrapper::Read(int64_t nbytes)
                         Read(nbytes, buffer->mutable_data()));
   ARROW_RETURN_NOT_OK(buffer->Resize(bytes_read, false));
   buffer->ZeroPadding();
-  return std::move(buffer);
+  return buffer;
 }
 
 reader::reader(const caf::settings& options, std::unique_ptr<std::istream> in)

--- a/libtenzir/src/format/csv.cpp
+++ b/libtenzir/src/format/csv.cpp
@@ -382,11 +382,11 @@ struct csv_parser_factory {
       if constexpr (std::is_same_v<U, duration_type>) {
         auto make_duration_parser = [&](auto period) {
           // clang-format off
-        return (-parsers::real ->* [](double x) {
+        return (-(parsers::real ->* [](double x) {
           using period_type = decltype(period);
           using double_duration = std::chrono::duration<double, period_type>;
           return std::chrono::duration_cast<duration>(double_duration{x});
-        }).with(add_t<duration>{bptr_});
+        })).with(add_t<duration>{bptr_});
           // clang-format on
         };
         if (auto unit = t.attribute("unit")) {


### PR DESCRIPTION
All supported compilers implement NRVO, so we don't need to disable this warning any more.

This also fixes an operator precedence bug in the old CSV parser that was found with the help of `-Wmaybe-uninitialized`.