### PR TITLE
Ignore events in `lookup` that did not bind

### DIFF
--- a/changelog/next/bug-fixes/3997--platform-periodic-reconnects.md
+++ b/changelog/next/bug-fixes/3997--platform-periodic-reconnects.md
@@ -1,1 +1,0 @@
-Tenzir nodes now have an increased time interval between reconnection attempts.

--- a/changelog/next/bug-fixes/4028--lookup-no-bind.md
+++ b/changelog/next/bug-fixes/4028--lookup-no-bind.md
@@ -1,0 +1,5 @@
+The `lookup` operator no longer tries to match internal metrics and diagnostics
+events.
+
+The `lookup` operator no longer returns events for which none of the provided
+fields exist.

--- a/changelog/next/changes/3997--platform-periodic-reconnects.md
+++ b/changelog/next/changes/3997--platform-periodic-reconnects.md
@@ -1,0 +1,2 @@
+Tenzir nodes no longer attempt reconnecting to app.tenzir.com immediately upon
+failure, but rather wait before reconnecting.

--- a/libtenzir/builtins/contexts/bloom_filter.cpp
+++ b/libtenzir/builtins/contexts/bloom_filter.cpp
@@ -8,6 +8,8 @@
 
 #include <tenzir/arrow_table_slice.hpp>
 #include <tenzir/concept/parseable/numeric.hpp>
+#include <tenzir/concept/parseable/tenzir/expression.hpp>
+#include <tenzir/concept/parseable/to.hpp>
 #include <tenzir/data.hpp>
 #include <tenzir/dcso_bloom_filter.hpp>
 #include <tenzir/detail/range_map.hpp>
@@ -152,8 +154,10 @@ public:
       auto result = disjunction{};
       result.reserve(fields.size());
       for (const auto& field : fields) {
+        auto lhs = to<operand>(field);
+        TENZIR_ASSERT(lhs);
         result.emplace_back(predicate{
-          field_extractor(field),
+          *lhs,
           relational_operator::in,
           data{key_values_list},
         });

--- a/libtenzir/builtins/contexts/lookup_table.cpp
+++ b/libtenzir/builtins/contexts/lookup_table.cpp
@@ -8,6 +8,8 @@
 
 #include <tenzir/arrow_table_slice.hpp>
 #include <tenzir/concept/parseable/numeric/bool.hpp>
+#include <tenzir/concept/parseable/tenzir/expression.hpp>
+#include <tenzir/concept/parseable/to.hpp>
 #include <tenzir/data.hpp>
 #include <tenzir/detail/range_map.hpp>
 #include <tenzir/expression.hpp>
@@ -259,8 +261,10 @@ public:
     auto result = disjunction{};
     result.reserve(fields.size());
     for (const auto& field : fields) {
+      auto lhs = to<operand>(field);
+      TENZIR_ASSERT(lhs);
       result.emplace_back(predicate{
-        field_extractor(field),
+        *lhs,
         relational_operator::in,
         data{keys},
       });
@@ -348,8 +352,10 @@ public:
       auto result = disjunction{};
       result.reserve(fields.size());
       for (const auto& field : fields) {
+        auto lhs = to<operand>(field);
+        TENZIR_ASSERT(lhs);
         result.emplace_back(predicate{
-          field_extractor(field),
+          *lhs,
           relational_operator::in,
           data{key_values_list},
         });
@@ -373,8 +379,10 @@ public:
         auto result = disjunction{};
         result.reserve(fields.size());
         for (const auto& field : fields) {
+          auto lhs = to<operand>(field);
+          TENZIR_ASSERT(lhs);
           result.emplace_back(predicate{
-            field_extractor(field),
+            *lhs,
             relational_operator::in,
             data{key_values_list},
           });

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "a13a6623e135724a934dc6cf3d35a3524a2fe512",
+  "rev": "aaba00f024ff3c29b2be08a9eb250cace4cfaa4d",
   "submodules": true,
   "shallow": true,
   "allRefs": true

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "007985b50f4d6a2957150a30989392745bdf04b8",
+  "rev": "a13a6623e135724a934dc6cf3d35a3524a2fe512",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
This fixes two issues in `lookup`:
1. The operator did not ignore internal events, and
2. the operator let events through for which the provided fields did not bind.