### PR TITLE
Include hidden pipelines in `show pipelines`

### DIFF
--- a/changelog/next/changes/4309--show-hidden-pipelines.md
+++ b/changelog/next/changes/4309--show-hidden-pipelines.md
@@ -1,0 +1,3 @@
+`show pipelines` now includes "hidden" pipelines run by the by the Tenzir
+Platform or through the API. These pipelines usually run background jobs, so
+they're intentionally hidden from the `/pipeline/list` API.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "253fae9ad51b847a4fd859454cd425b8d581a5a6",
+  "rev": "a64579fe55fd85333a86f661a4338e7d8d213c61",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
This fixes a bug: hidden pipelines are supposed to be exempt from `api /pipeline/list`, but not from `show pipelines`. Otherwise, it is impossible to retrieve their ids for debugging purposes.
