### PR TITLE
Fix verification of large FlatBuffers tables

### DIFF
--- a/changelog/next/bug-fixes/4137--large-lookup-table.md
+++ b/changelog/next/bug-fixes/4137--large-lookup-table.md
@@ -1,0 +1,2 @@
+Lookup tables with more than 1M entries failed to load after the node was
+restarted. This no longer happens.

--- a/libtenzir/include/tenzir/fbs/utils.hpp
+++ b/libtenzir/include/tenzir/fbs/utils.hpp
@@ -32,11 +32,6 @@ namespace tenzir::fbs {
 /// @returns The buffer of *builder*.
 chunk_ptr release(flatbuffers::FlatBufferBuilder& builder);
 
-/// Creates a verifier for a byte buffer.
-/// @xs The buffer to create a verifier for.
-/// @param A verifier that is ready to use.
-flatbuffers::Verifier make_verifier(std::span<const std::byte> xs);
-
 // -- generic (un)packing ----------------------------------------------------
 
 /// Adds a byte vector to builder for a type that is convertible to a byte

--- a/libtenzir/src/fbs/utils.cpp
+++ b/libtenzir/src/fbs/utils.cpp
@@ -28,9 +28,4 @@ chunk_ptr release(flatbuffers::FlatBufferBuilder& builder) {
   return chunk::make(builder.Release());
 }
 
-flatbuffers::Verifier make_verifier(std::span<const std::byte> xs) {
-  auto data = reinterpret_cast<const uint8_t*>(xs.data());
-  return flatbuffers::Verifier{data, xs.size()};
-}
-
 } // namespace tenzir::fbs


### PR DESCRIPTION
This fixes a bug when loading large lookup tables or other data persisted in a FlatBuffers table from disk. The default behavior of the FlatBuffers table verifier is to blame here.