### PR TITLE
Make `remote python` work

### DIFF
--- a/changelog/next/bug-fixes/3999-remote-python.md
+++ b/changelog/next/bug-fixes/3999-remote-python.md
@@ -1,0 +1,1 @@
+The `python` operator now works with when using the `remote` location override.

--- a/libtenzir/builtins/operators/python.cpp
+++ b/libtenzir/builtins/operators/python.cpp
@@ -149,8 +149,7 @@ public:
         // is smart enough to check if one is already present. We prevent this
         // hidden modification by starting the seamphore name with a slash.
         // This ensures that the truncation logic below is correct.
-        auto sem_name = fmt::format("/tnz-{}.{}.{}-{:x}", version::major,
-                                    version::minor, version::patch, venv_id);
+        auto sem_name = fmt::format("/tnz-python-{:x}", venv_id);
         // The semaphore name is restricted to a maximum length of 31 characters
         // (including the '\0') on macOS. This length has been experimentally
         // verified. We truncate it to this length unconditionally for
@@ -167,6 +166,7 @@ public:
             .note("could not acquire named semaphore '{}' within 60 seconds",
                   sem_name)
             .emit(ctrl.diagnostics());
+          boost::interprocess::named_semaphore::remove(sem_name.c_str());
           co_return;
         }
         auto sem_guard = caf::detail::scope_guard{[&] {


### PR DESCRIPTION
This fixes `remote python`, i.e., using explicit location overrides with the `python` operators to run a script at a node.

Additionally, this adds a 60 second timeout to waiting for the named semaphore guarding the virtualenv setup. During development of this branch, I managed to crash once while inside the critical section, and the operator was unusable afterwards as it locked up indefinitely. It's far from a perfect solution, but erroring after a minute is a lot better than being stuck with no way out.

Fixes tenzir/issues#1632