### PR TITLE
Improve formatting rules for lambdas

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -45,6 +45,7 @@ IndentWidth: 2
 IndentWrappedFunctionNames: false
 InsertBraces: true
 KeepEmptyLinesAtTheStartOfBlocks: false
+LambdaBodyIndentation: OuterScope
 Language: Cpp
 MacroBlockBegin: "CAF_BEGIN_TYPE_ID_BLOCK"
 MacroBlockEnd: "CAF_END_TYPE_ID_BLOCK"
@@ -57,6 +58,8 @@ PenaltyExcessCharacter: 100
 PenaltyReturnTypeOnItsOwnLine: 5
 PointerAlignment: Left
 ReflowComments: true
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Always
 SortIncludes: true
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
@@ -76,4 +79,3 @@ SpacesInSquareBrackets: false
 Standard: Cpp11
 UseTab: Never
 ...
-


### PR DESCRIPTION
```cpp
// before
foo([] {
      // …
    });

// after
foo([] {
  // …
});
```

I think this shouldn't be controversial, but I figured I'd open a separate PR anyways instead of sneaking this into the one where I actually made this change because I was annoyed by the old formatting rules.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made in the pull request description in a way that
   is consumable by everyone, not just developers who know the context of the
   change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://docs.tenzir.com/next/contribute/changelog
3. Provide instructions for the reviewer.
4. Remove this comment so it doesn't show up in the merge commit.
-->
