### PR TITLE
Find syntax errors before record batch reading

### DIFF
--- a/changelog/next/bug-fixes/4139.md
+++ b/changelog/next/bug-fixes/4139.md
@@ -1,0 +1,1 @@
+The python operator now checks for syntax errors on operator start up.

--- a/libtenzir/builtins/operators/python.cpp
+++ b/libtenzir/builtins/operators/python.cpp
@@ -265,13 +265,13 @@ public:
       }
       codepipe.close();
       ::close(errpipe.pipe().native_sink());
-      TENZIR_WARN("Done with set up");
       co_yield {}; // signal successful startup
-      TENZIR_WARN("Hi");
       for (auto&& slice : input) {
         if (!child.running()) {
           auto python_error = drain_pipe(errpipe);
-          diagnostic::error("{}", python_error).emit(ctrl.diagnostics());
+          diagnostic::error("{}", python_error)
+            .note("python process exited with exit-code 1")
+            .emit(ctrl.diagnostics());
           co_return;
         }
         if (slice.rows() == 0) {

--- a/libtenzir/builtins/operators/python.cpp
+++ b/libtenzir/builtins/operators/python.cpp
@@ -270,7 +270,7 @@ public:
         if (!child.running()) {
           auto python_error = drain_pipe(errpipe);
           diagnostic::error("{}", python_error)
-            .note("python process exited with exit-code 1")
+            .note("python process exited with error")
             .emit(ctrl.diagnostics());
           co_return;
         }
@@ -312,13 +312,17 @@ public:
         auto reader = arrow::ipc::RecordBatchStreamReader::Open(&file);
         if (!reader.status().ok()) {
           auto python_error = drain_pipe(errpipe);
-          diagnostic::error("{}", python_error).emit(ctrl.diagnostics());
+          diagnostic::error("{}", python_error)
+            .note("python process exited with error")
+            .emit(ctrl.diagnostics());
           co_return;
         }
         auto result_batch = (*reader)->ReadNext();
         if (!result_batch.status().ok()) {
           auto python_error = drain_pipe(errpipe);
-          diagnostic::error("{}", python_error).emit(ctrl.diagnostics());
+          diagnostic::error("{}", python_error)
+            .note("python process exited with error")
+            .emit(ctrl.diagnostics());
           co_return;
         }
         // The writer on the other side writes an invalid record batch as

--- a/libtenzir/builtins/operators/python.cpp
+++ b/libtenzir/builtins/operators/python.cpp
@@ -70,8 +70,9 @@ struct config {
 
 auto drain_pipe(bp::ipstream& pipe) -> std::string {
   auto result = std::string{};
-  if (pipe.peek() == bp::ipstream::traits_type::eof())
+  if (pipe.peek() == bp::ipstream::traits_type::eof()) {
     return result;
+  }
   auto line = std::string{};
   while (std::getline(pipe, line)) {
     if (not result.empty()) {
@@ -155,8 +156,9 @@ public:
         // verified. We truncate it to this length unconditionally for
         // consistency.
         constexpr auto semaphore_name_max_length = 30u;
-        if (sem_name.size() > semaphore_name_max_length)
+        if (sem_name.size() > semaphore_name_max_length) {
           sem_name.erase(semaphore_name_max_length);
+        }
         // The initial venv creation tends to take a very long time, and often
         // causes the pipline creation to take longer then what our FE tolerate
         // in terms of wait time. As a workaround we yield early, so that the
@@ -263,8 +265,15 @@ public:
       }
       codepipe.close();
       ::close(errpipe.pipe().native_sink());
+      TENZIR_WARN("Done with set up");
       co_yield {}; // signal successful startup
+      TENZIR_WARN("Hi");
       for (auto&& slice : input) {
+        if (!child.running()) {
+          auto python_error = drain_pipe(errpipe);
+          diagnostic::error("{}", python_error).emit(ctrl.diagnostics());
+          co_return;
+        }
         if (slice.rows() == 0) {
           co_yield {};
           continue;
@@ -383,18 +392,20 @@ public:
     -> caf::error override {
     auto create_virtualenv
       = try_get_or<bool>(plugin_config, "create-venvs", true);
-    if (!create_virtualenv)
+    if (!create_virtualenv) {
       return create_virtualenv.error();
-    if (!(*create_virtualenv))
+    }
+    if (!(*create_virtualenv)) {
       config.venv_base_dir = std::nullopt;
-    else if (const auto* cache_dir
-             = get_if<std::string>(&global_config, "tenzir.cache-directory"))
+    } else if (const auto* cache_dir = get_if<std::string>(
+                 &global_config, "tenzir.cache-directory")) {
       config.venv_base_dir
         = (std::filesystem::path{*cache_dir} / "python" / "venvs").string();
-    else
+    } else {
       config.venv_base_dir = (std::filesystem::temp_directory_path() / "tenzir"
                               / "python" / "venvs")
                                .string();
+    }
     auto implicit_requirements_default = std::string{
       detail::install_datadir() / "python"
       / fmt::format("tenzir-{}.{}.{}-py3-none-any.whl[operator]",

--- a/tenzir/integration/data/reference/python/test_python_operator_invalid_syntax/step_00.ref
+++ b/tenzir/integration/data/reference/python/test_python_operator_invalid_syntax/step_00.ref
@@ -1,2 +1,2 @@
-error: Empty output not allowed
+error: invalid syntax (<string>, line 1)
  = note: python process exited with error

--- a/tenzir/integration/data/reference/python/test_python_operator_invalid_syntax/step_01.ref
+++ b/tenzir/integration/data/reference/python/test_python_operator_invalid_syntax/step_01.ref
@@ -1,2 +1,2 @@
-error: Empty output not allowed
+error: invalid syntax (<string>, line 1)
  = note: python process exited with error

--- a/tenzir/integration/data/reference/python/test_python_operator_invalid_syntax_in_file/step_00.ref
+++ b/tenzir/integration/data/reference/python/test_python_operator_invalid_syntax_in_file/step_00.ref
@@ -1,2 +1,2 @@
-error: Empty output not allowed
+error: invalid syntax (<string>, line 1)
  = note: python process exited with error

--- a/tenzir/integration/tests/python.bats
+++ b/tenzir/integration/tests/python.bats
@@ -244,3 +244,21 @@ END
 @test "python operator empty input" {
   check tenzir 'version | put x=42 | python ""'
 }
+
+# bats test_tags=python
+@test "python operator invalid syntax" {
+  check ! tenzir 'shell "sleep 3; exit 1" | read json | python "x="'
+  check ! tenzir 'version | put x=42 | python "@@"'
+}
+
+# bats test_tags=python
+@test "python operator invalid syntax in file" {
+  echo "self.original_c = !!" >${BATS_TEST_TMPDIR}/code.py
+  check ! tenzir -f /dev/stdin <<END
+  shell "sleep 3; exit 1"
+    | read json
+    | put a.b.c = 2
+    | unflatten
+    | python --file ${BATS_TEST_TMPDIR}/code.py
+END
+}


### PR DESCRIPTION
1. Instead of compiling and executing the code at every record batch, compile only once at the beginning. Therefore, syntax errors can be identified even in a streaming context where the first record batch has not arrived.  
