### PR TITLE
Fix Pipelines as Code examples

### DIFF
--- a/web/blog/tenzir-v4.10/index.md
+++ b/web/blog/tenzir-v4.10/index.md
@@ -29,14 +29,15 @@ interface is disallowed for pipelines deployed as code.
 Here's a simple example to get you started:
 
 ```yaml {0} title="<prefix>/etc/tenzir/tenzir.yaml"
-pipelines:
-  suricata-over-tcp:
-    name: Import Suricata from TCP
-    definition: |
-      from tcp://0.0.0.0:34343 read suricata
-      | import
-    start:
-      failed: true  # always restart on failure
+tenzir:
+  pipelines:
+    suricata-over-tcp:
+      name: Import Suricata from TCP
+      definition: |
+        from tcp://0.0.0.0:34343 read suricata
+        | import
+      start:
+        failed: true  # always restart on failure
 ```
 
 :::tip Want to learn more?

--- a/web/versioned_docs/version-Tenzir v4.10/user-guides/run-pipelines/README.md
+++ b/web/versioned_docs/version-Tenzir v4.10/user-guides/run-pipelines/README.md
@@ -82,16 +82,17 @@ deployment in two ways:
 Here's a an example of deploying a pipeline through your configuration:
 
 ```yaml {0} title="<prefix>/etc/tenzir/tenzir.yaml"
-pipelines:
-  suricata-over-tcp:
-    name: Import Suricata from TCP
-    definition: |
-      from tcp://0.0.0.0:34343 read suricata
-      | import
-    start:
-      created: false    # start automatically
-      failed: true      # restart on failure
-      completed: false  # restart on completion
+tenzir:
+  pipelines:
+    suricata-over-tcp:
+      name: Import Suricata from TCP
+      definition: |
+        from tcp://0.0.0.0:34343 read suricata
+        | import
+      start:
+        created: false    # start automatically
+        failed: true      # restart on failure
+        completed: false  # restart on completion
 ```
 
 The boolean `start` configuration flags `completed` and `failed` default to

--- a/web/versioned_docs/version-Tenzir v4.11/user-guides/run-pipelines/README.md
+++ b/web/versioned_docs/version-Tenzir v4.11/user-guides/run-pipelines/README.md
@@ -82,16 +82,17 @@ deployment in two ways:
 Here's a an example of deploying a pipeline through your configuration:
 
 ```yaml {0} title="<prefix>/etc/tenzir/tenzir.yaml"
-pipelines:
-  suricata-over-tcp:
-    name: Import Suricata from TCP
-    definition: |
-      from tcp://0.0.0.0:34343 read suricata
-      | import
-    start:
-      created: false    # start automatically
-      failed: true      # restart on failure
-      completed: false  # restart on completion
+tenzir:
+  pipelines:
+    suricata-over-tcp:
+      name: Import Suricata from TCP
+      definition: |
+        from tcp://0.0.0.0:34343 read suricata
+        | import
+      start:
+        created: false    # start automatically
+        failed: true      # restart on failure
+        completed: false  # restart on completion
 ```
 
 The boolean `start` configuration flags `completed` and `failed` default to


### PR DESCRIPTION
These were missing a level of indentation, as reported by a user via Discord.