### PR TITLE
Remove metrics from `/pipeline/list`

### DIFF
--- a/changelog/next/changes/4114--removed-metrics-from-list-endpoint.md
+++ b/changelog/next/changes/4114--removed-metrics-from-list-endpoint.md
@@ -1,0 +1,3 @@
+The `show pipelines` operator and `/pipeline/list` endpoint no longer include
+pipeline metrics. We recommend using the `metrics` operator instead, which
+offers the same data in a more flexible way.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "9536026f0f9b370aa515f0ecc18705ed35401aa9",
+  "rev": "7540de3b7d14e2d2011b3d19c40b1407d49b087a",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "7540de3b7d14e2d2011b3d19c40b1407d49b087a",
+  "rev": "b0ec5033ea1fff15712c4ec1548a5178c53c1ada",
   "submodules": true,
   "shallow": true,
   "allRefs": true

--- a/web/openapi/openapi.yaml
+++ b/web/openapi/openapi.yaml
@@ -374,12 +374,6 @@ paths:
                       error: null
                       diagnostics:
                         []
-                      metrics:
-                        total:
-                          ingress:
-                            {}
-                          egress:
-                            {}
                     - id: 08446737-da9b-4787-8599-97d85c48c3bb
                       name: wrong-pipeline
                       definition: export asdf
@@ -389,12 +383,6 @@ paths:
                       error: format 'asdf' not found
                       diagnostics:
                         []
-                      metrics:
-                        total:
-                          ingress:
-                            {}
-                          egress:
-                            {}
         400:
           description: Invalid arguments.
           content:

--- a/web/openapi/openapi.yaml
+++ b/web/openapi/openapi.yaml
@@ -106,84 +106,6 @@ components:
         end:
           type: number
           example: 48
-    Metrics:
-      type: object
-      description: Information about pipeline data ingress and egress.
-      properties:
-        total:
-          type: object
-          description: Information about total pipeline metrics (e.g. total ingress/egress)
-          properties:
-            ingress:
-              type: object
-              description: Information about the total ingress. Contains no values when the source operator has not run.
-              properties:
-                unit:
-                  type: string
-                  enum:
-                    - bytes
-                    - events
-                  description: The unit of the input data.
-                  example: bytes
-                internal:
-                  type: boolean
-                  description: Whether the operator's ingress is internal.
-                  example: false
-                num_elements:
-                  type: integer
-                  description: The total amount of elements that entered the pipeline source.
-                  example: 109834
-                num_batches:
-                  type: integer
-                  description: The total amount of batches that were generated during data processing in the pipeline source.
-                  example: 2
-                num_approx_bytes:
-                  type: integer
-                  description: The total amount of bytes that entered the pipeline source. For events, this value is an approximation.
-                  example: 30414
-                total_seconds:
-                  type: number
-                  description: The total duration of the pipeline source operation in seconds.
-                  example: 1.233998321
-                processing_seconds:
-                  type: number
-                  description: The total duration of the pipeline source data processing in seconds.
-                  example: 1.179999992
-            egress:
-              type: object
-              description: Information about the total egress. Contains no values when the sink operator has not run.
-              properties:
-                unit:
-                  type: string
-                  enum:
-                    - bytes
-                    - events
-                  description: The unit of the output data.
-                  example: bytes
-                internal:
-                  type: boolean
-                  description: Whether the operator's egress is internal.
-                  example: false
-                num_elements:
-                  type: integer
-                  description: The total amount of elements that entered the pipeline sink.
-                  example: 30414
-                num_batches:
-                  type: integer
-                  description: The total amount of batches that were generated during data processing in the pipeline sink.
-                  example: 1
-                num_approx_bytes:
-                  type: integer
-                  description: The total amount of bytes that entered the pipeline sink. For events, this value is an approximation.
-                  example: 30414
-                total_seconds:
-                  type: number
-                  description: The total duration of the pipeline sink operation in seconds.
-                  example: 2.945935512
-                processing_seconds:
-                  type: number
-                  description: The total duration of the pipeline sink data processing in seconds.
-                  example: 1.452123512
     Note:
       type: object
       properties:
@@ -272,8 +194,6 @@ components:
           description: The error that the pipeline may have encountered during running.
         diagnostics:
           $ref: "#/components/schemas/Diagnostics"
-        metrics:
-          $ref: "#/components/schemas/Metrics"
         labels:
           $ref: "#/components/schemas/PipelineLabels"
         autostart:


### PR DESCRIPTION
We recommend getting metrics from the `metrics` operator for good reason, and it has been long enough now that we can safely remove the metrics from the endpoint. They were problematic from a performance perspective, as they required the `/pipeline` API to inspect operator metrics.