### PR TITLE
Minor installer improvements

### DIFF
--- a/scripts/debian/postinst
+++ b/scripts/debian/postinst
@@ -28,6 +28,7 @@ if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-decon
     # it known.
     /usr/bin/systemctl link /opt/tenzir/lib/systemd/system/tenzir-node.service
   fi
+  echo "export PATH=\$PATH:/opt/tenzir/bin" > /etc/profile.d/tenzir.sh
 fi
 
 # Automatically added by dh_installsystemd/13.3.4

--- a/scripts/debian/postinst
+++ b/scripts/debian/postinst
@@ -28,6 +28,7 @@ if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-decon
     # it known.
     /usr/bin/systemctl link /opt/tenzir/lib/systemd/system/tenzir-node.service
   fi
+  echo "Adding tenzir to \$PATH"
   echo "export PATH=\$PATH:/opt/tenzir/bin" > /etc/profile.d/tenzir.sh
 fi
 

--- a/scripts/debian/postrm
+++ b/scripts/debian/postrm
@@ -18,7 +18,7 @@ if [ "$1" = "purge" ] ; then
     deluser  --system tenzir || echo "Could not remove tenzir user."
 
     echo "Removing tenzir from \$PATH"
-    rm /etc/profile.d/tenzir.sh
+    rm -f /etc/profile.d/tenzir.sh
 fi
 
 # Automatically added by dh_installsystemd/13.3.4

--- a/scripts/debian/postrm
+++ b/scripts/debian/postrm
@@ -16,6 +16,9 @@ if [ "$1" = "purge" ] ; then
     rm -rf /var/log/tenzir
 
     deluser  --system tenzir || echo "Could not remove tenzir user."
+
+    echo "Removing tenzir from \$PATH"
+    rm /etc/profile.d/tenzir.sh
 fi
 
 # Automatically added by dh_installsystemd/13.3.4

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -164,6 +164,7 @@ echo "Using ${package}"
 # Download package.
 tmpdir="$(dirname "$(mktemp -u)")"
 action "Downloading ${package_url}"
+rm -f "${tmpdir}/${package}"
 # Wget does not support the file:// URL scheme.
 if check wget && beginswith "${package_url}" "https://"
 then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -210,7 +210,6 @@ fi
 
 # Trigger installation.
 action "Installing package into ${prefix}"
-insert_path="$sudo echo 'export PATH=\$PATH:/opt/tenzir/bin' > /etc/profile.d/tenzir.sh"
 if [ "${platform}" = "RPM" ]
 then
   cmd1="$sudo yum -y localinstall \"${tmpdir}/${package}\""
@@ -219,14 +218,11 @@ then
   echo
   echo "  - ${cmd1}"
   echo "  - ${cmd2}"
-  echo "  - ${insert_path}"
   confirm
   action "Installing via yum"
   eval "${cmd1}"
   action "Checking node status"
   eval "${cmd2}"
-  action "Adding /opt/tenzir/bin to the system path"
-  eval "${insert_path}"
 elif [ "${platform}" = "Debian" ]
 then
   cmd1="$sudo apt-get --yes install \"${tmpdir}/${package}\""
@@ -235,26 +231,24 @@ then
   echo
   echo "  - ${cmd1}"
   echo "  - ${cmd2}"
-  echo "  - ${insert_path}"
   confirm
   action "Installing via apt-get"
   eval "${cmd1}"
   action "Checking node status"
   eval "${cmd2}"
-  action "Adding /opt/tenzir/bin to the system path"
-  eval "${insert_path}"
 elif [ "${platform}" = "Linux" ]
 then
   cmd1="$sudo tar xzf \"${tmpdir}/${package}\" -C /"
+  cmd2="$sudo echo 'export PATH=\$PATH:/opt/tenzir/bin' > /etc/profile.d/tenzir.sh"
   echo "This script is about to run the following command:"
   echo
   echo "  - ${cmd1}"
-  echo "  - ${insert_path}"
+  echo "  - ${cmd2}"
   confirm
   action "Unpacking tarball"
   eval "${cmd1}"
   action "Adding /opt/tenzir/bin to the system path"
