### PR TITLE
Build an RPM package

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -125,6 +125,15 @@ jobs:
           name: tarball
           path: "./packages/tarball/*.tar.gz"
           if-no-files-found: error
+      - name: Upload RPM Package to Github
+        if: >-
+          runner.os == 'Linux' &&
+          steps.cfg.outputs.upload-to-github == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpm
+          path: "./packages/rpm/*.rpm"
+          if-no-files-found: error
       - name: Upload Debian Package to Github
         if: >-
           runner.os == 'Linux' &&
@@ -143,21 +152,39 @@ jobs:
           name: macOS
           path: "./packages/macOS/*.pkg"
           if-no-files-found: error
-      - name: Test Installation
+      - name: Test Installation (Ubuntu)
         if: runner.os == 'Linux'
         run: |
           deb_file="$(basename ./packages/debian/tenzir*.deb)"
-          docker build tenzir/services/systemd/test -t installer-test
-          docker run -d --name installer-test \
+          docker build tenzir/services/systemd/test -t installer-test-ubuntu
+          docker run -d --name installer-test-ubuntu \
                  --privileged \
                  --volume=.:/src/tenzir:ro \
                  --volume="./packages/debian":/tmp/packages:ro \
                  --volume=/sys/fs/cgroup:/sys/fs/cgroup:rw \
                  --cgroupns=host \
-                 installer-test
+                 installer-test-ubuntu
           # TODO: Ideally we would have some way to block until systemd is fully
           # booted, but sleeping a bit works almost every time.
           sleep 5
-          docker exec -e TENZIR_PACKAGE_URL="file:///tmp/packages/${deb_file}" installer-test bash -c \
+          docker exec -e TENZIR_PACKAGE_URL="file:///tmp/packages/${deb_file}" installer-test-ubuntu bash -c \
                  "/src/tenzir/scripts/install.sh"
-          docker exec installer-test halt
+          docker exec installer-test-ubuntu halt
+      - name: Test Installation (Rocky Linux)
+        if: runner.os == 'Linux'
+        run: |
+          rpm_file="$(basename ./packages/rpm/tenzir*.rpm)"
+          docker build tenzir/services/systemd/test -t installer-test-rocky
+          docker run -d --name installer-test-rocky \
+                 --privileged \
+                 --volume=.:/src/tenzir:ro \
+                 --volume="./packages/rpm":/tmp/packages:ro \
+                 --volume=/sys/fs/cgroup:/sys/fs/cgroup:rw \
+                 --cgroupns=host \
+                 eniocarboni/docker-rockylinux-systemd:9
+          # TODO: Ideally we would have some way to block until systemd is fully
+          # booted, but sleeping a bit works almost every time.
+          sleep 5
+          docker exec -e TENZIR_PACKAGE_URL="file:///tmp/packages/${rpm_file}" installer-test-rocky bash -c \
+                 "/src/tenzir/scripts/install.sh"
+          docker exec installer-test-rocky halt

--- a/changelog/next/features/4188--rpm-package.md
+++ b/changelog/next/features/4188--rpm-package.md
@@ -1,0 +1,1 @@
+We now offer an RPM package for RedHat Linux and its derivatives.

--- a/cmake/TenzirPackage.cmake
+++ b/cmake/TenzirPackage.cmake
@@ -81,6 +81,15 @@ set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA
     "${CMAKE_CURRENT_SOURCE_DIR}/scripts/debian/prerm")
 set(CPACK_DEBIAN_PACKAGE_DEBUG ON)
 
+set(CPACK_RPM_PRE_INSTALL_SCRIPT_FILE
+  "${CMAKE_CURRENT_SOURCE_DIR}/scripts/rpm/preinstall")
+set(CPACK_RPM_POST_INSTALL_SCRIPT_FILE
+  "${CMAKE_CURRENT_SOURCE_DIR}/scripts/rpm/postinstall")
+set(CPACK_RPM_PRE_UNINSTALL_SCRIPT_FILE
+  "${CMAKE_CURRENT_SOURCE_DIR}/scripts/rpm/preuninstall")
+set(CPACK_RPM_POST_UNINSTALL_SCRIPT_FILE
+  "${CMAKE_CURRENT_SOURCE_DIR}/scripts/rpm/postuninstall")
+
 # For the static binary builds it doesn't make much sense to install development
 # utilities, so we never do so.
 if (TENZIR_ENABLE_STATIC_EXECUTABLE)
