### PR TITLE
Fix loading of large contexts

### DIFF
--- a/changelog/next/bug-fixes/4033--large-context-load.md
+++ b/changelog/next/bug-fixes/4033--large-context-load.md
@@ -1,0 +1,1 @@
+Using `context load` with large context files no longer causes a crash.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "1d823e8e963568e90ce7a2ebb8896bf49aef7519",
+  "rev": "258f86c42a0317ec64f21c6563fc0cb85288cc53",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
This PR fixes a logic bug in `context load`, where each chunk of the input was attempted to be loaded individually, rather than loading the entire input. This error was only encountered, when loading contexts that were large enough to be split into multiple chunks.

Plugins PR https://github.com/tenzir/tenzir-plugins/pull/210