### PR TITLE
Add an email saver

### DIFF
--- a/changelog/next/features/4041.md
+++ b/changelog/next/features/4041.md
@@ -1,0 +1,2 @@
+The new `email` saver allows for sending pipeline data via email by connecting
+to a mail server via SMTP or SMTPS.

--- a/libtenzir/builtins/connectors/email.cpp
+++ b/libtenzir/builtins/connectors/email.cpp
@@ -189,9 +189,7 @@ public:
       }
       auto body = std::string_view{reinterpret_cast<const char*>(chunk->data()),
                                    chunk->size()};
-      // The RFC demands that we end with `<CR><LF>.<CR><LF>`.
-      auto mail
-        = fmt::format("{}\r\n{}\r\n.\r\n", fmt::join(headers, "\r\n"), body);
+      auto mail = fmt::format("{}\r\n{}", fmt::join(headers, "\r\n"), body);
       TENZIR_DEBUG("sending {}-byte chunk as email to {}", chunk->size(),
                    args.to);
       if (auto err = upload(*easy, chunk::make(std::move(mail)))) {

--- a/libtenzir/builtins/connectors/email.cpp
+++ b/libtenzir/builtins/connectors/email.cpp
@@ -241,6 +241,8 @@ public:
     parser.add("-e,--endpoint", args.endpoint, "<string>");
     parser.add("-f,--from", args.from, "<email>");
     parser.add("-s,--subject", args.subject, "<string>");
+    parser.add("-u,--username", args.username, "<string>");
+    parser.add("-p,--password", args.password, "<string>");
     parser.add("-P,--skip-peer-verification", args.skip_peer_verification);
     parser.add("-H,--skip-hostname-verification",
                args.skip_hostname_verification);

--- a/libtenzir/builtins/connectors/email.cpp
+++ b/libtenzir/builtins/connectors/email.cpp
@@ -120,7 +120,12 @@ public:
       }
     }
     // Allow one of the recipients to fail and still consider it okay.
