### PR TITLE
Fix the configured context load-related changelog entry

### DIFF
--- a/changelog/next/bug-fixes/4224--configured-context-loading-precedence.md
+++ b/changelog/next/bug-fixes/4224--configured-context-loading-precedence.md
@@ -1,4 +1,3 @@
 Configured and non-configured contexts with the same name will not cause
-non-deterministic behavior upon loading anymore. Non-configured contexts that
-share the same name with configured contexts will have a random suffix added to
-prevent potential data loss.
+non-deterministic behavior upon loading anymore. The node will shut down
+instead.


### PR DESCRIPTION
This is an update for a changelog entry that contained outdated information.
