### PR TITLE
Detach the index actor

### DIFF
--- a/libtenzir/src/execution_node.cpp
+++ b/libtenzir/src/execution_node.cpp
@@ -717,6 +717,10 @@ auto exec_node(
   receiver_actor<diagnostic> diagnostic_handler,
   receiver_actor<metric> metrics_handler, int index, bool has_terminal)
   -> exec_node_actor::behavior_type {
+  if (self->getf(caf::scheduled_actor::is_detached_flag)) {
+    const auto name = fmt::format("tenzir.exec-node.{}", op->name());
+    caf::detail::set_thread_name(name.c_str());
+  }
   self->state.self = self;
   self->state.op = std::move(op);
   auto time_starting_guard = make_timer_guard(

--- a/libtenzir/src/index.cpp
+++ b/libtenzir/src/index.cpp
@@ -1185,6 +1185,9 @@ index(index_actor::stateful_pointer<index_state> self,
     TENZIR_ARG(active_partition_timeout), TENZIR_ARG(max_inmem_partitions),
     TENZIR_ARG(taste_partitions), TENZIR_ARG(max_concurrent_partition_lookups),
     TENZIR_ARG(catalog_dir), TENZIR_ARG(index_config));
+  if (self->getf(caf::scheduled_actor::is_detached_flag)) {
+    caf::detail::set_thread_name("tenzir.index");
+  }
   TENZIR_VERBOSE("{} initializes index in {} with a maximum partition "
                  "size of {} events and {} resident partitions",
                  *self, dir, partition_capacity, max_inmem_partitions);

--- a/libtenzir/src/spawn_index.cpp
+++ b/libtenzir/src/spawn_index.cpp
@@ -53,7 +53,7 @@ spawn_index(node_actor::stateful_pointer<node_state> self,
       return err;
     TENZIR_VERBOSE("using customized indexing configuration {}", index_config);
   }
-  auto handle = self->spawn(
+  auto handle = self->spawn<caf::detached>(
     index, accountant, filesystem, catalog, indexdir,
     // TODO: Pass these options as a tenzir::data object instead.
     std::string{sd::store_backend},


### PR DESCRIPTION
The index actor is one of our busiest actors, and it's still one of the places where read and write paths collide. This change pins the actor onto a single thread that lives outside the actor system's thread pool.