-    code = easy.set(CURLOPT_MAIL_RCPT_ALLOWFAILS, 1);
+#if LIBCURL_VERSION_NUM < 0x080200
+    auto allowfails = CURLOPT_MAIL_RCPT_ALLLOWFAILS;
+#else
+    auto allowfails = CURLOPT_MAIL_RCPT_ALLOWFAILS;
+#endif
+    code = easy.set(allowfails, 1);
     if (code != curl::easy::code::ok) {
       auto err = to_error(code);
       diagnostic::error("failed to adjust recipient failure mode")

--- a/libtenzir/builtins/connectors/email.cpp
+++ b/libtenzir/builtins/connectors/email.cpp
@@ -1,0 +1,165 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2024 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <tenzir/argument_parser.hpp>
+#include <tenzir/curl.hpp>
+#include <tenzir/location.hpp>
+#include <tenzir/plugin.hpp>
+
+using namespace std::chrono_literals;
+
+namespace tenzir::plugins::email {
+
+constexpr auto default_smtp_server = "localhost";
+constexpr auto default_from = "Tenzir <noreply@tenzir.com>";
+constexpr auto default_subject = "Tenzir Pipeline Data";
+
+namespace {
+
+struct saver_args {
+  std::string smtp_server;
+  std::string from;
+  std::string to;
+  std::string subject;
+
+  friend auto inspect(auto& f, saver_args& x) -> bool {
+    return f.object(x)
+      .pretty_name("tenzir.plugins.email.saver_args")
+      .fields(f.field("smtp_server", x.smtp_server), f.field("from", x.from),
+              f.field("to", x.to), f.field("subject", x.subject));
+  }
+};
+
+class saver final : public plugin_saver {
+public:
+  saver() = default;
+
+  explicit saver(saver_args args) : args_{std::move(args)} {
+  }
+
+  auto instantiate(operator_control_plane& ctrl, std::optional<printer_info>)
+    -> caf::expected<std::function<void(chunk_ptr)>> override {
+    auto easy = curl::easy{};
+    auto code = easy.set(CURLOPT_URL, args_.smtp_server);
+    if (code != curl::easy::code::ok) {
+      auto err = to_error(code);
+      diagnostic::error("failed to set SMTP server request")
+        .note("server: {}", args_.smtp_server)
+        .note("{}", err)
+        .emit(ctrl.diagnostics());
+      return err;
+    }
+    // This option isn't strictly required and we may consider making it
+    // optional.
+    code = easy.set(CURLOPT_MAIL_FROM, args_.from);
+    if (code != curl::easy::code::ok) {
+      auto err = to_error(code);
+      diagnostic::error("failed to set From header")
+        .note("from: {}", args_.from)
+        .note("{}", err)
+        .emit(ctrl.diagnostics());
+      return err;
+    }
+    code = easy.add_mail_recipient(args_.to);
+    if (code != curl::easy::code::ok) {
+      auto err = to_error(code);
+      diagnostic::error("failed to set To header")
+        .note("to: {}", args_.to)
+        .note("{}", err)
+        .emit(ctrl.diagnostics());
+      return err;
+    }
+    return [&ctrl, easy = std::make_shared<curl::easy>(std::move(easy))](
+             chunk_ptr chunk) mutable {
+      if (not chunk || chunk->size() == 0) {
+        return;
+      }
+      // Unless we clean up the cURL handle, we're not going to send the SMPT
+      // QUIT command. This allows us to reuse the same connection, but it might
+      // not be a good idea because the server will ultimately time out our
+      // connection.
+      if (auto err = upload(*easy, chunk)) {
+        diagnostic::error("failed to set email body")
+          .note("{}", err)
+          .emit(ctrl.diagnostics());
+        return;
+      }
+      if (auto err = to_error(easy->perform())) {
+        diagnostic::error("failed to send email")
+          .note("{}", err)
+          .emit(ctrl.diagnostics());
+        return;
+      }
+    };
+  }
+
+  auto name() const -> std::string override {
+    return "email";
+  }
+
+  auto default_printer() const -> std::string override {
+    return "json";
+  }
+
+  auto is_joining() const -> bool override {
+    return true;
+  }
+
+  friend auto inspect(auto& f, saver& x) -> bool {
+    return f.object(x).pretty_name("saver").fields(f.field("args", x.args_));
+  }
+
+private:
+  saver_args args_;
+};
+
+class plugin final : public virtual saver_plugin<saver> {
+public:
+  auto parse_saver(parser_interface& p) const
+    -> std::unique_ptr<plugin_saver> override {
+    auto parser = argument_parser{
+      name(),
+      fmt::format("https://docs.tenzir.com/docs/connectors/{}", name())};
+    auto args = saver_args{};
+    parser.add(args.smtp_server, "<server>");
+    parser.add(args.from, "-f,--from");
+    parser.add(args.to, "-t,--to");
+    parser.add(args.subject, "-s,--subject");
+    parser.parse(p);
+    if (args.smtp_server.empty()) {
+      args.smtp_server = default_smtp_server;
+    } else if (args.smtp_server.find("://") == std::string_view::npos) {
+      args.smtp_server.insert(0, "smtp://");
+    } else if (args.smtp_server.starts_with("email://")) {
+      args.smtp_server.erase(0, 5);
+      args.smtp_server.insert(0, "smtp");
+    }
+    if (args.from.empty()) {
+      args.from = default_from;
+    }
+    if (args.to.empty()) {
+      diagnostic::error("no recipient specified")
+        .hint("add --to <recipient> to your invocation")
+        .throw_();
+    }
+    if (args.subject.empty()) {
+      args.subject = default_subject;
+    }
+    return std::make_unique<saver>(std::move(args));
+  }
+
+  auto name() const -> std::string override {
+    return "email";
+  }
+};
+
+} // namespace
+
+} // namespace tenzir::plugins::email
+
+TENZIR_REGISTER_PLUGIN(tenzir::plugins::email::plugin)

--- a/libtenzir/builtins/connectors/email.cpp
+++ b/libtenzir/builtins/connectors/email.cpp
@@ -267,6 +267,10 @@ public:
   auto name() const -> std::string override {
     return "email";
   }
+
+  auto supported_uri_scheme() const -> std::string override {
+    return "mailto";
+  }
 };
 
 } // namespace

