### PR TITLE
Remove wrong EXPOSE in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,8 +85,6 @@ RUN mkdir -p \
       /var/lib/tenzir \
       /var/log/tenzir
 
-EXPOSE 5158/tcp
-
 WORKDIR /var/lib/tenzir
 VOLUME ["/var/lib/tenzir"]
 
@@ -158,7 +156,6 @@ RUN apt-get update && \
 
 USER tenzir:tenzir
 
-EXPOSE 5158/tcp
 WORKDIR /var/lib/tenzir
 VOLUME ["/var/cache/tenzir", "/var/lib/tenzir"]
 

--- a/changelog/next/bug-fixes/4099--wrong-expose.md
+++ b/changelog/next/bug-fixes/4099--wrong-expose.md
@@ -1,0 +1,2 @@
+Tenzir Docker images no longer expose 5158/tcp by default, as this prevented
+running multiple containers in the same network or in host mode.

--- a/flake.nix
+++ b/flake.nix
@@ -59,9 +59,6 @@
                 "TENZIR_LOG_FILE=/var/log/tenzir/server.log"
                 "TENZIR_ENDPOINT=0.0.0.0"
               ];
-              ExposedPorts = {
-                "5158/tcp" = {};
-              };
               WorkingDir = "${tenzir-dir}";
               Volumes = {
                 "${tenzir-dir}" = {};


### PR DESCRIPTION
Our Docker images always exposed port 5158/tcp, regardless of how that was configured. This broke running multiple nodes in the same Docker Compose file or in host mode.
