### PR TITLE
Add targets to CMake for updating test references

### DIFF
--- a/.cmake-format
+++ b/.cmake-format
@@ -5,6 +5,12 @@ with section("parse"):
 
     # Specify structure for custom cmake functions
     additional_commands = {
+        "tenzirdefineupdateintegrationtarget": {
+            "spelling": "TenzirDefineUpdateIntegrationTarget",
+            "pargs": {
+                "nargs": 1,
+            },
+        },
         "tenzirexportcompilecommands": {
             "spelling": "TenzirExportCompileCommands",
             "pargs": {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -570,13 +570,6 @@ if (TENZIR_ENABLE_DEVELOPER_MODE OR TENZIR_ENABLE_BUILDID)
     INTERFACE "-fdebug-prefix-map=${CMAKE_CURRENT_SOURCE_DIR}=.")
 endif ()
 
-option(TENZIR_ENABLE_UPDATE_INTEGRATION_REFERENCES
-       "Update references when running in integration tests" OFF)
-add_feature_info(
-  "TENZIR_ENABLE_UPDATE_INTEGRATION_REFERENCES"
-  TENZIR_ENABLE_UPDATE_INTEGRATION_REFERENCES
-  "update references when running integration tests.")
-
 # -- additional warnings -------------------------------------------------------
 
 option(TENZIR_ENABLE_MORE_WARNINGS "Enable addditional warnings" OFF)

--- a/cmake/TenzirRegisterPlugin.cmake
+++ b/cmake/TenzirRegisterPlugin.cmake
@@ -1,5 +1,15 @@
 include_guard(GLOBAL)
 
+# Define a target for updating integration test references.
+macro (TenzirDefineUpdateIntegrationTarget _target)
+  add_custom_target(
+    update-${_target}
+    COMMAND "${CMAKE_COMMAND}" -E env UPDATE=1 "${CMAKE_COMMAND}" --build
+            "${CMAKE_BINARY_DIR}" --target ${_target}
+    COMMENT "Updating ${_target} test references..."
+    USES_TERMINAL)
+endmacro ()
+
 # Normalize the GNUInstallDirs to be relative paths, if possible.
 macro (TenzirNormalizeInstallDirs)
   foreach (
@@ -789,6 +799,7 @@ function (TenzirRegisterPlugin)
   # define integration tests.
   if (NOT TARGET integration)
     add_custom_target(integration)
+    TenzirDefineUpdateIntegrationTarget(integration)
   endif ()
 
   # Setup integration tests.
@@ -815,6 +826,7 @@ function (TenzirRegisterPlugin)
       USES_TERMINAL)
     unset(parallel_level)
     unset(TENZIR_PATH)
+    TenzirDefineUpdateIntegrationTarget(integration-${PLUGIN_TARGET})
 
     add_dependencies(integration-${PLUGIN_TARGET} tenzir::tenzir)
     add_dependencies(integration integration-${PLUGIN_TARGET})

--- a/tenzir/CMakeLists.txt
+++ b/tenzir/CMakeLists.txt
@@ -118,6 +118,7 @@ endif ()
 # -- integration tests ---------------------------------------------------------
 
 add_custom_target(integration)
+TenzirDefineUpdateIntegrationTarget(integration)
 
 include(ProcessorCount)
 ProcessorCount(parallel_level)
@@ -125,13 +126,14 @@ math(EXPR parallel_level "${parallel_level} + 2")
 add_custom_target(
   integration-core
   COMMAND
-    ${CMAKE_COMMAND} -E env
+    "${CMAKE_COMMAND}" -E env
     PATH="$<TARGET_FILE_DIR:tenzir::tenzir>:\$\$PATH:${CMAKE_CURRENT_SOURCE_DIR}/integration/lib/bats/bin"
     bats "-r" "-T" "--jobs" "${parallel_level}"
     "${CMAKE_CURRENT_SOURCE_DIR}/integration/tests"
   COMMENT "Executing integration tests..."
   USES_TERMINAL)
 unset(parallel_level)
+TenzirDefineUpdateIntegrationTarget(integration-core)
 
 add_dependencies(integration-core tenzir)
 add_dependencies(integration integration-core)
@@ -139,9 +141,11 @@ add_dependencies(integration integration-core)
 # link the full
 add_custom_target(
   link-integration
-  COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_BINARY_DIR}/share/tenzir"
+  COMMAND "${CMAKE_COMMAND}" -E make_directory
+          "${CMAKE_BINARY_DIR}/share/tenzir"
   COMMAND
-    ${CMAKE_COMMAND} -E create_symlink "${CMAKE_CURRENT_SOURCE_DIR}/integration"
+    "${CMAKE_COMMAND}" -E create_symlink
+    "${CMAKE_CURRENT_SOURCE_DIR}/integration"
     "${CMAKE_BINARY_DIR}/share/tenzir/integration"
   COMMENT "Linking integration test directory")
 

--- a/tenzir/integration/README.md
+++ b/tenzir/integration/README.md
@@ -8,7 +8,7 @@ the test output against a known reference file.
 
 # Running integration tests
 
-To run all tests, execute the `integration` target from cmake.
+To run all tests, execute the `integration` target from CMake.
 
 To run all tests in this directory, use `bats tests/`.
 
@@ -27,8 +27,8 @@ run the test file.
 
 # Updating and creating references
 
-To update or create reference files, set the `UPDATE=1` environment
-variable and run `bats`.
+To update or create reference files, run the `update-integration` target from
+CMake, or set the `UPDATE=1` environment variable and run `bats`.
 
 To update the references for one specific test, add the `bats:focus`
 tag to that test and run bats with `UPDATE=1`. Only that test will


### PR DESCRIPTION
Purely a convenience thing, because explaining that for every integration test target `integration*` there is a corresponding `update-integration*` is a lot easier than remembering which environment variable to set for updating test references.