### PR TITLE
Fix HTTP header parsing logic

### DIFF
--- a/libtenzir/src/http.cpp
+++ b/libtenzir/src/http.cpp
@@ -38,12 +38,24 @@ auto message::header(const std::string& name) const -> const struct header* {
 }
 
 auto request_item::parse(std::string_view str) -> std::optional<request_item> {
+  auto is_valid_header_name = [](std::string_view name) {
+    for (char c : name) {
+      if (std::isalnum(static_cast<unsigned char>(c)) == 0 and c != '-'
+          and c != '_') {
+        return false;
+      }
+    }
+    return true;
+  };
   auto xs = detail::split_escaped(str, ":=@", "\\", 1);
   if (xs.size() == 2)
     return request_item{.type = file_data_json, .key = xs[0], .value = xs[1]};
   xs = detail::split_escaped(str, ":=", "\\", 1);
   if (xs.size() == 2)
     return request_item{.type = data_json, .key = xs[0], .value = xs[1]};
+  xs = detail::split_escaped(str, ":", "\\", 1);
+  if (xs.size() == 2 and is_valid_header_name(xs[0]))
+    return request_item{.type = header, .key = xs[0], .value = xs[1]};
   xs = detail::split_escaped(str, "==", "\\", 1);
   if (xs.size() == 2)
     return request_item{.type = url_param, .key = xs[0], .value = xs[1]};
@@ -56,9 +68,6 @@ auto request_item::parse(std::string_view str) -> std::optional<request_item> {
   xs = detail::split_escaped(str, "=", "\\", 1);
   if (xs.size() == 2)
     return request_item{.type = data, .key = xs[0], .value = xs[1]};
-  xs = detail::split_escaped(str, ":", "\\", 1);
-  if (xs.size() == 2)
-    return request_item{.type = header, .key = xs[0], .value = xs[1]};
   return {};
 }
 


### PR DESCRIPTION
Trailing `=` in a Base64 header caused the wrong branch to be selected.
