### PR TITLE
Remove events output from many context operators

### DIFF
--- a/changelog/next/bug-fixes/4143--enrich-stop.md
+++ b/changelog/next/bug-fixes/4143--enrich-stop.md
@@ -1,0 +1,2 @@
+The `enrich` operator sometimes stopped working when it encountered an event for
+which the specified fields did not exist. This no longer happens.

--- a/changelog/next/changes/4143--context-breakup.md
+++ b/changelog/next/changes/4143--context-breakup.md
@@ -1,0 +1,5 @@
+The `context create`, `context reset`, `context update`, and `context load`
+operators no return information about the context. Pipelines ending with these
+operators will now be considered closed, and you will be asked to deploy them in
+the Explorer. Previously, users commonly added `discard` after these operators
+to force this behavior.

--- a/libtenzir/builtins/contexts/bloom_filter.cpp
+++ b/libtenzir/builtins/contexts/bloom_filter.cpp
@@ -166,11 +166,11 @@ public:
     return {};
   }
 
-  auto reset(context::parameter_map) -> caf::expected<record> override {
+  auto reset() -> caf::expected<void> override {
     auto params = bloom_filter_.parameters();
     TENZIR_ASSERT(params.n && params.p);
     bloom_filter_ = dcso_bloom_filter{*params.n, *params.p};
-    return show();
+    return {};
   }
 
   auto save() const -> caf::expected<save_result> override {

--- a/libtenzir/builtins/contexts/geoip.cpp
+++ b/libtenzir/builtins/contexts/geoip.cpp
@@ -32,6 +32,16 @@ namespace {
 
 auto constexpr path_key = "db-path";
 
+struct mmdb_deleter final {
+  auto operator()(MMDB_s* ptr) noexcept -> void {
+    if (ptr) {
+      MMDB_close(ptr);
+    }
+  }
+};
+
+using mmdb_ptr = std::unique_ptr<MMDB_s, mmdb_deleter>;
+
 #if MMDB_UINT128_IS_BYTE_ARRAY
 auto cast_128_bit_unsigned_to_64_bit(uint8_t uint128[16]) -> uint64_t {
   auto low = uint64_t{};
@@ -63,20 +73,13 @@ struct current_dump {
   int status = MMDB_SUCCESS;
   series_builder builder;
 };
-} // namespace
 
 class ctx final : public virtual context {
 public:
   ctx() noexcept = default;
 
-  explicit ctx(context::parameter_map parameters) noexcept {
-    reset(std::move(parameters));
-  }
-
-  ~ctx() override {
-    if (mmdb_) {
-      MMDB_close(&*mmdb_);
-    }
+  explicit ctx(std::string db_path, mmdb_ptr mmdb)
+    : db_path_{std::move(db_path)}, mmdb_{std::move(mmdb)} {
   }
 
   auto context_type() const -> std::string override {
@@ -307,7 +310,7 @@ public:
       const auto ip_string = is_ip
                                ? fmt::to_string(value)
                                : materialize(caf::get<std::string_view>(value));
-      auto result = MMDB_lookup_string(&*mmdb_, ip_string.data(),
+      auto result = MMDB_lookup_string(mmdb_.get(), ip_string.data(),
                                        &address_info_error, &status);
       if (address_info_error != MMDB_SUCCESS) {
         return caf::make_error(
@@ -372,7 +375,7 @@ public:
       case MMDB_RECORD_TYPE_SEARCH_NODE: {
         MMDB_search_node_s search_node{};
         current_dump.status
-          = MMDB_read_node(&*mmdb_, node_number, &search_node);
+          = MMDB_read_node(mmdb_.get(), node_number, &search_node);
         if (current_dump.status != MMDB_SUCCESS) {
           break;
         }
@@ -458,24 +461,16 @@ public:
     return {};
   }
 
-  auto reset(context::parameter_map parameters)
-    -> caf::expected<record> override {
-    if (parameters.contains(path_key) and parameters.at(path_key)) {
-      db_path_ = *parameters[path_key];
-    }
-    if (mmdb_) {
-      MMDB_close(&*mmdb_);
-    } else {
-      mmdb_ = MMDB_s{};
-    }
-    auto status = MMDB_open(db_path_.c_str(), MMDB_MODE_MMAP, &*mmdb_);
+  auto reset() -> caf::expected<void> override {
+    mmdb_ = mmdb_ptr{new MMDB_s};
+    const auto status
+      = MMDB_open(db_path_.c_str(), MMDB_MODE_MMAP, mmdb_.get());
     if (status != MMDB_SUCCESS) {
-      return caf::make_error(ec::filesystem_error,
-                             fmt::format("error opening IP database at path "
-                                         "'{}': {}",
-                                         db_path_, MMDB_strerror(status)));
+      return diagnostic::error("{}", MMDB_strerror(status))
+        .note("failed to open MaxMind database at `{}`", db_path_)
+        .to_error();
     }
-    return show();
+    return {};
   }
 
   auto snapshot(parameter_map, const std::vector<std::string>&) const
@@ -496,8 +491,7 @@ public:
 
 private:
   std::string db_path_;
-  record r_;
-  std::optional<MMDB_s> mmdb_;
+  mmdb_ptr mmdb_;
 };
 
 struct v1_loader : public context_loader {
@@ -521,9 +515,9 @@ struct v1_loader : public context_loader {
                              "context: invalid type or value for "
                              "DB path entry");
     }
-    context::parameter_map params;
-    params[path_key] = serialized_string->str();
-    return std::make_unique<ctx>(std::move(params));
+    const auto* plugin = plugins::find<context_plugin>("geoip");
+    TENZIR_ASSERT(plugin);
+    return plugin->make_context({{path_key, serialized_string->str()}});
   }
 };
 
@@ -539,9 +533,33 @@ class plugin : public virtual context_plugin {
 
   auto make_context(context::parameter_map parameters) const
     -> caf::expected<std::unique_ptr<context>> override {
-    return std::make_unique<ctx>(std::move(parameters));
+    auto db_path = std::string{};
+    for (const auto& [key, value] : parameters) {
+      if (key == path_key) {
+        if (not value) {
+          return diagnostic::error("missing value for option `{}`", key)
+            .usage("context create <name> geoip --db-path <path>")
+            .to_error();
+        }
+        db_path = *value;
+        continue;
+      }
+      return diagnostic::error("unsupported option `{}`", key)
+        .usage("context create <name> geoip --db-path <path>")
+        .to_error();
+    }
+    auto mmdb = mmdb_ptr{new MMDB_s};
+    const auto status = MMDB_open(db_path.c_str(), MMDB_MODE_MMAP, mmdb.get());
+    if (status != MMDB_SUCCESS) {
+      return diagnostic::error("{}", MMDB_strerror(status))
+        .note("failed to open MaxMind database at `{}`", db_path)
+        .to_error();
+    }
+    return std::make_unique<ctx>(std::move(db_path), std::move(mmdb));
   }
 };
+
+} // namespace
 
 } // namespace tenzir::plugins::geoip
 

--- a/libtenzir/builtins/contexts/lookup_table.cpp
+++ b/libtenzir/builtins/contexts/lookup_table.cpp
@@ -393,9 +393,9 @@ public:
       };
   }
 
-  auto reset(context::parameter_map) -> caf::expected<record> override {
+  auto reset() -> caf::expected<void> override {
     context_entries.clear();
-    return show();
+    return {};
   }
 
   auto save() const -> caf::expected<save_result> override {

--- a/libtenzir/include/tenzir/drain_bytes.hpp
+++ b/libtenzir/include/tenzir/drain_bytes.hpp
@@ -1,0 +1,59 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2024 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "tenzir/chunk.hpp"
+#include "tenzir/generator.hpp"
+
+namespace tenzir {
+
+// Drains a generator of bytes, yielding at most one non-empty chunk. Yields an
+// empty chunk whenever the input yields an empty chunk to allow usage in an
+// operator's generator.
+inline auto drain_bytes(generator<chunk_ptr> input) -> generator<chunk_ptr> {
+  auto result = chunk_ptr{};
+  auto it = input.begin();
+  while (it != input.end()) {
+    auto chunk = std::move(*it);
+    ++it;
+    if (not chunk) {
+      co_yield {};
+      continue;
+    }
+    result = std::move(chunk);
+    break;
+  }
+  if (not result) {
+    co_return;
+  }
+  auto byte_buffer = std::vector<std::byte>{};
+  while (it != input.end()) {
+    auto chunk = std::move(*it);
+    ++it;
+    if (not chunk) {
+      co_yield {};
+      continue;
+    }
+    if (result) [[unlikely]] {
+      byte_buffer.reserve(result->size());
+      byte_buffer.insert(byte_buffer.end(), result->begin(), result->end());
+      result = {};
+    }
+    byte_buffer.reserve(byte_buffer.size() + chunk->size());
+    byte_buffer.insert(byte_buffer.end(), chunk->begin(), chunk->end());
+  }
+  if (not result) {
+    result = chunk::make(std::move(byte_buffer));
+  } else {
+    TENZIR_ASSERT(byte_buffer.empty());
+  }
+  co_yield std::move(result);
+}
+
+} // namespace tenzir

--- a/libtenzir/include/tenzir/plugin.hpp
+++ b/libtenzir/include/tenzir/plugin.hpp
@@ -704,6 +704,8 @@ public:
 
   /// Information about a context update that gets propagated to live lookups.
   struct update_result {
+    // TODO The update info is no longer needed since context update became a
+    // sink operator.
     record update_info;
     // Function for emitting an updated expression. Used for retroactive lookups.
     make_query_type make_query = {};
@@ -743,7 +745,7 @@ public:
     = 0;
 
   /// Clears the context state, with optional parameters.
-  virtual auto reset(parameter_map parameters) -> caf::expected<record> = 0;
+  virtual auto reset() -> caf::expected<void> = 0;
 
   /// Create a snapshot of the initial expression.
   virtual auto snapshot(parameter_map parameters,

--- a/libtenzir/src/node.cpp
+++ b/libtenzir/src/node.cpp
@@ -478,6 +478,8 @@ node(node_actor::stateful_pointer<node_state> self, std::string /*name*/,
           // The spawn function can provide a better log message so we don't
           // print one here.
           continue;
+        self->system().registry().put(
+          fmt::format("tenzir.{}", component->component_name()), handle);
         if (auto err
             = register_component(self, caf::actor_cast<caf::actor>(handle),
                                  component->component_name()))

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "980605c1a92c61ff1b33934da0a8619cab2dd5a8",
+  "rev": "2c7648c823edeaefdc65aaa755c9559298135686",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/web/docs/operators/context.md
+++ b/web/docs/operators/context.md
@@ -2,7 +2,8 @@
 sidebar_custom_props:
   operator:
     source: true
-    transformation: true
+    transformation: false
+    sink: true
 ---
 
 # context
@@ -12,12 +13,12 @@ Manages a [context](../contexts.md).
 ## Synopsis
 
 ```
-context create <name> <context-type>
-context delete <name>
-context update <name> [<options>]
-context reset  <name>
-context save   <name>
-context load   <name>
+context create  <name> <type> [<args>]
+context delete  <name>
+context update  <name> [<args>]
+context reset   <name>
+context save    <name>
+context load    <name>
 context inspect <name>
 ```
 
@@ -25,17 +26,14 @@ context inspect <name>
 
 The `context` operator manages [context](../contexts.md) instances.
 
-- The `create` command creates a new context with a unique name. The pipeline
-  returns information about the new context.
+- The `create` command creates a new context with a unique name.
 
-- The `delete` command destroys a given context. The pipeline returns
-  information about the deleted context.
+- The `delete` command destroys a given context.
 
-- The `update` command adds new data to a given context. The pipeline returns
-  information about what the update performed.
+- The `update` command adds new data to a given context.
 
 - The `reset` command clears the state of a given context, as if it had just
-  been created. The pipeline returns information about the cleared context.
+  been created.
 
 - The `save` command outputs the state of the context, serialized into bytes.
   The result can be processed further in a pipeline,
@@ -43,8 +41,7 @@ The `context` operator manages [context](../contexts.md) instances.
   or to initialize another context with `context load`.
 
 - The `load` command takes in bytes, likely previously created with
-  `context save`, and initializes the context with that data. The pipeline
-  returns information about the populated context.
+  `context save`, and initializes the context with that data.
 
 - The `inspect` command dumps a specific context's user-provided data, usually
   the context's content.
@@ -53,13 +50,13 @@ The `context` operator manages [context](../contexts.md) instances.
 
 The name of the context to create, update, or delete.
 
-### `<context-type>`
+### `<type>`
 
 The context type for the new context.
 
 See the [list of available context types](../contexts.md).
 
-### `<options>`
+### `<args>`
 
 Context-specific options in the format `--key value` or `--flag`.
 


### PR DESCRIPTION
This change removes the events output from quite a few context-related operators, and also makes less of them take generic arguments in favor of fixed arguments that produce better diagnostics when they're misused.