### PR TITLE
Fix an off-by-one error when loading persisted contexts

### DIFF
--- a/changelog/next/bug-fixes/4045--context-load-off-by-one.md
+++ b/changelog/next/bug-fixes/4045--context-load-off-by-one.md
@@ -1,0 +1,2 @@
+We fixed a bug that caused every second context to become unavailable after a
+restarting the node.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "b552c95847f2629e5429d0bcb46c213a8b4505b8",
+  "rev": "692a8fef920bbbeea02e68b7186b2f1195896e98",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
This fixes a nasty off-by-one error when loading persisted contexts that reliably led to every second context to be skipped when loading from disk.