### PR TITLE
Make submodules easier to work with

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,30 +1,41 @@
 [submodule "libtenzir/aux/fast_float"]
 	path = libtenzir/aux/fast_float
 	url = https://github.com/fastfloat/fast_float
+	shallow = true
 [submodule "plugins/web/aux/restinio"]
 	path = plugins/web/aux/restinio
 	url = https://github.com/Stiffstream/restinio
+	shallow = true
 [submodule "web/.github"]
 	path = web/.github
 	url = https://github.com/tenzir/.github.git
+	shallow = true
 [submodule "contrib/tenzir-plugins"]
 	path = contrib/tenzir-plugins
 	url = git@github.com:tenzir/tenzir-plugins
+	shallow = false
+	update = rebase
 [submodule "libtenzir/aux/simdjson"]
 	path = libtenzir/aux/simdjson
 	url = https://github.com/simdjson/simdjson
+	shallow = true
 [submodule "libtenzir/aux/caf"]
 	path = libtenzir/aux/caf
 	url = https://github.com/tenzir/actor-framework
+	shallow = true
 [submodule "libtenzir/aux/pfs"]
 	path = libtenzir/aux/pfs
 	url = https://github.com/tenzir/pfs.git
+	shallow = true
 [submodule "tenzir/integration/bats"]
 	path = tenzir/integration/lib/bats
 	url = https://github.com/bats-core/bats-core
+	shallow = true
 [submodule "tenzir/integration/bats-support"]
 	path = tenzir/integration/lib/bats-support
 	url = https://github.com/bats-core/bats-support
+	shallow = true
 [submodule "tenzir/integration/bats-assert"]
 	path = tenzir/integration/lib/bats-assert
 	url = https://github.com/bats-core/bats-assert
+	shallow = true

--- a/nix/update-impl.sh
+++ b/nix/update-impl.sh
@@ -24,6 +24,7 @@ update-source-github() {
   _rev="$(get-submodule-rev "${_submodule}")"
   if [[ "${_version}" == "" ]]; then
     git -C "${toplevel}" submodule update --init "${_submodule}"
+    git -C "${_path}" fetch --tags
     _version="$(git -C "${_path}" describe --tag)"
   fi
 


### PR DESCRIPTION
For submodules other than `contrib/tenzir-plugins`, this sets the `shallow = true` option, which causes `git submodule update` to do a shallow clone of submodules, unless `--no-recommend-shallow` is used.

For `contrib/tenzir-plugins`, this explicitly disables shallow cloning, and sets the merge strategy to rebase in the submodule in case of uncomitted changes. This makes rebasing across submodule bumps a lot easier.