### PR TITLE
Introduce `--replace`, `--separate`, and `--yield` for contexts

### DIFF
--- a/changelog/next/bug-fixes/4040--multi-drop-select.md
+++ b/changelog/next/bug-fixes/4040--multi-drop-select.md
@@ -1,0 +1,9 @@
+`drop` and `select` silently ignored all but the first match of the specified
+type extractors and concepts. This no longer happens. For example, `drop :time`
+drops all fields with type `time` from events.
+
+Enriching a field adjacent events in `lookup` and `enrich` with a `lookup-table`
+context sometimes crashed when the lookup-table referred to values of different
+types.
+
+The `geoip` context sometimes returned incorrect values. This no longer happens.

--- a/changelog/next/bug-fixes/4040--multi-drop-select.md
+++ b/changelog/next/bug-fixes/4040--multi-drop-select.md
@@ -2,8 +2,8 @@
 type extractors and concepts. This no longer happens. For example, `drop :time`
 drops all fields with type `time` from events.
 
-Enriching a field adjacent events in `lookup` and `enrich` with a `lookup-table`
-context sometimes crashed when the lookup-table referred to values of different
-types.
+Enriching a field in adjacent events in `lookup` and `enrich` with a
+`lookup-table` context sometimes crashed when the lookup-table referred to
+values of different types.
 
 The `geoip` context sometimes returned incorrect values. This no longer happens.

--- a/changelog/next/changes/4040--context-metadata.md
+++ b/changelog/next/changes/4040--context-metadata.md
@@ -1,0 +1,3 @@
+The `enrich` and `lookup` operators now include the metadata in every context
+object to accomodate the new `--replace` and `--separate` options. Previously,
+the metadata was available once in the output field.

--- a/changelog/next/changes/4040--context-metadata.md
+++ b/changelog/next/changes/4040--context-metadata.md
@@ -1,3 +1,9 @@
 The `enrich` and `lookup` operators now include the metadata in every context
 object to accomodate the new `--replace` and `--separate` options. Previously,
 the metadata was available once in the output field.
+
+The `mode` field in the enrichments returned from the `lookup` operator is now
+`lookup.retro`, `lookup.live`, or `lookup.snapshot` depending on the mode.
+
+The `bloom-filter` context now always returns `true` or `false` for the context
+instead of embedding the result in a record with a single `data` field.

--- a/changelog/next/features/4040--context-replace-separate.md
+++ b/changelog/next/features/4040--context-replace-separate.md
@@ -1,0 +1,7 @@
+The `--replace` option for the `enrich` operator causes the input values to be
+replaced with their context instead of extending the event with the context,
+resulting in a leaner output.
+
+The `--separate` option makes the `enrich` and `lookup` operators handle each
+field individually, duplicating the event for each relevant field, and
+returning at most one context per output event.

--- a/changelog/next/features/4040--context-replace-separate.md
+++ b/changelog/next/features/4040--context-replace-separate.md
@@ -5,3 +5,8 @@ resulting in a leaner output.
 The `--separate` option makes the `enrich` and `lookup` operators handle each
 field individually, duplicating the event for each relevant field, and
 returning at most one context per output event.
+
+The `--yield <field>` option allows for adding only a part of a context with the
+`enrich` and `lookup` operators. For example, with a `geoip` context with a
+MaxMind country database, `--yield registered_country.iso_code` will cause the
+enrichment to only consist of the country's ISO code.

--- a/libtenzir/builtins/contexts/bloom_filter.cpp
+++ b/libtenzir/builtins/contexts/bloom_filter.cpp
@@ -57,18 +57,11 @@ public:
   /// Emits context information for every event in `slice` in order.
   auto apply(series array, bool replace) const
     -> caf::expected<std::vector<series>> override {
+    (void)replace;
     auto builder = series_builder{};
     for (const auto& value : array.values()) {
-      if (bloom_filter_.lookup(value)) {
-        auto ptr = bloom_filter_.data().data();
-        auto size = bloom_filter_.data().size();
-        auto r = builder.record();
-        r.field("data", std::basic_string<std::byte>{ptr, size});
-      } else if (replace) {
-        builder.data(value);
-      } else {
-        builder.null();
-      }
+      const auto contained = bloom_filter_.lookup(value);
+      builder.data(contained);
     }
     return builder.finish();
   }

--- a/libtenzir/builtins/contexts/bloom_filter.cpp
+++ b/libtenzir/builtins/contexts/bloom_filter.cpp
@@ -55,7 +55,7 @@ public:
   }
 
   /// Emits context information for every event in `slice` in order.
