### PR TITLE
Implement the `context rename` operator

### DIFF
--- a/changelog/next/features/4284--context-rename-operator.md
+++ b/changelog/next/features/4284--context-rename-operator.md
@@ -1,0 +1,2 @@
+The new `context rename` operator allows for renaming contexts while the node
+is running.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "92232d35daa7d63cbe2b5e86a2c3d2e9c3971945",
+  "rev": "3120d32fa75afd7e090aae68c19f1019f2cfa05d",
   "submodules": true,
   "shallow": true,
   "allRefs": true

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "67023a6a32a6833db01541533264f6c6397e5c81",
+  "rev": "92232d35daa7d63cbe2b5e86a2c3d2e9c3971945",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/web/docs/operators/context.md
+++ b/web/docs/operators/context.md
@@ -20,6 +20,7 @@ context reset   <name>
 context save    <name>
 context load    <name>
 context inspect <name>
+context rename  <old-name> <new-name> [--force]
 ```
 
 ## Description
@@ -45,6 +46,9 @@ The `context` operator manages [context](../contexts.md) instances.
 
 - The `inspect` command dumps a specific context's user-provided data, usually
   the context's content.
+
+- The `rename` operator renames a context. The `--force` parameter will allow
+  the operator to overwrite an already existing context.
 
 ### `<name>`
 
@@ -94,4 +98,17 @@ Inspect all data provided to `feodo`:
 
 ```
 context inspect feodo
+```
+
+Rename a context `feodo` to `feodo_old`:
+
+```
+context rename feodo feodo_old
+```
+
+Rename a context `test` to `feodo`, potentially overwriting an existing
+context `feodo`:
+
+```
+context rename test feodo --force
 ```


### PR DESCRIPTION
This change implements context renaming while the node is running via the `context rename` operator.

Also fixes a few bugs along the way.