### PR TITLE
Make shutdown for `export --live` immediate

### DIFF
--- a/libtenzir/builtins/operators/export.cpp
+++ b/libtenzir/builtins/operators/export.cpp
@@ -107,7 +107,7 @@ public:
     }
     co_yield {};
     auto [importer] = std::move(*components);
-    auto bridge = ctrl.self().spawn(make_bridge, importer, expr_);
+    auto bridge = ctrl.self().spawn<caf::linked>(make_bridge, importer, expr_);
     auto next = table_slice{};
     while (true) {
       ctrl.self()


### PR DESCRIPTION
Before this change, `export --live` waited for one further batch of events to arrive before shutting down, as the awaited request from the export operator to the exporter bridge actor for live exports held a strong reference to the latter. Now, we link the bridge actor to the execution node, making the shutdown immediate through a system message.