### PR TITLE
Tone down execution node backoff behavior

### DIFF
--- a/changelog/next/bug-fixes/4297--backoff-changes.md
+++ b/changelog/next/bug-fixes/4297--backoff-changes.md
@@ -1,0 +1,3 @@
+We fixed a regression that caused excess CPU usage for some operators when idle.
+This was most visible with the `subscribe`, `export`, `metrics`, `diagnostics`,
+`lookup` and `enrich` operators.

--- a/libtenzir/src/execution_node.cpp
+++ b/libtenzir/src/execution_node.cpp
@@ -236,8 +236,9 @@ struct exec_node_state {
   caf::typed_response_promise<void> start_rp = {};
 
   /// Exponential backoff for scheduling.
-  static constexpr duration min_backoff = std::chrono::milliseconds{10};
-  static constexpr duration max_backoff = std::chrono::milliseconds{1000};
+  static constexpr duration min_backoff = std::chrono::milliseconds{250};
+  static constexpr duration max_backoff = std::chrono::minutes{1};
+  static constexpr double backoff_rate = 2.0;
   duration backoff = duration::zero();
   caf::disposable backoff_disposable = {};
 
@@ -576,8 +577,9 @@ struct exec_node_state {
     } else if (backoff == duration::zero()) {
       backoff = min_backoff;
     } else {
-      backoff = std::min(std::chrono::duration_cast<duration>(1.25 * backoff),
-                         max_backoff);
+      backoff
+        = std::min(std::chrono::duration_cast<duration>(backoff_rate * backoff),
+                   max_backoff);
     }
     TENZIR_TRACE("{} {} schedules run with a delay of {}", *self, op->name(),
                  data{backoff});
@@ -647,7 +649,8 @@ struct exec_node_state {
     advance_generator();
     // We can continue execution under the following circumstances:
     // 1. The operator's generator is not yet completed.
-    // 2. The operator has one of the three following reasons to do work:
+    // 2. The operator did not signal that we're supposed to wait.
+    // 3. The operator has one of the three following reasons to do work:
     //   a. The upstream operator has completed.
     //   b. The operator has downstream demand and can produce output
     //      independently from receiving input.
@@ -655,13 +658,16 @@ struct exec_node_state {
     //   d. The operator is a command, i.e., has both a source and a sink.
     const auto should_continue
       = instance->it != instance->gen.end()                         // (1)
-        and (not previous                                           // (2a)
-             or (demand.has_value() and op->input_independent())    // (2b)
-             or not inbound_buffer.empty()                          // (2c)
-             or detail::are_same_v<std::monostate, Input, Output>); // (2d)
+        and not waiting                                             // (2)
+        and (not previous                                           // (3a)
+             or (demand.has_value() and op->input_independent())    // (3b)
+             or not inbound_buffer.empty()                          // (3c)
+             or detail::are_same_v<std::monostate, Input, Output>); // (3d)
     if (should_continue) {
       schedule_run(false);
-    } else if (demand.has_value() or std::is_same_v<Output, std::monostate>) {
+    } else if (not waiting
+               and (demand.has_value()
+                    or std::is_same_v<Output, std::monostate>)) {
       // If we shouldn't continue, but there is an upstream demand, then we may
       // be in a situation where the operator has internally buffered events and
       // needs to be polled until some operator-internal timeout expires before

--- a/libtenzir/src/execution_node.cpp
+++ b/libtenzir/src/execution_node.cpp
@@ -650,7 +650,7 @@ struct exec_node_state {
     // We can continue execution under the following circumstances:
     // 1. The operator's generator is not yet completed.
     // 2. The operator did not signal that we're supposed to wait.
-    // 3. The operator has one of the three following reasons to do work:
+    // 3. The operator has one of the four following reasons to do work:
     //   a. The upstream operator has completed.
     //   b. The operator has downstream demand and can produce output
     //      independently from receiving input.


### PR DESCRIPTION
This turns down the execution node backoff behavior. Instead of going from 10ms to 1s with 1.25x increases, we now go from 250ms to 1 min with 2x increases.

Additionally, this causes execution nodes that explicitly ask not to be scheduled to be exempt from backoff and not to be scheduled at all.