### PR TITLE
Tune down ZMQ logging

### DIFF
--- a/plugins/zmq/src/plugin.cpp
+++ b/plugins/zmq/src/plugin.cpp
@@ -211,7 +211,7 @@ public:
   auto send(chunk_ptr chunk, std::optional<std::chrono::milliseconds> timeout
                              = {}) -> caf::error {
     try {
-      TENZIR_DEBUG("waiting until socket is ready to send");
+      TENZIR_TRACE("waiting until socket is ready to send");
       if (not poll(socket_, ZMQ_POLLOUT, timeout)) {
         return caf::make_error(ec::timeout, "timed out while polling socket");
       }
@@ -219,7 +219,7 @@ public:
       auto flags = ::zmq::send_flags::none;
       auto bytes = socket_.send(message, flags);
       TENZIR_ASSERT(bytes); // only nullopt in non-blocking mode.
-      TENZIR_DEBUG("sent message with {} bytes", *bytes);
+      TENZIR_TRACE("sent message with {} bytes", *bytes);
       return {};
     } catch (const ::zmq::error_t& e) {
       return make_error(e);
@@ -229,7 +229,7 @@ public:
   auto receive(std::optional<std::chrono::milliseconds> timeout = {})
     -> caf::expected<chunk_ptr> {
     try {
-      TENZIR_DEBUG("waiting until socket is ready to receive");
+      TENZIR_TRACE("waiting until socket is ready to receive");
       if (not poll(socket_, ZMQ_POLLIN, timeout)) {
         return caf::make_error(ec::timeout, "timed out while polling socket");
       }
@@ -237,7 +237,7 @@ public:
       auto flags = ::zmq::recv_flags::none;
       auto bytes = socket_.recv(*message, flags);
       TENZIR_ASSERT(bytes); // only nullopt in non-blocking mode.
-      TENZIR_DEBUG("got 0mq message with {} bytes", *bytes);
+      TENZIR_TRACE("got 0mq message with {} bytes", *bytes);
       const auto* data = message->data();
       auto size = message->size();
       auto deleter = [msg = std::move(message)]() noexcept {};


### PR DESCRIPTION
The ZMQ Plugin prints debug information about every send and receive operation. This drowns out all other messages from the log files. This change reduces the level of these logs to TRACE, so that they don't get emitted in the default settings.
