### PR TITLE
Allow components to depend on other components

### DIFF
--- a/libtenzir/builtins/components/metrics_collector.cpp
+++ b/libtenzir/builtins/components/metrics_collector.cpp
@@ -63,7 +63,9 @@ struct metrics_collector_state {
         return ok.error();
       }
     }
-    TENZIR_ASSERT(not instances.empty());
+    if (instances.empty()) {
+      return {};
+    }
     detail::weak_run_delayed_loop(
       self, std::chrono::seconds{30},
       [this] {
@@ -139,9 +141,6 @@ public:
 
   auto make_component(node_actor::stateful_pointer<node_state> node) const
     -> component_plugin_actor override {
-    if (collect(plugins::get<metrics_plugin>()).empty()) {
-      return {};
-    }
     auto [importer] = node->state.registry.find<importer_actor>();
     return node->spawn<caf::linked>(metrics_collector, std::move(importer));
   }

--- a/libtenzir/include/tenzir/node.hpp
+++ b/libtenzir/include/tenzir/node.hpp
@@ -75,7 +75,7 @@ struct node_state {
   component_registry registry = {};
 
   /// The list of component plugin actors in the order that they were spawned.
-  std::vector<component_plugin_actor> ordered_components = {};
+  std::vector<std::string> ordered_components = {};
 
   /// Components that are still alive for lifetime-tracking.
   std::set<std::pair<caf::actor_addr, std::string>> alive_components = {};

--- a/libtenzir/include/tenzir/node.hpp
+++ b/libtenzir/include/tenzir/node.hpp
@@ -74,6 +74,9 @@ struct node_state {
   /// The component registry.
   component_registry registry = {};
 
+  /// The list of component plugin actors in the order that they were spawned.
+  std::vector<component_plugin_actor> ordered_components = {};
+
   /// Components that are still alive for lifetime-tracking.
   std::set<std::pair<caf::actor_addr, std::string>> alive_components = {};
 

--- a/libtenzir/include/tenzir/plugin.hpp
+++ b/libtenzir/include/tenzir/plugin.hpp
@@ -147,6 +147,11 @@ public:
   /// Defaults to the plugin name.
   virtual std::string component_name() const;
 
+  /// Components that should be created before the current one so initialization
+  /// can succeed.
+  /// Defaults to empty list.
+  virtual auto wanted_components() const -> std::vector<std::string>;
+
   /// Creates an actor as a component in the NODE.
   /// @param node A stateful pointer to the NODE actor.
   /// @returns The actor handle to the NODE component.

--- a/libtenzir/src/node.cpp
+++ b/libtenzir/src/node.cpp
@@ -284,6 +284,56 @@ auto node_state::get_endpoint_handler(const http_request_description& desc)
   return result->second;
 }
 
+auto spawn_components(node_actor::stateful_pointer<node_state> self) -> void {
+  using component_plugin_map = std::unordered_map<std::string, const component_plugin*>;
+  // 1. Collect all component_plugins into a name -> plugin* map:
+  component_plugin_map todo = {};
+  for (const auto* component : plugins::get<component_plugin>()) {
+    todo.emplace(component->component_name(), component);
+  }
+  // 2. Calculate an ordered loading sequnce based on the wanted_components of
+  //    each plugin.
+  std::vector<const component_plugin*> sequenced_components = {};
+  std::unordered_set<std::string> done = {};
+  auto derive_sequence = [&](auto derive_sequence, const std::string& name) {
+    auto entry = todo.find(name);
+    if (entry == todo.end()) {
+      return;
+    }
+    const auto* plugin = entry->second;
+    todo.erase(entry);
+    if (done.contains(name)) {
+      return;
+    }
+    for (auto& wanted : plugin->wanted_components()) {
+      derive_sequence(derive_sequence, wanted);
+    }
+    done.insert(name);
+    sequenced_components.push_back(plugin);
+  };
+  while (not todo.empty()) {
+    derive_sequence(derive_sequence, todo.begin()->second->component_name());
+  }
+  // 3. Load all components in order.
+  for (const auto* plugin : sequenced_components) {
+    auto name = plugin->component_name();
+    auto handle = plugin->make_component(self);
+    if (!handle) {
+      diagnostic::error("{} failed to create the {} component", *self, name)
+        .throw_();
+    }
+    self->system().registry().put(fmt::format("tenzir.{}", name), handle);
+    if (auto err = register_component(self, caf::actor_cast<caf::actor>(handle),
+                                      name)) {
+      diagnostic::error(err)
+        .note("{} failed to register component {} in component registry", *self,
+              name)
+        .throw_();
+    }
+    self->state.ordered_components.push_back(handle);
+  }
+}
+
 node_actor::behavior_type
 node(node_actor::stateful_pointer<node_state> self, std::string /*name*/,
      std::filesystem::path dir) {
@@ -328,6 +378,19 @@ node(node_actor::stateful_pointer<node_state> self, std::string /*name*/,
                      component->type, msg.reason);
         self->send_exit(self, caf::exit_reason::user_shutdown);
       }
+    }
+  });
+  self->set_exception_handler([=](std::exception_ptr& ptr) -> caf::error {
+    try {
+      std::rethrow_exception(ptr);
+    } catch (const diagnostic& diag) {
+      return diag.to_error();
+    } catch (const std::exception& err) {
+      return diagnostic::error("{}", err.what())
+        .note("unhandled exception in {}", *self)
+        .to_error();
+    } catch (...) {
+      return diagnostic::error("unhandled exception in {}", *self).to_error();
     }
   });
   // Terminate deterministically on shutdown.
