### PR TITLE
Improve error message for `--arrays-of-objects`

### DIFF
--- a/libtenzir/builtins/formats/json.cpp
+++ b/libtenzir/builtins/formats/json.cpp
@@ -830,8 +830,8 @@ public:
         auto arr = doc.value_unsafe().get_array();
         if (arr.error()) {
           state.abort_requested = true;
-          diagnostic::error("{}", error_message(err))
-            .note("expected an array of objects")
+          diagnostic::error("expected an array of objects")
+            .note("got: {}", view)
             .emit(this->ctrl_.diagnostics());
           co_return;
         }


### PR DESCRIPTION
Previously, when using `read json --arrays-of-objects` with a non-array input, we reported the following (confusing) error:
```
error: SUCCESS: No error
 = note: expected an array of objects
```
This PR changes it to something like:
```
error: expected an array of objects
 = note: got: <a snippet from the actual input>
```


