### PR TITLE
Fix reopening ports while subprocesses are open

### DIFF
--- a/changelog/next/bug-fixes/4170--fix-port-reopen.md
+++ b/changelog/next/bug-fixes/4170--fix-port-reopen.md
@@ -1,0 +1,2 @@
+We fixed a bug that prevented restarts of pipelines containing a listening
+connector under specific circumstances.

--- a/libtenzir/builtins/operators/shell.cpp
+++ b/libtenzir/builtins/operators/shell.cpp
@@ -11,6 +11,7 @@
 #include <tenzir/chunk.hpp>
 #include <tenzir/concept/parseable/string/quoted_string.hpp>
 #include <tenzir/concept/parseable/tenzir/pipeline.hpp>
+#include <tenzir/detail/preserved_fds.hpp>
 #include <tenzir/error.hpp>
 #include <tenzir/logger.hpp>
 #include <tenzir/pipeline.hpp>
@@ -58,6 +59,8 @@ public:
             bp::std_out > result.stdout_,
             bp::std_in < bp::close,
             bp::on_exit(exit_handler),
+            detail::preserved_fds{{STDOUT_FILENO, STDERR_FILENO}},
+            boost::process::limit_handles,
           };
           break;
         case stdin_mode::inherit:
@@ -67,6 +70,8 @@ public:
             result.command_,
             bp::std_out > result.stdout_,
             bp::on_exit(exit_handler),
+            detail::preserved_fds{{STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO}},
+            boost::process::limit_handles,
           };
           break;
         case stdin_mode::pipe:
@@ -77,6 +82,8 @@ public:
             bp::std_out > result.stdout_,
             bp::std_in < result.stdin_,
             bp::on_exit(exit_handler),
+            detail::preserved_fds{{STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO}},
+            boost::process::limit_handles,
           };
           break;
       }

--- a/libtenzir/include/tenzir/detail/preserved_fds.hpp
+++ b/libtenzir/include/tenzir/detail/preserved_fds.hpp
@@ -1,0 +1,26 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2024 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <boost/process/detail/handler.hpp>
+#include <boost/process/handles.hpp>
+
+#include <vector>
+
+namespace tenzir::detail {
+
+struct preserved_fds : boost::process::detail::handler,
+                       boost::process::detail::uses_handles {
+  std::vector<int> fds;
+  preserved_fds(std::vector<int> pfds);
+
+  auto get_used_handles() -> std::vector<int>&;
+};
+
+} // namespace tenzir::detail

--- a/libtenzir/src/detail/preserved_fds.cpp
+++ b/libtenzir/src/detail/preserved_fds.cpp
@@ -1,0 +1,19 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2024 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "tenzir/detail/preserved_fds.hpp"
+
+namespace tenzir::detail {
+
+preserved_fds::preserved_fds(std::vector<int> pfds) : fds(std::move(pfds)) {
+}
+auto preserved_fds::get_used_handles() -> std::vector<int>& {
+  return fds;
+}
+
+} // namespace tenzir::detail

--- a/shell.nix
+++ b/shell.nix
@@ -16,6 +16,14 @@ in
           pkgs.shfmt
           pkgs.poetry
           pkgs.python3Packages.spdx-tools
+          (pkgs.python3.withPackages (ps: with ps; [
+            aiohttp
+            dynaconf
+            numpy
+            pandas
+            pyarrow
+            python-box
+          ]))
         ] ++ pkgs.tenzir-integration-test-deps
           ++ lib.optionals (!(pkgs.stdenv.hostPlatform.useLLVM or false)) [
           # Make clang available as alternative compiler when it isn't the default.


### PR DESCRIPTION
This fixes an unwanted interaction between the `http` and `tcp` connectors and the `python` and `shell` operators. When a connector opens a listening port the forked subprocesses would inherit the file descriptors representing the resource. That prevented the connector from being recreated while the subprocesses were still running.