### PR TITLE
Reduce CPU usage of `summarize … [update-]timeout …`

### DIFF
--- a/libtenzir/builtins/operators/export.cpp
+++ b/libtenzir/builtins/operators/export.cpp
@@ -252,9 +252,6 @@ public:
   auto optimize(expression const& filter, event_order order) const
     -> optimize_result override {
     (void)order;
-    if (mode_.live) {
-      return do_not_optimize(*this);
-    }
     auto clauses = std::vector<expression>{};
     if (expr_ != caf::none and expr_ != trivially_true_expression()) {
       clauses.push_back(expr_);

--- a/libtenzir/builtins/operators/summarize.cpp
+++ b/libtenzir/builtins/operators/summarize.cpp
@@ -850,9 +850,11 @@ public:
   }
 
   auto input_independent() const -> bool override {
-    if (config_.created_timeout or config_.update_timeout) {
-      return true;
-    }
+    // Returning false here is technically incorrect when using summarize with
+    // timeouts. However, the handling of input-independent non-source operators
+    // in the execution nodes is so bad, that we accept a potential delay here
+    // over excess CPU usage.
+    // TODO: Fix this properly in the execution nodes.
     return false;
   }
 

--- a/libtenzir/src/execution_node.cpp
+++ b/libtenzir/src/execution_node.cpp
@@ -656,18 +656,18 @@ struct exec_node_state {
     //      independently from receiving input.
     //   c. The operator has input it can consume.
     //   d. The operator is a command, i.e., has both a source and a sink.
+    const auto has_demand
+      = demand.has_value() or std::is_same_v<Output, std::monostate>;
     const auto should_continue
       = instance->it != instance->gen.end()                         // (1)
         and not waiting                                             // (2)
         and (not previous                                           // (3a)
-             or (demand.has_value() and op->input_independent())    // (3b)
+             or (has_demand and op->input_independent())            // (3b)
              or not inbound_buffer.empty()                          // (3c)
              or detail::are_same_v<std::monostate, Input, Output>); // (3d)
     if (should_continue) {
       schedule_run(false);
-    } else if (not waiting
-               and (demand.has_value()
-                    or std::is_same_v<Output, std::monostate>)) {
+    } else if (not waiting and has_demand) {
       // If we shouldn't continue, but there is an upstream demand, then we may
       // be in a situation where the operator has internally buffered events and
       // needs to be polled until some operator-internal timeout expires before


### PR DESCRIPTION
This makes a small change to the scheduling behavior of `summarize … timeout …` and `summarize … update-timeout …`, which are now scheduled less aggressively.