@@ -100,9 +109,10 @@ set(CPACK_COMPONENTS_GROUPING ALL_COMPONENTS_IN_ONE)
 # ones we support, and the list of available Generators can change with future
 # releases of CMake.
 # https://cmake.org/cmake/help/latest/module/CPackComponent.html#variable:CPACK_%3CGENNAME%3E_COMPONENT_INSTALL
-set(CPACK_DEB_COMPONENT_INSTALL ON)
 set(CPACK_ARCHIVE_COMPONENT_INSTALL ON)
+set(CPACK_DEB_COMPONENT_INSTALL ON)
 set(CPACK_PRODUCTBUILD_COMPONENT_INSTALL ON)
+set(CPACK_RPM_COMPONENT_INSTALL ON)
 
 # Set up CPack as configured above. Note that the calls to cpack_add_component
 # must come _after_ the CPack include, while the variables must be set _before_

--- a/scripts/rpm/postinstall
+++ b/scripts/rpm/postinstall
@@ -1,0 +1,6 @@
+if [ $1 -eq 1 ]; then
+  # Initial installation
+  systemctl link /opt/tenzir/lib/systemd/system/tenzir-node.service || :
+  systemctl enable tenzir-node.service >/dev/null 2>&1 || :
+  systemctl start tenzir-node.service >/dev/null 2>&1 || :
+fi

--- a/scripts/rpm/postuninstall
+++ b/scripts/rpm/postuninstall
@@ -1,0 +1,8 @@
+if [ $1 -ge 1 ]; then
+  # Package upgrade, not uninstall
+  fi [ -x "/usr/lib/systemd/systemd-update-helper" ]; then
+    /usr/lib/systemd/systemd-update-helper mark-restart-system-units tenzir-node.service || :
+  else
+    systemctl try-restart tenzir-node.service >/dev/null 2>&1 || :
+  fi
+fi

--- a/scripts/rpm/preinstall
+++ b/scripts/rpm/preinstall
@@ -1,0 +1,14 @@
+mkdir -p /usr/lib/sysusers.d
+echo 'u tenzir - "Tenzir Node" /var/lib/tenzir /sbin/nologin' > /usr/lib/sysusers.d/tenzir.conf
+
+# Generated from the above tenzir.conf.
+getent group 'tenzir' >/dev/null || groupadd -r 'tenzir' || :
+getent passwd 'tenzir' >/dev/null || \
+    useradd -r -g 'tenzir' -d '/var/lib/tenzir' -s '/usr/sbin/nologin' -c 'Tenzir Node' 'tenzir' || :
+
+# Added manually
+mkdir -p /var/lib/tenzir
+chown tenzir:tenzir /var/lib/tenzir
+
+mkdir -p /var/log/tenzir
+chown tenzir:tenzir /var/log/tenzir

--- a/scripts/rpm/preuninstall
+++ b/scripts/rpm/preuninstall
@@ -1,0 +1,10 @@
+if [ $1 -eq 0 ]; then
+  # Package removal, not upgrade
+  if [ -x "/usr/lib/systemd/systemd-update-helper" ]; then
+    /usr/lib/systemd/systemd-update-helper remove-system-units tenzir-node.service || :
+  else
+    systemctl --no-reload disable tenzir-node.service > /dev/null 2>&1 || :
+    systemctl stop tenzir-node.service > /dev/null 2>&1 || :
+  fi
+  [ -L /etc/systemd/system/tenzir-node.service ] && rm /etc/systemd/system/tenzir-node.service || :
+fi

--- a/tenzir/services/systemd/tenzir-node.service.in
+++ b/tenzir/services/systemd/tenzir-node.service.in
@@ -32,7 +32,7 @@ RestrictSUIDSGID=yes
 LimitNOFILE=65535
 
 # system access
-ExecPaths=@CMAKE_INSTALL_FULL_LIBEXECDIR@/tenzir-df-percent.sh
+ExecPaths=@CMAKE_INSTALL_FULL_BINDIR@ @CMAKE_INSTALL_FULL_LIBEXECDIR@
 ProtectSystem=strict
 ReadWritePaths=/tmp
 PrivateTmp=no


### PR DESCRIPTION
This adds an RPM package build and integrates it with the installer and CI.
The package should work with RedHat, OpenSuse and their derivatives.
Installer testing is done with Rocky Linux.