@@ -457,25 +520,7 @@ node(node_actor::stateful_pointer<node_state> self, std::string /*name*/,
       return rp;
     },
     [self](atom::internal, atom::spawn, atom::plugin) -> caf::result<void> {
-      // Add all plugins to the component registry.
-      for (const auto& component : plugins::get<component_plugin>()) {
-        auto handle = component->make_component(self);
-        if (!handle)
-          // The spawn function can provide a better log message so we don't
-          // print one here.
-          continue;
-        self->system().registry().put(
-          fmt::format("tenzir.{}", component->component_name()), handle);
-        if (auto err
-            = register_component(self, caf::actor_cast<caf::actor>(handle),
-                                 component->component_name()))
-          return caf::make_error( //
-            ec::unspecified, fmt::format("{} failed to register component {} "
-                                         "from plugin {} in component "
-                                         "registry: {}",
-                                         *self, component->component_name(),
-                                         component->name(), err));
-      }
+      spawn_components(self);
       return {};
     },
     [self](atom::spawn, const invocation& inv) {

--- a/libtenzir/src/node.cpp
+++ b/libtenzir/src/node.cpp
@@ -330,7 +330,7 @@ auto spawn_components(node_actor::stateful_pointer<node_state> self) -> void {
               name)
         .throw_();
     }
-    self->state.ordered_components.push_back(handle);
+    self->state.ordered_components.push_back(name);
   }
 }
 
@@ -417,6 +417,12 @@ node(node_actor::stateful_pointer<node_state> self, std::string /*name*/,
     // Core components are terminated in a second stage, we remove them from the
     // registry upfront and deal with them later.
     std::vector<caf::actor> core_shutdown_handles;
+    for (const auto& name :
+         self->state.ordered_components | std::ranges::views::reverse) {
+      if (auto comp = registry.remove(name)) {
+        core_shutdown_handles.push_back(comp->actor);
+      }
+    }
     caf::actor filesystem_handle;
     // The components listed here need to be terminated in sequential order.
     // The importer needs to shut down first because it might still have

--- a/libtenzir/src/plugin.cpp
+++ b/libtenzir/src/plugin.cpp
@@ -405,6 +405,10 @@ std::string component_plugin::component_name() const {
   return this->name();
 }
 
+auto component_plugin::wanted_components() const -> std::vector<std::string> {
+  return {};
+}
+
 // -- loader plugin -----------------------------------------------------------
 
 auto loader_parser_plugin::supported_uri_schemes() const

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "8815c99140d25fb128fb2e0b51eafd20ebcaef2c",
+  "rev": "967c69cee9fe2d1fc9681e68951f36544bff9410",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
This extends the component_plugin interface so that can provide a list of other components that have to be instantiated before the plugins own component can be spawned.
