### PR TITLE
Fix using `summarize … by x` when `x` is of type `null`

### DIFF
--- a/changelog/next/bug-fixes/4289--summarize-by-null.md
+++ b/changelog/next/bug-fixes/4289--summarize-by-null.md
@@ -1,0 +1,3 @@
+The `summarize` operator no longer crashes when grpuping by a field of type
+`null`, i.e., a field whose type could not be inferred because all of its values
+were `null`.

--- a/libtenzir/builtins/operators/summarize.cpp
+++ b/libtenzir/builtins/operators/summarize.cpp
@@ -396,6 +396,10 @@ public:
             // already warned and can ignore it.
             continue;
           }
+          if (not other->type) {
+            // We can skip `null_type` as that is compatible with every other.
+            continue;
+          }
           if (existing.is_dead()) {
             continue;
           }
@@ -470,7 +474,7 @@ public:
       auto new_bucket = std::make_shared<bucket>();
       new_bucket->group_by_types.reserve(bound.group_by_columns.size());
       for (auto&& column : bound.group_by_columns) {
-        if (column) {
+        if (column and column->type) {
           new_bucket->group_by_types.push_back(
             group_type::make_active(column->type));
         } else {

--- a/libtenzir/src/table_slice.cpp
+++ b/libtenzir/src/table_slice.cpp
@@ -872,11 +872,9 @@ auto resolve_operand(const table_slice& slice, const operand& op)
     }
     inferred_type = *tmp_inferred_type;
     if (not inferred_type) {
-      inferred_type = type{string_type{}};
-      // Tenzir has no N/A type equivalent for Arrow, so we just use a string
-      // type here.
+      inferred_type = type{null_type{}};
       auto builder
-        = string_type::make_arrow_builder(arrow::default_memory_pool());
+        = null_type::make_arrow_builder(arrow::default_memory_pool());
       const auto append_result = builder->AppendNulls(batch->num_rows());
       TENZIR_ASSERT(append_result.ok(), append_result.ToString().c_str());
       array = builder->Finish().ValueOrDie();


### PR DESCRIPTION
This is a two-fold change:
1. The `put`, `set`, `extend`, and `replace` operators when used to assign a field the value `null` set the string type rather than the null type, because they predated the null type. This is now fixed.
2. The `summarize` operator no longer crashes when grouping by a null type.

Fixes tenzir/issues#1900