### PR TITLE
Fix the build with Arrow 16+

### DIFF
--- a/libtenzir/builtins/connectors/s3.cpp
+++ b/libtenzir/builtins/connectors/s3.cpp
@@ -80,7 +80,7 @@ public:
     -> std::optional<generator<chunk_ptr>> override {
     return
       [](s3_args args, operator_control_plane& ctrl) -> generator<chunk_ptr> {
-        auto uri = arrow::internal::Uri{};
+        auto uri = arrow::util::Uri{};
         const auto parse_result = uri.Parse(args.uri.inner);
         if (not parse_result.ok()) {
           diagnostic::error("failed to parse URI `{}`: {}", args.uri.inner,
@@ -163,7 +163,7 @@ public:
 
   auto instantiate(operator_control_plane& ctrl, std::optional<printer_info>)
     -> caf::expected<std::function<void(chunk_ptr)>> override {
-    auto uri = arrow::internal::Uri{};
+    auto uri = arrow::util::Uri{};
     const auto parse_result = uri.Parse(args_.uri.inner);
     if (not parse_result.ok()) {
       return caf::make_error(ec::filesystem_error,

--- a/libtenzir/include/tenzir/fwd.hpp
+++ b/libtenzir/include/tenzir/fwd.hpp
@@ -11,6 +11,7 @@
 #include "tenzir/config.hpp" // IWYU pragma: export
 #include "tenzir/tql/fwd.hpp"
 
+#include <arrow/util/config.h>
 #include <caf/config.hpp>
 #include <caf/fwd.hpp>
 #include <caf/type_id.hpp>
@@ -58,6 +59,20 @@ namespace io {
 class RandomAccessFile;
 
 } // namespace io
+
+// For backwards compatibility with versions before Arrow 16, we alias Uri to
+// the namespace it was moved to when it stabilized.
+#if ARROW_VERSION_MAJOR < 16
+
+namespace internal {
+class Uri;
+} // namespace internal
+
+namespace util {
+using ::arrow::internal::Uri;
+} // namespace util
+
+#endif
 
 } // namespace arrow
 

--- a/libtenzir/src/detail/loader_saver_resolver.cpp
+++ b/libtenzir/src/detail/loader_saver_resolver.cpp
@@ -59,7 +59,7 @@ auto try_plugin_by_url(located<std::string_view> src)
   // Not using caf::uri for anything else but checking for URL validity
   // This is because it makes the interaction with located<...> very difficult
   // TODO: We don't want to allow just any URIs, only URLs
-  auto uri = arrow::internal::Uri{};
+  auto uri = arrow::util::Uri{};
   if (not uri.Parse(std::string{src.inner}).ok()) {
     return {};
   }

--- a/libtenzir/src/socket.cpp
+++ b/libtenzir/src/socket.cpp
@@ -25,7 +25,7 @@ namespace tenzir {
 
 auto socket_endpoint::parse(std::string_view url)
   -> caf::expected<socket_endpoint> {
-  auto uri = arrow::internal::Uri{};
+  auto uri = arrow::util::Uri{};
   if (not uri.Parse(std::string{url}).ok()) {
     return ec::parse_error;
   }

--- a/plugins/gcs/src/plugin.cpp
+++ b/plugins/gcs/src/plugin.cpp
@@ -68,7 +68,7 @@ public:
     -> std::optional<generator<chunk_ptr>> override {
     return
       [](gcs_args args, operator_control_plane& ctrl) -> generator<chunk_ptr> {
-        auto uri = arrow::internal::Uri{};
+        auto uri = arrow::util::Uri{};
         const auto parse_result = uri.Parse(args.uri.inner);
         if (not parse_result.ok()) {
           diagnostic::error("failed to parse URI `{}`: {}", args.uri.inner,
@@ -146,7 +146,7 @@ public:
 
   auto instantiate(operator_control_plane& ctrl, std::optional<printer_info>)
     -> caf::expected<std::function<void(chunk_ptr)>> override {
-    auto uri = arrow::internal::Uri{};
+    auto uri = arrow::util::Uri{};
     const auto parse_result = uri.Parse(args_.uri.inner);
     if (not parse_result.ok()) {
       diagnostic::error("failed to parse URI `{}`: {}", args_.uri.inner,


### PR DESCRIPTION
Arrow stabilized the `arrow::util::Uri` API, which was previously in the internal namespace.
