### PR TITLE
Remove the macOS package upload

### DIFF
--- a/.github/workflows/nix.nu
+++ b/.github/workflows/nix.nu
@@ -70,11 +70,11 @@ def upload_packages [
         print $"::attaching ($name)-x86_64-linux.tar.gz to ($git_tag)"
         gh release upload $git_tag $"($name)-x86_64-linux.tar.gz" --clobber
       }
-      if $os == "Darwin" {
-        cp ($pkgs | get 0) $"($name)-arm64-darwin.pkg"
-        print $"::attaching ($name)-arm64-darwin.pkg to ($git_tag)"
-        gh release upload $git_tag $"($name)-arm64-darwin.pkg" --clobber
-      }
+      # if $os == "Darwin" {
+      #   cp ($pkgs | get 0) $"($name)-arm64-darwin.pkg"
+      #   print $"::attaching ($name)-arm64-darwin.pkg to ($git_tag)"
+      #   gh release upload $git_tag $"($name)-arm64-darwin.pkg" --clobber
+      # }
     }
   }
 }


### PR DESCRIPTION
The package is broken, so for now it's better not to upload it at all. No changelog entry necessary as we never announced it in the first place.