### PR TITLE
Improve `slice` with positive begin and negative end

### DIFF
--- a/changelog/next/bug-fixes/4210--slice-negative-end.md
+++ b/changelog/next/bug-fixes/4210--slice-negative-end.md
@@ -1,0 +1,3 @@
+The `slice` operator no longer waits for all input to arrive when used with a
+positive begin and a negative (or missing) end value, which rendered it unusable
+with infinite inputs. Instead, the operator now yields results earlier.

--- a/libtenzir/builtins/operators/slice.cpp
+++ b/libtenzir/builtins/operators/slice.cpp
@@ -195,7 +195,7 @@ public:
 
   auto optimize(const expression& filter, event_order order) const
     -> optimize_result override {
-    if (not begin_ and not end_) {
+    if (begin_.value_or(0) == 0 and not end_) {
       // If there's neither a begin nor an end, then this operator is a no-op.
       // We optimize it away here.
       return optimize_result{filter, order, nullptr};


### PR DESCRIPTION
Before this change, the `slice` operator would wait for its entire input to arrive when used with a positive begin and a negative (or missing) end value. This changes the implementation to return events eagerly that are known to be before the end of the range.

Fixes tenzir/issues#1820