### PR TITLE
Remove the superfluous path separators when using S3 or GS connectors

### DIFF
--- a/changelog/next/bug-fixes/4222--remove-superfluous-path-separators.md
+++ b/changelog/next/bug-fixes/4222--remove-superfluous-path-separators.md
@@ -1,0 +1,2 @@
+Paths for `s3` and `gs` connectors are not broken anymore during
+loading/saving.

--- a/libtenzir/builtins/connectors/s3.cpp
+++ b/libtenzir/builtins/connectors/s3.cpp
@@ -102,7 +102,7 @@ public:
           co_return;
         }
         auto file_info = fs.ValueUnsafe()->GetFileInfo(
-          fmt::format("{}/{}", uri.host(), uri.path()));
+          fmt::format("{}{}", uri.host(), uri.path()));
         if (not file_info.ok()) {
           diagnostic::error("failed to get file info for URI "
                             "`{}`: {}",
@@ -183,7 +183,7 @@ public:
                                          fs.status().ToString()));
     }
     auto file_info = fs.ValueUnsafe()->GetFileInfo(
-      fmt::format("{}/{}", uri.host(), uri.path()));
+      fmt::format("{}{}", uri.host(), uri.path()));
     if (not file_info.ok()) {
       return caf::make_error(ec::filesystem_error,
                              fmt::format("failed to get file info from path "

--- a/plugins/gcs/src/plugin.cpp
+++ b/plugins/gcs/src/plugin.cpp
@@ -83,7 +83,7 @@ public:
         // be changed to a Result, sometime in the future.
         auto fs = arrow::fs::GcsFileSystem::Make(opts);
         auto file_info
-          = fs->GetFileInfo(fmt::format("{}/{}", uri.host(), uri.path()));
+          = fs->GetFileInfo(fmt::format("{}{}", uri.host(), uri.path()));
         if (not file_info.ok()) {
           diagnostic::error("failed to get file info for URI "
                             "`{}`: {}",
@@ -160,7 +160,7 @@ public:
     // changed to a Result, sometime in the future.
     auto fs = arrow::fs::GcsFileSystem::Make(opts);
     auto file_info
-      = fs->GetFileInfo(fmt::format("{}/{}", uri.host(), uri.path()));
+      = fs->GetFileInfo(fmt::format("{}{}", uri.host(), uri.path()));
     if (not file_info.ok()) {
       diagnostic::error("failed to get file info from URI `{}`: {}",
                         args_.uri.inner, file_info.status().ToString())


### PR DESCRIPTION
Arrow 16 tightened their URI parsing: Double slashes for post-bucket path separators are now forbidden. We previously generated S3 and GCSs paths out of a parsed `arrow::util::Uri`, using a `"{}/{}", uri.host(), uri.path()"` format string to compensate for missing slashes. This exposed an unnecessary additional slash that this change removes.

See this Arrow PR diff: https://github.com/apache/arrow/commit/0148db4f97bfcf80237b265ee0d9a4b61194ffde
