### PR TITLE
Support building against simdjson v3.8.0

### DIFF
--- a/libtenzir/builtins/formats/json.cpp
+++ b/libtenzir/builtins/formats/json.cpp
@@ -377,6 +377,15 @@ private:
         }
         return add_value(builder, result.value_unsafe());
       }
+      case simdjson::ondemand::number_type::big_integer: {
+        // this can fail if the number is too big for a double
+        auto result = val.get_double();
+        if (result.error()) {
+          report_parse_err(val, "a number");
+          return false;
+        }
+        return add_value(builder, result.value_unsafe());
+      }
     }
     TENZIR_UNREACHABLE();
   }


### PR DESCRIPTION
The latest simdjson release introduced support for detecting big integers. That broke our build with `-Werror=switch`, which we enable by default.

This also bumps the vendored simdjson to the latest version.