### PR TITLE
Support 0mq inproc sockets

### DIFF
--- a/changelog/next/changes/4117--0mq-optional-monitoring.md
+++ b/changelog/next/changes/4117--0mq-optional-monitoring.md
@@ -1,0 +1,3 @@
+The `0mq` connector no longer automatically monitors TCP sockets to wait until
+at least one remote peer is present. Explicitly pass `--monitor` for this
+behavior.

--- a/changelog/next/features/4117--0mq-inproc-sockets.md
+++ b/changelog/next/features/4117--0mq-inproc-sockets.md
@@ -1,0 +1,3 @@
+The `0mq` connector now supports `inproc` socket endpoint URLs, allowing you to
+create arbitrary publish/subscribe topologies within a node. For example, `save
+zmq inproc://foo` writes messages to the in-process socket named `foo`.

--- a/plugins/zmq/src/plugin.cpp
+++ b/plugins/zmq/src/plugin.cpp
@@ -333,8 +333,11 @@ private:
   }
 
   /// Starts listening on the provided endpoint.
-  auto listen(const std::string& endpoint) -> void {
+  auto listen(const std::string& endpoint,
+              std::chrono::milliseconds reconnect_interval = 1s) -> void {
     TENZIR_VERBOSE("listening to endpoint {}", endpoint);
+    auto ms = detail::narrow_cast<int>(reconnect_interval.count());
+    socket_.set(::zmq::sockopt::reconnect_ivl, ms); // for TCP only, not inproc
     socket_.bind(endpoint);
   }
 
@@ -343,7 +346,7 @@ private:
                std::chrono::milliseconds reconnect_interval = 1s) -> void {
     TENZIR_VERBOSE("connecting to endpoint {}", endpoint);
     auto ms = detail::narrow_cast<int>(reconnect_interval.count());
-    socket_.set(::zmq::sockopt::reconnect_ivl, ms);
+    socket_.set(::zmq::sockopt::reconnect_ivl, ms); // for TCP only, not inproc
     socket_.connect(endpoint);
   }
 

--- a/web/docs/connectors/zmq.md
+++ b/web/docs/connectors/zmq.md
@@ -12,7 +12,7 @@ Loads bytes from and saves bytes to ZeroMQ messages.
 ## Synopsis
 
 ```
-zmq [-l|--listen] [-c|--connect] [<endpoint>]
+zmq [-l|--listen] [-c|--connect] [-m|--monitor] [<endpoint>]
 ```
 
 ## Description
@@ -26,6 +26,12 @@ Indpendent of the socket type, the `zmq` connector supports specfiying the
 direction of connection establishment with `--listen` and `--connect`. This can be
 helpful to work around firewall restrictions and fit into broader set of
 existing ZeroMQ applications.
+
+With the `--monitor` option, you can activate message buffering for TCP
+sockets that hold off sending messages until *at least one* remote peer has
+connected. This can be helpful when you want to delay publishing until you have
+one connected subscriber, e.g., when the publisher spawns before any subscriber
+exists.
 
 The default format for the `zmq` connector is [`json`](../formats/json.md).
 
@@ -47,6 +53,10 @@ By default, the loader connects and the saver listens.
 Connect to the ZeroMQ socket.
 
 By default, the loader connects and the saver listens.
+
+### `-m|--monitor`
+
+Monitors a 0mq socket over TCP until the remote side establishes a connection.
 
 ### `<endpoint>`
 


### PR DESCRIPTION
As a poorman's pub/sub, we want to use our existing `zmq` connector in combination with `bitz`. This requires support for [inproc sockets](http://api.zeromq.org/4-2:zmq-inproc) sockets, which this PR adds.
