### PR TITLE
Fix the lifetime tracking of node components

### DIFF
--- a/libtenzir/include/tenzir/node.hpp
+++ b/libtenzir/include/tenzir/node.hpp
@@ -77,6 +77,9 @@ struct node_state {
   /// The component registry.
   component_registry registry = {};
 
+  /// Components that are still alive for lifetime-tracking.
+  std::set<std::pair<caf::actor_addr, std::string>> alive_components = {};
+
   /// Counters for multi-instance components.
   std::unordered_map<std::string, uint64_t> label_counters = {};
 


### PR DESCRIPTION
The old code had a race condition that sometimes triggered an assertion failure in CI. Now the tracking is properly implemented through monitoring, which should fix the issue we've been seeing.