### PR TITLE
Remove the matcher plugin

### DIFF
--- a/.github/workflows/tenzir.yaml
+++ b/.github/workflows/tenzir.yaml
@@ -834,9 +834,6 @@ jobs:
           - name: NIC
             target: nic
             path: plugins/nic
-          - name: Matcher
-            target: matcher
-            path: contrib/tenzir-plugins/matcher
           - name: Parquet
             target: parquet
             path: plugins/parquet

--- a/Dockerfile
+++ b/Dockerfile
@@ -190,14 +190,6 @@ RUN cmake -S contrib/tenzir-plugins/context -B build-context -G Ninja \
       DESTDIR=/plugin/context cmake --install build-context --strip --component Runtime && \
       rm -rf build-context
 
-FROM plugins-source AS matcher-plugin
-
-RUN cmake -S contrib/tenzir-plugins/matcher -B build-matcher -G Ninja \
-      -D CMAKE_INSTALL_PREFIX:STRING="$PREFIX" && \
-      cmake --build build-matcher --parallel && \
-      DESTDIR=/plugin/matcher cmake --install build-matcher --strip --component Runtime && \
-      rm -rf build-matcher
-
 FROM plugins-source AS pipeline-manager-plugin
 
 RUN cmake -S contrib/tenzir-plugins/pipeline-manager -B build-pipeline-manager -G Ninja \
@@ -219,7 +211,6 @@ RUN cmake -S contrib/tenzir-plugins/platform -B build-platform -G Ninja \
 FROM tenzir-de AS tenzir-ce
 
 COPY --from=context-plugin --chown=tenzir:tenzir /plugin/context /
-COPY --from=matcher-plugin --chown=tenzir:tenzir /plugin/matcher /
 COPY --from=pipeline-manager-plugin --chown=tenzir:tenzir /plugin/pipeline-manager /
 COPY --from=platform-plugin --chown=tenzir:tenzir /plugin/platform /
 

--- a/changelog/next/changes/4024--removed-matcher.md
+++ b/changelog/next/changes/4024--removed-matcher.md
@@ -1,0 +1,3 @@
+The `matcher` plugin no longer exists. It has long been deprecated, and with the
+release of Tenzir v4.10 is fully superseded by the `lookup`, which is better in
+many ways.

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -387,7 +387,6 @@ in {
     in
       pkg.withPlugins (ps: [
         ps.context
-        ps.matcher
         ps.pipeline-manager
         ps.platform
       ]);
@@ -399,7 +398,6 @@ in {
       pkg.withPlugins (ps: [
         ps.compaction
         ps.context
-        ps.matcher
         ps.pipeline-manager
         ps.platform
       ]);

--- a/nix/tenzir/plugins/names.nix
+++ b/nix/tenzir/plugins/names.nix
@@ -1,7 +1,6 @@
 [
   "compaction"
   "context"
-  "matcher"
   "pipeline-manager"
   "platform"
 ]

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "05587129e85f9c6a5e50ff9045fe466c9d1d081b",
+  "rev": "f1e11b0fadce1c92bcb3ac782ff57b92cfab4b5b",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/web/docs/why-tenzir.md
+++ b/web/docs/why-tenzir.md
@@ -233,7 +233,7 @@ application protocol, domain name, or hash value.
 Key-value stores alone are not suitable as foundation for running security
 analytics workloads. There are narrow use cases where key-value stores can
 facilitate certain capabilities, e.g., when processing watch lists. (Tenzir
-offers a *matcher* plugin for this purpose.)
+offers a *context* plugin for this purpose.)
 :::
 
 ### Tenzir vs. Graph DBs


### PR DESCRIPTION
At long last, it's time to remove the matcher plugin. It has been superseded by the `lookup` plugin, which is superior in many ways.