### PR TITLE
Add an RPM tab in the deploy-a-node documentation

### DIFF
--- a/web/docs/setup-guides/deploy-a-node.md
+++ b/web/docs/setup-guides/deploy-a-node.md
@@ -64,6 +64,18 @@ dpkg -i tenzir-static-amd64-linux.deb
 [tenzir-debian-package]: https://github.com/tenzir/tenzir/releases/latest/download/tenzir-static-amd64-linux.deb
 
 </TabItem>
+<TabItem value="rpm_based" label="RPM based (RedHat / OpenSUSE / ...)">
+
+Download the latest [RPM package][tenzir-rpm-package] and install it via
+`rpm`:
+
+```bash
+yum -y localinstall tenzir-static-amd64-linux.rpm
+```
+
+[tenzir-rpm-package]: https://github.com/tenzir/tenzir/releases/latest/download/tenzir-static-amd64-linux.rpm
+
+</TabItem>
 <TabItem value="nix" label="Nix">
 
 Use our `flake.nix`:

--- a/web/docs/setup-guides/deploy-a-node.md
+++ b/web/docs/setup-guides/deploy-a-node.md
@@ -64,13 +64,13 @@ dpkg -i tenzir-static-amd64-linux.deb
 [tenzir-debian-package]: https://github.com/tenzir/tenzir/releases/latest/download/tenzir-static-amd64-linux.deb
 
 </TabItem>
-<TabItem value="rpm_based" label="RPM based (RedHat / OpenSUSE / ...)">
+<TabItem value="rpm_based" label="RPM-based (RedHat, OpenSUSE, Fedora)">
 
 Download the latest [RPM package][tenzir-rpm-package] and install it via
 `rpm`:
 
 ```bash
-yum -y localinstall tenzir-static-amd64-linux.rpm
+rpm -i tenzir-static-amd64-linux.rpm
 ```
 
 [tenzir-rpm-package]: https://github.com/tenzir/tenzir/releases/latest/download/tenzir-static-amd64-linux.rpm


### PR DESCRIPTION
This adds one missing piece from #4188, namely the addition of an `RPM` tab in the manual node installation instructions.