### PR TITLE
Fix crash when using configured pipelines for the first time

### DIFF
--- a/changelog/next/bug-fixes/4020--configured-pipelines-crash.md
+++ b/changelog/next/bug-fixes/4020--configured-pipelines-crash.md
@@ -1,0 +1,3 @@
+When upgrading from a previous version to Tenzir v4.10 and using configured
+pipelines for the first time, the node sometimes crashed on startup. This no
+longer happens.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "301296f251ed94c3288e70d9f1f854fa3e41fa8f",
+  "rev": "fb15b7cd7c077806f3c028d00387adb74f2e8d34",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
This fixes a crash that you could sometimes run into when upgrading to Tenzir v4.10 and using configured pipelines for the first time.