### PR TITLE
Make tests independent of Accept-Encoding header

### DIFF
--- a/tenzir/integration/data/misc/scripts/webserver.py
+++ b/tenzir/integration/data/misc/scripts/webserver.py
@@ -35,8 +35,11 @@ class Handler(BaseHTTPRequestHandler):
         # Ensure determinism.
         headers = Message()
         for key, value in self.headers.items():
-            if key == "User-Agent" and value.startswith("Tenzir/"):
-                value = value[: value.find("/") + 1] + "*.*.*"
+            if key == "User-Agent":
+                if value.startswith("Tenzir/"):
+                    value = "Tenzir/*.*.*"
+            elif key == "Accept-Encoding":
+                value = "*"
             headers[key] = value
         result = f"\n{headers}{content.decode('utf-8')}"
         if REFLECT:

--- a/tenzir/integration/data/reference/http/test_load_http_post/step_00.ref
+++ b/tenzir/integration/data/reference/http/test_load_http_post/step_00.ref
@@ -1,7 +1,7 @@
 "POST / HTTP/1.1" 200 -
 
 Host: localhost:50380
-Accept-Encoding: deflate, gzip
+Accept-Encoding: *
 User-Agent: Tenzir/*.*.*
 Content-Type: application/json
 Accept: application/json, */*

--- a/tenzir/integration/data/reference/http/test_load_http_post_form/step_00.ref
+++ b/tenzir/integration/data/reference/http/test_load_http_post_form/step_00.ref
@@ -1,7 +1,7 @@
 "POST / HTTP/1.1" 200 -
 
 Host: localhost:50381
-Accept-Encoding: deflate, gzip
+Accept-Encoding: *
 User-Agent: Tenzir/*.*.*
 Content-Type: application/x-www-form-urlencoded
 Accept: */*

--- a/tenzir/integration/data/reference/http/test_save_http_post/step_00.ref
+++ b/tenzir/integration/data/reference/http/test_save_http_post/step_00.ref
@@ -1,7 +1,7 @@
 "POST / HTTP/1.1" 200 -
 
 Host: localhost:51381
-Accept-Encoding: deflate, gzip
+Accept-Encoding: *
 User-Agent: Tenzir/*.*.*
 Accept: */*
 Content-Type: application/json

--- a/tenzir/integration/data/reference/http/test_save_http_post/step_01.ref
+++ b/tenzir/integration/data/reference/http/test_save_http_post/step_01.ref
@@ -1,7 +1,7 @@
 "POST / HTTP/1.1" 200 -
 
 Host: localhost:51382
-Accept-Encoding: deflate, gzip
+Accept-Encoding: *
 User-Agent: Tenzir/*.*.*
 Accept: */*
 Content-Type: application/json

--- a/tenzir/integration/data/reference/http/test_save_http_post_add_header/step_00.ref
+++ b/tenzir/integration/data/reference/http/test_save_http_post_add_header/step_00.ref
@@ -1,7 +1,7 @@
 "POST / HTTP/1.1" 200 -
 
 Host: localhost:51385
-Accept-Encoding: deflate, gzip
+Accept-Encoding: *
 User-Agent: Tenzir/*.*.*
 X-Test: foo
 Accept: */*

--- a/tenzir/integration/data/reference/http/test_save_http_post_delete_header/step_00.ref
+++ b/tenzir/integration/data/reference/http/test_save_http_post_delete_header/step_00.ref
@@ -1,7 +1,7 @@
 "POST / HTTP/1.1" 200 -
 
 Host: localhost:51383
-Accept-Encoding: deflate, gzip
+Accept-Encoding: *
 User-Agent: Tenzir/*.*.*
 Accept: */*
 Content-Length: 19

--- a/tenzir/integration/data/reference/http/test_save_http_post_overwrite_header/step_00.ref
+++ b/tenzir/integration/data/reference/http/test_save_http_post_overwrite_header/step_00.ref
@@ -1,7 +1,7 @@
 "POST / HTTP/1.1" 200 -
 
 Host: localhost:51384
-Accept-Encoding: deflate, gzip
+Accept-Encoding: *
 User-Agent: Test
 Accept: */*
 Content-Type: application/json

--- a/tenzir/integration/data/reference/http/test_save_http_put/step_00.ref
+++ b/tenzir/integration/data/reference/http/test_save_http_put/step_00.ref
@@ -1,7 +1,7 @@
 "PUT / HTTP/1.1" 200 -
 
 Host: localhost:51380
-Accept-Encoding: deflate, gzip
+Accept-Encoding: *
 User-Agent: Tenzir/*.*.*
 Accept: */*
 Content-Type: application/json


### PR DESCRIPTION
This PR makes the HTTP integration tests independent of the value of the `Accept-Encoding` header.
