### PR TITLE
Use `llvm@17` in the macOS CI

### DIFF
--- a/.github/workflows/tenzir.yaml
+++ b/.github/workflows/tenzir.yaml
@@ -665,7 +665,7 @@ jobs:
       - if: ${{ matrix.tenzir.name == 'macOS' }}
         name: Setup Homebrew Clang
         run: |
-          llvm_root="$(brew --prefix llvm)"
+          llvm_root="$(brew --prefix llvm@17)"
           echo "${llvm_root}/bin" >> $GITHUB_PATH
           echo "LDFLAGS=-Wl,-rpath,${llvm_root}" >> $GITHUB_ENV
           echo "CPPFLAGS=-isystem ${llvm_root}/include" >> $GITHUB_ENV

--- a/scripts/macOS/install-dev-dependencies.sh
+++ b/scripts/macOS/install-dev-dependencies.sh
@@ -20,7 +20,7 @@ brew install --overwrite \
     libpcap \
     librdkafka \
     libunwind-headers \
-    llvm \
+    llvm@17 \
     ninja \
     nmap \
     openssl \

--- a/web/docs/developer-guides/build-from-source.md
+++ b/web/docs/developer-guides/build-from-source.md
@@ -63,16 +63,17 @@ The minimum specified versions reflect those versions that we use in CI and
 manual testing. Older versions may still work in select cases.
 
 :::tip macOS
-On macOS, we recommend using the latest Clang from the Homebrew `llvm` package
-with the following settings:
+On macOS, we recommend using Clang from the Homebrew `llvm@17` package with the
+following settings:
 
 ```bash
-export PATH="$(brew --prefix llvm)/bin:${PATH}"
-export CC="$(brew --prefix llvm)/bin/clang"
-export CXX="$(brew --prefix llvm)/bin/clang++"
-export LDFLAGS="-Wl,-rpath,$(brew --prefix llvm) ${LDFLAGS}"
-export CPPFLAGS="-isystem $(brew --prefix llvm)/include ${CPPFLAGS}"
-export CXXFLAGS="-isystem $(brew --prefix llvm)/include/c++/v1 ${CXXFLAGS}"
+export LLVM_PREFIX="$(brew --prefix llvm@17)"
+export PATH="${LLVM_PREFIX}/bin:${PATH}"
+export CC="${LLVM_PREFIX}/bin/clang"
+export CXX="${LLVM_PREFIX}/bin/clang++"
+export LDFLAGS="-Wl,-rpath,${LLVM_PREFIX} ${LDFLAGS}"
+export CPPFLAGS="-isystem ${LLVM_PREFIX}/include ${CPPFLAGS}"
+export CXXFLAGS="-isystem ${LLVM_PREFIX}/include/c++/v1 ${CXXFLAGS}"
 ```
 
 Installing via CMake on macOS configures a [launchd](https://www.launchd.info)


### PR DESCRIPTION
Clang 18 has an internal compiler errror when building Tenzir, CAF has a lot of new warnings, and Apache Arrow doesn't build against it either. For now, there isn't much we can do but pin LLVM to the previous version to unbreak our CI.