### PR TITLE
Fix `offset{}.get(…)` for struct arrays and record batches

### DIFF
--- a/libtenzir/src/offset.cpp
+++ b/libtenzir/src/offset.cpp
@@ -58,11 +58,7 @@ auto offset::get(const arrow::RecordBatch& batch) const noexcept
 auto offset::get(const arrow::StructArray& struct_array) const noexcept
   -> std::shared_ptr<arrow::Array> {
   if (empty()) {
-    // If the offset is empty, we are already at the desired level, and can just
-    // wrap the struct array back into a shared pointer.
-    auto result = struct_array.View(struct_array.type());
-    TENZIR_ASSERT(result.ok(), result.status().ToString().c_str());
-    return result.MoveValueUnsafe();
+    return std::make_shared<arrow::StructArray>(struct_array.data());
   }
   auto impl
     = [](auto&& impl, std::span<const offset::value_type> index,

--- a/libtenzir/src/offset.cpp
+++ b/libtenzir/src/offset.cpp
@@ -57,6 +57,13 @@ auto offset::get(const arrow::RecordBatch& batch) const noexcept
 
 auto offset::get(const arrow::StructArray& struct_array) const noexcept
   -> std::shared_ptr<arrow::Array> {
+  if (empty()) {
+    // If the offset is empty, we are already at the desired level, and can just
+    // wrap the struct array back into a shared pointer.
+    auto result = struct_array.View(struct_array.type());
+    TENZIR_ASSERT(result.ok(), result.status().ToString().c_str());
+    return result.MoveValueUnsafe();
+  }
   auto impl
     = [](auto&& impl, std::span<const offset::value_type> index,
          const arrow::StructArray& array) -> std::shared_ptr<arrow::Array> {


### PR DESCRIPTION
This fixes access into struct arrays and record batches for empty offsets. This is handled nicely already for table slices, but it looks like we forgot this overload. I ran into this while working on some other code, and figured it'd be worth extracting this fix already. It shouldn't be possible for users to run into this before TQL2.