### PR TITLE
Make the parallel level in `lookup` configurable

### DIFF
--- a/changelog/next/features/4300--lookup-parallel-level.md
+++ b/changelog/next/features/4300--lookup-parallel-level.md
@@ -1,0 +1,5 @@
+The `lookup` operator gained a new `--parallel <level>` option controlling the
+number of partitions the operator is allowed to open at once for retrospective
+lookups. This can significantly increase performance at the cost of higher
+resource usage. The option defaults to 3. To restore the previous behavior, set
+the option to 1.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "adcc36c9bbb7ce646438839ebe81fdd0adee2f78",
+  "rev": "0bf116c95b8e0b194da58ba22b3ac40fd63976d0",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/web/docs/operators/lookup.md
+++ b/web/docs/operators/lookup.md
@@ -14,10 +14,12 @@ and translates context updates into historical queries.
 ```
 lookup <context>          [--field <field...>] [--separate]
                           [--live] [--retro] [--snapshot]
-                          [--yield <field>] [<context-options>]
+                          [--yield <field>] [--parallel <level>]
+                          [<context-options>]
 lookup <output>=<context> [--field <field...>] [--separate]
                           [--live] [--retro] [--snapshot]
-                          [--yield <field>] [<context-options>]
+                          [--yield <field>] [--parallel <level>]
+                          [<context-options>]
 ```
 
 ## Description
@@ -87,6 +89,14 @@ By default, snapshotting is disabled. Not all contexts support this operation.
 
 Provide a field into the context object to use as the context instead. If the
 key does not exist within the context, a `null` value is used instead.
+
+### `--parallel <level>`
+
+The number of partitions to open in parallel for retrospective lookups. This
+number directly correlates with memory usage and performance of the `lookup`
+operator.
+
+Defaults to 3.
 
 ### `<context-options>`
 


### PR DESCRIPTION
This adds a new `--parallel <level>` option to the `lookup` operator that controls how many partitions it opens at once for retrospective lookups. Cranking this number up makes lookups significantly faster, but also causes its resource usage to rise accordingly.