### PR TITLE
Allow pip to write to stdout in venv creation

### DIFF
--- a/changelog/next/features/4279--allow-pip-stdout.md
+++ b/changelog/next/features/4279--allow-pip-stdout.md
@@ -1,0 +1,2 @@
+We fixed bug that caused python-pip to fail when creating the runtime
+environment for the python operator.

--- a/libtenzir/builtins/operators/python.cpp
+++ b/libtenzir/builtins/operators/python.cpp
@@ -285,7 +285,7 @@ public:
           TENZIR_VERBOSE("installing python modules with: '{}'",
                          fmt::join(pip_invocation, "' '"));
           if (bp::system(pip_invocation, env, bp::std_err > std_err,
-                         detail::preserved_fds{{STDERR_FILENO}},
+                         detail::preserved_fds{{STDOUT_FILENO, STDERR_FILENO}},
                          boost::process::limit_handles)
               != 0) {
             auto pip_error = drain_pipe(std_err);


### PR DESCRIPTION
Pip sometimes wants to draw a spinner on `stdout` during package installation. This currently leads to setup failures, because we're closing `stdout` before execing pip and pip does not check if `stdout` is `None` when probing if it is a TTY.