### PR TITLE
Fix start abort error message

### DIFF
--- a/changelog/next/bug-fixes/4288--start-abort-error.md
+++ b/changelog/next/bug-fixes/4288--start-abort-error.md
@@ -1,0 +1,2 @@
+Errors during pipeline startup are properly propagated instead of being replaced
+by `error: failed to run` in some situations.

--- a/libtenzir/builtins/commands/exec.cpp
+++ b/libtenzir/builtins/commands/exec.cpp
@@ -104,7 +104,7 @@ auto exec_command(const invocation& inv, caf::actor_system& sys) -> bool {
   }
   if (cfg.dump_diagnostics) {
     auto diag = collecting_diagnostic_handler{};
-    auto result = exec_command_impl(std::move(content), diag, cfg, sys);
+    auto result = exec_command_impl(content, diag, cfg, sys);
     dump_diagnostics_to_stdout(std::move(diag).collect(), filename,
                                std::move(content));
     return result;

--- a/libtenzir/builtins/commands/exec.cpp
+++ b/libtenzir/builtins/commands/exec.cpp
@@ -49,7 +49,7 @@ auto exec_command_impl(std::string content, diagnostic_handler& dh,
   if (result) {
     return true;
   }
-  if (result != ec::silent) {
+  if (result != ec::silent && result != caf::exit_reason::user_shutdown) {
     dh.emit(diagnostic::error(result.error()).done());
   }
   return false;

--- a/libtenzir/builtins/commands/exec.cpp
+++ b/libtenzir/builtins/commands/exec.cpp
@@ -42,14 +42,20 @@ private:
   diagnostic_handler& inner_;
 };
 
-auto exec_command(const invocation& inv, caf::actor_system& sys)
-  -> caf::expected<void> {
-  const auto& args = inv.arguments;
-  if (args.size() != 1) {
-    return caf::make_error(
-      ec::invalid_argument,
-      fmt::format("expected exactly one argument, but got {}", args.size()));
+auto exec_command_impl(std::string content, diagnostic_handler& dh,
+                       const exec_config& cfg, caf::actor_system& sys) -> bool {
+  auto result = exec_pipeline(
+    std::move(content), std::make_unique<diagnostic_handler_ref>(dh), cfg, sys);
+  if (result) {
+    return true;
   }
+  if (result != ec::silent) {
+    dh.emit(diagnostic::error(result.error()).done());
+  }
+  return false;
+}
+
+auto exec_command(const invocation& inv, caf::actor_system& sys) -> bool {
   auto cfg = exec_config{};
   cfg.dump_tokens = caf::get_or(inv.options, "tenzir.exec.dump-tokens", false);
   cfg.dump_ast = caf::get_or(inv.options, "tenzir.exec.dump-ast", false);
@@ -71,12 +77,25 @@ auto exec_command(const invocation& inv, caf::actor_system& sys)
   cfg.tql2 = caf::get_or(inv.options, "tenzir.exec.tql2", cfg.tql2);
   auto filename = std::string{};
   auto content = std::string{};
+  const auto& args = inv.arguments;
+  auto color = (isatty(STDERR_FILENO) == 1
+                && detail::getenv("NO_COLOR").value_or("").empty())
+                 ? color_diagnostics::yes
+                 : color_diagnostics::no;
+  auto printer = make_diagnostic_printer(std::nullopt, color, std::cerr);
+  if (args.size() != 1) {
+    printer->emit(diagnostic::error("expected exactly one argument, but got {}",
+                                    args.size())
+                    .done());
+    return false;
+  }
   if (as_file) {
     filename = args[0];
     auto result = detail::load_contents(filename);
-    if (!result) {
+    if (not result) {
       // TODO: Better error message.
-      return result.error();
+      printer->emit(diagnostic::error(result.error()).done());
+      return false;
     }
     content = std::move(*result);
   } else {
@@ -85,18 +104,14 @@ auto exec_command(const invocation& inv, caf::actor_system& sys)
   }
   if (cfg.dump_diagnostics) {
     auto diag = collecting_diagnostic_handler{};
-    auto result = exec_pipeline(
-      content, std::make_unique<diagnostic_handler_ref>(diag), cfg, sys);
+    auto result = exec_command_impl(std::move(content), diag, cfg, sys);
     dump_diagnostics_to_stdout(std::move(diag).collect(), filename,
                                std::move(content));
     return result;
   }
-  auto color = isatty(STDERR_FILENO) == 1
-               && detail::getenv("NO_COLOR").value_or("").empty();
-  auto printer = make_diagnostic_printer(
-    location_origin{filename, content},
-    color ? color_diagnostics::yes : color_diagnostics::no, std::cerr);
-  return exec_pipeline(std::move(content), std::move(printer), cfg, sys);
+  printer = make_diagnostic_printer(location_origin{filename, content}, color,
+                                    std::cerr);
+  return exec_command_impl(std::move(content), *printer, cfg, sys);
 }
 
 class plugin final : public virtual command_plugin {
@@ -138,18 +153,8 @@ public:
     auto factory = command::factory{
       {"exec",
        [=](const invocation& inv, caf::actor_system& sys) -> caf::message {
-         auto result = exec_command(inv, sys);
-         if (not result) {
-           if (result != ec::diagnostic and result != ec::silent) {
-             auto diag = make_diagnostic_printer(
-               std::nullopt, color_diagnostics::yes, std::cerr);
-             diag->emit(diagnostic::error(result.error())
-                          .note("pipeline execution failed")
-                          .done());
-           }
-           return caf::make_message(ec::silent);
-         }
-         return {};
+         auto success = exec_command(inv, sys);
+         return caf::make_message(success ? ec::no_error : ec::silent);
        }},
     };
     return {std::move(exec), std::move(factory)};

--- a/libtenzir/builtins/operators/serve.cpp
+++ b/libtenzir/builtins/operators/serve.cpp
@@ -69,6 +69,8 @@
 #include <caf/stateful_actor.hpp>
 #include <caf/typed_event_based_actor.hpp>
 
+#include <sstream>
+
 namespace tenzir::plugins::serve {
 
 namespace {
@@ -773,7 +775,15 @@ struct serve_handler_state {
         [rp](caf::error& err) mutable {
           // TODO: Use a struct with distinct fields for user-facing
           // error message and detail here.
-          auto rsp = rest_response::make_error(400, fmt::to_string(err), {});
+          // TODO: We don't have the source here to print snippets of the
+          // diagnostic! Either `serve` needs to be aware of that (which seems
+          // like a very bad idea), or the diagnostics need to be rendered
+          // somewhere else.
+          auto stream = std::stringstream{};
+          auto printer = make_diagnostic_printer(
+            std::nullopt, color_diagnostics::yes, stream);
+          printer->emit(diagnostic::error(err).done());
+          auto rsp = rest_response::make_error(400, stream.str(), {});
           rp.deliver(std::move(rsp));
         });
     return rp;

--- a/libtenzir/src/exec_pipeline.cpp
+++ b/libtenzir/src/exec_pipeline.cpp
@@ -226,7 +226,7 @@ auto exec_pipeline(std::string content,
         if (msg.reason) {
           result = msg.reason;
         }
-        self->quit(msg.reason);
+        self->quit();
       });
       self->state.executor = self->spawn<caf::monitored>(
         pipeline_executor, std::move(pipe),

--- a/libtenzir/src/execution_node.cpp
+++ b/libtenzir/src/execution_node.cpp
@@ -409,8 +409,7 @@ struct exec_node_state {
               = make_timer_guard(metrics.time_scheduled, metrics.time_starting);
             TENZIR_DEBUG("{} {} forwards error during startup: {}", *self,
                          op->name(), error);
-            start_rp.deliver(
-              add_context(error, "{} {} failed to start", *self, op->name()));
+            start_rp.deliver(error);
           });
       return start_rp;
     }

--- a/libtenzir/src/pipeline_executor.cpp
+++ b/libtenzir/src/pipeline_executor.cpp
@@ -165,8 +165,7 @@ void pipeline_executor_state::abort_start(caf::error reason) {
     self->quit(ec::silent);
     return;
   }
-  abort_start(
-    diagnostic::error(reason).note("pipeline failed to start").done());
+  abort_start(diagnostic::error(std::move(reason)).done());
 }
 
 void pipeline_executor_state::finish_start() {

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "a8bd763873b284606c3d4da13711a11894768ce5",
+  "rev": "a0351671ea38d6bf503388e2b58334a7a55490a0",
   "submodules": true,
   "shallow": true,
   "allRefs": true

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "0dc9659052f1fa570813d2c10271d435535a5ae0",
+  "rev": "a8bd763873b284606c3d4da13711a11894768ce5",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "a0351671ea38d6bf503388e2b58334a7a55490a0",
+  "rev": "57a66d109049af3a70aabdcf0f84eb27026d0aba",
   "submodules": true,
   "shallow": true,
   "allRefs": true

--- a/web/openapi/openapi.yaml
+++ b/web/openapi/openapi.yaml
@@ -191,11 +191,13 @@ components:
           type: bool
           description: Whether this pipeline is hidden. Hidden pipelines are only available through the `show pipelines` operator.
         created_at:
-          type: string
-          description: The timestamp of the pipeline creation.
+          type: integer
+          format: int64
+          description: The Unix timestamp of the pipeline creation time in nanoseconds.
         last_modified:
-          type: string
-          description: The timestamp of the last pipeline modification.
+          type: integer
+          format: int64
+          description: The Unix timestamp of the last pipeline modification in nanoseconds.
         start_time:
           type: string
           description: If the pipeline has been started, the ISO 8601 timestamp of the most recent start.
@@ -390,8 +392,8 @@ paths:
                       name: user-assigned-name
                       definition: export | where foo | publish /bar
                       hidden: false
-                      created_at: 2024-06-11T16:30:16.312547
-                      last_modifed: 2024-06-12T12:31:20.549823
+                      created_at: 1706180157837037485
+                      last_modifed: 1706180157837038016
                       state: running
                       error: null
                       diagnostics:
@@ -400,8 +402,8 @@ paths:
                       name: wrong-pipeline
                       definition: export asdf
                       hidden: false
-                      created_at: 2024-06-11T16:30:16.312547
-                      last_modifed: 2024-06-12T12:31:20.549823
+                      created_at: 1706180157837037485
+                      last_modifed: 1706180157837038016
                       state: failed
                       error: format 'asdf' not found
                       diagnostics:

--- a/web/openapi/openapi.yaml
+++ b/web/openapi/openapi.yaml
@@ -191,13 +191,11 @@ components:
           type: bool
           description: Whether this pipeline is hidden. Hidden pipelines are only available through the `show pipelines` operator.
         created_at:
-          type: integer
-          format: int64
-          description: The Unix timestamp of the pipeline creation time in nanoseconds.
+          type: string
+          description: The timestamp of the pipeline creation.
         last_modified:
-          type: integer
-          format: int64
-          description: The Unix timestamp of the last pipeline modification in nanoseconds.
+          type: string
+          description: The timestamp of the last pipeline modification.
         start_time:
           type: string
           description: If the pipeline has been started, the ISO 8601 timestamp of the most recent start.
@@ -392,8 +390,8 @@ paths:
                       name: user-assigned-name
                       definition: export | where foo | publish /bar
                       hidden: false
-                      created_at: 1706180157837037485
-                      last_modifed: 1706180157837038016
+                      created_at: 2024-06-11T16:30:16.312547
+                      last_modifed: 2024-06-12T12:31:20.549823
                       state: running
                       error: null
                       diagnostics:
@@ -402,8 +400,8 @@ paths:
                       name: wrong-pipeline
                       definition: export asdf
                       hidden: false
-                      created_at: 1706180157837037485
-                      last_modifed: 1706180157837038016
+                      created_at: 2024-06-11T16:30:16.312547
+                      last_modifed: 2024-06-12T12:31:20.549823
                       state: failed
                       error: format 'asdf' not found
                       diagnostics:


### PR DESCRIPTION
This changes the error message for something like `version | version` from
~~~
error: failed to run
error: 
~~~
to
~~~
error: 'version' does not accept events as input
 = note: failed type inference
~~~
I don't think the resulting diagnostic is good, but this PR is just about restoring the behavior that we had previously (until it was broken by one of the diagnostic propagation PRs). 