### PR TITLE
Disable the `web` plugin on macOS

### DIFF
--- a/.github/workflows/tenzir.yaml
+++ b/.github/workflows/tenzir.yaml
@@ -579,13 +579,9 @@ jobs:
             dependencies-script-path: scripts/macOS/install-dev-dependencies.sh
             cmake-extra-flags: -DTENZIR_ENABLE_BUNDLED_CAF:BOOL=ON
             bundled-plugins:
-              # - Parquet uses illegal instructions on macOS in Arrow version
-              #   14.0.1, so we disable it in the macOS CI. Last checked on
-              #   2023-12-16.
-              # - The http-parser package is disabled on Hoembrew, which means
-              #   we cannot build the web plugin on macOS anymore. Last checked
-              #   on 2024-01-31.
-              - plugins/[^(parquet)(web)]*
+              # macOS runners in GitHub Actions CI are very limited, so we
+              # prefer to have fewer jobs running and build the proprietary
+              # plugins as bundled on macOS.
               - contrib/tenzir-plugins/*
     env:
       BUILD_DIR: build

--- a/plugins/web/CMakeLists.txt
+++ b/plugins/web/CMakeLists.txt
@@ -1,5 +1,13 @@
 cmake_minimum_required(VERSION 3.19...3.28 FATAL_ERROR)
 
+if (APPLE)
+  message(
+    WARNING
+      "The http_parser library is unmaintained and no longer available on macOS; disabling the web plugin"
+  )
+  return()
+endif ()
+
 project(
   web
   DESCRIPTION "Web plugin for Tenzir"


### PR DESCRIPTION
The Homebrew package for its http parser dependency was disabled quite a while ago because the library is unmaintained and no longer compiled from source against our current compiler toolchain, so it's really hard to build the `web` plugin on macOS. This just disables it.

This also re-enables the `parquet` plugin on macOS, as that no longer uses illegal instruction as far as I can tell.