### PR TITLE
Fix crash in `sigma` operator for non-existent file

### DIFF
--- a/changelog/next/bug-fixes/4010--sigma-crash-missing-file.md
+++ b/changelog/next/bug-fixes/4010--sigma-crash-missing-file.md
@@ -1,0 +1,2 @@
+The `sigma` operator sometimes crashed when pointed to a non-existent file or
+directory. This no longer happens.

--- a/plugins/sigma/src/plugin.cpp
+++ b/plugins/sigma/src/plugin.cpp
@@ -60,6 +60,7 @@ public:
         diagnostic::warning("sigma operator ignores rule '{}'", path.string())
           .note("failed to read file: {}", query.error())
           .emit(ctrl.diagnostics());
+        return;
       }
       auto query_str = std::string_view{
         reinterpret_cast<const char*>(query->data()),


### PR DESCRIPTION
This fixes a potential crash in the `sigma` operator when reading a non-existent file.