### PR TITLE
Create a variant of the tenzir-demo image for use in the platform CI

### DIFF
--- a/.github/workflows/docker-config-base.json
+++ b/.github/workflows/docker-config-base.json
@@ -49,6 +49,14 @@
         "622024652768.dkr.ecr.eu-west-1.amazonaws.com",
         "docker.io"
       ]
+    },
+    {
+      "name": "tenzir-minidemo",
+      "target": "tenzir-minidemo",
+      "registries": [
+        "622024652768.dkr.ecr.eu-west-1.amazonaws.com",
+        "docker.io"
+      ]
     }
   ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -260,6 +260,14 @@ ENV TENZIR_PIPELINES__M57_SURICATA__NAME='M57 Suricata' \
     TENZIR_PIPELINES__M57_ZEEK__DEFINITION='from https://storage.googleapis.com/tenzir-datasets/M57/zeek-all.log.zst read zeek-tsv | import' \
     TENZIR_PIPELINES__M57_ZEEK__LABELS='zeek'
 
+# -- tenzir-minidemo -------------------------------------------------------------
+
+FROM tenzir-node-ce AS tenzir-minidemo
+
+ENV TENZIR_PIPELINES__M57_SURICATA__NAME='M57 Suricata' \
+    TENZIR_PIPELINES__M57_SURICATA__DEFINITION='from https://storage.googleapis.com/tenzir-datasets/M57/suricata.json.zst read suricata --no-infer | where #schema != "suricata.stats" | head 10 | import' \
+    TENZIR_PIPELINES__M57_SURICATA__LABELS='suricata'
+
 # -- tenzir-node -----------------------------------------------------------------
 
 FROM tenzir-node-ce AS tenzir-node


### PR DESCRIPTION
The existing tenzir-demo image has delays of 10s and more on weak machines when processing pipeline launch and update endpoints, because the pipeline manager competes with the running imports for resources. This leads to sporadic failure of our integration tests.

Since rewriting the scheduler to fix this would be a huge undertaking, we instead build a variant of the demo image with less things going on.
