### PR TITLE
Make a few more operators initialize quickly

### DIFF
--- a/libtenzir/builtins/operators/slice.cpp
+++ b/libtenzir/builtins/operators/slice.cpp
@@ -36,6 +36,7 @@ public:
     if (end <= begin) {
       co_return;
     }
+    co_yield {};
     auto offset = int64_t{0};
     for (auto&& slice : input) {
       if (slice.rows() == 0) {
@@ -59,6 +60,7 @@ public:
     -> generator<table_slice> {
     TENZIR_ASSERT(begin >= 0);
     TENZIR_ASSERT(end <= 0);
+    co_yield {};
     auto offset = int64_t{0};
     auto buffer = std::vector<table_slice>{};
     for (auto&& slice : input) {
@@ -95,6 +97,7 @@ public:
     -> generator<table_slice> {
     TENZIR_ASSERT(begin <= 0);
     TENZIR_ASSERT(end >= 0);
+    co_yield {};
     auto offset = int64_t{0};
     auto buffer = std::vector<table_slice>{};
     for (auto&& slice : input) {
@@ -137,6 +140,7 @@ public:
     if (end <= begin) {
       co_return;
     }
+    co_yield {};
     auto offset = int64_t{0};
     auto buffer = std::vector<table_slice>{};
     for (auto&& slice : input) {

--- a/libtenzir/builtins/operators/sort.cpp
+++ b/libtenzir/builtins/operators/sort.cpp
@@ -179,6 +179,7 @@ public:
                                ? arrow::compute::NullPlacement::AtStart
                                : arrow::compute::NullPlacement::AtEnd;
     auto state = sort_state{key_, options};
+    co_yield {};
     for (auto&& slice : input) {
       co_yield state.try_add(std::move(slice), ctrl);
     }

--- a/libtenzir/builtins/operators/summarize.cpp
+++ b/libtenzir/builtins/operators/summarize.cpp
@@ -766,6 +766,7 @@ public:
   auto
   operator()(generator<table_slice> input, operator_control_plane& ctrl) const
     -> generator<table_slice> {
+    co_yield {};
     auto impl = implementation{};
     for (auto&& slice : input) {
       if (slice.rows() == 0) {

--- a/libtenzir/include/tenzir/pipeline.hpp
+++ b/libtenzir/include/tenzir/pipeline.hpp
@@ -698,6 +698,7 @@ public:
   auto
   operator()(generator<table_slice> input, operator_control_plane& ctrl) const
     -> generator<remove_generator_t<output_type>> {
+    co_yield {};
     auto states = std::unordered_map<type, state_type>{};
     for (auto&& slice : input) {
       if (slice.rows() == 0) {


### PR DESCRIPTION
This modifies some more operators to always yield an empty value quickly, signaling a successful startup of the operator. I'm hoping that this reduces the likelihood of 504 timeout errors on app.tenzir.com for long pipelines.