### PR TITLE
Support zero-copy reading in new Feather parser

### DIFF
--- a/libtenzir/builtins/formats/bitz.cpp
+++ b/libtenzir/builtins/formats/bitz.cpp
@@ -74,7 +74,7 @@ public:
           co_yield std::move(result);
         }
       },
-      make_byte_reader(std::move(input)), ctrl);
+      make_byte_view_reader(std::move(input)), ctrl);
   }
 
   friend auto inspect(auto& f, bitz_parser& x) -> bool {

--- a/libtenzir/builtins/formats/pcap.cpp
+++ b/libtenzir/builtins/formats/pcap.cpp
@@ -68,7 +68,7 @@ public:
                    bool emit_file_headers) -> generator<table_slice> {
       // A PCAP file starts with a 24-byte header.
       auto input_file_header = file_header{};
-      auto read_n = make_byte_reader(std::move(input));
+      auto read_n = make_byte_view_reader(std::move(input));
       co_yield {};
       while (true) {
         auto length = sizeof(file_header);

--- a/libtenzir/include/tenzir/make_byte_reader.hpp
+++ b/libtenzir/include/tenzir/make_byte_reader.hpp
@@ -14,76 +14,94 @@
 namespace tenzir {
 
 /// Returns a stateful function that retrieves a given number of bytes in a
+/// contiguous buffer from a generator of chunks. The last chunk is underful,
+/// i.e., smaller than the number of bytes requested, and zero-sized if the
+/// input boundaries are aligned. The function returns nullptr whenever it
+/// merges buffers from multiple chunks. This does not indicate completion.
+inline auto make_byte_reader(generator<chunk_ptr> input) {
+  input.begin(); // prime the pump
+  return [input = std::move(input), buffer = chunk::make_empty(),
+          offset = size_t{0}](size_t num_bytes) mutable -> chunk_ptr {
+    TENZIR_ASSERT(num_bytes > 0);
+    TENZIR_ASSERT(buffer);
+    // If the buffer size exactly matches what is requested, then we can just
+    // return the buffer itself.
+    if (offset == 0 and buffer->size() == num_bytes) {
+      TENZIR_ASSERT(buffer->size() - offset == num_bytes);
+      offset = buffer->size();
+      return buffer;
+    }
+    // If we have a buffer and it's non-empty, then we can just return a slice
+    // of the buffer.
+    if (buffer->size() - offset >= num_bytes) {
+      auto result = buffer->slice(offset, num_bytes);
+      offset += num_bytes;
+      TENZIR_ASSERT(result->size() == num_bytes);
+      return result;
+    }
+    // Otherwise we need to read more.
+    auto current = input.unsafe_current();
+    if (current == input.end()) {
+      if (offset == 0) {
+        offset = buffer->size();
+        TENZIR_ASSERT(buffer->size() <= num_bytes);
+        return buffer;
+      }
+      auto result = buffer->slice(offset, num_bytes);
+      offset = buffer->size();
+      TENZIR_ASSERT(result->size() <= num_bytes);
+      return result;
+    }
+    auto chunk = std::move(*current);
+    ++current;
+    if (not chunk) {
+      return {};
+    }
+    if (buffer->size() == offset) {
+      buffer = std::move(chunk);
+    } else {
+      auto merged_buffer = std::make_unique<chunk::value_type[]>(
+        buffer->size() - offset + chunk->size());
+      std::memcpy(merged_buffer.get(), buffer->data() + offset,
+                  buffer->size() - offset);
+      std::memcpy(merged_buffer.get() + buffer->size() - offset, chunk->data(),
+                  chunk->size());
+      const auto merged_buffer_view = std::span{
+        merged_buffer.get(), buffer->size() - offset + chunk->size()};
+      buffer
+        = chunk::make(merged_buffer_view,
+                      [merged_buffer = std::move(merged_buffer)]() noexcept {
+                        static_cast<void>(merged_buffer);
+                      });
+    }
+    offset = 0;
+    // Now that we read more, we can try again to return something.
+    if (buffer->size() == num_bytes) {
+      TENZIR_ASSERT(buffer->size() - offset == num_bytes);
+      offset = buffer->size();
+      return buffer;
+    }
+    if (buffer->size() > num_bytes) {
+      auto result = buffer->slice(0, num_bytes);
+      offset = num_bytes;
+      TENZIR_ASSERT(result->size() == num_bytes);
+      return result;
+    }
+    return {};
+  };
+}
+
+/// Returns a stateful function that retrieves a given number of bytes in a
 /// contiguous buffer from a generator of chunks. The last span is underful,
 /// i.e., smaller than the number of bytes requested, and zero-sized if the
 /// input boundaries are aligned. The function returns nullopt whenever it
 /// merges buffers from multiple chunks. This does not indicate completion.
-inline auto make_byte_reader(generator<chunk_ptr> input) {
-  input.begin(); // prime the pump
+inline auto make_byte_view_reader(generator<chunk_ptr> input) {
   return
-    [input = std::move(input), chunk = chunk_ptr{}, chunk_offset = size_t{0},
-     buffer = std::vector<std::byte>{}, buffer_offset = size_t{0}](
+    [byte_reader = make_byte_reader(std::move(input))](
       size_t num_bytes) mutable -> std::optional<std::span<const std::byte>> {
-      // The internal chunk is not available when we first enter this function
-      // and as well when we have no more chunks (at the end).
-      if (!chunk) {
-        TENZIR_ASSERT(chunk_offset == 0);
-        // Can we fulfill our request from the buffer?
-        if (buffer.size() - buffer_offset >= num_bytes) {
-          auto result = as_bytes(buffer).subspan(buffer_offset, num_bytes);
-          buffer_offset += num_bytes;
-          return result;
-        }
-        // Can we get more chunks?
-        auto current = input.unsafe_current();
-        if (current == input.end()) {
-          // We're done and return an underful chunk.
-          auto result = as_bytes(buffer).subspan(buffer_offset);
-          buffer_offset = buffer.size();
-          TENZIR_ASSERT(result.size() < num_bytes);
-          return result;
-        }
-        chunk = std::move(*current);
-        ++current;
-        if (!chunk) {
-          return std::nullopt;
-        }
-      }
-      // We have a chunk.
-      TENZIR_ASSERT(chunk != nullptr);
-      if (buffer.size() == buffer_offset) {
-        // Have consumed the entire chunk last time? Then reset and try again.
-        if (chunk_offset == chunk->size()) {
-          chunk_offset = 0;
-          chunk = nullptr;
-          return std::nullopt;
-        }
-        TENZIR_ASSERT(chunk_offset < chunk->size());
-        // If we have a chunk, but not enough bytes, then we must buffer.
-        if (chunk->size() - chunk_offset < num_bytes) {
-          buffer = {chunk->begin() + chunk_offset, chunk->end()};
-          buffer_offset = 0;
-          chunk = nullptr;
-          chunk_offset = 0;
-          return std::nullopt;
-        }
-        // Enough in the chunk, simply yield from it.
-        auto result = as_bytes(*chunk).subspan(chunk_offset, num_bytes);
-        chunk_offset += num_bytes;
-        return result;
-      }
-      // If we need to process both a buffer and chunk, we copy over the chunk
-      // remainder into the buffer.
-      buffer.erase(buffer.begin(), buffer.begin() + buffer_offset);
-      buffer_offset = 0;
-      buffer.reserve(buffer.size() + chunk->size() - chunk_offset);
-      buffer.insert(buffer.end(), chunk->begin() + chunk_offset, chunk->end());
-      chunk = nullptr;
-      chunk_offset = 0;
-      if (buffer.size() >= num_bytes) {
-        auto result = as_bytes(buffer).subspan(0, num_bytes);
-        buffer_offset = num_bytes;
-        return result;
+      if (auto bytes = byte_reader(num_bytes)) {
+        return as_bytes(*bytes);
       }
       return std::nullopt;
     };

--- a/libtenzir/src/chunk.cpp
+++ b/libtenzir/src/chunk.cpp
@@ -356,7 +356,7 @@ chunk::iterator chunk::end() const noexcept {
 // -- accessors ----------------------------------------------------------------
 
 chunk_ptr chunk::slice(size_type start, size_type length) const {
-  TENZIR_ASSERT(start < size());
+  TENZIR_ASSERT(start <= size());
   if (length > size() - start)
     length = size() - start;
   return slice(view_.subspan(start, length));


### PR DESCRIPTION
This change builds on top of @balavinaithirthan's upcoming Feather format and adds zero-copy support to it. This is a vast improvement when reading Feather from a memory-mapped file, where copies of data can now be avoided entirely until we need to do IPC or exchange any columns.