### PR TITLE
Fix shutdown of connected pipelines alongside node

### DIFF
--- a/changelog/next/bug-fixes/4093--node-shutdown.md
+++ b/changelog/next/bug-fixes/4093--node-shutdown.md
@@ -1,0 +1,3 @@
+Pipelines run with the `tenzir` binary that connected to a Tenzir Node did
+sometimes not shut down correctly when the node shut down. This now happens
+reliably.

--- a/libtenzir/include/tenzir/node.hpp
+++ b/libtenzir/include/tenzir/node.hpp
@@ -90,6 +90,10 @@ struct node_state {
 
   /// Flag to signal if the node received an exit message.
   bool tearing_down = false;
+
+  /// Weak handles to remotely spawned and monitored exec ndoes for cleanup on
+  /// node shutdown.
+  std::unordered_set<caf::actor_addr> monitored_exec_nodes = {};
 };
 
 /// Spawns a node.

--- a/tenzir/integration/tests/shutdown.bats
+++ b/tenzir/integration/tests/shutdown.bats
@@ -1,0 +1,18 @@
+: "${BATS_TEST_TIMEOUT:=10}"
+
+setup() {
+  bats_load_library bats-support
+  bats_load_library bats-assert
+  bats_load_library bats-tenzir
+}
+
+@test "remote operators shut down with node" {
+  setup_node_with_default_config
+  check ! --bg client tenzir 'export --live'
+  # HACK: We run something else that goes through the node actor, just so that
+  # we can be sure that the remote operator was actually spawned from the
+  # background process.
+  check tenzir 'api /ping | discard'
+  teardown_node
+  wait "${client[@]}"
+}


### PR DESCRIPTION
In some cases, pipelines created with a `tenzir` process connected to a `tenzir-node` process did not shut down correctly when the `tenzir-node` process was terminated. This change makes it so that remotely spawned operators are always shut down reliably.

Fixes tenzir/issues#1712