### PR TITLE
Improve integration test robustness

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -46,6 +46,15 @@ jobs:
           git submodule update --init --recursive libtenzir
           git submodule update --init --recursive plugins
           git submodule update --init --recursive tenzir
+      - name: Tailscale
+        if: false
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+          version: 1.66.4
+          args: --ssh
       - name: Configure
         id: cfg
         run: |

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -30,6 +30,15 @@ jobs:
           done
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Tailscale
+        if: false
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+          version: 1.66.4
+          args: --ssh
       - name: Configure
         id: cfg
         run: |

--- a/.github/workflows/tenzir.yaml
+++ b/.github/workflows/tenzir.yaml
@@ -620,9 +620,24 @@ jobs:
         name: Install extra dependencies
         run: |
           apt-get update
-          apt-get -y install git sudo
+          apt-get -y install curl git sudo
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Tailscale
+        if: false && runner.os == 'Linux'
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+          version: 1.66.4
+          args: --ssh
+          # 1. Kernel space networking needs CAP_NET_ADMIN but that is not
+          #    available in containerized GitHub Actions jobs.
+          # 2. Tailscale SSH doesn't work without an accessible statedir. This
+          #    is only needed inside of containerized jobs.
+          #    -> https://github.com/tailscale/tailscale/issues/11039
+          tailscaled-args: --tun=userspace-networking --state=$HOME/tailscaled.state --statedir=$HOME/var/lib/tailscale
       - name: Publish tenzir.spdx.json to GitHub Release
         if: ${{ github.event_name == 'release' && matrix.tenzir.name == 'Debian' }}
         uses: actions/upload-release-asset@v1
@@ -851,6 +866,21 @@ jobs:
         run: |
           apt-get update
           apt-get -y install git curl jq sudo xz-utils
+      - name: Tailscale
+        if: false && matrix.plugin.name == 'Context'
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+          version: 1.66.4
+          args: --ssh
+          # 1. Kernel space networking needs CAP_NET_ADMIN but that is not
+          #    available in containerized GitHub Actions jobs.
+          # 2. Tailscale SSH doesn't work without an accessible statedir. This
+          #    is only needed inside of containerized jobs.
+          #    -> https://github.com/tailscale/tailscale/issues/11039
+          tailscaled-args: --tun=userspace-networking --state=$HOME/tailscaled.state --statedir=$HOME/var/lib/tailscale
       - name: Install Nix
         uses: cachix/install-nix-action@V27
         with:

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -439,6 +439,7 @@ in {
     curl
     jq
     lsof
+    perl
     procps
     socat
     # toybox provides a portable `rev`, but it also comes with a `cp` that does

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "e4fd9e9d732b7f40f76fcc2f436c1854a7489afb",
+  "rev": "afc6eebb82eb79e330b4e84241a9d992ad624eb3",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/plugins/fluent-bit/integration/tests/tests.bats
+++ b/plugins/fluent-bit/integration/tests/tests.bats
@@ -20,6 +20,11 @@ setup() {
 }
 
 @test "read stdin via fluent-bit" {
+  # In general we deem the fluent-bit stdin functionality as too unreliable.
+  # Please refrain if you came here with the intention to re-enable this test,
+  # we only keep it to document that the operator should not be tested this
+  # way.
+  skip "This test often fails to produce any output when run on GitHub Actions Runners"
   # fluent-bit has an internal race condition that can cause the loss of
   # events during startup. We have to accept this for now and avoid
   # test flakyness with a bit of trickery.
@@ -27,7 +32,7 @@ setup() {
     while :; do
       echo '{"foo": {"bar": 42}}'
       sleep 1
-    done |
+    done || exit 1 |
       tenzir 'fluent-bit stdin | drop timestamp | head 1' |
       grep -v 'kevent'
   )"


### PR DESCRIPTION
This PR addresses a bit of flakyness in the integration tests:
* The `read stdin via fluent-bit` test is now skipped because it sometimes fails to produce any output.
* The tests of the `lookup` operator now install a test timeout and add some waiting time for initializing background lookups before continuing with subsequent steps.

This PR also adds opt-in CI steps to connect to the Tenzir tailnet for debugging.