### PR TITLE
Make `ip == subnet` and `string == pattern` commutative

### DIFF
--- a/changelog/next/bug-fixes/4280--commutative-comparison.md
+++ b/changelog/next/bug-fixes/4280--commutative-comparison.md
@@ -1,0 +1,2 @@
+`subnet == ip` and `pattern == string` predicates now behave just like `ip ==
+subnet` and `string == pattern` predicates.

--- a/libtenzir/src/evaluate.cpp
+++ b/libtenzir/src/evaluate.cpp
@@ -56,8 +56,16 @@ struct cell_evaluator<relational_operator::equal> {
     return rhs.match(lhs);
   }
 
+  static bool evaluate(view<pattern> lhs, const std::string& rhs) noexcept {
+    return evaluate(rhs, materialize(lhs));
+  }
+
   static bool evaluate(view<ip> lhs, const subnet& rhs) noexcept {
     return rhs.contains(lhs);
+  }
+
+  static bool evaluate(view<subnet> lhs, const ip& rhs) noexcept {
+    return evaluate(rhs, materialize(lhs));
   }
 };
 


### PR DESCRIPTION
While `ip == subnet` worked, `subnet == ip` did not. The same applied to `string == pattern` and `pattern == string`.