### PR TITLE
Add a `--timeout <duration>` option to `batch`

### DIFF
--- a/changelog/next/features/4095--batch-timeout.md
+++ b/changelog/next/features/4095--batch-timeout.md
@@ -1,0 +1,2 @@
+The `batch` operator gained a new `--timeout <duration>` option that control the
+maixmum latency for withholding events for batching.

--- a/changelog/next/features/4095--batch-timeout.md
+++ b/changelog/next/features/4095--batch-timeout.md
@@ -1,2 +1,2 @@
-The `batch` operator gained a new `--timeout <duration>` option that control the
-maixmum latency for withholding events for batching.
+The `batch` operator gained a new `--timeout <duration>` option that controls
+the maixmum latency for withholding events for batching.

--- a/web/docs/operators/batch.md
+++ b/web/docs/operators/batch.md
@@ -17,13 +17,18 @@ underlying pipeline execution engine. Use with caution!
 ## Synopsis
 
 ```
-batch [<limit>]
+batch [--timeout <duration>] [<limit>]
 ```
 
 ## Description
 
 The `batch` operator takes its input and rewrites it into batches of up to the
 desired size.
+
+### `--timeout <duration>`
+
+Specifies a maximum latency for events passing through the batch operator. When
+unspecified, an infinite duration is used.
 
 ### `<limit>`
 


### PR DESCRIPTION
This makes the `batch` operator a bit more flexible, allowing users to control batching not just by size, but also by latency. Without this option, choosing a large batch size often resulted in events being delayed a lot until the desired batch size was available. Now, there is a maximum latency for events.

This doesn't have a direct use case (yet), but I plan to make use of this implicitly internally as part of the upcoming database plugin when writing files. We should also consider inserting this into pipelines in front of operators whose performance suffers heavily when using too small batches.