### PR TITLE
Add percentile aggregation functions

### DIFF
--- a/changelog/next/changes/4273--approx-median.md
+++ b/changelog/next/changes/4273--approx-median.md
@@ -1,0 +1,2 @@
+The `approximate_median` aggregation function is now called `median`. We found
+the longer name, despite being more accurate, to be rather unintuitive.

--- a/changelog/next/features/4273--percentile.md
+++ b/changelog/next/features/4273--percentile.md
@@ -1,0 +1,2 @@
+The `p99`, `p95`, `p90`, `p75`, and `p50` aggregation functions calculate
+commonly used percentiles of grouped values in the `summarize` operator.

--- a/web/docs/operators/summarize.md
+++ b/web/docs/operators/summarize.md
@@ -46,8 +46,10 @@ The following aggregation functions are available:
 - `all`: Computes the conjunction (AND) of all grouped values. Requires the
   values to be booleans.
 - `mean`: Computes the mean of all grouped values.
-- `approximate_median`: Computes the apprximate median of all grouped values
-  with a T-Digest algorithm.
+- `median`: Computes the approximate median of all grouped values with a
+  t-digest algorithm.
+- `p99`, `p95`, `p90`, `p75`, `p50`: Computes the 99th, 95th, 90th, 75th, or
+  50th percentile of all grouped values with a t-digest algorithm.
 - `stddev`: Computes the standard deviation of all grouped values.
 - `variance`: Computes the variance of all grouped values.
 - `distinct`: Creates a sorted list of all unique grouped values that are not


### PR DESCRIPTION
This adds aggregation functions `p99`, `p95`, `p90`, `p75`, and `p50`, and renames `approximate_median` to `median`.

With TQL2 we probably want this to just be `percentile(0.99, foo)` rather than `p99(foo)`, but for now this is the best we can do and I had a use case for these.