### PR TITLE
Fix bloom filter contexts for `enrich … --filter`

### DIFF
--- a/changelog/next/changes/4040--context-metadata.md
+++ b/changelog/next/changes/4040--context-metadata.md
@@ -5,5 +5,5 @@ the metadata was available once in the output field.
 The `mode` field in the enrichments returned from the `lookup` operator is now
 `lookup.retro`, `lookup.live`, or `lookup.snapshot` depending on the mode.
 
-The `bloom-filter` context now always returns `true` or `false` for the context
+The `bloom-filter` context now always returns `true` or `null` for the context
 instead of embedding the result in a record with a single `data` field.

--- a/libtenzir/builtins/contexts/bloom_filter.cpp
+++ b/libtenzir/builtins/contexts/bloom_filter.cpp
@@ -60,8 +60,11 @@ public:
     (void)replace;
     auto builder = series_builder{};
     for (const auto& value : array.values()) {
-      const auto contained = bloom_filter_.lookup(value);
-      builder.data(contained);
+      if (bloom_filter_.lookup(value)) {
+        builder.data(true);
+      } else {
+        builder.null();
+      }
     }
     return builder.finish();
   }

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "9b2af6b2edf88ef91f736b5d269b112d40011f5d",
+  "rev": "d6efac384a6ddecbb0c826b27c53c82086d74c7e",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
This makes a further adjustment to a change from #4040 that fixes filtering with a bloom-filter context. That change hasn't made it into any release yet, so there's no changelog entry necessary.