### PR TITLE
Support multiple table slice schemas when dumping contexts

### DIFF
--- a/changelog/next/bug-fixes/4236--multiple-schemas-in-contexts.md
+++ b/changelog/next/bug-fixes/4236--multiple-schemas-in-contexts.md
@@ -1,0 +1,2 @@
+`context inspect` will not crash anymore when encountering contexts that
+contain multi-schema data.

--- a/libtenzir/builtins/contexts/lookup_table.cpp
+++ b/libtenzir/builtins/contexts/lookup_table.cpp
@@ -286,13 +286,17 @@ public:
       row.field("key", key.to_original_data());
       row.field("value", value);
       if (entry_builder.length() >= context::dump_batch_size_limit) {
-        co_yield entry_builder.finish_assert_one_slice(
-          fmt::format("tenzir.{}.info", context_type()));
+        for (auto&& slice : entry_builder.finish_as_table_slice(
+               fmt::format("tenzir.{}.info", context_type()))) {
+          co_yield std::move(slice);
+        }
       }
     }
     // Dump all remaining entries that did not reach the size limit.
-    co_yield entry_builder.finish_assert_one_slice(
-      fmt::format("tenzir.{}.info", context_type()));
+    for (auto&& slice : entry_builder.finish_as_table_slice(
+           fmt::format("tenzir.{}.info", context_type()))) {
+      co_yield std::move(slice);
+    }
   }
 
   /// Updates the context.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "607884babc9f1684754de6a01b1d7c47c4bc6dcc",
+  "rev": "14e8d404c7f61e8a10c842c367b089e6c78b3413",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
The `lookup-table` (and theoretically the `geoip`) context did not handle multi-schema table slices correctly when being inspected. This change fixes that.
