### PR TITLE
Fix HTTP PUT with empty request body

### DIFF
--- a/changelog/next/bug-fixes/4092--http-put-fix.md
+++ b/changelog/next/bug-fixes/4092--http-put-fix.md
@@ -1,0 +1,2 @@
+We fixed a bug in the `http` saver that prevented sending HTTP PUT requests with
+an empty request body.

--- a/libtenzir/include/tenzir/curl.hpp
+++ b/libtenzir/include/tenzir/curl.hpp
@@ -510,8 +510,7 @@ auto escape(std::string_view str) -> std::string;
 /// @returns The encoded string.
 auto escape(const record& xs) -> std::string;
 
-/// Instructs an easy handle to upload a chunk. This sets `CURLOPT_UPLOAD` and
-/// sets the read callback to read the chunk.
-auto upload(easy& handle, chunk_ptr chunk) -> caf::error;
+/// Prepares an easy handle with a chunk through the read callback.
+auto set(easy& handle, chunk_ptr chunk) -> caf::error;
 
 } // namespace tenzir::curl

--- a/libtenzir/src/curl.cpp
+++ b/libtenzir/src/curl.cpp
@@ -398,14 +398,9 @@ auto escape(const record& xs) -> std::string {
   return fmt::format("{}", fmt::join(kvps, "&"));
 }
 
-auto upload(easy& handle, chunk_ptr chunk) -> caf::error {
+auto set(easy& handle, chunk_ptr chunk) -> caf::error {
   TENZIR_ASSERT(chunk);
   TENZIR_ASSERT(chunk->size() > 0);
-  if (auto err = to_error(handle.set(CURLOPT_UPLOAD, 1))) {
-    return err;
-  }
-  // Using CURLOPT_UPLOAD expects that we go through the read callback, and we
-  // must set CURLOPT_INFILESIZE(_LARGE).
   auto size = detail::narrow_cast<long>(chunk->size());
   if (auto err = to_error(handle.set_infilesize(size))) {
     return err;

--- a/libtenzir/src/version.cpp
+++ b/libtenzir/src/version.cpp
@@ -90,6 +90,9 @@ auto tenzir_features() -> std::vector<std::string> {
     "chart_operator",
     // The `/serve` endpoint supports the new `use_simple_format: bool` option.
     "serve_use_simple_format_option",
+    // The node supports HTTP PUT upload to a platform-provided URL for
+    // downloading Explorer results.
+    "http_put_upload",
   };
 }
 


### PR DESCRIPTION
This PR fixes a bug when attempting to send a HTTP PUT request with an empty request body.