-  auto apply(series array) const
+  auto apply(series array, bool replace) const
     -> caf::expected<std::vector<series>> override {
     auto builder = series_builder{};
     for (const auto& value : array.values()) {
@@ -64,6 +64,8 @@ public:
         auto size = bloom_filter_.data().size();
         auto r = builder.record();
         r.field("data", std::basic_string<std::byte>{ptr, size});
+      } else if (replace) {
+        builder.data(value);
       } else {
         builder.null();
       }

--- a/libtenzir/builtins/contexts/geoip.cpp
+++ b/libtenzir/builtins/contexts/geoip.cpp
@@ -284,7 +284,7 @@ public:
   }
 
   /// Emits context information for every event in `slice` in order.
-  auto apply(series array) const
+  auto apply(series array, bool replace) const
     -> caf::expected<std::vector<series>> override {
     auto status = 0;
     MMDB_entry_data_list_s* entry_data_list = nullptr;
@@ -322,8 +322,12 @@ public:
                                         "GeoIP database: {}",
                                         ip_string, MMDB_strerror(status)));
       }
-      if (result.found_entry) {
-        builder.null();
+      if (not result.found_entry) {
+        if (replace) {
+          builder.data(value);
+        } else {
+          builder.null();
+        }
         continue;
       }
       status = MMDB_get_entry_data_list(&result.entry, &entry_data_list);

--- a/libtenzir/builtins/contexts/geoip.cpp
+++ b/libtenzir/builtins/contexts/geoip.cpp
@@ -323,7 +323,7 @@ public:
                                         ip_string, MMDB_strerror(status)));
       }
       if (not result.found_entry) {
-        if (replace) {
+        if (replace and not caf::holds_alternative<caf::none_t>(value)) {
           builder.data(value);
         } else {
           builder.null();

--- a/libtenzir/builtins/contexts/lookup_table.cpp
+++ b/libtenzir/builtins/contexts/lookup_table.cpp
@@ -233,7 +233,7 @@ public:
       if (auto it = context_entries.find(materialize(value));
           it != context_entries.end()) {
         builder.data(it->second);
-      } else if (replace) {
+      } else if (replace and not caf::holds_alternative<caf::none_t>(value)) {
         builder.data(value);
       } else {
         builder.null();

--- a/libtenzir/builtins/contexts/lookup_table.cpp
+++ b/libtenzir/builtins/contexts/lookup_table.cpp
@@ -226,13 +226,15 @@ public:
     return "lookup-table";
   }
 
-  auto apply(series array) const
+  auto apply(series array, bool replace) const
     -> caf::expected<std::vector<series>> override {
     auto builder = series_builder{};
     for (const auto& value : array.values()) {
       if (auto it = context_entries.find(materialize(value));
           it != context_entries.end()) {
         builder.data(it->second);
+      } else if (replace) {
+        builder.data(value);
       } else {
         builder.null();
       }

--- a/libtenzir/builtins/operators/drop.cpp
+++ b/libtenzir/builtins/operators/drop.cpp
@@ -79,8 +79,8 @@ public:
     };
     auto transformations = std::vector<indexed_transformation>{};
     for (const auto& field : config_.fields) {
-      if (auto index = schema.resolve_key_or_concept_once(field)) {
-        transformations.push_back({std::move(*index), transform_fn});
+      for (auto index : schema.resolve(field)) {
+        transformations.push_back({std::move(index), transform_fn});
       }
     }
     // transform_columns requires the transformations to be sorted, and that may
@@ -88,6 +88,9 @@ public:
     // again in that case.
     if (config_.fields.size() > 1)
       std::sort(transformations.begin(), transformations.end());
+    transformations.erase(std::unique(transformations.begin(),
+                                      transformations.end()),
+                          transformations.end());
     return transformations;
   }
 

--- a/libtenzir/builtins/operators/select.cpp
+++ b/libtenzir/builtins/operators/select.cpp
@@ -59,11 +59,12 @@ public:
     -> caf::expected<state_type> override {
     auto indices = state_type{};
     for (const auto& field : config_.fields) {
-      if (auto index = schema.resolve_key_or_concept_once(field)) {
-        indices.push_back(std::move(*index));
+      for (auto index : schema.resolve(field)) {
+        indices.push_back(std::move(index));
       }
     }
     std::sort(indices.begin(), indices.end());
+    indices.erase(std::unique(indices.begin(), indices.end()), indices.end());
     return indices;
   }
 

--- a/libtenzir/include/tenzir/plugin.hpp
+++ b/libtenzir/include/tenzir/plugin.hpp
@@ -746,7 +746,11 @@ public:
   virtual auto context_type() const -> std::string = 0;
 
   /// Emits context information for every event in `array` in order.
-  virtual auto apply(series array) const -> caf::expected<std::vector<series>>
+  /// @param array The values to look up in the context.
+  /// @param replace If true, return the input values for missing fields rather
+  /// than nulls.
+  virtual auto apply(series array, bool replace) const
+    -> caf::expected<std::vector<series>>
     = 0;
 
   /// Inspects the context.

--- a/libtenzir/include/tenzir/type.hpp
+++ b/libtenzir/include/tenzir/type.hpp
@@ -310,6 +310,10 @@ public:
   [[nodiscard]] std::shared_ptr<arrow::ArrayBuilder>
   make_arrow_builder(arrow::MemoryPool* pool) const noexcept;
 
+  /// Resolves a field extractor, concept, or type extractor on a schema.
+  /// @returns nullopt if the type is not a valid schema.
+  [[nodiscard]] generator<offset> resolve(std::string_view key) const noexcept;
+
   /// Resolves a key on a schema.
   /// @returns nullopt if the type is not a valid schema.
   [[nodiscard]] generator<offset>

--- a/libtenzir/src/type.cpp
+++ b/libtenzir/src/type.cpp
@@ -1067,6 +1067,17 @@ type::make_arrow_builder(arrow::MemoryPool* pool) const noexcept {
   return caf::visit(f, *this);
 }
 
+generator<offset> type::resolve(std::string_view key) const noexcept {
+  const auto* rt = caf::get_if<record_type>(this);
+  if (not rt) {
+    return {};
+  }
+  if (key.starts_with(':')) {
+    return rt->resolve_type_extractor(key);
+  }
+  return rt->resolve_key_or_concept(key, name());
+}
+
 generator<offset>
 type::resolve_key_or_concept(std::string_view key) const noexcept {
   const auto* rt = caf::get_if<record_type>(this);

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "6da7b915a2ad6786630076818f7f5aad176bb541",
+  "rev": "98652307f5fa3708523e1b54f0e7191247d31b40",
   "submodules": true,
   "shallow": true,
   "allRefs": true

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "8ac76ce1b5fb91a271072937dcfd5f163fe054e3",
+  "rev": "6da7b915a2ad6786630076818f7f5aad176bb541",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/web/docs/connectors/s3.md
+++ b/web/docs/connectors/s3.md
@@ -57,14 +57,14 @@ session-token: your-session-token (optional)
 The path to the S3 object.
 
 The syntax is
-`s3://<bucket-name>/<full-path-to-object>(?<options>)`.
+`s3://[<access-key>:secret-key>@]<bucket-name>/<full-path-to-object>(?<options>)`.
 
 Options can be appended to the path as query parameters, as per
 [Arrow](https://arrow.apache.org/docs/r/articles/fs.html#connecting-directly-with-a-uri):
 
 > For S3, the options that can be included in the URI as query parameters are
-> `region`, `scheme`, `endpoint_override`, `access_key`, `secret_key`,
-> `allow_bucket_creation`, and `allow_bucket_deletion`.
+> `region`, `scheme`, `endpoint_override`, `allow_bucket_creation`, and
+> `allow_bucket_deletion`.
 
 ### `--anonymous` (Loader, Saver)
 

--- a/web/docs/operators/enrich.md
+++ b/web/docs/operators/enrich.md
@@ -12,9 +12,9 @@ Enriches events with a context.
 
 ```
 enrich <name>          [--field <field...>] [--replace] [--filter] [--separate]
-                       [<context-options>]
+                       [--yield <field>] [<context-options>]
 enrich <output>=<name> [--field <field...>] [--filter] [--separate]
-                       [<context-options>]
+                       [--yield <field>] [<context-options>]
 ```
 
 ## Description
@@ -51,6 +51,15 @@ This option is incompatible with `--replace`.
 When multiple fields are provided, e.g., when using `--field :ip` to enrich all
 IP address fields, duplicate the event for every provided field and enrich them
 individually.
+
+When using the option, the context moves from `<output>.context.<path...>` to
+`<output>` in the resulting event, with a new field `<output>.path` containing
+the enriched path.
+
+### `--yield <path>`
+
+Provide a field into the context object to use as the context instead. If the
+key does not exist within the context, a `null` value is used instead.
 
 ### `<context-options>`
 

--- a/web/docs/operators/enrich.md
+++ b/web/docs/operators/enrich.md
@@ -11,8 +11,10 @@ Enriches events with a context.
 ## Synopsis
 
 ```
-enrich <name>          [--field <field...>] [--filter] [<context-options>]
-enrich <output>=<name> [--field <field...>] [--filter] [<context-options>]
+enrich <name>          [--field <field...>] [--replace] [--filter] [--separate]
+                       [<context-options>]
+enrich <output>=<name> [--field <field...>] [--filter] [--separate]
+                       [<context-options>]
 ```
 
 ## Description
@@ -33,10 +35,22 @@ the name of the context.
 
 A comma-separated list of fields, type extractors, or concepts to match.
 
+### `--replace`
+
+Replace the given fields with their respective context, omitting all
+meta-information.
+
 ### `--filter`
 
-An optional flag that enables the operator to filter events that do not
-contain a context.
+Filter events that do not match the context.
+
+This option is incompatible with `--replace`.
+
+### `--separate`
+
+When multiple fields are provided, e.g., when using `--field :ip` to enrich all
+IP address fields, duplicate the event for every provided field and enrich them
+individually.
 
 ### `<context-options>`
 

--- a/web/docs/operators/lookup.md
+++ b/web/docs/operators/lookup.md
@@ -12,8 +12,12 @@ and translates context updates into historical queries.
 ## Synopsis
 
 ```
-lookup <context>          [--field <field...>] [--live] [--retro] [--snapshot] [<context-options>]
-lookup <output>=<context> [--field <field...>] [--live] [--retro] [--snapshot] [<context-options>]
+lookup <context>          [--field <field...>] [--separate]
+                          [--live] [--retro] [--snapshot]
+                          [<context-options>]
+lookup <output>=<context> [--field <field...>] [--separate]
+                          [--live] [--retro] [--snapshot]
+                          [<context-options>]
 ```
 
 ## Description
@@ -44,6 +48,12 @@ Defaults to the name of the context.
 ### `--field <field...>`
 
 A comma-separated list of fields, type extractors, or concepts to match.
+
+### `--separate`
+
+When multiple fields are provided, e.g., when using `--field :ip` to enrich all
+IP address fields, duplicate the event for every provided field and enrich them
+individually.
 
 ### `--live`
 

--- a/web/docs/operators/lookup.md
+++ b/web/docs/operators/lookup.md
@@ -14,10 +14,10 @@ and translates context updates into historical queries.
 ```
 lookup <context>          [--field <field...>] [--separate]
                           [--live] [--retro] [--snapshot]
-                          [<context-options>]
+                          [--yield <field>] [<context-options>]
 lookup <output>=<context> [--field <field...>] [--separate]
                           [--live] [--retro] [--snapshot]
-                          [<context-options>]
+                          [--yield <field>] [<context-options>]
 ```
 
 ## Description
@@ -55,6 +55,10 @@ When multiple fields are provided, e.g., when using `--field :ip` to enrich all
 IP address fields, duplicate the event for every provided field and enrich them
 individually.
 
+When using the option, the context moves from `<output>.context.<path...>` to
+`<output>` in the resulting event, with a new field `<output>.path` containing
+the enriched path.
+
 ### `--live`
 
 Enables live lookup for incoming events.
@@ -78,6 +82,11 @@ Creates a snapshot of the context at the time of execution. In combination with
 state.
 
 By default, snapshotting is disabled. Not all contexts support this operation.
+
+### `--yield <path>`
+
+Provide a field into the context object to use as the context instead. If the
+key does not exist within the context, a `null` value is used instead.
 
 ### `<context-options>`
 


### PR DESCRIPTION
This adds `--yield` and `--separate` options to the `lookup` and `enrich` operators, and the `--replace` option for `enrich`.

The `--replace` option makes the `enrich` operator replace the input value with the context as opposed to adding it to the output, and makes the output a lot leaner.

The `--separate` option causes the operators duplicate the input events for each matched field alongside making the nesting structure a lot less deep for the context.

The `--yield <field>` option causes the operators to add only the specified subset of the context.

Additionally, this changes the context structure slightly to add the meta information per context as opposed to once per event. This makes it easier to work with the results of the two operators in downstream tooling.

This also fixes a bug in the `geoip` context, which sometimes returned bogus values, and changes the `bloom-filter` context to just return a boolean instead of a record containing a single field containing a boolean.