### PR TITLE
Treat `publish`, `subscribe`, and `version` as internal

### DIFF
--- a/libtenzir/builtins/operators/from_load_read.cpp
+++ b/libtenzir/builtins/operators/from_load_read.cpp
@@ -46,6 +46,10 @@ public:
     return do_not_optimize(*this);
   }
 
+  auto internal() const -> bool override {
+    return loader_->internal();
+  }
+
   friend auto inspect(auto& f, load_operator& x) -> bool {
     return plugin_inspect(f, x.loader_);
   }

--- a/libtenzir/builtins/operators/to_write_save.cpp
+++ b/libtenzir/builtins/operators/to_write_save.cpp
@@ -236,6 +236,10 @@ public:
     return "save";
   }
 
+  auto internal() const -> bool override {
+    return saver_->internal();
+  }
+
   auto optimize(expression const& filter, event_order order) const
     -> optimize_result override {
     (void)filter, (void)order;
@@ -347,6 +351,10 @@ public:
     -> optimize_result override {
     (void)filter, (void)order;
     return optimize_result{std::nullopt, event_order::schema, copy()};
+  }
+
+  auto internal() const -> bool override {
+    return saver_->internal();
   }
 
   friend auto inspect(auto& f, write_and_save_operator& x) -> bool {

--- a/libtenzir/builtins/operators/version.cpp
+++ b/libtenzir/builtins/operators/version.cpp
@@ -44,6 +44,10 @@ public:
     return do_not_optimize(*this);
   }
 
+  auto internal() const -> bool override {
+    return true;
+  }
+
   friend auto inspect(auto& f, version_operator& x) -> bool {
     return f.object(x)
       .pretty_name("tenzir.plugins.version.version_operator")

--- a/libtenzir/include/tenzir/plugin.hpp
+++ b/libtenzir/include/tenzir/plugin.hpp
@@ -333,6 +333,10 @@ public:
   virtual auto default_parser() const -> std::string {
     return "json";
   }
+
+  virtual auto internal() const -> bool {
+    return false;
+  }
 };
 
 /// @see operator_parser_plugin
@@ -496,6 +500,10 @@ public:
 
   virtual auto default_printer() const -> std::string {
     return "json";
+  }
+
+  virtual auto internal() const -> bool {
+    return false;
   }
 };
 

--- a/libtenzir/src/exec_pipeline.cpp
+++ b/libtenzir/src/exec_pipeline.cpp
@@ -25,8 +25,12 @@ auto format_metric(const metric& metric) -> std::string {
   auto result = std::string{};
   auto it = std::back_inserter(result);
   constexpr auto indent = std::string_view{"  "};
-  it = fmt::format_to(it, "operator #{} ({})\n", metric.operator_index + 1,
+  it = fmt::format_to(it, "operator #{} ({})", metric.operator_index + 1,
                       metric.operator_name);
+  if (metric.internal) {
+    it = fmt::format_to(it, " (internal)");
+  }
+  it = fmt::format_to(it, "\n");
   it = fmt::format_to(it, "{}total: {}\n", indent, data{metric.time_total});
   it = fmt::format_to(it, "{}scheduled: {} ({:.2f}%)\n", indent,
                       data{metric.time_scheduled},

--- a/plugins/zmq/src/plugin.cpp
+++ b/plugins/zmq/src/plugin.cpp
@@ -404,6 +404,10 @@ public:
     return "json";
   }
 
+  auto internal() const -> bool override {
+    return args_.endpoint and args_.endpoint->inner.starts_with("inproc://");
+  }
+
   friend auto inspect(auto& f, zmq_loader& x) -> bool {
     return f.object(x)
       .pretty_name("zmq_loader")
@@ -454,6 +458,10 @@ public:
 
   auto default_printer() const -> std::string override {
     return "json";
+  }
+
+  auto internal() const -> bool override {
+    return args_.endpoint and args_.endpoint->inner.starts_with("inproc://");
   }
 
   auto is_joining() const -> bool override {


### PR DESCRIPTION
Now that we render metrics from node-internal operators grayed-out, it became quickly apparent that these three were not categorized correctly.