### PR TITLE
Evaluate `ip == subnet` predicates

### DIFF
--- a/changelog/next/bug-fixes/4268--ip-equals-subnet.md
+++ b/changelog/next/bug-fixes/4268--ip-equals-subnet.md
@@ -1,0 +1,5 @@
+Predicates of the form `ip == subnet` and `ip in [subnet1, subnet2, …]` now
+work as expected.
+
+The `lookup` operator now correctly handles subnet keys when using the `--retro`
+or `--snapshot` options.

--- a/libtenzir/src/evaluate.cpp
+++ b/libtenzir/src/evaluate.cpp
@@ -55,6 +55,10 @@ struct cell_evaluator<relational_operator::equal> {
   static bool evaluate(std::string_view lhs, const pattern& rhs) noexcept {
     return rhs.match(lhs);
   }
+
+  static bool evaluate(view<ip> lhs, const subnet& rhs) noexcept {
+    return rhs.contains(lhs);
+  }
 };
 
 template <>


### PR DESCRIPTION
A user in Discord asked this question:

> Hey, is there a chance to formulate the following statement more simple: `src_ip in 192.168.0.0/16 || src_ip in 172.16.0.0/12 || src_ip in 10.0.0.0/8`. I tried src_ip in `[192.168.0.0/16, 172.16.0.0/12, 10.0.0.0/8]` but this doesn't work.

We _used_ to support this transparently, because `ip == subnet` was treated the same way as `ip in subnet`, and `x in [y1, y2, ...]` resolves to `x == y1 or x == y2 or ...`. This PR adds back support for `ip == subnet`.

The subnet key support in `lookup-table` contexts also relies on this working when used with the `lookup` operator, which is fixed by this change as well.