### PR TITLE
Fix test that relied on the patch version number

### DIFF
--- a/tenzir/integration/data/reference/pipelines_local/test_set_operator/step_00.ref
+++ b/tenzir/integration/data/reference/pipelines_local/test_set_operator/step_00.ref
@@ -1,1 +1,1 @@
-{"version": 123, "build": null, "major": -1, "minor": -1, "patch": -1, "foo": "patch", "baz": 4, "qux": null, "schema": "tenzir.version", "schema2": "foo.bar"}
+{"version": 123, "build": null, "major": -1, "minor": -1, "patch": -1, "foo": "patch", "qux": null, "schema": "tenzir.version", "schema2": "foo.bar", "baz": -1}

--- a/tenzir/integration/tests/pipelines_local.bats
+++ b/tenzir/integration/tests/pipelines_local.bats
@@ -520,5 +520,5 @@ EOF
 }
 
 @test "set operator" {
-  check tenzir 'version | set foo="patch", :uint64=-1, :ip=1.1.1.1, baz=patch, qux=foo, version=123, #schema="foo.bar", schema=#schema, build=null | set schema2=#schema'
+  check tenzir 'version | set foo="patch", :uint64=-1, :ip=1.1.1.1, qux=foo, version=123, #schema="foo.bar", schema=#schema, build=null | set schema2=#schema, baz=patch'
 }


### PR DESCRIPTION
We should _really_ stop using the `version` operator as sample data...