### PR TITLE
Add a `rendered` field to diagnostics

### DIFF
--- a/changelog/next/features/4290--rendered-diagnostics.md
+++ b/changelog/next/features/4290--rendered-diagnostics.md
@@ -1,0 +1,3 @@
+Newly created diagnostics returned from the `diagnostics` now contain a
+`rendered` field that contains a rendered form of the diagnostic. To restore the
+previous behavior, use `diagnostics | drop rendered`.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "0dc9659052f1fa570813d2c10271d435535a5ae0",
+  "rev": "78644e68473ef1661415615774bb82fdfd08521a",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/web/docs/operators/diagnostics.md
+++ b/web/docs/operators/diagnostics.md
@@ -47,6 +47,7 @@ Contains detailed information about the diagnostic.
 |`severity`|`string`|The diagnostic severity.|
 |`notes`|`list<record>`|The diagnostic notes. Can be empty.|
 |`annotations`|`list<record>`|The diagnostic annotations. Can be empty.|
+|`rendered`|`string`|The rendered diagnostic, as printed on the command-line.|
 
 The record `notes` has the following schema:
 


### PR DESCRIPTION
The new `rendered` field contains the rendered diagnostic for use in the app so that it can display diagnostics the same way we render them on the command-line.