### PR TITLE
Fix a race condition in `/serve`

### DIFF
--- a/changelog/next/bug-fixes/4123--serve-504.md
+++ b/changelog/next/bug-fixes/4123--serve-504.md
@@ -1,0 +1,2 @@
+We fixed a bug that caused the explorer to sometimes show 504 Gateway Timeout
+errors for pipelines where the first result took over two seconds to arrive.


### PR DESCRIPTION
This fixes a very odd race condition in the bridge between the `serve` operator and the `/serve` API endpoint. When a pipeline completes, we keep its last result set around so that it can be retrieved in case the last request failed. However, when a second pipeline using serve in precisely that time frame was started and ran into a timeout on its first request, we accidentally leaked resources for the first pipeline and had the request for the second pipeline go unanswered, leading to a 504 error in the explorer.

The cuplrit behind this was in a wrong comparison in the handler that delivers underful results when a timeout hit that compared using the continuation token as opposed to the serve id. Since both the initial and the final continuation tokens are null, it found the wrong serve request, and then failed to answer for it as that was already done. The serve request it was actually supposed to answer was left unanswered.

The fix for this is rather simple. I also rewrote some checks into assertions that would've caught this issue a lot earlier.