### PR TITLE
Implement a KISS version of pub/sub

### DIFF
--- a/.github/workflows/tenzir.yaml
+++ b/.github/workflows/tenzir.yaml
@@ -818,6 +818,9 @@ jobs:
           - name: Sigma
             target: sigma
             path: plugins/sigma
+          - name: VAST
+            target: vast
+            path: contrib/tenzir-plugins/vast
           - name: Velociraptor
             target: velociraptor
             path: plugins/velociraptor

--- a/.github/workflows/tenzir.yaml
+++ b/.github/workflows/tenzir.yaml
@@ -563,13 +563,16 @@ jobs:
             cmake-extra-flags: -DTENZIR_ENABLE_BUNDLED_CAF:BOOL=ON
             bundled-plugins:
               # We enable some plugins here, because:
-              #  * fluent-bit: The plugin library links to libfluent-bit.so, which
-              #    is built by upstream without support for `dlopen()`, the
-              #    integrated build method used here works around that by linking
-              #    libfluent-bit.so to libtenzir.so directly. The alternative
-              #    workaround of using LD_PRELOAD for the standalone plugin build
-              #    does not work in the GitHub Actions Runner.
+              # - fluent-bit: The plugin library links to libfluent-bit.so, which
+              #   is built by upstream without support for `dlopen()`, the
+              #   integrated build method used here works around that by linking
+              #   libfluent-bit.so to libtenzir.so directly. The alternative
+              #   workaround of using LD_PRELOAD for the standalone plugin build
+              #   does not work in the GitHub Actions Runner.
+              # - zmq: The VAST plugin requires it, so for it to pass CI it has
+              #   to be bundled already.
               - plugins/fluent-bit
+              - plugins/zmq
           - os: macos-14
             container: null
             name: macOS
@@ -830,9 +833,6 @@ jobs:
           - name: Yara
             target: yara
             path: plugins/yara
-          - name: ZeroMQ
-            target: zmq
-            path: plugins/zmq
     env:
       INSTALL_DIR: "${{ github.workspace }}/_install"
       BUILD_DIR: "${{ github.workspace }}/_build"

--- a/Dockerfile
+++ b/Dockerfile
@@ -223,6 +223,15 @@ RUN cmake -S contrib/tenzir-plugins/platform -B build-platform -G Ninja \
       DESTDIR=/plugin/platform cmake --install build-platform --strip --component Runtime && \
       rm -rf build-platform
 
+FROM plugins-source AS vast-plugin
+
+RUN cmake -S contrib/tenzir-plugins/vast -B build-vast -G Ninja \
+      -D CMAKE_INSTALL_PREFIX:STRING="$PREFIX" && \
+      cmake --build build-vast --parallel && \
+      cmake --build build-vast --target integration && \
+      DESTDIR=/plugin/vast cmake --install build-vast --strip --component Runtime && \
+      rm -rf build-vast
+
 # -- tenzir-ce -------------------------------------------------------------------
 
 FROM tenzir-de AS tenzir-ce
@@ -231,6 +240,7 @@ COPY --from=context-plugin --chown=tenzir:tenzir /plugin/context /
 COPY --from=matcher-plugin --chown=tenzir:tenzir /plugin/matcher /
 COPY --from=pipeline-manager-plugin --chown=tenzir:tenzir /plugin/pipeline-manager /
 COPY --from=platform-plugin --chown=tenzir:tenzir /plugin/platform /
+COPY --from=vast-plugin --chown=tenzir:tenzir /plugin/vast /
 
 # -- tenzir-node-ce ------------------------------------------------------------
 
@@ -263,7 +273,6 @@ ENTRYPOINT ["tenzir-node"]
 FROM tenzir-ce AS tenzir-ee
 
 COPY --from=compaction-plugin --chown=tenzir:tenzir /plugin/compaction /
-COPY --from=context-plugin --chown=tenzir:tenzir /plugin/context /
 
 # -- tenzir-node-ee ------------------------------------------------------------
 

--- a/libtenzir/builtins/connectors/email.cpp
+++ b/libtenzir/builtins/connectors/email.cpp
@@ -297,8 +297,8 @@ public:
     return "email";
   }
 
-  auto supported_uri_scheme() const -> std::string override {
-    return "mailto";
+  auto supported_uri_schemes() const -> std::vector<std::string> override {
+    return {"mailto"};
   }
 };
 

--- a/libtenzir/builtins/connectors/udp.cpp
+++ b/libtenzir/builtins/connectors/udp.cpp
@@ -106,7 +106,7 @@ auto udp_loader_impl(operator_control_plane& ctrl, loader_args args)
     constexpr auto usec
       = std::chrono::duration_cast<std::chrono::microseconds>(poll_timeout)
           .count();
