### PR TITLE
Adjust `chart` syntax from `--key value` to `key=value`

### DIFF
--- a/changelog/next/changes/4107--chart-syntax.md
+++ b/changelog/next/changes/4107--chart-syntax.md
@@ -1,0 +1,2 @@
+`chart` operator now uses a `key=value` syntax for its arguments,
+instead of shell-like `--key value`.

--- a/changelog/next/changes/4107--chart-title.md
+++ b/changelog/next/changes/4107--chart-title.md
@@ -1,0 +1,2 @@
+The `--title` option is removed from `chart`. The same can be achieved
+through the dashboard in the Tenzir App.

--- a/libtenzir/include/tenzir/concept/parseable/core/rule.hpp
+++ b/libtenzir/include/tenzir/concept/parseable/core/rule.hpp
@@ -114,8 +114,8 @@ public:
   }
 
   template <class RHS>
-  requires(!detail::is_same_or_derived_v<type_erased_parser, RHS>)
-    type_erased_parser(RHS&& rhs)
+    requires(!detail::is_same_or_derived_v<type_erased_parser, RHS>)
+  type_erased_parser(RHS&& rhs)
     : parser_{make_parser<RHS>(std::forward<RHS>(rhs))} {
     static_assert(parser<std::decay_t<RHS>>);
   }
@@ -126,9 +126,8 @@ public:
   }
 
   template <class RHS>