-  eval "${insert_path}"
+  eval "${cmd2}"
 elif [ "${platform}" = "macOS" ]
 then
   cmd1="$sudo installer -pkg \"${tmpdir}/${package}\" -target /"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -225,12 +225,6 @@ then
   eval "${cmd2}"
 elif [ "${platform}" = "Debian" ]
 then
-  # adduser is required by the Debian package installation.
-  if ! check adduser
-  then
-    echo "Could not find ${bold}adduser${normal} in \$PATH."
-    exit 1
-  fi
   cmd1="$sudo apt-get --yes install \"${tmpdir}/${package}\""
   cmd2="$sudo systemctl status tenzir-node || [ ! -d /run/systemd/system ]"
   echo "This script is about to run the following commands:"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -210,6 +210,7 @@ fi
 
 # Trigger installation.
 action "Installing package into ${prefix}"
+insert_path="$sudo echo 'export PATH=\$PATH:/opt/tenzir/bin' > /etc/profile.d/tenzir.sh"
 if [ "${platform}" = "RPM" ]
 then
   cmd1="$sudo yum -y localinstall \"${tmpdir}/${package}\""
@@ -218,11 +219,14 @@ then
   echo
   echo "  - ${cmd1}"
   echo "  - ${cmd2}"
+  echo "  - ${insert_path}"
   confirm
   action "Installing via yum"
   eval "${cmd1}"
   action "Checking node status"
   eval "${cmd2}"
+  action "Adding /opt/tenzir/bin to the system path"
+  eval "${insert_path}"
 elif [ "${platform}" = "Debian" ]
 then
   cmd1="$sudo apt-get --yes install \"${tmpdir}/${package}\""
@@ -231,20 +235,26 @@ then
   echo
   echo "  - ${cmd1}"
   echo "  - ${cmd2}"
+  echo "  - ${insert_path}"
   confirm
   action "Installing via apt-get"
   eval "${cmd1}"
   action "Checking node status"
   eval "${cmd2}"
+  action "Adding /opt/tenzir/bin to the system path"
+  eval "${insert_path}"
 elif [ "${platform}" = "Linux" ]
 then
   cmd1="$sudo tar xzf \"${tmpdir}/${package}\" -C /"
   echo "This script is about to run the following command:"
   echo
   echo "  - ${cmd1}"
+  echo "  - ${insert_path}"
   confirm
   action "Unpacking tarball"
   eval "${cmd1}"
+  action "Adding /opt/tenzir/bin to the system path"
+  eval "${insert_path}"
 elif [ "${platform}" = "macOS" ]
 then
   cmd1="$sudo installer -pkg \"${tmpdir}/${package}\" -target /"

--- a/scripts/rpm/postinstall
+++ b/scripts/rpm/postinstall
@@ -3,4 +3,6 @@ if [ $1 -eq 1 ]; then
   systemctl link /opt/tenzir/lib/systemd/system/tenzir-node.service || :
   systemctl enable tenzir-node.service >/dev/null 2>&1 || :
   systemctl start tenzir-node.service >/dev/null 2>&1 || :
+
+  echo "export PATH=\$PATH:/opt/tenzir/bin" > /etc/profile.d/tenzir.sh
 fi

--- a/scripts/rpm/postuninstall
+++ b/scripts/rpm/postuninstall
@@ -5,4 +5,7 @@ if [ $1 -ge 1 ]; then
   else
     systemctl try-restart tenzir-node.service >/dev/null 2>&1 || :
   fi
+elif [ $1 -eq 0 ]; then
+  # uninstall
+  rm /etc/profile.d/tenzir.sh
 fi

--- a/scripts/rpm/postuninstall
+++ b/scripts/rpm/postuninstall
@@ -7,5 +7,5 @@ if [ $1 -ge 1 ]; then
   fi
 elif [ $1 -eq 0 ]; then
   # uninstall
-  rm /etc/profile.d/tenzir.sh
+  rm -f /etc/profile.d/tenzir.sh
 fi


### PR DESCRIPTION
* Clear the destination path of the package download so `curl` does not abort.
* Drop the check for `adduser`, because it is out of place in the installer.
* Add `/opt/tenzir/bin` to the system default path for ease of use.