### PR TITLE
Add multi-line syslog message support

### DIFF
--- a/changelog/next/changes/4080--multiline-syslog.md
+++ b/changelog/next/changes/4080--multiline-syslog.md
@@ -1,0 +1,2 @@
+Lines of input containing an invalid syslog messages are now assumed to
+be a continuation of a message on a previous line, if there's any.

--- a/changelog/next/features/4080--multiline-syslog.md
+++ b/changelog/next/features/4080--multiline-syslog.md
@@ -1,0 +1,1 @@
+Syslog messages spanning multiple lines are now supported.

--- a/tenzir/integration/data/inputs/syslog/multiline.log
+++ b/tenzir/integration/data/inputs/syslog/multiline.log
@@ -5,3 +5,8 @@
     File "script.py", line 10, in <module>
         value = my_list[10]
 IndexError: list index out of range
+2024-02-28 11:58:42.181570 windows_station process[12345]: Placeholder message
+2024-02-28 11:59:42.181570 windows_station process[12345]: Other message
+2024-02-28 12:57:42.181478 windows_station cribl[47425]: Exception in thread "main" java.lang.NullPointerException
+    at com.example.App.method(App.java:42)
+    at com.example.App.main(App.java:20)

--- a/tenzir/integration/data/reference/pipelines_local/test_syslog_format/step_02.ref
+++ b/tenzir/integration/data/reference/pipelines_local/test_syslog_format/step_02.ref
@@ -1,7 +1,5 @@
-{"facility": null, "severity": null, "timestamp": "2024-02-28T11:57:42.181478", "hostname": "windows_station", "app_name": "cribl", "process_id": "47425", "content": "Exception in thread \"main\" java.lang.NullPointerException"}
-{"syslog_message": "    at com.example.App.method(App.java:42)"}
-{"syslog_message": "    at com.example.App.main(App.java:20)"}
-{"facility": null, "severity": null, "timestamp": "2024-02-28T11:57:42.181570", "hostname": "windows_station", "app_name": "rsyslog", "process_id": "23006", "content": "Traceback (most recent call last):"}
-{"syslog_message": "    File \"script.py\", line 10, in <module>"}
-{"syslog_message": "        value = my_list[10]"}
-{"syslog_message": "IndexError: list index out of range"}
+{"facility": null, "severity": null, "timestamp": "2024-02-28T11:57:42.181478", "hostname": "windows_station", "app_name": "cribl", "process_id": "47425", "content": "Exception in thread \"main\" java.lang.NullPointerException\n    at com.example.App.method(App.java:42)\n    at com.example.App.main(App.java:20)"}
+{"facility": null, "severity": null, "timestamp": "2024-02-28T11:57:42.181570", "hostname": "windows_station", "app_name": "rsyslog", "process_id": "23006", "content": "Traceback (most recent call last):\n    File \"script.py\", line 10, in <module>\n        value = my_list[10]\nIndexError: list index out of range"}
+{"facility": null, "severity": null, "timestamp": "2024-02-28T11:58:42.181570", "hostname": "windows_station", "app_name": "process", "process_id": "12345", "content": "Placeholder message"}
+{"facility": null, "severity": null, "timestamp": "2024-02-28T11:59:42.181570", "hostname": "windows_station", "app_name": "process", "process_id": "12345", "content": "Other message"}
+{"facility": null, "severity": null, "timestamp": "2024-02-28T12:57:42.181478", "hostname": "windows_station", "app_name": "cribl", "process_id": "47425", "content": "Exception in thread \"main\" java.lang.NullPointerException\n    at com.example.App.method(App.java:42)\n    at com.example.App.main(App.java:20)"}


### PR DESCRIPTION
Closes https://github.com/tenzir/issues/issues/1068

This PR adds support for multi-line syslog messages. This is achieved through a simple assumption, where if a line of input couldn't be parsed as a syslog message, it's assumed to be a continuation of a message in a preceding line (if any). This is technically a change in behavior, which is reflected in the changelog.