### PR TITLE
Treat AMQP library exceptions as actual errors

### DIFF
--- a/changelog/next/bug-fixes/4212-satta.md
+++ b/changelog/next/bug-fixes/4212-satta.md
@@ -1,0 +1,3 @@
+The `amqp` connector now properly signals more errors caused, for example, by
+networking issues. This enables pipelines using this connector to trigger their
+retry behavior.

--- a/plugins/amqp/src/plugin.cpp
+++ b/plugins/amqp/src/plugin.cpp
@@ -350,8 +350,15 @@ public:
     if (ret.library_error == AMQP_STATUS_TIMEOUT)
       return chunk_ptr{};
     // Now we're leaving the happy path.
-    if (ret.reply_type == AMQP_RESPONSE_LIBRARY_EXCEPTION
-        && ret.library_error == AMQP_STATUS_UNEXPECTED_STATE) {
+    TENZIR_DEBUG("reply type is {}, library error {} ({})", ret.reply_type,
+                 ret.library_error, amqp_error_string2(ret.library_error));
+    if (ret.reply_type == AMQP_RESPONSE_LIBRARY_EXCEPTION) {
+      if (ret.library_error != AMQP_STATUS_UNEXPECTED_STATE) {
+        // Likely unrecoverable error, let the retry logic handle this
+        return caf::make_error(ec::unspecified,
+                               fmt::format("amqp: {}",
+                               amqp_error_string2(ret.library_error)));
+      }
       TENZIR_DEBUG("waiting for frame");
       auto frame = amqp_frame_t{};
       auto status = amqp_simple_wait_frame(conn_, &frame);


### PR DESCRIPTION
This ensures that the `amqp` operator actually fails in cases such as network disconnects, which otherwise would not cause pipelines with amqp connectors to restart on failure.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made in the pull request description in a way that
   is consumable by everyone, not just developers who know the context of the
   change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://docs.tenzir.com/next/contribute/changelog
3. Provide instructions for the reviewer.
4. Remove this comment so it doesn't show up in the merge commit.
-->
