### PR TITLE
Change the syntax of the `slice` operator

### DIFF
--- a/changelog/next/changes/4211--slice-syntax.md
+++ b/changelog/next/changes/4211--slice-syntax.md
@@ -1,0 +1,4 @@
+The `slice` operator now expects its arguments in the form `<begin>:<end>`,
+where either the begin or the end value may be omitted. For example, `slice 10:`
+returns all but the first 10 events, `slice 10:20` returns events 10 to 20
+(exclusive), and `slice :-10` returns all but the last 10 events.

--- a/libtenzir/builtins/operators/head.cpp
+++ b/libtenzir/builtins/operators/head.cpp
@@ -31,7 +31,7 @@ public:
     parser.add(count, "<limit>");
     parser.parse(p);
     auto result = pipeline::internal_parse_as_operator(
-      fmt::format("slice --end {}", count.value_or(10)));
+      fmt::format("slice :{}", count.value_or(10)));
     if (not result) {
       diagnostic::error("failed to transform `head` into `slice` operator: {}",
                         result.error())

--- a/libtenzir/builtins/operators/tail.cpp
+++ b/libtenzir/builtins/operators/tail.cpp
@@ -31,7 +31,7 @@ public:
     parser.add(count, "<limit>");
     parser.parse(p);
     auto result = pipeline::internal_parse_as_operator(
-      fmt::format("slice --begin -{}", count.value_or(10)));
+      fmt::format("slice -{}:", count.value_or(10)));
     if (not result) {
       diagnostic::error("failed to transform `tail` into `slice` operator: {}",
                         result.error())

--- a/plugins/parquet/integration/tests/tests.bats
+++ b/plugins/parquet/integration/tests/tests.bats
@@ -17,7 +17,7 @@ setup() {
 
 @test "Additional write options" {
   check tenzir "from ${BATS_TENZIR_DATADIR}/inputs/zeek/conn.log.gz read zeek-tsv | write parquet --compression-level 10 --compression-type brotli | read parquet | measure | drop timestamp"
-  check tenzir "from ${BATS_TENZIR_DATADIR}/inputs/zeek/conn.log.gz read zeek-tsv | slice --begin 1150 --end 1160 | write parquet --compression-level 7 --compression-type gzip | read parquet"
+  check tenzir "from ${BATS_TENZIR_DATADIR}/inputs/zeek/conn.log.gz read zeek-tsv | slice 1150:1160 | write parquet --compression-level 7 --compression-type gzip | read parquet"
   check tenzir "from ${BATS_TENZIR_DATADIR}/inputs/zeek/conn.log.gz read zeek-tsv | write parquet --compression-type snappy | read parquet | summarize count(.)"
   check tenzir "from ${BATS_TENZIR_DATADIR}/inputs/zeek/conn.log.gz read zeek-tsv | write parquet --compression-level -1 --compression-type zstd | read parquet | measure | drop timestamp"
   gunzip -c "${BATS_TENZIR_DATADIR}/inputs/zeek/conn.log.gz" |

--- a/tenzir/integration/tests/feather.bats
+++ b/tenzir/integration/tests/feather.bats
@@ -34,7 +34,7 @@ setup() {
 
 @test "Additional write options" {
   check tenzir "from ${BATS_TENZIR_DATADIR}/inputs/zeek/conn.log.gz read zeek-tsv | batch 256 | write feather --compression-level 10 --compression-type zstd | read feather | measure | drop timestamp"
-  check tenzir "from ${BATS_TENZIR_DATADIR}/inputs/zeek/conn.log.gz read zeek-tsv | slice --begin 1150 --end 1160 | batch 512 | write feather --compression-level 7 --compression-type lz4 --min-space-savings .6 | read feather"
+  check tenzir "from ${BATS_TENZIR_DATADIR}/inputs/zeek/conn.log.gz read zeek-tsv | slice 1150:1160 | batch 512 | write feather --compression-level 7 --compression-type lz4 --min-space-savings .6 | read feather"
   gunzip -c "${BATS_TENZIR_DATADIR}/inputs/zeek/conn.log.gz" |
     check tenzir "read zeek-tsv | write feather --compression-level 7 | read feather | summarize count(.)"
   check tenzir "from ${BATS_TENZIR_DATADIR}/inputs/zeek/conn.log.gz read zeek-tsv | batch 256 | write feather --compression-level -1 --compression-type zstd --min-space-savings 0 | read feather | measure | drop timestamp"

--- a/tenzir/integration/tests/pipelines_local.bats
+++ b/tenzir/integration/tests/pipelines_local.bats
@@ -497,16 +497,16 @@ EOF
 
 # bats test_tags=pipelines, xsv
 @test "Slice" {
-  check tenzir "from ${INPUTSDIR}/zeek/conn.log.gz read zeek-tsv | head 100 | enumerate | slice --begin 1"
-  check tenzir "from ${INPUTSDIR}/zeek/conn.log.gz read zeek-tsv | head 100 | enumerate | slice --begin -1"
-  check tenzir "from ${INPUTSDIR}/zeek/conn.log.gz read zeek-tsv | head 100 | enumerate | slice --end 1"
-  check tenzir "from ${INPUTSDIR}/zeek/conn.log.gz read zeek-tsv | head 100 | enumerate | slice --end -1"
-  check tenzir "from ${INPUTSDIR}/zeek/conn.log.gz read zeek-tsv | head 100 | enumerate | slice --begin 1 --end 1"
-  check tenzir "from ${INPUTSDIR}/zeek/conn.log.gz read zeek-tsv | head 100 | enumerate | slice --begin 1 --end 2"
-  check tenzir "from ${INPUTSDIR}/zeek/conn.log.gz read zeek-tsv | head 100 | enumerate | slice --begin 1 --end -1"
-  check tenzir "from ${INPUTSDIR}/zeek/conn.log.gz read zeek-tsv | head 100 | enumerate | slice --begin -1 --end 1"
-  check tenzir "from ${INPUTSDIR}/zeek/conn.log.gz read zeek-tsv | head 100 | enumerate | slice --begin -1 --end -1"
-  check tenzir "from ${INPUTSDIR}/zeek/conn.log.gz read zeek-tsv | head 100 | enumerate | slice --begin -2 --end -1"
+  check tenzir "from ${INPUTSDIR}/zeek/conn.log.gz read zeek-tsv | head 100 | enumerate | slice 1:"
+  check tenzir "from ${INPUTSDIR}/zeek/conn.log.gz read zeek-tsv | head 100 | enumerate | slice -1:"
+  check tenzir "from ${INPUTSDIR}/zeek/conn.log.gz read zeek-tsv | head 100 | enumerate | slice :1"
+  check tenzir "from ${INPUTSDIR}/zeek/conn.log.gz read zeek-tsv | head 100 | enumerate | slice :-1"
+  check tenzir "from ${INPUTSDIR}/zeek/conn.log.gz read zeek-tsv | head 100 | enumerate | slice 1:1"
+  check tenzir "from ${INPUTSDIR}/zeek/conn.log.gz read zeek-tsv | head 100 | enumerate | slice 1:2"
+  check tenzir "from ${INPUTSDIR}/zeek/conn.log.gz read zeek-tsv | head 100 | enumerate | slice 1:-1"
+  check tenzir "from ${INPUTSDIR}/zeek/conn.log.gz read zeek-tsv | head 100 | enumerate | slice -1:1"
+  check tenzir "from ${INPUTSDIR}/zeek/conn.log.gz read zeek-tsv | head 100 | enumerate | slice -1:-1"
+  check tenzir "from ${INPUTSDIR}/zeek/conn.log.gz read zeek-tsv | head 100 | enumerate | slice -2:-1"
 }
 
 # bats test_tags=pipelines

--- a/web/docs/operators/head.md
+++ b/web/docs/operators/head.md
@@ -6,7 +6,7 @@ sidebar_custom_props:
 
 # head
 
-Limits the input to the first *N* events.
+Limits the input to the first _N_ events.
 
 ## Synopsis
 
@@ -20,7 +20,7 @@ The semantics of the `head` operator are the same of the equivalent Unix tool:
 process a fixed number of events from the input. The operator terminates
 after it has reached its limit.
 
-`head <limit>` is a shorthand notation for [`slice --end <limit>`](slice.md).
+`head <limit>` is a shorthand notation for [`slice :<limit>`](slice.md).
 
 ### `<limit>`
 

--- a/web/docs/operators/slice.md
+++ b/web/docs/operators/slice.md
@@ -11,7 +11,9 @@ Keep a range events within the half-closed interval `[begin, end)`.
 ## Synopsis
 
 ```
-slice [--begin <begin>] [--end <end>]
+slice <begin>:<end>
+slice <begin>:
+slice        :<end>
 ```
 
 ## Description
@@ -34,29 +36,29 @@ negative number to count from the end.
 Get the second 100 events:
 
 ```
-slice --begin 100 --end 200
+slice 100:200
 ```
 
 Get the last five events:
 
 ```
-slice --begin -5
+slice -5:
 ```
 
 Skip the last ten events:
 
 ```
-slice --end -10
+slice :-10
 ```
 
 Return the last 50 events, except for the last 2:
 
 ```
-slice --begin -50 --end -2
+slice -50:-2
 ```
 
 Skip the first and the last event:
 
 ```
-slice --begin 1 --end -1
+slice 1:-1
 ```

--- a/web/docs/operators/tail.md
+++ b/web/docs/operators/tail.md
@@ -6,7 +6,7 @@ sidebar_custom_props:
 
 # tail
 
-Limits the input to the last *N* events.
+Limits the input to the last _N_ events.
 
 ## Synopsis
 
@@ -17,9 +17,9 @@ tail [<limit>]
 ## Description
 
 The semantics of the `tail` operator are the same of the equivalent Unix tool:
-consume all input and only display the last *N* events.
+consume all input and only display the last _N_ events.
 
-`tail <limit>` is a shorthand notation for [`slice --begin -<limit>`](slice.md).
+`tail <limit>` is a shorthand notation for [`slice -<limit>:`](slice.md).
 
 ### `<limit>`
 


### PR DESCRIPTION
This changes the `slice` operator to use a more familiar syntax for slicing events: `<begin>:<end>`, `<begin>:`, or `:<end>`.

This makes room for adding strides to the operator in the famililar Python syntax.