### PR TITLE
Disable the `parquet` store backend

### DIFF
--- a/libtenzir/src/application.cpp
+++ b/libtenzir/src/application.cpp
@@ -93,9 +93,6 @@ void add_root_opts(command& cmd) {
                                "cycles");
   cmd.options.add<std::string>("?tenzir", "aging-query",
                                "query for aging out obsolete data");
-  cmd.options.add<std::string>("?tenzir", "store-backend",
-                               "store plugin to use for imported "
-                               "data");
   cmd.options.add<std::string>("?tenzir", "connection-timeout",
                                "the timeout for connecting to "
                                "a Tenzir server (default: 5m)");

--- a/libtenzir/src/spawn_importer.cpp
+++ b/libtenzir/src/spawn_importer.cpp
@@ -30,8 +30,7 @@ spawn_importer(node_actor::stateful_pointer<node_state> self,
   // FIXME: Notify exporters with a continuous query.
   auto [index, accountant]
     = self->state.registry.find<index_actor, accountant_actor>();
-  auto store_backend = caf::get_or(args.inv.options, "tenzir.store-backend",
-                                   std::string{defaults::store_backend});
+  auto store_backend = std::string{defaults::store_backend};
   if (!index)
     return caf::make_error(ec::missing_component, "index");
   auto handle = self->spawn(importer, args.dir / args.label, index, accountant);

--- a/libtenzir/src/spawn_index.cpp
+++ b/libtenzir/src/spawn_index.cpp
@@ -56,7 +56,7 @@ spawn_index(node_actor::stateful_pointer<node_state> self,
   auto handle = self->spawn(
     index, accountant, filesystem, catalog, indexdir,
     // TODO: Pass these options as a tenzir::data object instead.
-    opt("tenzir.store-backend", std::string{sd::store_backend}),
+    std::string{sd::store_backend},
     opt("tenzir.max-partition-size", sd::max_partition_size),
     opt("tenzir.active-partition-timeout", sd::active_partition_timeout),
     opt("tenzir.max-resident-partitions", sd::max_in_mem_partitions),

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -156,11 +156,7 @@ tenzir:
   # The amount of queries that can be executed in parallel.
   max-queries: 10
 
-  # The store backend to use. Can be 'feather', or the name of a user-provided
-  # store plugin.
-  store-backend: feather
-
-  # Zstd compression level applied to both Feather and Parquet store backends.
+  # Zstd compression level applied to the Feather store backend.
   # zstd-compression-level: <default>
 
   # Interval between two aging cycles.

--- a/web/docs/setup-guides/tune-performance/README.md
+++ b/web/docs/setup-guides/tune-performance/README.md
@@ -152,58 +152,6 @@ applies to a single field, `suricata.http.http.url`, and has false-positive rate
 of 0.5%. The second rule creates one sketch for all fields of type `ip` that has
 a false-positive rate of 10%.
 
-### Select the store format
-
-Tenzir arranges data in horizontal partitions for sharding. Each partition has a
-unique schema and is effectively a concatenation of batches. The *store* inside
-a partition holds this data and can have multiple formats:
-
-1. **Feather**: writes Apache Feather V2 files
-2. **Parquet**: writes [Apache Parquet](https://parquet.apache.org/) files
-
-Tenzir defaults to the `feather` store. To use the Parquet store, adjust
-`tenzir.store-backend`:
-
-```yaml
-tenzir:
-  plugins:
-    - parquet
-  store-backend: parquet
-```
-
-There's an inherent space-time tradeoff between the stores that affects CPU,
-memory, and storage characteristics. Compared to the Feather store, Parquet
-differs as follows:
-
-1. Parquet files occupy ~40% less space, which also reduces I/O pressure during
-   querying.
-2. Parquet utilizes more CPU cycles during ingest (~10%) and querying.
-
-Parquet has the major advantage that it's the de-facto standard for encoding
-columnar data in modern data architectures. This allows other applications that
-support reading from Parquet *native* access to the data.
-
-:::tip Recommendation
-
-Use Parquet when:
-
-1. Storage is scarce, and you want to increase data retention
-2. Workloads are I/O-bound and you have available CPU
-3. Reading data with with off-the-shelf data science tools is a use case
-
-For an in-depth comparison, take a look at our [blog post on Feather and
-Parquet](/blog/parquet-and-feather-writing-security-telemetry).
-
-One final word of caution: a query over a Parquet store is currently not
-interruptible and executes over the entire store. This is a deficiency in our
-implementation that we aim to fix in the future. We recommend Feather when tail
-latencies are an issue.
-:::
-
-Tenzir supports [rebuilding the entire database](#rebuild-partitions) in case
-you want to switch to a different store format. However, Tenzir works perfectly
-fine with a mixed-storage configuration, so a full rebuild is not required.
-
 ### Adjust the store compression
 
 Tenzir compresses partitions using Zstd for partitions at rest. To fine-tune the


### PR DESCRIPTION
Parquet as a format is entirely fine, but the store backend has a bunch of issues. This removes the option and forces use of the `feather` store backend instead.

Parquet can still be used in combination with the `from`, `load`, `to`, and `save` operators.