### PR TITLE
Handle loading of configured and non-configured contexts with the same name

### DIFF
--- a/changelog/next/bug-fixes/4224--configured-context-loading-precedence.md
+++ b/changelog/next/bug-fixes/4224--configured-context-loading-precedence.md
@@ -1,0 +1,4 @@
+Configured and non-configured contexts with the same name will not cause
+non-deterministic behavior upon loading anymore. Non-configured contexts that
+share the same name with configured contexts will have a random suffix added to
+prevent potential data loss.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "3a978317ec2406306c42e2a2f52cf8691ad24d5f",
+  "rev": "b4a3737443f8af664142614757af31e7e0f1d0d4",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
This change adds order to the chaos of loading contexts.
Configured contexts will be loaded first, and non-configured contexts that happen to share the same name will be renamed to avoid non-deterministic loading conflicts.
