### PR TITLE
Fix panic on parsing invalid syslog messages

### DIFF
--- a/changelog/next/bug-fixes/4012--multiline-syslog.md
+++ b/changelog/next/bug-fixes/4012--multiline-syslog.md
@@ -1,0 +1,2 @@
+Parsing an invalid syslog message (using the schema `syslog.unknown`)
+no longer causes a crash.

--- a/libtenzir/builtins/formats/syslog.cpp
+++ b/libtenzir/builtins/formats/syslog.cpp
@@ -78,12 +78,12 @@ private:
 
 struct unknown_syslog_builder {
 public:
-  using message_type = std::string;
+  using message_type = std::string_view;
 
   unknown_syslog_builder() : builder_(format::syslog::make_unknown_type()) {
   }
 
-  auto add(const message_type& line) -> bool {
+  auto add(message_type line) -> bool {
     return builder_.add(line);
   }
 

--- a/tenzir/integration/data/inputs/syslog/multiline.log
+++ b/tenzir/integration/data/inputs/syslog/multiline.log
@@ -1,0 +1,7 @@
+2024-02-28 11:57:42.181478 windows_station cribl[47425]: Exception in thread "main" java.lang.NullPointerException
+    at com.example.App.method(App.java:42)
+    at com.example.App.main(App.java:20)
+2024-02-28 11:57:42.181570 windows_station rsyslog[23006]: Traceback (most recent call last):
+    File "script.py", line 10, in <module>
+        value = my_list[10]
+IndexError: list index out of range

--- a/tenzir/integration/data/reference/pipelines_local/test_syslog_format/step_02.ref
+++ b/tenzir/integration/data/reference/pipelines_local/test_syslog_format/step_02.ref
@@ -1,0 +1,7 @@
+{"facility": null, "severity": null, "timestamp": "2024-02-28T11:57:42.181478", "hostname": "windows_station", "app_name": "cribl", "process_id": "47425", "content": "Exception in thread \"main\" java.lang.NullPointerException"}
+{"syslog_message": "    at com.example.App.method(App.java:42)"}
+{"syslog_message": "    at com.example.App.main(App.java:20)"}
+{"facility": null, "severity": null, "timestamp": "2024-02-28T11:57:42.181570", "hostname": "windows_station", "app_name": "rsyslog", "process_id": "23006", "content": "Traceback (most recent call last):"}
+{"syslog_message": "    File \"script.py\", line 10, in <module>"}
+{"syslog_message": "        value = my_list[10]"}
+{"syslog_message": "IndexError: list index out of range"}

--- a/tenzir/integration/tests/pipelines_local.bats
+++ b/tenzir/integration/tests/pipelines_local.bats
@@ -428,6 +428,7 @@ setup() {
 @test "Syslog format" {
   check tenzir "from ${INPUTSDIR}/syslog/syslog.log read syslog"
   check tenzir "from ${INPUTSDIR}/syslog/syslog-rfc3164.log read syslog"
+  check tenzir "from ${INPUTSDIR}/syslog/multiline.log read syslog"
 }
 
 # bats test_tags=pipelines


### PR DESCRIPTION
Reported on Discord.

This PR fixes a logic bug in the parser, that previously caused a panic, when encountering an invalid syslog message. This is caused by a multiline message, where the latter lines are not valid messages themselves. We don't currently provide proper support for multiline syslog messages, but now we no longer crash.

Lines that don't look like a syslog message on their own are parsed as `syslog.unknown`, with the entire line contained in a field called `syslog_message`, as can be seen in the test reference files.
