### PR TITLE
Allow configuring timeouts per lookup table entry

### DIFF
--- a/changelog/next/features/5126.md
+++ b/changelog/next/features/5126.md
@@ -1,0 +1,4 @@
+`context update <context_name>` for `lookup-table` now takes in 
+additional arguments. `--update-timeout` represents an event 
+lifetime that is reset upon access and `create-timeout` 
+represents the total lifetime after event creation.

--- a/changelog/next/features/5126.md
+++ b/changelog/next/features/5126.md
@@ -1,4 +1,4 @@
-`context update <context_name>` for `lookup-table` now takes in 
-additional arguments. `--update-timeout` represents an event 
-lifetime that is reset upon access and `create-timeout` 
-represents the total lifetime after event creation.
+`context update <context_name>` for `lookup-table` can now accept
+additional arguments. `--update-timeout` represents an event
+lifetime that resets upon access and `create-timeout`
+represents a constant event lifetime.

--- a/changelog/next/features/5126.md
+++ b/changelog/next/features/5126.md
@@ -1,4 +1,4 @@
-`context update <context_name>` for `lookup-table` can now accept
-additional arguments. `--update-timeout` represents an event
-lifetime that resets upon access and `create-timeout`
-represents a constant event lifetime.
+`context update <name>` for `lookup-table` contexts now supports per-entry
+timeouts. The `--create-timeout <duration>` option sets the time after which
+lookup table entries expire, and the `--update-timeout <duration>` option sets
+the time after which lookup table entries expire if they are not accessed.

--- a/libtenzir/builtins/contexts/bloom_filter.cpp
+++ b/libtenzir/builtins/contexts/bloom_filter.cpp
@@ -55,7 +55,7 @@ public:
   }
 
   /// Emits context information for every event in `slice` in order.
-  auto apply(series array, bool replace) const
+  auto apply(series array, bool replace)
     -> caf::expected<std::vector<series>> override {
     (void)replace;
     auto builder = series_builder{};

--- a/libtenzir/builtins/contexts/geoip.cpp
+++ b/libtenzir/builtins/contexts/geoip.cpp
@@ -312,7 +312,7 @@ public:
   }
 
   /// Emits context information for every event in `slice` in order.
