### PR TITLE
Add configurable contexts

### DIFF
--- a/changelog/next/features/4126--configurable-contexts.md
+++ b/changelog/next/features/4126--configurable-contexts.md
@@ -1,0 +1,2 @@
+You can now define contexts and their creation parameters in the
+`tenzir.contexts` section of the configuration file.

--- a/libtenzir/builtins/components/metrics_collector.cpp
+++ b/libtenzir/builtins/components/metrics_collector.cpp
@@ -6,6 +6,7 @@
 // SPDX-FileCopyrightText: (c) 2023 The Tenzir Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+#include <tenzir/collect.hpp>
 #include <tenzir/data.hpp>
 #include <tenzir/detail/weak_run_delayed.hpp>
 #include <tenzir/node.hpp>

--- a/libtenzir/builtins/components/metrics_collector.cpp
+++ b/libtenzir/builtins/components/metrics_collector.cpp
@@ -62,10 +62,7 @@ struct metrics_collector_state {
         return std::move(ok.error());
       }
     }
-    if (instances.empty()) {
-      TENZIR_VERBOSE("{} shuts down because all metrics are disabled", *self);
-      self->quit();
-    }
+    TENZIR_ASSERT(not instances.empty());
     detail::weak_run_delayed_loop(
       self, std::chrono::seconds{30},
       [this] {
@@ -141,8 +138,11 @@ public:
 
   auto make_component(node_actor::stateful_pointer<node_state> node) const
     -> component_plugin_actor override {
+    if (collect(plugins::get<metrics_plugin>()).empty()) {
+      return {};
+    }
     auto [importer] = node->state.registry.find<importer_actor>();
-    return node->spawn(metrics_collector, std::move(importer));
+    return node->spawn<caf::linked>(metrics_collector, std::move(importer));
   }
 };
 

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "994165f3e1a0c9d45a2da705393d518983355a41",
+  "rev": "a8e829a2fddd1aae0fc4836f39d05b7c71c6d726",
   "submodules": true,
   "shallow": true,
   "allRefs": true

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "f13a4d7d1448ea047878acad2f6d5ce174b9911e",
+  "rev": "994165f3e1a0c9d45a2da705393d518983355a41",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -159,24 +159,20 @@ tenzir:
   # Zstd compression level applied to the Feather store backend.
   # zstd-compression-level: <default>
 
-  # Configured contexts can be declared here. The key specifies the context
-  # name, the value is an object with a required `type` and a set of arguments
-  # as mandated by the context type.
+  # Context configured as part of the configuration that are always available.
   contexts:
-    # Example:
-    # ```
-    # lt:
-    #   type: lookup-table
-    # geoip:
-    #   type: geoip
-    #   arguments:
-    #     db-path: /data/GeoLite2-ASN.mmdb
-    # bf:
-    #   type: bloom-filter
-    #   arguments:
-    #     capacity: 100
-    #     fp-probability: 0.1
-    # ```
+    # A unique name for the context that's used in the context, enrich, and
+    # lookup operators to refer to the context.
+    indicators:
+      # The type of the context.
+      type: bloom-filter
+      # Arguments for creating the context, depending on the type. Refer to the
+      # documentation of the individual context types to see the arguments they
+      # require. Note that changes to these arguments to not apply to any
+      # contexts that were previously created.
+      arguments:
+        capacity: 1B
+        fp-probability: 0.001
 
   # The `index` key is used to adjust the false-positive rate of
   # the first-level lookup data structures (called synopses) in the

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -159,6 +159,25 @@ tenzir:
   # Zstd compression level applied to the Feather store backend.
   # zstd-compression-level: <default>
 
+  # Configured contexts can be declared here. The key specifies the context
+  # name, the value is an object with a required `type` and a set of arguments
+  # as mandated by the context type.
+  contexts:
+    # Example:
+    # ```
+    # lt:
+    #   type: lookup-table
+    # geoip:
+    #   type: geoip
+    #   arguments:
+    #     db-path: /data/GeoLite2-ASN.mmdb
+    # bf:
+    #   type: bloom-filter
+    #   arguments:
+    #     capacity: 100
+    #     fp-probability: 0.1
+    # ```
+
   # The `index` key is used to adjust the false-positive rate of
   # the first-level lookup data structures (called synopses) in the
   # catalog. The lower the false-positive rate the more space will be

--- a/web/docs/contexts.md
+++ b/web/docs/contexts.md
@@ -16,6 +16,26 @@ The list below shows all available context types. For a more in-depth
 introduction into the contextualization framework, please refer to our blog post
 [Contextualization Made Simple](/blog/contextualization-made-simple).
 
+To create a context, use the [`context create`](operators/context.md) operator
+or configure the context as part of your configuration file:
+
+```yaml {0} title="<prefix>/etc/tenzir/tenzir.yaml"
+tenzir:
+  contexts:
+    # A unique name for the context that's used in the context, enrich, and
+    # lookup operators to refer to the context.
+    indicators:
+      # The type of the context.
+      type: bloom-filter
+      # Arguments for creating the context, depending on the type. Refer to the
+      # documentation of the individual context types to see the arguments they
+      # require. Note that changes to these arguments to not apply to any
+      # contexts that were previously created.
+      arguments:
+        capacity: 1B
+        fp-probability: 0.001
+```
+
 import DocCardList from '@theme/DocCardList';
 
 <DocCardList />


### PR DESCRIPTION
Similar to configurable pipelines, we can now also configure contexts in `tenzir.yaml` files:
```
tenzir:
  contexts:
    lt:
      type: lookup-table
    geoip:
      type: geoip
      arguments:
        db-path: /path/to/GeoLite2-ASN.mmdb
    bf:
      type: bloom-filter
      arguments:
        capacity: 100
        fp-probability: 0.1

```