### PR TITLE
Generalize `every` to work with all operators

### DIFF
--- a/changelog/next/features/4109--every-generalized.md
+++ b/changelog/next/features/4109--every-generalized.md
@@ -1,0 +1,3 @@
+The `every <duration>` operator modifier now supports all operators, turning
+blocking operators like `tail`, `sort` or `summarize` into operators that emit
+events every `<duration>`.

--- a/tenzir/integration/data/reference/every/test_every_modifier/step_01.ref
+++ b/tenzir/integration/data/reference/every/test_every_modifier/step_01.ref
@@ -1,2 +1,1 @@
-error: `every` must be used with a source operator
- = note: pipeline failed to start
+{"index": 0}

--- a/tenzir/integration/data/reference/every/test_every_modifier/step_02.ref
+++ b/tenzir/integration/data/reference/every/test_every_modifier/step_02.ref
@@ -1,2 +1,0 @@
-error: `every` must be used with a source operator
- = note: pipeline failed to start

--- a/tenzir/integration/tests/every.bats
+++ b/tenzir/integration/tests/every.bats
@@ -17,8 +17,7 @@ teardown() {
 
 @test "every modifier" {
   check tenzir "every 5ms version | head"
-  check ! tenzir "version | every 1s head"
-  check ! tenzir "version | head | write yaml | every 1s save stdout"
+  check tenzir "every 5ms version | every 500ms tail 1 | head 1"
 }
 
 @test "every with remote" {

--- a/web/docs/language/operator-modifiers.md
+++ b/web/docs/language/operator-modifiers.md
@@ -8,7 +8,7 @@ Operator modifiers are keywords that may occur before an operator.
 
 ## Scheduled Executions
 
-The special keyword `every` enables scheduled execution of a source operator.
+The special keyword `every` enables scheduled execution of an operator.
 
 Use the operator modifier like this:
 


### PR DESCRIPTION
This enables streaming aggregations by turning blocking operators into operators that stream their results at a fixed interval. This is best explained on an example. The following pipeline returns the total ingress as bytes per minute per pipeline:

```
metrics --live
| where #schema == "tenzir.metrics.operator"
| where source == true
| every 1min summarize ingress=sum(output.approx_bytes), duration=sum(duration) by pipeline
```

Similarly, this pipeline returns for every managed pipeline how many diagnostics were encountered, grouped by severity (warning or error):

```
diagnostics --live
| every 10s count=count(.) by severity
```