### PR TITLE
Fix invalid assertion in `compress` operator

### DIFF
--- a/changelog/next/bug-fixes/4048--compress-equal-size.md
+++ b/changelog/next/bug-fixes/4048--compress-equal-size.md
@@ -1,0 +1,2 @@
+The `compress` and `to` operators no longer fail when compression is unable to
+further reduce the size of a batch of bytes.

--- a/changelog/v4.10.4/bug-fixes/4031.md
+++ b/changelog/v4.10.4/bug-fixes/4031.md
@@ -1,2 +1,2 @@
-The `http` saver now correctly sets the `Content-Length` header when issueing
+The `http` saver now correctly sets the `Content-Length` header when issuing
 HTTP requests.

--- a/libtenzir/builtins/operators/compress_decompress.cpp
+++ b/libtenzir/builtins/operators/compress_decompress.cpp
@@ -202,7 +202,7 @@ public:
         }
         if (result->bytes_written > 0) {
           TENZIR_ASSERT(result->bytes_written
-                        < detail::narrow_cast<int64_t>(out_buffer.size()));
+                        <= detail::narrow_cast<int64_t>(out_buffer.size()));
           co_yield chunk::copy(
             as_bytes(out_buffer).subspan(0, result->bytes_written));
         } else {


### PR DESCRIPTION
The result of a compression may sometimes be the same size as the uncompressed chunk.