### PR TITLE
Fix a crash in the Sigma operator

### DIFF
--- a/changelog/next/bug-fixes/4034--sigma-type-infer-crash.md
+++ b/changelog/next/bug-fixes/4034--sigma-type-infer-crash.md
@@ -1,0 +1,2 @@
+The `sigma` operator crashed for some rules when trying to attach the rule to
+the matched event. This no longer happens.


### PR DESCRIPTION
This fixes a crash in the Sigma operator when type inference failed due to mixed types in a list. Instead, we now just use the series builder for attaching the rule to the output, which already supports this.