### PR TITLE
Do not persist pipeline state updates on node shutdown

### DIFF
--- a/changelog/next/bug-fixes/4261--pipeline-updates-node-shutdown.md
+++ b/changelog/next/bug-fixes/4261--pipeline-updates-node-shutdown.md
@@ -1,0 +1,4 @@
+Some *Running* pipelines were considered *Completed* when the node shut down,
+causing them not to start up again automatically when the node restarted. Now,
+the node only considers pipelines *Completed* that entered the state on their
+own before the node's shutdown.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "242490b97fdf578bf8ad85501507ff07b22458ba",
+  "rev": "831ffb7ccf26d80072e63f8516ff826f159c86b4",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
This fixes a bug in pipeline management that caused the states of pipeline to be persisted even when the node was already shutting down.

Shutting down a node naturally stops some source operators. Pipelines with these sources naturally complete when the node shuts down. However, from a user perspective, these pipelines should run again when the node starts up again, as they were running when the node was stopped.

To solve this problem, the pipeline manager component no longer writes state updates for pipelines _after_ the node shutdown sequence started.