### PR TITLE
Add support for void-to-void operators

### DIFF
--- a/libtenzir/builtins/operators/every.cpp
+++ b/libtenzir/builtins/operators/every.cpp
@@ -119,8 +119,11 @@ public:
     if (output->is<table_slice>()) {
       return run<table_slice>(op_->copy(), interval_, std::move(input), ctrl);
     }
-    TENZIR_ASSERT(output->is<chunk_ptr>());
-    return run<chunk_ptr>(op_->copy(), interval_, std::move(input), ctrl);
+    if (output->is<chunk_ptr>()) {
+      return run<chunk_ptr>(op_->copy(), interval_, std::move(input), ctrl);
+    }
+    TENZIR_ASSERT(output->is<void>());
+    return run<std::monostate>(op_->copy(), interval_, std::move(input), ctrl);
   }
 
   auto copy() const -> operator_ptr override {


### PR DESCRIPTION
These operators are effectively commands, i.e., they cannot actually be combined with any other operator, except for operator modifiers.

The rationale for this is an upcoming change to `context save`, `context update`, and `context create` that turns the three operators into sinks. But since `context create` already is a source operator this means that we now had to implement support for operators that are both a source and a sink at the same time. Luckily this was rather easy to implement.

For testing, I modified the `version` soucce operator to return a `generator<std::monostate>` and to print the event on the stderr instead. The only code outside of the execution nodes that I needed to modify was the `every` operator modifier that ran into an assertion for void-to-void operators.