### PR TITLE
Fix a wrong key in the configured pipeline example

### DIFF
--- a/web/docs/user-guides/run-pipelines/README.md
+++ b/web/docs/user-guides/run-pipelines/README.md
@@ -102,5 +102,5 @@ tenzir:
       # - Omit the option, or set it to null or false to disable.
       # - Set the option to true to enable with the default delay of 1 minute.
       # - Set the option to a valid duration to enable with a custom delay.
-      retry-on-error: 1 minute
+      restart-on-error: 1 minute
 ```

--- a/web/versioned_docs/version-Tenzir v4.12/user-guides/run-pipelines/README.md
+++ b/web/versioned_docs/version-Tenzir v4.12/user-guides/run-pipelines/README.md
@@ -102,5 +102,5 @@ tenzir:
       # - Omit the option, or set it to null or false to disable.
       # - Set the option to true to enable with the default delay of 1 minute.
       # - Set the option to a valid duration to enable with a custom delay.
-      retry-on-error: 1 minute
+      restart-on-error: 1 minute
 ```


### PR DESCRIPTION
This change fixes the wrong `retry-on-error` key in the configured pipeline example in the documentation.
