### PR TITLE
Shut down node a configured pipeline fails to start

### DIFF
--- a/changelog/next/bug-fixes/4097--configured-pipeline-startup-errors.md
+++ b/changelog/next/bug-fixes/4097--configured-pipeline-startup-errors.md
@@ -1,0 +1,3 @@
+Nodes now shut down with a non-zero exit code when pipelines configured as part
+of the `tenzir.yaml` file fail to start, making such configuration errors easier
+to spot.

--- a/libtenzir/include/tenzir/shutdown.hpp
+++ b/libtenzir/include/tenzir/shutdown.hpp
@@ -38,23 +38,30 @@ namespace tenzir {
 /// shutdown sequence.
 /// @param self The actor to terminate.
 /// @param xs Actors that need to shutdown before *self* quits.
+/// @param reason The error message to terminate with; defaults to
+/// caf::exit_reason::user_shutdown.
 /// @relates terminate
 template <class Policy>
-void shutdown(caf::event_based_actor* self, std::vector<caf::actor> xs);
+void shutdown(caf::event_based_actor* self, std::vector<caf::actor> xs,
+              caf::error reason = caf::exit_reason::user_shutdown);
 
 template <class Policy, class... Ts>
 void shutdown(caf::typed_event_based_actor<Ts...>* self,
-              std::vector<caf::actor> xs) {
+              std::vector<caf::actor> xs,
+              caf::error reason = caf::exit_reason::user_shutdown) {
   auto handle = caf::actor_cast<caf::event_based_actor*>(self);
-  shutdown<Policy>(handle, std::move(xs));
+  shutdown<Policy>(handle, std::move(xs), std::move(reason));
 }
 
 template <class Policy>
-void shutdown(caf::scoped_actor& self, std::vector<caf::actor> xs);
+void shutdown(caf::scoped_actor& self, std::vector<caf::actor> xs,
+              caf::error reason = caf::exit_reason::user_shutdown);
 
 template <class Policy, class Actor>
-void shutdown(Actor&& self, caf::actor x) {
-  shutdown<Policy>(std::forward<Actor>(self), std::vector{std::move(x)});
+void shutdown(Actor&& self, caf::actor x,
+              caf::error reason = caf::exit_reason::user_shutdown) {
+  shutdown<Policy>(std::forward<Actor>(self), std::vector{std::move(x)},
+                   std::move(reason));
 }
 
 } // namespace tenzir

--- a/libtenzir/src/node.cpp
+++ b/libtenzir/src/node.cpp
@@ -522,9 +522,11 @@ node(node_actor::stateful_pointer<node_state> self, std::string /*name*/,
     auto core_shutdown_sequence
       = [=, core_shutdown_handles = std::move(core_shutdown_handles),
          filesystem_handle = std::move(filesystem_handle)]() mutable {
-          for (const auto& comp : core_shutdown_handles)
+          for (const auto& comp : core_shutdown_handles) {
             self->demonitor(comp);
-          shutdown<policy::sequential>(self, std::move(core_shutdown_handles));
+          }
+          shutdown<policy::sequential>(self, std::move(core_shutdown_handles),
+                                       msg.reason);
           // We deliberately do not send an exit message to the filesystem
           // actor, as that would mean that actors not tracked by the component
           // registry which hold a strong handle to the filesystem actor cannot

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "ba4ad114a0626c53fc3786292d8f11f04d210f1b",
+  "rev": "6680dcf0b85a1b64332d77c34a14f3a25269faf8",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
A configured pipeline with a syntax error should not allow nodes to start up successfully.

Fixes tenzir/issues#1714