### PR TITLE
Add a missing brace to the S3 syntax example

### DIFF
--- a/web/docs/connectors/s3.md
+++ b/web/docs/connectors/s3.md
@@ -57,7 +57,7 @@ session-token: your-session-token (optional)
 The path to the S3 object.
 
 The syntax is
-`s3://[<access-key>:secret-key>@]<bucket-name>/<full-path-to-object>(?<options>)`.
+`s3://[<access-key>:<secret-key>@]<bucket-name>/<full-path-to-object>(?<options>)`.
 
 Options can be appended to the path as query parameters, as per
 [Arrow](https://arrow.apache.org/docs/r/articles/fs.html#connecting-directly-with-a-uri):


### PR DESCRIPTION
A single-symbol fix.