-  auto apply(series array, bool replace) const
+  auto apply(series array, bool replace)
     -> caf::expected<std::vector<series>> override {
     if (!mmdb_) {
       return caf::make_error(ec::lookup_error,

--- a/libtenzir/builtins/contexts/lookup_table.cpp
+++ b/libtenzir/builtins/contexts/lookup_table.cpp
@@ -34,7 +34,6 @@
 #include <arrow/type.h>
 #include <caf/error.hpp>
 #include <caf/sum_type.hpp>
-#include <sys/_types/_u_int8_t.h>
 #include <tsl/robin_map.h>
 
 #include <memory>
@@ -686,7 +685,7 @@ struct v1_loader : public context_loader {
                                "context entry in serialized entry list, "
                                "entry must be a record");
       }
-      if (not record->fields() or record->fields()->size() != 4) {
+      if (not record->fields()) {
         return caf::make_error(ec::serialization_error,
                                "failed to deserialize lookup table "
                                "context: invalid or missing value for "

--- a/libtenzir/builtins/contexts/lookup_table.cpp
+++ b/libtenzir/builtins/contexts/lookup_table.cpp
@@ -318,7 +318,10 @@ public:
                                "heterogeneous keys");
       }
     }
-    for (const auto& [k, _] : subnet_entries.nodes()) {
+    for (const auto& [k, v] : subnet_entries.nodes()) {
+      if (v->is_expired(now)) {
+        continue;
+      }
       keys.emplace_back(k);
     }
     auto result = disjunction{};
@@ -364,6 +367,9 @@ public:
     auto entry_builder = series_builder{};
     const auto now = time::clock::now();
     for (const auto& [key, value] : subnet_entries.nodes()) {
+      if (value->is_expired(now)) {
+        continue;
+      }
       TENZIR_ASSERT(value);
       auto row = entry_builder.record();
       row.field("key", data{key});

--- a/libtenzir/include/tenzir/detail/subnet_tree.hpp
+++ b/libtenzir/include/tenzir/detail/subnet_tree.hpp
@@ -29,10 +29,10 @@ public:
   ~type_erased_subnet_tree() noexcept;
   auto lookup(subnet key) const -> const std::any*;
   auto lookup(subnet key) -> std::any*;
-  auto match(ip key) const -> const std::any*;
-  auto match(ip key) -> std::any*;
-  auto match(subnet key) const -> const std::any*;
-  auto match(subnet key) -> std::any*;
+  auto match(ip key) const -> std::pair<subnet, const std::any*>;
+  auto match(ip key) -> std::pair<subnet, std::any*>;
+  auto match(subnet key) const -> std::pair<subnet, const std::any*>;
+  auto match(subnet key) -> std::pair<subnet, std::any*>;
   auto search(ip key) const -> generator<std::pair<subnet, const std::any*>>;
   auto search(ip key) -> generator<std::pair<subnet, std::any*>>;
   auto search(subnet key) const
@@ -75,24 +75,28 @@ public:
 
   /// Looks for the longest-prefix match of a subnet in which the given IP
   /// address occurs.
-  auto match(ip key) const -> const T* {
-    return std::any_cast<T>(impl_.match(key));
+  auto match(ip key) const -> std::pair<subnet, const T*> {
+    auto [subnet, value] = impl_.match(key);
+    return {subnet, std::any_cast<T>(value)};
   }
 
   /// Looks for the longest-prefix match of a subnet in which the given IP
   /// address occurs.
-  auto match(ip key) -> T* {
-    return std::any_cast<T>(impl_.match(key));
+  auto match(ip key) -> std::pair<subnet, T*> {
+    auto [subnet, value] = impl_.match(key);
+    return {subnet, std::any_cast<T>(value)};
   }
 
   /// Looks for the longest-prefix match of a subnet.
-  auto match(subnet key) const -> const T* {
-    return std::any_cast<T>(impl_.match(key));
+  auto match(subnet key) const -> std::pair<subnet, const T*> {
+    auto [subnet, value] = impl_.match(key);
+    return {subnet, std::any_cast<T>(value)};
   }
 
   /// Looks for the longest-prefix match of a subnet.
-  auto match(subnet key) -> T* {
-    return std::any_cast<T>(impl_.match(key));
+  auto match(subnet key) -> std::pair<subnet, T*> {
+    auto [subnet, value] = impl_.match(key);
+    return {subnet, std::any_cast<T>(value)};
   }
 
   /// Performs a prefix-search for a given IP address, returning all subnets

--- a/libtenzir/include/tenzir/detail/subnet_tree.hpp
+++ b/libtenzir/include/tenzir/detail/subnet_tree.hpp
@@ -12,56 +12,152 @@
 #include <tenzir/generator.hpp>
 #include <tenzir/subnet.hpp>
 
+#include <any>
+
 namespace tenzir::detail {
 
-class subnet_tree {
+class type_erased_subnet_tree {
 public:
-  /// Constructs an empty tree.
-  subnet_tree();
-
-  subnet_tree(subnet_tree&& other) noexcept;
-  auto operator=(subnet_tree&& other) noexcept -> subnet_tree&;
-
-  /// Destroys a tree.
-  ~subnet_tree();
-
-  /// Looks for a value for a given key.
-  /// @note Unlike `search`, this performs an exact match and not a
-  /// longest-prefix match.
-  auto lookup(subnet key) const -> const data*;
-
-  /// Looks for the longest-prefix match of a subnet in which the given IP
-  /// address occurs.
-  auto match(ip key) const -> const data*;
-
-  /// Looks for the longest-prefix match of a subnet.
-  auto match(subnet key) const -> const data*;
-
-  /// Performs a prefix-search for a given IP address, returning all subnets
-  /// that contain it.
-  auto search(ip key) const
-    -> generator<std::pair<subnet, const data*>>;
-
-  /// Performs a prefix-search for a given subnet, returning all subnets that
-  /// contain it.
+  type_erased_subnet_tree() noexcept;
+  type_erased_subnet_tree(const type_erased_subnet_tree& other) noexcept
+    = delete;
+  auto operator=(const type_erased_subnet_tree& other) noexcept
+    -> type_erased_subnet_tree& = delete;
+  type_erased_subnet_tree(type_erased_subnet_tree&& other) noexcept;
+  auto operator=(type_erased_subnet_tree&& other) noexcept
+    -> type_erased_subnet_tree&;
+  ~type_erased_subnet_tree() noexcept;
+  auto lookup(subnet key) const -> const std::any*;
+  auto lookup(subnet key) -> std::any*;
+  auto match(ip key) const -> const std::any*;
+  auto match(ip key) -> std::any*;
+  auto match(subnet key) const -> const std::any*;
+  auto match(subnet key) -> std::any*;
+  auto search(ip key) const -> generator<std::pair<subnet, const std::any*>>;
+  auto search(ip key) -> generator<std::pair<subnet, std::any*>>;
   auto search(subnet key) const
-    -> generator<std::pair<subnet, const data*>>;
-
-  /// Retrieves all nodes in the tree.
-  auto nodes() const -> generator<std::pair<subnet, const data*>>;
-
-  /// Inserts a key-value pair.
-  auto insert(subnet key, data value) -> bool;
-
-  /// Removes a node.
+    -> generator<std::pair<subnet, const std::any*>>;
+  auto search(subnet key) -> generator<std::pair<subnet, std::any*>>;
+  auto nodes() const -> generator<std::pair<subnet, const std::any*>>;
+  auto nodes() -> generator<std::pair<subnet, std::any*>>;
+  auto insert(subnet key, std::any value) -> bool;
   auto erase(subnet key) -> bool;
-
-  /// Removes all elements from the tree.
   auto clear() -> void;
 
 private:
   struct impl;
   std::unique_ptr<impl> impl_;
+};
+
+template <class T = data>
+class subnet_tree {
+public:
+  subnet_tree() noexcept = default;
+  subnet_tree(const subnet_tree& other) = delete;
+  auto operator=(const subnet_tree& other) -> subnet_tree& = delete;
+  subnet_tree(subnet_tree&& other) noexcept = default;
+  auto operator=(subnet_tree&& other) noexcept -> subnet_tree& = default;
+  ~subnet_tree() noexcept = default;
+
+  /// Looks for a value for a given key.
+  /// @note Unlike `search`, this performs an exact match and not a
+  /// longest-prefix match.
+  auto lookup(subnet key) const -> const T* {
+    return std::any_cast<T>(impl_.lookup(key));
+  }
+
+  /// Looks for a value for a given key.
+  /// @note Unlike `search`, this performs an exact match and not a
+  /// longest-prefix match.
+  auto lookup(subnet key) -> T* {
+    return std::any_cast<T>(impl_.lookup(key));
+  }
+
+  /// Looks for the longest-prefix match of a subnet in which the given IP
+  /// address occurs.
+  auto match(ip key) const -> const T* {
+    return std::any_cast<T>(impl_.match(key));
+  }
+
+  /// Looks for the longest-prefix match of a subnet in which the given IP
+  /// address occurs.
+  auto match(ip key) -> T* {
+    return std::any_cast<T>(impl_.match(key));
+  }
+
+  /// Looks for the longest-prefix match of a subnet.
+  auto match(subnet key) const -> const T* {
+    return std::any_cast<T>(impl_.match(key));
+  }
+
+  /// Looks for the longest-prefix match of a subnet.
+  auto match(subnet key) -> T* {
+    return std::any_cast<T>(impl_.match(key));
+  }
+
+  /// Performs a prefix-search for a given IP address, returning all subnets
+  /// that contain it.
+  auto search(ip key) const -> generator<std::pair<subnet, const T*>> {
+    for (auto&& [key, value] : impl_.search(key)) {
+      co_yield {key, std::any_cast<T>(value)};
+    }
+  }
+
+  /// Performs a prefix-search for a given IP address, returning all subnets
+  /// that contain it.
+  auto search(ip key) -> generator<std::pair<subnet, T*>> {
+    for (auto&& [key, value] : impl_.search(key)) {
+      co_yield {key, std::any_cast<T>(value)};
+    }
+  }
+
+  /// Performs a prefix-search for a given subnet, returning all subnets that
+  /// contain it.
+  auto search(subnet key) const -> generator<std::pair<subnet, const T*>> {
+    for (auto&& [key, value] : impl_.search(key)) {
+      co_yield {key, std::any_cast<T>(value)};
+    }
+  }
+
+  /// Performs a prefix-search for a given subnet, returning all subnets that
+  /// contain it.
+  auto search(subnet key) -> generator<std::pair<subnet, T*>> {
+    for (auto&& [key, value] : impl_.search(key)) {
+      co_yield {key, std::any_cast<T>(value)};
+    }
+  }
+
+  /// Retrieves all nodes in the tree.
+  auto nodes() const -> generator<std::pair<subnet, const T*>> {
+    for (auto&& [key, value] : impl_.nodes()) {
+      co_yield {key, std::any_cast<T>(value)};
+    }
+  }
+
+  /// Retrieves all nodes in the tree.
+  auto nodes() -> generator<std::pair<subnet, T*>> {
+    for (auto&& [key, value] : impl_.nodes()) {
+      co_yield {key, std::any_cast<T>(value)};
+    }
+  }
+
+  /// Inserts a key-value pair.
+  auto insert(subnet key, T value) -> bool {
+    return impl_.insert(key, std::move(value));
+  }
+
+  /// Removes a node.
+  auto erase(subnet key) -> bool {
+    return impl_.erase(key);
+  }
+
+  /// Removes all elements from the tree.
+  auto clear() -> void {
+    impl_.clear();
+  }
+
+private:
+  type_erased_subnet_tree impl_;
 };
 
 } // namespace tenzir::detail

--- a/libtenzir/include/tenzir/plugin.hpp
+++ b/libtenzir/include/tenzir/plugin.hpp
@@ -699,7 +699,7 @@ public:
   /// @param array The values to look up in the context.
   /// @param replace If true, return the input values for missing fields rather
   /// than nulls.
-  virtual auto apply(series array, bool replace) const
+  virtual auto apply(series array, bool replace)
     -> caf::expected<std::vector<series>>
     = 0;
 

--- a/libtenzir/src/detail/subnet_tree.cpp
+++ b/libtenzir/src/detail/subnet_tree.cpp
@@ -773,6 +773,9 @@ auto make_subnet(const prefix_t* prefix) -> subnet {
 
 auto make_subnet_data_pair(patricia_node_t* node)
   -> std::pair<subnet, std::any*> {
+  if (not node) {
+    return {{}, nullptr};
+  }
   return {make_subnet(node->prefix), reinterpret_cast<std::any*>(node->data)};
 }
 
@@ -837,32 +840,35 @@ auto type_erased_subnet_tree::lookup(subnet key) -> std::any* {
   return node ? reinterpret_cast<std::any*>(node->data) : nullptr;
 }
 
-auto type_erased_subnet_tree::match(ip key) const -> const std::any* {
+auto type_erased_subnet_tree::match(ip key) const
+  -> std::pair<subnet, const std::any*> {
   return match(subnet{key, 128});
 }
 
-auto type_erased_subnet_tree::match(ip key) -> std::any* {
+auto type_erased_subnet_tree::match(ip key) -> std::pair<subnet, std::any*> {
   return match(subnet{key, 128});
 }
 
-auto type_erased_subnet_tree::match(subnet key) const -> const std::any* {
+auto type_erased_subnet_tree::match(subnet key) const
+  -> std::pair<subnet, const std::any*> {
   auto* prefix = make_prefix(key);
   if (prefix == nullptr) {
-    return nullptr;
+    return make_subnet_data_pair(nullptr);
   }
   auto* node = patricia_search_best(impl_->tree.get(), prefix);
   Deref_Prefix(prefix);
-  return node ? reinterpret_cast<const std::any*>(node->data) : nullptr;
+  return make_subnet_data_pair(node);
 }
 
-auto type_erased_subnet_tree::match(subnet key) -> std::any* {
+auto type_erased_subnet_tree::match(subnet key)
+  -> std::pair<subnet, std::any*> {
   auto* prefix = make_prefix(key);
   if (prefix == nullptr) {
-    return nullptr;
+    return make_subnet_data_pair(nullptr);
   }
   auto* node = patricia_search_best(impl_->tree.get(), prefix);
   Deref_Prefix(prefix);
-  return node ? reinterpret_cast<std::any*>(node->data) : nullptr;
+  return make_subnet_data_pair(node);
 }
 
 auto type_erased_subnet_tree::search(ip key) const

--- a/libtenzir/src/detail/subnet_tree.cpp
+++ b/libtenzir/src/detail/subnet_tree.cpp
@@ -771,16 +771,16 @@ auto make_subnet(const prefix_t* prefix) -> subnet {
   return subnet{ip::v6(bytes), narrow_cast<uint8_t>(prefix->bitlen)};
 }
 
-auto make_subnet_data_pair(const patricia_node_t* node)
-  -> std::pair<subnet, const data*> {
-  return {make_subnet(node->prefix), reinterpret_cast<const data*>(node->data)};
+auto make_subnet_data_pair(patricia_node_t* node)
+  -> std::pair<subnet, std::any*> {
+  return {make_subnet(node->prefix), reinterpret_cast<std::any*>(node->data)};
 }
 
 } // namespace
 
-struct subnet_tree::impl {
+struct type_erased_subnet_tree::impl {
   static auto delete_data(void* ptr) -> void {
-    delete reinterpret_cast<data*>(ptr);
+    delete reinterpret_cast<std::any*>(ptr);
   }
 
   struct patricia_tree_deleter {
@@ -791,60 +791,92 @@ struct subnet_tree::impl {
     }
   };
 
-  impl() {
+  impl() noexcept {
     tree.reset(New_Patricia(128));
   }
 
   std::unique_ptr<patricia_tree_t, patricia_tree_deleter> tree;
 };
 
-subnet_tree::subnet_tree() : impl_{std::make_unique<impl>()} {
+type_erased_subnet_tree::type_erased_subnet_tree() noexcept
+  : impl_{std::make_unique<impl>()} {
 }
 
-subnet_tree::subnet_tree(subnet_tree&& other) noexcept
+type_erased_subnet_tree::type_erased_subnet_tree(
+  type_erased_subnet_tree&& other) noexcept
   : impl_{std::move(other.impl_)} {
 }
 
-auto subnet_tree::operator=(subnet_tree&& other) noexcept -> subnet_tree& {
+auto type_erased_subnet_tree::operator=(type_erased_subnet_tree&& other) noexcept
+  -> type_erased_subnet_tree& {
   impl_ = std::move(other.impl_);
   return *this;
 }
 
-subnet_tree::~subnet_tree() {
+type_erased_subnet_tree::~type_erased_subnet_tree() noexcept {
   // Needs to be defined for pimpl.
 }
 
-auto subnet_tree::lookup(subnet key) const -> const data* {
+auto type_erased_subnet_tree::lookup(subnet key) const -> const std::any* {
   auto* prefix = make_prefix(key);
   if (prefix == nullptr) {
     return nullptr;
   }
   auto* node = patricia_search_exact(impl_->tree.get(), prefix);
   Deref_Prefix(prefix);
-  return node ? reinterpret_cast<const data*>(node->data) : nullptr;
+  return node ? reinterpret_cast<const std::any*>(node->data) : nullptr;
 }
 
-auto subnet_tree::match(ip key) const -> const data* {
+auto type_erased_subnet_tree::lookup(subnet key) -> std::any* {
+  auto* prefix = make_prefix(key);
+  if (prefix == nullptr) {
+    return nullptr;
+  }
+  auto* node = patricia_search_exact(impl_->tree.get(), prefix);
+  Deref_Prefix(prefix);
+  return node ? reinterpret_cast<std::any*>(node->data) : nullptr;
+}
+
+auto type_erased_subnet_tree::match(ip key) const -> const std::any* {
   return match(subnet{key, 128});
 }
 
-auto subnet_tree::match(subnet key) const -> const data* {
+auto type_erased_subnet_tree::match(ip key) -> std::any* {
+  return match(subnet{key, 128});
+}
+
+auto type_erased_subnet_tree::match(subnet key) const -> const std::any* {
   auto* prefix = make_prefix(key);
   if (prefix == nullptr) {
     return nullptr;
   }
   auto* node = patricia_search_best(impl_->tree.get(), prefix);
   Deref_Prefix(prefix);
-  return node ? reinterpret_cast<const data*>(node->data) : nullptr;
+  return node ? reinterpret_cast<const std::any*>(node->data) : nullptr;
 }
 
-auto subnet_tree::search(ip key) const
-  -> generator<std::pair<subnet, const data*>> {
+auto type_erased_subnet_tree::match(subnet key) -> std::any* {
+  auto* prefix = make_prefix(key);
+  if (prefix == nullptr) {
+    return nullptr;
+  }
+  auto* node = patricia_search_best(impl_->tree.get(), prefix);
+  Deref_Prefix(prefix);
+  return node ? reinterpret_cast<std::any*>(node->data) : nullptr;
+}
+
+auto type_erased_subnet_tree::search(ip key) const
+  -> generator<std::pair<subnet, const std::any*>> {
   return search(subnet{key, 128});
 }
 
-auto subnet_tree::search(subnet key) const
-  -> generator<std::pair<subnet, const data*>> {
+auto type_erased_subnet_tree::search(ip key)
+  -> generator<std::pair<subnet, std::any*>> {
+  return search(subnet{key, 128});
+}
+
+auto type_erased_subnet_tree::search(subnet key) const
+  -> generator<std::pair<subnet, const std::any*>> {
   auto* prefix = make_prefix(key);
   auto num_elements = 0;
   patricia_node_t** xs = nullptr;
@@ -858,7 +890,23 @@ auto subnet_tree::search(subnet key) const
   }
 }
 
-auto subnet_tree::nodes() const -> generator<std::pair<subnet, const data*>> {
+auto type_erased_subnet_tree::search(subnet key)
+  -> generator<std::pair<subnet, std::any*>> {
+  auto* prefix = make_prefix(key);
+  auto num_elements = 0;
+  patricia_node_t** xs = nullptr;
+  patricia_search_all(impl_->tree.get(), prefix, &xs, &num_elements);
+  auto guard = caf::detail::make_scope_guard([prefix, xs] {
+    Deref_Prefix(prefix);
+    free(xs);
+  });
+  for (auto i = 0; i < num_elements; ++i) {
+    co_yield make_subnet_data_pair(xs[i]);
+  }
+}
+
+auto type_erased_subnet_tree::nodes() const
+  -> generator<std::pair<subnet, const std::any*>> {
   patricia_node_t* node;
   PATRICIA_WALK(impl_->tree->head, node) {
     co_yield make_subnet_data_pair(node);
@@ -866,7 +914,16 @@ auto subnet_tree::nodes() const -> generator<std::pair<subnet, const data*>> {
   PATRICIA_WALK_END;
 }
 
-auto subnet_tree::insert(subnet key, data value) -> bool {
+auto type_erased_subnet_tree::nodes()
+  -> generator<std::pair<subnet, std::any*>> {
+  patricia_node_t* node;
+  PATRICIA_WALK(impl_->tree->head, node) {
+    co_yield make_subnet_data_pair(node);
+  }
+  PATRICIA_WALK_END;
+}
+
+auto type_erased_subnet_tree::insert(subnet key, std::any value) -> bool {
   auto* prefix = make_prefix(key);
   if (prefix == nullptr) {
     return false;
@@ -878,15 +935,15 @@ auto subnet_tree::insert(subnet key, data value) -> bool {
   }
   auto result = true;
   if (node->data != nullptr) {
-    delete reinterpret_cast<const data*>(node->data);
+    delete reinterpret_cast<const std::any*>(node->data);
     result = false;
   }
   // Deleted in Clear_Patricia() or Destroy_Patricia().
-  node->data = new data{std::move(value)};
+  node->data = new std::any{std::move(value)};
   return result;
 }
 
-auto subnet_tree::erase(subnet key) -> bool {
+auto type_erased_subnet_tree::erase(subnet key) -> bool {
   auto* prefix = make_prefix(key);
   TENZIR_ASSERT(prefix != nullptr);
   auto* node = patricia_search_exact(impl_->tree.get(), prefix);
@@ -895,14 +952,14 @@ auto subnet_tree::erase(subnet key) -> bool {
     return false;
   }
   if (node->data != nullptr) {
-    delete reinterpret_cast<const data*>(node->data);
+    delete reinterpret_cast<const std::any*>(node->data);
   }
   patricia_remove(impl_->tree.get(), node);
   return true;
 }
 
-auto subnet_tree::clear() -> void {
-  Clear_Patricia(impl_->tree.get(), subnet_tree::impl::delete_data);
+auto type_erased_subnet_tree::clear() -> void {
+  Clear_Patricia(impl_->tree.get(), type_erased_subnet_tree::impl::delete_data);
 }
 
 } // namespace tenzir::detail

--- a/libtenzir/test/detail/subnet_tree.cpp
+++ b/libtenzir/test/detail/subnet_tree.cpp
@@ -32,22 +32,22 @@ TEST(prefix matching) {
   CHECK(xs.lookup(sn_0_25));
   CHECK(xs.lookup(sn_1_24));
   CHECK(xs.lookup(sn_0_23));
-  CHECK(xs.match(*to<ip>("192.168.0.1")));
-  CHECK(xs.match(*to<ip>("192.168.1.255")));
+  CHECK(xs.match(*to<ip>("192.168.0.1")).second);
+  CHECK(xs.match(*to<ip>("192.168.1.255")).second);
   {
-    const auto* ptr = xs.match(*to<subnet>("192.168.0.128/25"));
-    REQUIRE(ptr);
-    CHECK_EQUAL(*ptr, data{0u});
+    const auto ptr = xs.match(*to<subnet>("192.168.0.128/25"));
+    REQUIRE(ptr.second);
+    CHECK_EQUAL(*ptr.second, data{0u});
   }
   {
-    const auto* ptr = xs.match(*to<subnet>("192.168.0.0/25"));
-    REQUIRE(ptr);
-    CHECK_EQUAL(*ptr, data{1u});
+    const auto ptr = xs.match(*to<subnet>("192.168.0.0/25"));
+    REQUIRE(ptr.second);
+    CHECK_EQUAL(*ptr.second, data{1u});
   }
   // Check for true negatives.
   CHECK(not xs.lookup(*to<subnet>("192.168.0.0/22")));
-  CHECK(not xs.match(*to<ip>("192.168.2.0")));
-  CHECK(not xs.match(*to<ip>("10.0.0.1")));
+  CHECK(not xs.match(*to<ip>("192.168.2.0")).second);
+  CHECK(not xs.match(*to<ip>("10.0.0.1")).second);
   // Prefix match of IP addresses.
   auto subnets = std::set<subnet>{};
   for (auto [sn, _] : xs.search(*to<ip>("192.168.0.1")))

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "bb4dc108258b4a639c8af0a097d9f42095aacaf1",
+  "rev": "19a05e5b017ef29a8f422c010668039a2cb2e644",
   "submodules": true,
   "shallow": true,
   "allRefs": true

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "0dc9659052f1fa570813d2c10271d435535a5ae0",
+  "rev": "bb4dc108258b4a639c8af0a097d9f42095aacaf1",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/web/docs/contexts/lookup-table.md
+++ b/web/docs/contexts/lookup-table.md
@@ -7,7 +7,7 @@ data.
 
 ```
 context create  <name> lookup-table
-context update  <name> [--key <field>] [--erase]
+context update  <name> [--key <field>] [--create-timeout <time>] [--update-timeout <time>] [--erase]
 context delete  <name>
 context reset   <name>
 context save    <name>
@@ -41,6 +41,18 @@ The following options are currently supported for the `lookup-table` context:
 The field in the input that holds the unique key for the lookup table.
 
 Defaults to the first field of the input.
+
+### ``--create-timeout <time>`
+
+The lifetime of events added in the context update.
+
+Defaults to no timeout.
+
+### `--update-timeout <time>`
+
+An event lifetime that resets on every access.
+
+Defaults to no timeout.
 
 ### `--erase`
 

--- a/web/docs/contexts/lookup-table.md
+++ b/web/docs/contexts/lookup-table.md
@@ -7,7 +7,9 @@ data.
 
 ```
 context create  <name> lookup-table
-context update  <name> [--key <field>] [--create-timeout <time>] [--update-timeout <time>] [--erase]
+context update  <name> [--key <field>] [--erase]
+                       [--create-timeout <duration>]
+                       [--update-timeout <duration>]
 context delete  <name>
 context reset   <name>
 context save    <name>
@@ -42,15 +44,15 @@ The field in the input that holds the unique key for the lookup table.
 
 Defaults to the first field of the input.
 
-### ``--create-timeout <time>`
+### ``--create-timeout <duration>`
 
-The lifetime of events added in the context update.
+The time after which lookup table entries expire.
 
 Defaults to no timeout.
 
-### `--update-timeout <time>`
+### `--update-timeout <duration>`
 
-An event lifetime that resets on every access.
+The time after which lookup table entries expire if they are not accessed.
 
 Defaults to no timeout.
 


### PR DESCRIPTION
The context update operator can now handle two additional flags, update-timeout and create-timeout, allowing the user to control when entries should be expired. The operator introduces a new struct value_data which holds additional time information along with the original value data. Expired entries are removed from memory on save() and load(). Update-timeout only tracks running time.