### PR TITLE
Fix a regression in `from <uri>`

### DIFF
--- a/libtenzir/src/detail/loader_saver_resolver.cpp
+++ b/libtenzir/src/detail/loader_saver_resolver.cpp
@@ -7,11 +7,12 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include <tenzir/concept/parseable/tenzir/identifier.hpp>
-#include <tenzir/curl.hpp>
 #include <tenzir/detail/file_path_to_plugin_name.hpp>
 #include <tenzir/detail/loader_saver_resolver.hpp>
 #include <tenzir/prepend_token.hpp>
 #include <tenzir/tql/parser.hpp>
+
+#include <arrow/util/uri.h>
 
 namespace tenzir::detail {
 
@@ -54,8 +55,8 @@ auto try_plugin_by_url(located<std::string_view> src)
   // Not using caf::uri for anything else but checking for URL validity
   // This is because it makes the interaction with located<...> very difficult
   // TODO: We don't want to allow just any URIs, only URLs
-  auto url = curl::url{};
-  if (url.set(curl::url::part::url, src.inner) != curl::url::code::ok) {
+  auto uri = arrow::internal::Uri{};
+  if (not uri.Parse(std::string{src.inner}).ok()) {
     return {};
   }
   // In a valid URL, the first ':' is guaranteed to separate the scheme from


### PR DESCRIPTION
This fixes an oversight from #4043 that led to a CI failure; we hastily merged it earlier to get the fix in for S3 with explicit credentials, but overlooked that the URI parser from libcurl rejects schemes it does not support. The fix is to simply switch to the Arrow URI parser instead, which is a lot more forgiving.