### PR TITLE
Fix partial specialization of S3 configuration in URL

### DIFF
--- a/changelog/next/bug-fixes/4001--s3-overrides.md
+++ b/changelog/next/bug-fixes/4001--s3-overrides.md
@@ -1,0 +1,2 @@
+The S3 connector no longer ignores the default credentials provider for the
+current user when any arguments are specified in the URI explicitly.

--- a/changelog/next/features/4001--s3-config.md
+++ b/changelog/next/features/4001--s3-config.md
@@ -1,0 +1,2 @@
+S3 access and secret keys can now be specified in the S3 plugin's configuration
+file.

--- a/web/docs/connectors/s3.md
+++ b/web/docs/connectors/s3.md
@@ -47,8 +47,8 @@ If a config file `<prefix>/etc/tenzir/plugin/s3.yaml` or
 default AWS credentials. The configuration file must have the following format:
 
 ```yaml
-secret-key: your-secret-key
 access-key: your-access-key
+secret-key: your-secret-key
 session-token: your-session-token (optional)
 ```
 

--- a/web/docs/connectors/s3.md
+++ b/web/docs/connectors/s3.md
@@ -30,7 +30,7 @@ object. The `s3` saver writes bytes to an S3 object in an S3 bucket.
 
 The connector tries to retrieve the appropriate credentials using AWS's
 [default credentials provider
-chain](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html).
+chain](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html).
 
 :::info
 Make sure to configure AWS credentials for the same user account that runs
@@ -41,6 +41,16 @@ The `tenzir-node` systemd unit by default creates a `tenzir` user and runs as
 that user, meaning that the AWS credentials must also be configured for that
 user. The directory `~/.aws` must be readable for the `tenzir` user.
 :::
+
+If a config file `<prefix>/etc/tenzir/plugin/s3.yaml` or
+`~/.config/tenzir/plugin/s3.yaml` exists, it is always preferred over the
+default AWS credentials. The configuration file must have the following format:
+
+```yaml
+secret-key: your-secret-key
+access-key: your-access-key
+session-token: your-session-token (optional)
+```
 
 ### `<uri>` (Loader, Saver)
 
@@ -53,8 +63,8 @@ Options can be appended to the path as query parameters, as per
 [Arrow](https://arrow.apache.org/docs/r/articles/fs.html#connecting-directly-with-a-uri):
 
 > For S3, the options that can be included in the URI as query parameters are
-`region`, `scheme`, `endpoint_override`, `access_key`, `secret_key`,
-`allow_bucket_creation`, and `allow_bucket_deletion`.
+> `region`, `scheme`, `endpoint_override`, `access_key`, `secret_key`,
+> `allow_bucket_creation`, and `allow_bucket_deletion`.
 
 ### `--anonymous` (Loader, Saver)
 


### PR DESCRIPTION
This fixes partial overrides of the S3 configuration in the arguments to the URL. Previously, when providing any arguments to the S3 connector as part of the URL, it failed to respect the default credentials from the configuration file.

Additionally, this makes it possible to specify the S3 secrets in the S3 plugin's configuration file directly.