### PR TITLE
Prevent tcp socket inheritance to child processes

### DIFF
--- a/changelog/next/bug-fixes/3998--tcp-connector-cloexec.md
+++ b/changelog/next/bug-fixes/3998--tcp-connector-cloexec.md
@@ -1,0 +1,2 @@
+We fixed a problem with the TCP connector that caused pipeline restarts on the
+same port to fail if running `shell` or `python` operators were present.


### PR DESCRIPTION
Child processes created via `shell` or `python` inherit all currently open file descriptors from the node, which prevent the TCP connector form getting the same port upon restart, because it was now blocked by the children, because of the inherited open file descriptors.

To prevent this, we now create our own socket with `FN_CLOEXEC` that we assign to the ASIO abstraction where possible, and use `fcntl` where not.
