### PR TITLE
Enable selective deletion of lookup table entries

### DIFF
--- a/changelog/next/features/4274--lookup-table-erase.md
+++ b/changelog/next/features/4274--lookup-table-erase.md
@@ -1,2 +1,5 @@
 For `lookup-table` contexts, the new `--erase` option for `context update`
 enables selective deletion of lookup table entries.
+
+The `context update` operator now defaults the `--key <field>` option to the
+first field in the input when no field is explicitly specified.

--- a/changelog/next/features/4274--lookup-table-erase.md
+++ b/changelog/next/features/4274--lookup-table-erase.md
@@ -1,0 +1,2 @@
+For `lookup-table` contexts, the new `--erase` option for `context update`
+enables selective deletion of lookup table entries.

--- a/libtenzir/builtins/contexts/bloom_filter.cpp
+++ b/libtenzir/builtins/contexts/bloom_filter.cpp
@@ -117,18 +117,33 @@ public:
   auto update(table_slice slice, context::parameter_map parameters)
     -> caf::expected<update_result> override {
     TENZIR_ASSERT(slice.rows() != 0);
+    if (caf::get<record_type>(slice.schema()).num_fields() == 0) {
+      return caf::make_error(ec::invalid_argument,
+                             "context update cannot handle empty input events");
+    }
     if (not parameters.contains("key")) {
       return caf::make_error(ec::invalid_argument, "missing 'key' parameter");
     }
-    auto key_field = parameters["key"];
-    if (not key_field) {
-      return caf::make_error(ec::invalid_argument,
-                             "invalid 'key' parameter; 'key' must be a string");
-    }
-    auto key_column = slice.schema().resolve_key_or_concept_once(*key_field);
+    auto key_column = [&]() -> caf::expected<offset> {
+      if (not parameters.contains("key")) {
+        return offset{0};
+      }
+      auto key_field = parameters["key"];
+      if (not key_field) {
+        return caf::make_error(ec::invalid_argument, "invalid 'key' parameter; "
+                                                     "'key' must be a string");
+      }
+      auto key_column = slice.schema().resolve_key_or_concept_once(*key_field);
+      if (not key_column) {
+        return caf::make_error(ec::invalid_argument,
+                               fmt::format("key '{}' does not exist in schema "
+                                           "'{}'",
+                                           *key_field, slice.schema()));
+      }
+      return std::move(*key_column);
+    }();
     if (not key_column) {
-      // If there's no key column then we cannot do much.
-      return update_result{record{}};
+      return std::move(key_column.error());
     }
     auto [key_type, key_array] = key_column->get(slice);
     auto context_array = std::static_pointer_cast<arrow::Array>(

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "20fc00935426b2190826b0e1827797c854df0953",
+  "rev": "637f2530feb5108dd32675140e4fa16bb2a43af7",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/web/docs/contexts/bloom-filter.md
+++ b/web/docs/contexts/bloom-filter.md
@@ -6,7 +6,7 @@ A space-efficient data structure to represent large sets.
 
 ```
 context create  <name> bloom-filter --capacity <capacity> --fp-probability <probability>
-context update  <name> --key <field>
+context update  <name> [--key <field>]
 context delete  <name>
 context reset   <name>
 context save    <name>
@@ -62,3 +62,5 @@ The field in the input to be inserted into the Bloom filter.
 
 If an element exists already in the Bloom filter, the update operation is a
 no-op.
+
+Defaults to the first field of the input.

--- a/web/docs/contexts/lookup-table.md
+++ b/web/docs/contexts/lookup-table.md
@@ -7,7 +7,7 @@ data.
 
 ```
 context create  <name> lookup-table
-context update  <name> --key <field> [--erase]
+context update  <name> [--key <field>] [--erase]
 context delete  <name>
 context reset   <name>
 context save    <name>
@@ -39,6 +39,8 @@ The following options are currently supported for the `lookup-table` context:
 ### `--key <field>`
 
 The field in the input that holds the unique key for the lookup table.
+
+Defaults to the first field of the input.
 
 ### `--erase`
 

--- a/web/docs/contexts/lookup-table.md
+++ b/web/docs/contexts/lookup-table.md
@@ -7,7 +7,7 @@ data.
 
 ```
 context create  <name> lookup-table
-context update  <name> --key <field>
+context update  <name> --key <field> [--erase]
 context delete  <name>
 context reset   <name>
 context save    <name>
@@ -39,3 +39,8 @@ The following options are currently supported for the `lookup-table` context:
 ### `--key <field>`
 
 The field in the input that holds the unique key for the lookup table.
+
+### `--erase`
+
+When updating a lookup table, erase fields with matching keys instead of adding
+new entries.


### PR DESCRIPTION
For `lookup-table` contexts, the `context update` operator now sports a new `--erase` flag, which entries to be removed rather than aded.