### PR TITLE
Prepare repository for Tenzir v4.11.1

### DIFF
--- a/.github/workflows/tenzir.yaml
+++ b/.github/workflows/tenzir.yaml
@@ -111,7 +111,7 @@ jobs:
             # We filter out versions older than limit_version, and a set of
             # releases that are known to be broken, e.g., because their upload
             # failed in CI.
-            filtered_versions=$(printf "$dated_versions" | awk '-F#' '{if($0>="'$dated_limit_version'")print$2}' | grep -v 'v4.6.[0-1]')
+            filtered_versions=$(printf "$dated_versions" | awk '-F#' '{if($0>="'$dated_limit_version'")print$2}' | grep -v 'v4.11.0')
             version_matrix="$(printf "$filtered_versions\nlatest\n" | jq -R | jq -sc 'map({version: .})')"
           else
             version_matrix="$(printf "latest\n" | jq -R | jq -sc 'map({version: .})')"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tenzir"
-version = "4.11.0"
+version = "4.11.1"
 description = "A security telemetry engine for detection and response"
 authors = ["Tenzir <engineering@tenzir.com>"]
 maintainers = ["Tenzir <engineering@tenzir.com>"]

--- a/scripts/prepare-release
+++ b/scripts/prepare-release
@@ -58,7 +58,7 @@ git switch -C "topic/release-${new_version}" origin/main
 version_json="$(jq --arg v "${new_version#v}" '."tenzir-version" = $v' version.json)"
 echo -E "${version_json}" > version.json
 things_done+="
-* Updated \`/version.json\` to ${new_version}."
+* Updated \`/version.json\` to \`${new_version}\`."
 
 # If the new version is not a release candidate, change mentions of the version
 # in README.md as well, and create a new docs version.
@@ -126,7 +126,7 @@ pushd "${source_dir}/python"
 poetry version "${new_version#v}"
 popd
 things_done+="
-* Updated the python bindings version in \`/python/pyproject.toml\` to ${new_version}."
+* Updated the python bindings version in \`/python/pyproject.toml\` to \`${new_version}\`."
 
 # Commit and open a PR against tenzir/tenzir.
 pushd "${source_dir}"
@@ -134,7 +134,7 @@ git add --all
 git commit -F- <<EOF
 Prepare repository for Tenzir ${new_version}
 
-This commit is was created with /scripts/prepare-release.
+This commit was created with \`/scripts/prepare-release\`.
 
 Here is a high-level summary of the changes:
 ${things_done}

--- a/version.json
+++ b/version.json
@@ -4,7 +4,7 @@
     "annotated git tag without the leading 'v'.",
     "This value gets updated automatically by `scripts/prepare-release`."
   ],
-  "tenzir-version": "4.11.0",
+  "tenzir-version": "4.11.1",
   "tenzir-partition-version_COMMENT": [
     "The partition version. This number must be bumped alongside the release",
     "version for releases that contain major format changes to the on-disk",

--- a/web/blog/tenzir-v4.11/index.md
+++ b/web/blog/tenzir-v4.11/index.md
@@ -6,7 +6,7 @@ tags: [contexts, every, set, email, sqs]
 comments: true
 ---
 
-Our latest [v4.11](https://github.com/tenzir/tenzir/releases/tag/v4.11.0)
+Our latest [v4.11](https://github.com/tenzir/tenzir/releases/tag/v4.11.1)
 release delivers powerful automation features, such as scheduling pipelines in a
 given time interval and sending pipeline data as emails.
 


### PR DESCRIPTION
This commit was created with /scripts/prepare-release.

Here is a high-level summary of the changes:

* Updated `/version.json` to v4.11.1.
* Generated a new entry in the docs version selector list.
* Removed the docs for the previous release candidate.
* Moved all changelog entries from `/changelog/next` to `/changelog/v4.11.1`.
* Updated the python bindings version in `/python/pyproject.toml` to v4.11.1.