### PR TITLE
Detach the pipeline manager

### DIFF
--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "312f94703f82c3906465e90e6104c99b784307b3",
+  "rev": "16a0ae542d77b73573a5885e7e1d7ef8c822c2fb",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
On a node where several pipelines are running, the the pipeline manager competes with them for scheduling time, causing the /pipeline/create endpoint to take upwards of 10s on non-powerful systems like ECS nodes or github runners.

See https://github.com/tenzir/tenzir-plugins/pull/252