-    TENZIR_DEBUG("polling socket");
+    TENZIR_TRACE("polling socket");
     auto ready = detail::rpoll(*socket.fd, usec);
     if (not ready) {
       diagnostic::error("failed to poll socket")
@@ -127,7 +127,7 @@ auto udp_loader_impl(operator_control_plane& ctrl, loader_args args)
         .emit(ctrl.diagnostics());
       co_return;
     }
-    TENZIR_DEBUG("got {} bytes", received_bytes);
+    TENZIR_TRACE("got {} bytes", received_bytes);
     TENZIR_ASSERT(received_bytes
                   < detail::narrow_cast<ssize_t>(buffer.size()) - 1);
     // Append a newline unless we have one already.
@@ -210,7 +210,7 @@ public:
           .emit(ctrl.diagnostics());
         return;
       }
-      TENZIR_DEBUG("sent {} bytes", sent_bytes);
+      TENZIR_TRACE("sent {} bytes", sent_bytes);
       if (detail::narrow_cast<size_t>(sent_bytes) < chunk->size()) {
         diagnostic::warning("incomplete UDP send operation")
           .note("got {} bytes but sent only {}", sent_bytes, chunk->size())

--- a/libtenzir/builtins/operators/from_load_read.cpp
+++ b/libtenzir/builtins/operators/from_load_read.cpp
@@ -134,7 +134,9 @@ throw_loader_not_found(located<std::string_view> x, bool use_uri_schemes) {
   auto available = std::vector<std::string>{};
   for (auto const* p : plugins::get<loader_parser_plugin>()) {
     if (use_uri_schemes) {
-      available.push_back(p->supported_uri_scheme());
+      for (auto uri_scheme : p->supported_uri_schemes()) {
+        available.push_back(std::move(uri_scheme));
+      }
     } else {
       available.push_back(p->name());
     }

--- a/libtenzir/builtins/operators/to_write_save.cpp
+++ b/libtenzir/builtins/operators/to_write_save.cpp
@@ -46,7 +46,9 @@ throw_saver_not_found(located<std::string_view> x, bool use_uri_schemes) {
   auto available = std::vector<std::string>{};
   for (auto p : plugins::get<saver_parser_plugin>()) {
     if (use_uri_schemes) {
-      available.push_back(p->supported_uri_scheme());
+      for (auto uri_scheme : p->supported_uri_schemes()) {
+        available.push_back(std::move(uri_scheme));
+      }
     } else {
       available.push_back(p->name());
     }

--- a/libtenzir/include/tenzir/plugin.hpp
+++ b/libtenzir/include/tenzir/plugin.hpp
@@ -382,7 +382,7 @@ public:
     -> std::unique_ptr<plugin_loader>
     = 0;
 
-  virtual auto supported_uri_scheme() const -> std::string;
+  virtual auto supported_uri_schemes() const -> std::vector<std::string>;
 };
 
 using loader_serialization_plugin = serialization_plugin<plugin_loader>;
@@ -546,7 +546,7 @@ public:
     -> std::unique_ptr<plugin_saver>
     = 0;
 
-  virtual auto supported_uri_scheme() const -> std::string;
+  virtual auto supported_uri_schemes() const -> std::vector<std::string>;
 };
 
 using saver_serialization_plugin = serialization_plugin<plugin_saver>;

--- a/libtenzir/src/detail/loader_saver_resolver.cpp
+++ b/libtenzir/src/detail/loader_saver_resolver.cpp
@@ -43,9 +43,13 @@ struct try_plugin_by_url_result {
 
 template <typename Plugin>
 auto find_plugin_by_scheme(std::string_view scheme) -> const Plugin* {
-  for (auto&& plugin : plugins::get<Plugin>())
-    if (plugin->supported_uri_scheme() == scheme)
-      return plugin;
+  for (auto&& plugin : plugins::get<Plugin>()) {
+    for (const auto& supported_uri_scheme : plugin->supported_uri_schemes()) {
+      if (supported_uri_scheme == scheme) {
+        return plugin;
+      }
+    }
+  }
   return nullptr;
 }
 

--- a/libtenzir/src/plugin.cpp
+++ b/libtenzir/src/plugin.cpp
@@ -438,14 +438,16 @@ component_plugin_actor analyzer_plugin::make_component(
 
 // -- loader plugin -----------------------------------------------------------
 
-auto loader_parser_plugin::supported_uri_scheme() const -> std::string {
-  return this->name();
+auto loader_parser_plugin::supported_uri_schemes() const
+  -> std::vector<std::string> {
+  return {this->name()};
 }
 
 // -- saver plugin ------------------------------------------------------------
 
-auto saver_parser_plugin::supported_uri_scheme() const -> std::string {
-  return this->name();
+auto saver_parser_plugin::supported_uri_schemes() const
+  -> std::vector<std::string> {
+  return {this->name()};
 }
 
 // -- store plugin -------------------------------------------------------------

--- a/nix/tenzir/plugins/names.nix
+++ b/nix/tenzir/plugins/names.nix
@@ -4,4 +4,5 @@
   "matcher"
   "pipeline-manager"
   "platform"
+  "vast"
 ]

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "8e209a2e7130475d843fdf47e72c38d575080ae5",
+  "rev": "4f79ff6f1d4a384da71977e13a485519ea18f9a4",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/plugins/gcs/src/plugin.cpp
+++ b/plugins/gcs/src/plugin.cpp
@@ -265,8 +265,8 @@ public:
     return "gcs";
   }
 
-  auto supported_uri_scheme() const -> std::string override {
-    return "gs";
+  auto supported_uri_schemes() const -> std::vector<std::string> override {
+    return {"gs"};
   }
 };
 

--- a/plugins/zmq/src/plugin.cpp
+++ b/plugins/zmq/src/plugin.cpp
@@ -552,6 +552,10 @@ public:
   auto name() const -> std::string override {
     return "zmq";
   }
+
+  auto supported_uri_schemes() const -> std::vector<std::string> override {
+    return {"zmq", "inproc"};
+  }
 };
 
 } // namespace

--- a/web/docs/operators/publish.md
+++ b/web/docs/operators/publish.md
@@ -6,7 +6,8 @@ sidebar_custom_props:
 
 # publish
 
-Publishes events at a Tenzir Node. The dual to [`subscribe`](subscribe.md).
+Publishes events to a channel with a topic. The dual to
+[`subscribe`](subscribe.md).
 
 ## Synopsis
 
@@ -15,7 +16,7 @@ publish [<topic>]
 ```
 ## Description
 
-The `publish` operator publishes events at a Tenzir Node in a channel with the
+The `publish` operator publishes events at a node in a channel with the
 specified topic. Any number of subscribers using the [`subscribe`](subscribe.md)
 operator receive the events immediately.
 
@@ -24,9 +25,11 @@ operator receive the events immediately.
 An optional topic for publishing events under. The provided topic must be
 unique.
 
+Defaults to the empty string.
+
 ## Examples
 
-Publish Zeek conn logs at a Tenzir Node under the topic `zeek-conn`.
+Publish Zeek conn logs under the topic `zeek-conn`.
 
 ```
 from file conn.log read zeek-tsv | publish zeek-conn

--- a/web/docs/operators/publish.md
+++ b/web/docs/operators/publish.md
@@ -1,0 +1,33 @@
+---
+sidebar_custom_props:
+  operator:
+    sink: true
+---
+
+# publish
+
+Publishes events at a Tenzir Node. The dual to [`subscribe`](subscribe.md).
+
+## Synopsis
+
+```
+publish [<topic>]
+```
+## Description
+
+The `publish` operator publishes events at a Tenzir Node in a channel with the
+specified topic. Any number of subscribers using the [`subscribe`](subscribe.md)
+operator receive the events immediately.
+
+### `<topic>`
+
+An optional topic for publishing events under. The provided topic must be
+unique.
+
+## Examples
+
+Publish Zeek conn logs at a Tenzir Node under the topic `zeek-conn`.
+
+```
+from file conn.log read zeek-tsv | publish zeek-conn
+```

--- a/web/docs/operators/subscribe.md
+++ b/web/docs/operators/subscribe.md
@@ -6,18 +6,20 @@ sidebar_custom_props:
 
 # subscribe
 
-Subscribes to events at a Tenzir Node. The dual to [`publish`](publish.md).
+Subscribes to events from a channel with a topic. The dual to
+[`publish`](publish.md).
 
 ## Synopsis
 
 ```
 subscribe [<topic>]
 ```
+
 ## Description
 
-The `subscribe` operator subscribes to events at a Tenzir Node from a channel
-with the specified topic. Multiple `subscribe` operators with the same topic
-receive the same events.
+The `subscribe` operator subscribes to events Node from a channel with the
+specified topic. Multiple `subscribe` operators with the same topic receive the
+same events.
 
 ### `<topic>`
 

--- a/web/docs/operators/subscribe.md
+++ b/web/docs/operators/subscribe.md
@@ -1,0 +1,32 @@
+---
+sidebar_custom_props:
+  operator:
+    source: true
+---
+
+# subscribe
+
+Subscribes to events at a Tenzir Node. The dual to [`publish`](publish.md).
+
+## Synopsis
+
+```
+subscribe [<topic>]
+```
+## Description
+
+The `subscribe` operator subscribes to events at a Tenzir Node from a channel
+with the specified topic. Multiple `subscribe` operators with the same topic
+receive the same events.
+
+### `<topic>`
+
+An optional topic identifying the channel events are published under.
+
+## Examples
+
+Subscribe to the events under the topic `zeek-conn`:
+
+```
+subscribe zeek-conn
+```


### PR DESCRIPTION
This change implements a single-producer multi-consumer version of pub/sub that builds on top of the recently added BITZ format and the ZeroMQ connector's `inproc` sockets.

It's very simple to use: You run `publish <topic>` to publish, and `subscribe <topic>` to subscribe.