### PR TITLE
Restrict magic-nix-cache to hosted runners

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -92,6 +92,7 @@ jobs:
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Use Magic Nix Cache
+        if: runner.environment == 'github-hosted'
         uses: DeterminateSystems/magic-nix-cache-action@v4
         with:
           # disables telemetry


### PR DESCRIPTION
This action prepends `nix.conf` every time it runs.