### PR TITLE
Fix index roundtrip unit test

### DIFF
--- a/libtenzir/test/partition_roundtrip.cpp
+++ b/libtenzir/test/partition_roundtrip.cpp
@@ -80,7 +80,6 @@ TEST(index roundtrip) {
   flatbuffers::FlatBufferBuilder builder;
   auto index = pack(builder, state);
   REQUIRE(index);
-  tenzir::fbs::FinishIndexBuffer(builder, *index);
   auto fb = builder.GetBufferPointer();
   auto sz = builder.GetSize();
   auto span = std::span(fb, sz);


### PR DESCRIPTION
The unit test calls `tenzir::fbs::FinishIndexBuffer`, even though this was already called by `pack(...)`, leading to a failing assertion and therefore CI fail.