### PR TITLE
Revert recent changes to the `export` operator

### DIFF
--- a/libtenzir/builtins/operators/export.cpp
+++ b/libtenzir/builtins/operators/export.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2023 The Tenzir Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#include "tenzir/query_cursor.hpp"
-
 #include <tenzir/actors.hpp>
 #include <tenzir/argument_parser.hpp>
 #include <tenzir/atoms.hpp>
@@ -90,8 +88,8 @@ class export_operator final : public crtp_operator<export_operator> {
 public:
   export_operator() = default;
 
-  explicit export_operator(expression expr, bool live, bool low_priority)
-    : expr_{std::move(expr)}, live_{live}, low_priority_(low_priority) {
+  explicit export_operator(expression expr, bool live)
+    : expr_{std::move(expr)}, live_{live} {
   }
 
   auto run_live(operator_control_plane& ctrl) const -> generator<table_slice> {
@@ -138,7 +136,8 @@ public:
     // can offer a better mechanism here.
     auto blocking_self = caf::scoped_actor(ctrl.self().system());
     auto components
-      = get_node_components<index_actor>(blocking_self, ctrl.node());
+      = get_node_components<catalog_actor, accountant_actor, filesystem_actor>(
+        blocking_self, ctrl.node());
     if (!components) {
       diagnostic::error(components.error())
         .note("failed to get importer")
@@ -146,17 +145,20 @@ public:
       co_return;
     }
     co_yield {};
-    auto [index] = std::move(*components);
+    auto [catalog, accountant, fs] = std::move(*components);
+    auto current_slice = std::optional<table_slice>{};
     auto query_context
       = tenzir::query_context::make_extract("export", blocking_self, expr_);
-    query_context.priority = low_priority_ ? query_context::priority::low
-                                           : query_context::priority::normal;
-    auto query_cursor = tenzir::query_cursor{};
+    query_context.id = uuid::random();
+    TENZIR_DEBUG("export operator starts catalog lookup with id {} and "
+                 "expression {}",
+                 query_context.id, expr_);
+    auto current_result = catalog_lookup_result{};
     ctrl.self()
-      .request(index, caf::infinite, atom::evaluate_v, query_context)
+      .request(catalog, caf::infinite, atom::candidates_v, query_context)
       .await(
-        [&query_cursor](tenzir::query_cursor cursor) {
-          query_cursor = cursor;
+        [&current_result](catalog_lookup_result result) {
+          current_result = std::move(result);
         },
         [&ctrl](const caf::error& err) {
           diagnostic::error(err)
@@ -164,57 +166,44 @@ public:
             .emit(ctrl.diagnostics());
         });
     co_yield {};
-    if (query_cursor.candidate_partitions == 0) {
-      co_return;
-    }
-    auto inflight_partitions = query_cursor.scheduled_partitions;
-    TENZIR_DEBUG("export operator got {}/{} partitions ({} in flight)",
-                 query_cursor.scheduled_partitions,
-                 query_cursor.candidate_partitions, inflight_partitions);
-    auto current_slice = std::optional<table_slice>{};
-    while (true) {
-      if (inflight_partitions == 0) {
-        if (query_cursor.scheduled_partitions
-            == query_cursor.candidate_partitions) {
-          break;
-        }
-        constexpr auto BATCH_SIZE = uint32_t{1};
-        ctrl.self()
-          .request(index, caf::infinite, atom::query_v, query_cursor.id,
-                   BATCH_SIZE)
-          .await(
-            [&]() {
-              query_cursor.scheduled_partitions += BATCH_SIZE;
-              inflight_partitions += BATCH_SIZE;
-              TENZIR_DEBUG(
-                "export operator got {}/{} partitions ({} in flight)",
-                query_cursor.scheduled_partitions,
-                query_cursor.candidate_partitions, inflight_partitions);
-            },
-            [&](const caf::error& err) {
-              diagnostic::error(err)
-                .note("failed to request further results")
-                .emit(ctrl.diagnostics());
-            });
-        co_yield {};
+    for (const auto& [type, info] : current_result.candidate_infos) {
+      auto bound_expr = tailor(info.exp, type);
+      if (not bound_expr) {
+        // failing to bind is not an error.
+        continue;
       }
-      while (inflight_partitions > 0) {
-        blocking_self->receive(
-          [&](table_slice& slice) {
-            current_slice = std::move(slice);
-          },
-          [&](atom::done) {
-            inflight_partitions = 0;
-          },
-          [&](const caf::error& err) {
-            diagnostic::warning(err).emit(ctrl.diagnostics());
-            inflight_partitions = 0;
-          });
-        if (current_slice) {
-          co_yield std::move(*current_slice);
-          current_slice.reset();
-        } else {
-          co_yield {};
+      query_context.expr = std::move(*bound_expr);
+      for (const auto& partition_info : info.partition_infos) {
+        const auto& uuid = partition_info.uuid;
+        auto partition = blocking_self->spawn(
+          passive_partition, uuid, accountant, fs,
+          std::filesystem::path{"index"} / fmt::format("{:l}", uuid));
+        auto recieving_slices = true;
+        auto current_error = caf::error{};
+        blocking_self->send(partition, atom::query_v, query_context);
+        while (recieving_slices) {
+          blocking_self->receive(
+            [&current_slice](table_slice slice) {
+              current_slice = std::move(slice);
+            },
+            [&recieving_slices](uint64_t) {
+              recieving_slices = false;
+            },
+            [&recieving_slices, &current_error](caf::error e) {
+              recieving_slices = false;
+              current_error = std::move(e);
+            });
+          if (current_error) {
+            diagnostic::warning(current_error).emit(ctrl.diagnostics());
+            co_yield {};
+            continue;
+          }
+          if (current_slice) {
+            co_yield *current_slice;
+            current_slice.reset();
+          } else {
+            co_yield {};
+          }
         }
       }
     }
@@ -225,7 +214,10 @@ public:
   }
 
   auto detached() const -> bool override {
-    return !live_;
+    if (live_) {
+      return false;
+    }
+    return true;
   }
 
   auto location() const -> operator_location override {
@@ -250,9 +242,9 @@ public:
     }
     auto expr = clauses.empty() ? trivially_true_expression()
                                 : expression{conjunction{std::move(clauses)}};
-    return optimize_result{
-      trivially_true_expression(), event_order::ordered,
-      std::make_unique<export_operator>(std::move(expr), live_, low_priority_)};
+    return optimize_result{trivially_true_expression(), event_order::ordered,
+                           std::make_unique<export_operator>(std::move(expr),
+                                                             live_)};
   }
 
   friend auto inspect(auto& f, export_operator& x) -> bool {
@@ -263,7 +255,6 @@ public:
 private:
   expression expr_;
   bool live_;
-  bool low_priority_;
 };
 
 class plugin final : public virtual operator_plugin<export_operator> {
@@ -276,14 +267,15 @@ public:
     auto parser = argument_parser{"export", "https://docs.tenzir.com/next/"
                                             "operators/sources/export"};
     bool live = false;
-    bool low_priority = false;
     auto internal = false;
+    auto low_priority = false;
     parser.add("--live", live);
-    parser.add("--internal", internal);
-    // TODO: Ideally this should be one level further up, ie.
-    // `tenzir --low-priority <pipeline>`
     parser.add("--low-priority", low_priority);
+    parser.add("--internal", internal);
     parser.parse(p);
+    // The --low-priority option is currently a no-op, and will be brought back
+    // alongside the database plugin.
+    (void)low_priority;
     return std::make_unique<export_operator>(
       expression{
         predicate{
@@ -292,7 +284,7 @@ public:
           data{internal},
         },
       },
-      live, low_priority);
+      live);
   }
 };
 


### PR DESCRIPTION
This reverts the recent change to the `export` operatot that made it go through the index actor, similar to the old `vast export` command. In some production setups, we've seen the index be so busy sorting the priority queue of partitions that something as simple as `export | head 1` takes minutes to finish.

We made these changes in the first place to reduce the pressure from having too many queries running from _Threat Bus_ in parallel, but that's alongside the matcher plugin on its way out and effectively superseded by the `lookup` operator, so it should be safe to make this change.