-  requires(!detail::is_same_or_derived_v<type_erased_parser, RHS>)
-    type_erased_parser&
-    operator=(RHS&& rhs) {
+    requires(!detail::is_same_or_derived_v<type_erased_parser, RHS>)
+  type_erased_parser& operator=(RHS&& rhs) {
     static_assert(parser<std::decay_t<RHS>>);
     parser_ = make_parser<RHS>(std::forward<RHS>(rhs));
     return *this;
@@ -154,6 +153,9 @@ class rule : public parser_base<rule<Iterator, Attribute>> {
     // static_assert(is_compatible_attribute<RHS, typename RHS::attribute>{},
     //              "incompatible parser attributes");
     using rule_type = detail::rule_definition<RHS, Iterator, Attribute>;
+    if (not parser_) {
+      parser_ = std::make_shared<rule_pointer>();
+    }
     *parser_ = std::make_unique<rule_type>(std::forward<RHS>(rhs));
   }
 
@@ -164,12 +166,14 @@ public:
   }
 
   template <parser RHS>
-  requires(!detail::is_same_or_derived_v<rule, RHS>) rule(RHS&& rhs) : rule{} {
+    requires(!detail::is_same_or_derived_v<rule, RHS>)
+  rule(RHS&& rhs) : rule{} {
     make_parser<RHS>(std::forward<RHS>(rhs));
   }
 
   template <parser RHS>
-  requires(!detail::is_same_or_derived_v<rule, RHS>) auto operator=(RHS&& rhs) {
+    requires(!detail::is_same_or_derived_v<rule, RHS>)
+  auto operator=(RHS&& rhs) {
     make_parser<RHS>(std::forward<RHS>(rhs));
   }
 
@@ -223,7 +227,9 @@ public:
     return (*ptr)->parse(f, l, x);
   }
 
-  bool parse(Iterator& f, const Iterator& l, Attribute& x) const {
+  bool parse(Iterator& f, const Iterator& l, Attribute& x) const
+    requires(not std::is_same_v<Attribute, unused_type>)
+  {
     auto ptr = parser_.lock();
     TENZIR_ASSERT(ptr != nullptr);
     return (*ptr)->parse(f, l, x);

--- a/tenzir/integration/data/reference/pipelines_local/test_chart_arguments/step_00.ref
+++ b/tenzir/integration/data/reference/pipelines_local/test_chart_arguments/step_00.ref
@@ -1,8 +1,8 @@
-error: unknown option `-x`
+error: unknown option `x`
  --> <input>:1:34
   |
-1 | from stdin read json | chart pie -x b
-  |                                  ^^ 
+1 | from stdin read json | chart pie x=b
+  |                                  ^ 
   |
-  = usage: chart pie [--name <field>] [--value <field>] [--title <title>]
+  = usage: chart pie [name=<field>] [value=<field>]
   = docs: https://docs.tenzir/operators/chart

--- a/tenzir/integration/data/reference/pipelines_local/test_chart_arguments/step_01.ref
+++ b/tenzir/integration/data/reference/pipelines_local/test_chart_arguments/step_01.ref
@@ -1,8 +1,8 @@
-error: unknown option `-x`
- --> <input>:1:44
+error: unknown option `x`
+ --> <input>:1:42
   |
-1 | from stdin read json | chart pie --value b -x e
-  |                                            ^^ 
+1 | from stdin read json | chart pie value=b x=e
+  |                                          ^ 
   |
-  = usage: chart pie [--name <field>] [--value <field>] [--title <title>]
+  = usage: chart pie [name=<field>] [value=<field>]
   = docs: https://docs.tenzir/operators/chart

--- a/tenzir/integration/data/reference/pipelines_local/test_chart_arguments/step_02.ref
+++ b/tenzir/integration/data/reference/pipelines_local/test_chart_arguments/step_02.ref
@@ -1,7 +1,7 @@
 error: invalid chart type
  --> <input>:1:30
   |
-1 | from stdin read json | chart piett --value b
+1 | from stdin read json | chart piett value=b
   |                              ^^^^^ 
   |
   = hint: valid chart types are: line, area, bar, pie

--- a/tenzir/integration/data/reference/vast/test_bar_chart/step_00.ref
+++ b/tenzir/integration/data/reference/vast/test_bar_chart/step_00.ref
@@ -1,1 +1,1 @@
-{"chart": "bar", "title": "zeek.conn", "x": "ts", "y": "uid"}
+{"chart": "bar", "x": "ts", "y": "uid"}

--- a/tenzir/integration/data/reference/vast/test_line_chart/step_00.ref
+++ b/tenzir/integration/data/reference/vast/test_line_chart/step_00.ref
@@ -1,1 +1,1 @@
-{"chart": "line", "title": "zeek.conn", "x": "ts", "y": "orig_bytes"}
+{"chart": "line", "x": "ts", "y": "orig_bytes"}

--- a/tenzir/integration/tests/pipelines_local.bats
+++ b/tenzir/integration/tests/pipelines_local.bats
@@ -401,11 +401,11 @@ setup() {
 # bats test_tags=pipelines,chart
 @test "Chart Arguments" {
   cat ${INPUTSDIR}/json/all-types.json |
-    check ! tenzir "from stdin read json | chart pie -x b"
+    check ! tenzir "from stdin read json | chart pie x=b"
   cat ${INPUTSDIR}/json/all-types.json |
-    check ! tenzir "from stdin read json | chart pie --value b -x e"
+    check ! tenzir "from stdin read json | chart pie value=b x=e"
   cat ${INPUTSDIR}/json/all-types.json |
-    check ! tenzir "from stdin read json | chart piett --value b"
+    check ! tenzir "from stdin read json | chart piett value=b"
 }
 
 # bats test_tags=pipelines

--- a/tenzir/integration/tests/vast.bats
+++ b/tenzir/integration/tests/vast.bats
@@ -257,7 +257,7 @@ teardown() {
 @test "Line chart" {
   import_zeek_conn
 
-  check tenzir "export | head 10 | sort ts asc | chart line -x ts -y orig_bytes | get-attributes"
-  check tenzir "export | head 10 | sort ts asc | chart line -x ts -y orig_bytes"
-  check ! tenzir "export | head 10 | sort ts desc | chart line -x ts -y orig_bytes"
+  check tenzir "export | head 10 | sort ts asc | chart line x=ts y=orig_bytes | get-attributes"
+  check tenzir "export | head 10 | sort ts asc | chart line x=ts y=orig_bytes"
+  check ! tenzir "export | head 10 | sort ts desc | chart line x=ts y=orig_bytes"
 }

--- a/web/docs/operators/chart.md
+++ b/web/docs/operators/chart.md
@@ -11,10 +11,10 @@ Add metadata to a schema, necessary for rendering as a chart.
 ## Synopsis
 
 ```
-chart line [--title <title>] [-x|--x-axis <field>] [-y|--y-axis <field>]
-chart area [--title <title>] [-x|--x-axis <field>] [-y|--y-axis <field>]
-chart bar  [--title <title>] [-x|--x-axis <field>] [-y|--y-axis <field>]
-chart pie  [--title <title>] [--name <field>] [--value <field>]
+chart line [x=<field>] [y=<field>]
+chart area [x=<field>] [y=<field>]
+chart bar  [x=<field>] [y=<field>]
+chart pie  [name=<field>] [value=<field>]
 ```
 
 ## Description
@@ -23,11 +23,7 @@ The `chart` operator adds attributes to the schema of the input events,
 that are used to guide rendering of the data as a chart.
 The operator does no rendering itself.
 
-### `--title <title>`
-
-Set the chart title. Defaults to the schema name.
-
-### `-x|--x-axis <field>` (`line`, `area`, and `bar` charts only)
+### `x=<field>` (`line`, `area`, and `bar` charts only)
 
 Set the field used for the X-axis. Defaults to the first field in the schema.
 
@@ -36,18 +32,18 @@ Values in this field must be strictly increasing
 when creating a `line` or `area` chart,
 or unique when creating a `bar` chart.
 
-### `-y|--y-axis <field>` (`line`, `area`, and `bar` charts only)
+### `y=<field>` (`line`, `area`, and `bar` charts only)
 
 Set the field used for the Y-axis. Defaults to the second field in the schema.
 
-### `--name <field>` (`pie` chart only)
+### `name=<field>` (`pie` chart only)
 
 Set the field used for the names of the segments.
 Defaults to the first field in the schema.
 
 Values in this field must be unique.
 
-### `--value <field>` (`pie` chart only)
+### `value=<field>` (`pie` chart only)
 
 Set the field used for the value of a segment.
 Defaults to the second field in the schema.
@@ -61,7 +57,7 @@ export
 | where #schema == "suricata.flow"
 | top src_ip
 /* -x and -y are defaulted to `src_ip` and `count` */
-| chart bar --title "Most common src_ip values"
+| chart bar
 ```
 
 Render historical import throughput statistics as a line chart:
@@ -72,5 +68,5 @@ metrics
 | where source == true
 | summarize bytes=sum(output.approx_bytes) by timestamp resolution 1s
 | sort timestamp desc
-| chart line -x timestamp -y bytes --title "Import volume over time"
+| chart line x=timestamp y=bytes
 ```


### PR DESCRIPTION
Done in preparation for https://github.com/tenzir/issues/issues/1637, which specifies a `key=value` syntax instead of `--key value`, which we have currently.

Simultaneously, also removes the `--title` option from `chart`, closing https://github.com/tenzir/issues/issues/1653