### PR TITLE
Fix the schema name in `show contexts`

### DIFF
--- a/changelog/next/bug-fixes/4082--show-contexts-schema.md
+++ b/changelog/next/bug-fixes/4082--show-contexts-schema.md
@@ -1,0 +1,2 @@
+The schema name of events returned by `show contexts` sometimes did not match
+the type of the context. This now works reliably.

--- a/libtenzir/builtins/contexts/bloom_filter.cpp
+++ b/libtenzir/builtins/contexts/bloom_filter.cpp
@@ -77,9 +77,6 @@ public:
 
   /// Inspects the context.
   auto show() const -> record override {
-    auto ptr = reinterpret_cast<const std::byte*>(bloom_filter_.data().data());
-    auto size = bloom_filter_.data().size();
-    auto data = std::basic_string<std::byte>{ptr, size};
     return record{
       {"num_elements", bloom_filter_.num_elements()},
       {"parameters",
@@ -89,7 +86,6 @@ public:
          {"p", bloom_filter_.parameters().p},
          {"k", bloom_filter_.parameters().k},
        }},
-      {"data", std::move(data)},
     };
   }
 

--- a/libtenzir/builtins/operators/every.cpp
+++ b/libtenzir/builtins/operators/every.cpp
@@ -201,6 +201,7 @@ public:
         .throw_();
     }
     auto result = plugin->parse_operator(p);
+    TENZIR_ASSERT(result);
     if (auto* pipe = dynamic_cast<pipeline*>(result.get())) {
       auto ops = std::move(*pipe).unwrap();
       for (auto& op : ops) {

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "0025f9282e9c9380a62cfb17eb735c20fb5e7e05",
+  "rev": "a4bfe3e783b59a6b1479b48a1e3328de57a05056",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
This erroneously showed a single schema name for all contexts, even when they have differing types.