### PR TITLE
Remove a duplicated version check

### DIFF
--- a/libtenzir/src/connect_to_node.cpp
+++ b/libtenzir/src/connect_to_node.cpp
@@ -174,19 +174,6 @@ connect_to_node(caf::scoped_actor& self, const caf::settings& opts) {
     return caf::make_error(ec::system_error,
                            "failed to connect to node: handle is invalid");
   }
-  self->request(*result, timeout, atom::get_v, atom::version_v)
-    .receive(
-      [&](record& remote_version) {
-        // TODO
-        (void)details::check_version(remote_version);
-      },
-      [&](caf::error& error) {
-        result = caf::make_error(ec::version_error,
-                                 fmt::format("failed to receive remote version "
-                                             "within specified "
-                                             "connection-timeout of {}: {}",
-                                             timeout, std::move(error)));
-      });
   return result;
 }
 


### PR DESCRIPTION
While investigating the spurious connection failure from tenzir/issues#1529 I noticed that we do the version check twice: once in the `connector` actor with the proper configured timeout, and then once again in the `connect_to_node` function afterwards, which under the hood already uses the `connector` actor and thus did the check again for no reason, effectively dobuling the maximum possible connection timeout in case the first check succeeded late and the second check timed out.