### PR TITLE
Add the `ttl` to the `/pipeline/list` API

### DIFF
--- a/changelog/next/features/4314--ttl-in-api.md
+++ b/changelog/next/features/4314--ttl-in-api.md
@@ -1,0 +1,3 @@
+The `/pipeline/list` API now includes a new `ttl` field showing the TTL of the
+pipeline. The remaining TTL moved from `ttl_expires_in_ns` to a `remaining_ttl`
+field, aligning the output of the API with the `show pipelines` operator.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "39457727a92e05ec5732b8642bfd1605ee24337e",
+  "rev": "38777483ed54780d846668be936344d5d1650ec2",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/web/openapi/openapi.yaml
+++ b/web/openapi/openapi.yaml
@@ -228,10 +228,14 @@ components:
           $ref: "#/components/schemas/PipelineAutostart"
         autodelete:
           $ref: "#/components/schemas/PipelineAutodelete"
-        ttl_expires_in_ns:
-          type: integer
-          description: If a TTL exists for this pipeline, the remaining TTL in nanoseconds.
-          example: 23400569058
+        ttl:
+          type: string
+          description: If a TTL exists for this pipeline, the TTL as a duration string.
+          example: 2.0m
+        remaining_ttl:
+          type: string
+          description: If a TTL exists for this pipeline, the remaining TTL as a duration string.
+          example: 10.0s
     PipelineLabel:
       type: object
       properties:


### PR DESCRIPTION
Turns out that it's rather useful to show the TTL in addition to the remaining TTL when listing pipelines.

Fixes https://github.com/tenzir/issues/issues/1905