### PR TITLE
Restore implicit `read json` in `from tcp`

### DIFF
--- a/changelog/next/bug-fixes/4175--from-tcp-read-json.md
+++ b/changelog/next/bug-fixes/4175--from-tcp-read-json.md
@@ -1,0 +1,2 @@
+We accidentally removed the implicit `read json` from `from tcp` in Tenzir
+v4.12. The shortform now works as expected again.


### PR DESCRIPTION
We accidentally broke this with the Tenzir v4.12 release.