### PR TITLE
Log leftover actor ids when shutting down

### DIFF
--- a/nix/caf/source.json
+++ b/nix/caf/source.json
@@ -1,7 +1,7 @@
 {
   "owner": "tenzir",
   "repo": "actor-framework",
-  "rev": "4ff66bf218dec0514829230af6f41fb8ed09aa5c",
-  "sha256": "s7CdmQ64whJ7o7KiIxKLrZSR4RRJnNzcgGuqGKcxCzI=",
+  "rev": "1399678d5a14ef8ed750afd01cdd73ef1c3dde9f",
+  "sha256": "1PXCMqO47AJvuw1tImTeGN6OakwS9me5lNvExuD94Yw=",
   "version": "0.18.7"
 }

--- a/tenzir/tenzir.cpp
+++ b/tenzir/tenzir.cpp
@@ -237,5 +237,11 @@ auto main(int argc, char** argv) -> int {
     render_error(*root, run_error, std::cerr);
     return EXIT_FAILURE;
   }
+  while (sys.registry().running() > 1) {
+    TENZIR_VERBOSE("remaining actors: [{}], named: [{}]",
+                   fmt::join(sys.registry().running_ids(), ", "),
+                   fmt::join(sys.registry().named_actors(), ", "));
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+  }
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This is an experimental change to the actor system registry in CAF. Instead of maintaining a simple running actor counter, it now keeps all ids of the running actors. This change should allow us to debug actor termination problems.