--- a/libtenzir/builtins/connectors/email.cpp
+++ b/libtenzir/builtins/connectors/email.cpp
@@ -209,7 +209,7 @@ public:
     if (args.smtp_server.empty()) {
       args.smtp_server = default_smtp_server;
     } else if (args.smtp_server.find("://") == std::string_view::npos) {
-      args.smtp_server.insert(0, "smtp://");
+      args.smtp_server.insert(0, "smtps://");
     } else if (args.smtp_server.starts_with("email://")) {
       args.smtp_server.erase(0, 5);
       args.smtp_server.insert(0, "smtp");

--- a/libtenzir/builtins/connectors/email.cpp
+++ b/libtenzir/builtins/connectors/email.cpp
@@ -197,7 +197,7 @@ public:
       name(),
       fmt::format("https://docs.tenzir.com/docs/connectors/{}", name())};
     auto args = saver_args{};
-    parser.add("-S,--server", args.smtp_server, "<string>");
+    parser.add("-m,--server", args.smtp_server, "<string>");
     parser.add("-f,--from", args.from, "<email>");
     parser.add("-s,--subject", args.subject, "<string>");
     parser.add("-P,--skip-peer-verification", args.skip_peer_verification);

--- a/libtenzir/include/tenzir/curl.hpp
+++ b/libtenzir/include/tenzir/curl.hpp
@@ -223,6 +223,10 @@ public:
   /// be deleted instead.
   auto set_http_header(std::string_view name, std::string_view value) -> code;
 
+  /// Adds a recipient to the internal list for `CURLOPT_MAIL_RCPT`.
+  /// @param mail The email address of a recipient.
+  auto add_mail_recipient(std::string_view mail) -> code;
+
   /// Enumerates the list of all added headers.
   auto headers() -> generator<std::pair<std::string_view, std::string_view>>;
 
@@ -238,6 +242,7 @@ private:
   std::unique_ptr<read_callback> on_read_{};
   std::unique_ptr<mime> mime_{};
   slist headers_;
+  slist mail_recipients_;
 };
 
 /// @relates easy

--- a/libtenzir/include/tenzir/curl.hpp
+++ b/libtenzir/include/tenzir/curl.hpp
@@ -241,7 +241,7 @@ private:
   std::unique_ptr<write_callback> on_write_{};
   std::unique_ptr<read_callback> on_read_{};
   std::unique_ptr<mime> mime_{};
-  slist headers_;
+  slist http_headers_;
   slist mail_recipients_;
 };
 

--- a/libtenzir/include/tenzir/curl.hpp
+++ b/libtenzir/include/tenzir/curl.hpp
@@ -501,4 +501,8 @@ auto escape(std::string_view str) -> std::string;
 /// @returns The encoded string.
 auto escape(const record& xs) -> std::string;
 
+/// Instructs an easy handle to upload a chunk. This sets `CURLOPT_UPLOAD` and
+/// sets the read callback to read the chunk.
+auto upload(easy& handle, chunk_ptr chunk) -> caf::error;
+
 } // namespace tenzir::curl

--- a/libtenzir/include/tenzir/curl.hpp
+++ b/libtenzir/include/tenzir/curl.hpp
@@ -358,7 +358,7 @@ public:
     /// @param buffer The data to copy into the part.
     auto data(std::span<const std::byte> buffer) -> easy::code;
 
-    /// Sets the data by menas of a read callback.
+    /// Sets the data by means of a read callback.
     /// @param on_read The read callback to read in parts. The caller must
     /// ensure that the pointer remains valid.
     /// @pre `on_read != nullptr`

