### PR TITLE
Fix JSON printer handling of `inf` and `nan`

### DIFF
--- a/changelog/next/bug-fixes/4087--fix-json-printer-inf-nan.md
+++ b/changelog/next/bug-fixes/4087--fix-json-printer-inf-nan.md
@@ -1,0 +1,3 @@
+The JSON printer previously printed invalid JSON for `inf` and `nan`, which
+means that `serve` could sometimes emit invalid JSON, which is not handled well
+by platform/app. Instead, we now emit `null`.

--- a/libtenzir/include/tenzir/concept/printable/tenzir/json.hpp
+++ b/libtenzir/include/tenzir/concept/printable/tenzir/json.hpp
@@ -19,6 +19,7 @@
 
 #include <fmt/format.h>
 
+#include <cmath>
 #include <optional>
 
 namespace tenzir {
@@ -58,6 +59,14 @@ struct json_printer : printer_base<json_printer> {
     }
 
     auto operator()(view<double> x) noexcept -> bool {
+      switch (std::fpclassify(x)) {
+        case FP_NORMAL:
+        case FP_SUBNORMAL:
+        case FP_ZERO:
+          break;
+        default:
+          return (*this)(caf::none);
+      }
       if (double i; std::modf(x, &i) == 0.0) // NOLINT
         out_ = fmt::format_to(out_, options_.style.number, "{}.0", i);
       else

--- a/tenzir/integration/data/reference/pipelines_local/test_weird_json_floats/step_00.ref
+++ b/tenzir/integration/data/reference/pipelines_local/test_weird_json_floats/step_00.ref
@@ -1,0 +1,1 @@
+{"inf": null, "nan": null, "subnormal": 2.2250738585072e-310, "zero": -0.0}

--- a/tenzir/integration/tests/pipelines_local.bats
+++ b/tenzir/integration/tests/pipelines_local.bats
@@ -611,3 +611,19 @@ EOF
 EOF
 
 }
+
+# bats test_tags=json
+@test "weird json floats" {
+  check tenzir -f /dev/stdin <<EOF
+version |
+python "
+  import sys
+
+  self.inf = float(\"inf\");
+  self.nan = float(\"nan\");
+  self.zero = -0.0
+  self.subnormal = sys.float_info.min / 100
+" |
+put inf, nan, subnormal, zero
+EOF
+}


### PR DESCRIPTION
The JSON printer previously printed invalid JSON for `inf` and `nan`, which means that `serve` could sometimes emit invalid JSON, which is not handled well by platform/app. Instead, we now emit `null`.

```diff
- {"inf": inf.0, "nan": nan, "subnormal": 2.2250738585072e-310, "zero": -0.0}
+ {"inf": null, "nan": null, "subnormal": 2.2250738585072e-310, "zero": -0.0}
```