### PR TITLE
Add configurable pipelines

### DIFF
--- a/changelog/next/features/4006--configurable-pipelines.md
+++ b/changelog/next/features/4006--configurable-pipelines.md
@@ -1,0 +1,2 @@
+We made it possible to set pipelines declaratively in the `tenzir.yaml`
+configuration file.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "748d9c64f64fd6d002e964508822f2df6006a6bd",
+  "rev": "e34f69ff49ded8ef9681716d744646a179641df8",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/web/docs/user-guides/run-pipelines/README.md
+++ b/web/docs/user-guides/run-pipelines/README.md
@@ -89,9 +89,11 @@ pipelines:
       from tcp://0.0.0.0:34343 read suricata
       | import
     start:
+      created: false    # start automatically
       failed: true      # restart on failure
       completed: false  # restart on completion
 ```
 
-All boolean configuration flags default to `false`. In the above example, we
-assign `start.completed` only to showcase all available options.
+The boolean `start` configuration flags `completed` and `failed` default to
+`false`, `created` defaults to `true`.. In the above example, we assign
+`start.completed` only to showcase all available options.


### PR DESCRIPTION
This addition allows defining pipelines in `tenzir.yaml`. Configured pipelines will be started automatically with the node.

Here is an example for how to use this functionality from `tenzir.yaml`:

```
pipelines:
  my-fancy-pipeline:
    definition: show version | write json -c | save stdout
    autostart:
      failed: false
  json-import:
    name: JSON Import
    definition: from tcp://0.0.0.0:34343 read json | import
    autostart:
      failed: true
```