### PR TITLE
Make `python` operator not discard fields that start with an underscore

### DIFF
--- a/changelog/next/bug-fixes/4085--python-operator-underscore.md
+++ b/changelog/next/bug-fixes/4085--python-operator-underscore.md
@@ -1,0 +1,1 @@
+The `python` operator no longer discards field that start with an underscore.


### PR DESCRIPTION
Fields starting with `_` were previously discarded due to some implementation details. However, following #4036, this is no longer necessary. I also used this opportunity to clean up the surrounding code.