--- a/libtenzir/src/curl.cpp
+++ b/libtenzir/src/curl.cpp
@@ -99,7 +99,6 @@ auto easy::set(mime handle) -> code {
   auto curl_code = curl_easy_setopt(easy_.get(), CURLOPT_READFUNCTION, nullptr);
   TENZIR_ASSERT(curl_code == CURLE_OK);
   // Set MIME structure as the new thing.
-  TENZIR_ASSERT(curl_code == CURLE_OK);
   curl_code
     = curl_easy_setopt(easy_.get(), CURLOPT_MIMEPOST, handle.mime_.get());
   if (curl_code == CURLE_OK) {
@@ -140,10 +139,10 @@ auto easy::set_http_header(std::string_view name, std::string_view value)
     TENZIR_ASSERT(i != std::string_view::npos);
     return str.substr(0, i);
   };
+  // Check if we are overwriting a header. Since slits are immutable, this
+  // would require rebuilding the list (and has quadratic overhead).
   for (auto header : http_headers_.items()) {
     if (header_name(header) == name) {
-      // For the rare case that we overwrite a header, we're fine to pay the
-      // quadratic overhead of rebuild the list.
       slist copy;
       for (auto item : http_headers_.items()) {
         if (header_name(item) != name) {

--- a/libtenzir/src/curl.cpp
+++ b/libtenzir/src/curl.cpp
@@ -144,30 +144,30 @@ auto easy::set_http_header(std::string_view name, std::string_view value)
     TENZIR_ASSERT(i != std::string_view::npos);
     return str.substr(0, i);
   };
-  for (auto header : headers_.items()) {
+  for (auto header : http_headers_.items()) {
     if (header_name(header) == name) {
       // For the rare case that we overwrite a header, we're fine to pay the
       // quadratic overhead of rebuild the list.
       slist copy;
-      for (auto item : headers_.items()) {
+      for (auto item : http_headers_.items()) {
         if (header_name(item) != name) {
           copy.append(item);
         }
       }
-      headers_ = std::move(copy);
+      http_headers_ = std::move(copy);
       break;
     }
   }
   auto header = fmt::format("{}: {}", name, value);
-  headers_.append(header);
+  http_headers_.append(header);
   auto curl_code
-    = curl_easy_setopt(easy_, CURLOPT_HTTPHEADER, headers_.slist_.get());
+    = curl_easy_setopt(easy_, CURLOPT_HTTPHEADER, http_headers_.slist_.get());
   return static_cast<code>(curl_code);
 }
 
 auto easy::headers()
   -> generator<std::pair<std::string_view, std::string_view>> {
-  for (auto str : headers_.items()) {
+  for (auto str : http_headers_.items()) {
     auto split = detail::split(str, ": ");
     TENZIR_ASSERT(split.size() == 2);
     co_yield std::pair{split[0], split[1]};

--- a/libtenzir/src/curl.cpp
+++ b/libtenzir/src/curl.cpp
@@ -130,6 +130,13 @@ auto easy::set_postfieldsize(long size) -> code {
   return static_cast<code>(curl_code);
 }
 
+auto easy::add_mail_recipient(std::string_view mail) -> easy::code {
+  mail_recipients_.append(mail);
+  auto curl_code
+    = curl_easy_setopt(easy_, CURLOPT_MAIL_RCPT, mail_recipients_.slist_.get());
+  return static_cast<code>(curl_code);
+}
+
 auto easy::set_http_header(std::string_view name, std::string_view value)
   -> code {
   auto header_name = [](std::string_view str) {

--- a/web/docs/connectors/email.md
+++ b/web/docs/connectors/email.md
@@ -12,6 +12,7 @@ Emails pipeline data through a SMTP server.
 
 ```
 email [-e|--endpoint] [-f|--from <email>] [-s|--subject <string>]
+      [-u|--username <string>] [-p|--password <string>]
       [-P|--skip-peer-verification] [-H|--skip-hostname-verification]
       [-m|--mime] [-v|--verbose]
       <recipient>
@@ -52,6 +53,14 @@ server which might cause the email to be rejected.
 ### `-s|--subject <string>`
 
 The `Subject` header.
+
+### `-u|--username <string>`
+
+The username in an authenticated SMTP connection.
+
+### `-p|--password <string>`
+
+The password in an authenticated SMTP connection.
 
 ### `-P|--skip-peer-verification`
 

--- a/web/docs/connectors/email.md
+++ b/web/docs/connectors/email.md
@@ -13,6 +13,7 @@ Emails pipeline data through a SMTP server.
 ```
 email [-e|--endpoint] [-f|--from <email>] [-s|--subject <string>]
       [-u|--username <string>] [-p|--password <string>]
+      [-i|--authzid <string>] [-a|--authorization <string>]
       [-P|--skip-peer-verification] [-H|--skip-hostname-verification]
       [-m|--mime] [-v|--verbose]
       <recipient>
@@ -62,9 +63,24 @@ The username in an authenticated SMTP connection.
 
 The password in an authenticated SMTP connection.
 
-### `-a|--authzid <string>`
+### `-i|--authzid <string>`
 
 The authorization identity in an authenticated SMTP connection.
+
+This option is only applicable to the PLAIN SASL authentication mechanism where
+it is optional. When not specified only the authentication identity (`authcid`)
+as specified by the username is sent to the server, along with the password. The
+server derives an `authzid` from the `authcid` when not provided, which it then
+uses internally. When the `authzid` is specified it can be used to access
+another user's inbox, that the user has been granted access to, or a shared
+mailbox.
+
+### `-a|--authorization <string>`
+
+The authorization options for an authenticated SMTP connection.
+
+This login option defines the preferred authentication mechanism, e.g.,
+`AUTH=PLAIN`, `AUTH=LOGIN`, or `AUTH=*`.
 
 ### `-P|--skip-peer-verification`
 

--- a/web/docs/connectors/email.md
+++ b/web/docs/connectors/email.md
@@ -1,0 +1,98 @@
+---
+sidebar_custom_props:
+  connector:
+    saver: true
+---
+
+# email
+
+Emails pipeline data through a SMTP server.
+
+## Synopsis
+
+```
+email [-m|--server] [-f|--from <email>] [-s|--subject <string>]
+      [-P|--skip-peer-verification] [-H|--skip-hostname-verification]
+      [-v|--verbose]
+      <recipient>
+```
+
+## Description
+
+The `email` saver establish a SMTP(S) connection to a mail server and sends
+bytes as email body.
+
+The default printer for the `email` saver is [`json`](../formats/json.md).
+
+### `<recipient>`
+
+The recipient of the mail.
+
+The expected format is either `Name <user@example.org>` with the email in angle
+brackets, or a plain email adress, such as `user@example.org`.
+
+### `-m|--server`
+
+The address of the mail server.
+
+To choose between SMTP and SMTPS, provide a URL with with the corresponding
+scheme. For example, `smtp://127.0.0.1:25` will establish an unencrypted
+connection, whereas `smtps://127.0.0.1:25` an encrypted one. If you specify a
+server without a schema, the protocol defaults to SMTPS.
+
+Defaults to `smtp://localhost:25`.
+
+### `-f|--from <email>`
+
+The `From` header.
+
+If you do not specify this parameter, an empty address is sent to the SMTP
+server which might cause the email to be rejected.
+
+### `-s|--subject <string>`
+
+The `Subject` header.
+
+### `-P|--skip-peer-verification`
+
+Skips certificate verification.
+
+By default, an SMTPS connection verifies the authenticity of the peer's
+certificate. During connection negotiation, the server sends a certificate
+indicating its identity. We verify whether the certificate is authentic,
+i.e., that you can trust that the server is who the certificate says it is.
+
+Providing this flag disables loading of the CA certificates and verification of
+the peer certificate.
+
+### `-H|--skip-hostname-verification`
+
+Ignores verification of the server name in the certificate.
+
+When negotiating TLS and SSL connections, the server sends a certificate
+indicating its identity. By default, that certificate must indicate that the
+server is the server to which you meant to connect, or the connection fails.
+That is, the server has to have the same name in the certificate as is in the
+URL you operate against. We consider the server the intended one when the
+*Common Name* field or a *Subject Alternate Name* field in the certificate
+matches the hostname in the URL.
+
+Providing this flag skips this check, but it makes the connection insecure.
+
+### `-v|--verbose`
+
+Enables verbose output on stderr.
+
+This option is helpful for debugging on the command line.
+
+## Examples
+
+Send the Tenzir version string as CSV to `user@example.org`:
+
+```
+version
+| write csv
+| save email user@example.org
+```
+
+Send an email through a remote  `user@example.org`:

--- a/web/docs/connectors/email.md
+++ b/web/docs/connectors/email.md
@@ -62,6 +62,10 @@ The username in an authenticated SMTP connection.
 
 The password in an authenticated SMTP connection.
 
+### `-a|--authzid <string>`
+
+The authorization identity in an authenticated SMTP connection.
+
 ### `-P|--skip-peer-verification`
 
 Skips certificate verification.

--- a/web/docs/connectors/email.md
+++ b/web/docs/connectors/email.md
@@ -11,9 +11,9 @@ Emails pipeline data through a SMTP server.
 ## Synopsis
 
 ```
-email [-m|--server] [-f|--from <email>] [-s|--subject <string>]
+email [-e|--endpoint] [-f|--from <email>] [-s|--subject <string>]
       [-P|--skip-peer-verification] [-H|--skip-hostname-verification]
-      [-v|--verbose]
+      [-m|--mime] [-v|--verbose]
       <recipient>
 ```
 
@@ -31,9 +31,9 @@ The recipient of the mail.
 The expected format is either `Name <user@example.org>` with the email in angle
 brackets, or a plain email adress, such as `user@example.org`.
 
-### `-m|--server`
+### `-e|--endpoint`
 
-The address of the mail server.
+The endpoint of the mail server.
 
 To choose between SMTP and SMTPS, provide a URL with with the corresponding
 scheme. For example, `smtp://127.0.0.1:25` will establish an unencrypted
@@ -79,6 +79,13 @@ matches the hostname in the URL.
 
 Providing this flag skips this check, but it makes the connection insecure.
 
+### `-m|--mime`
+
+Wraps the chunk into a MIME part.
+
+The saver takes the uses the metadata of the byte chunk for the `Content-Type`
+MIME header.
+
 ### `-v|--verbose`
 
 Enables verbose output on stderr.
@@ -95,4 +102,28 @@ version
 | save email user@example.org
 ```
 
-Send an email through a remote  `user@example.org`:
+Send the email body as MIME part:
+
+```
+version
+| write json
+| save email --mime user@example.org
+```
+
+This may result in the following email body:
+
+```
+--------------------------s89ecto6c12ILX7893YOEf
+Content-Type: application/json
+Content-Transfer-Encoding: quoted-printable
+
+{
+  "version": "4.10.4+ge0a060567b-dirty",
+  "build": "ge0a060567b-dirty",
+  "major": 4,
+  "minor": 10,
+  "patch": 4
+}
+
+--------------------------s89ecto6c12ILX7893YOEf--
+```


### PR DESCRIPTION
This PR adds an email saver.

```[tasklist]
- [x] Implement SMTP and SMTPS
- [x] Write documentation
- [x] Add changelog entry
```

### Review instructions

I tested this with this pipeline:

```
version
| repeat 3
| write json
| save email -f mavam@localhost -v user@example.org
```

~For the first version of the `email` saver, I deliberately ignored MIME parts. Libcurl [supports this nicely](https://curl.se/libcurl/c/smtp-mime.html), but I'd rather get some experience with this before going more complex.~ Turns out that this was easier than expected. It's now part of the PR.

An open question is how to batch events. Today, we only have the `batch` operator. In TQLv2, we'll be able to window at the event level, which is the missing piece here. I think we can ignore this problem until then.