### PR TITLE
Fix shutdown of `every <interval> <transformation|sink>`

### DIFF
--- a/changelog/next/bug-fixes/4166--every-transformation-shutdown.md
+++ b/changelog/next/bug-fixes/4166--every-transformation-shutdown.md
@@ -1,0 +1,2 @@
+Transformations or sinks used with the `every` operator modifier did not shut
+down correctly when exhausting their input. This now work as expected.


### PR DESCRIPTION
`every` when used with a transformation or a sink did not shut down properly before this change.
