### PR TITLE
Add missing `-X` option for `kafka` saver

### DIFF
--- a/changelog/next/bug-fixes/4317--kafka-args.md
+++ b/changelog/next/bug-fixes/4317--kafka-args.md
@@ -1,0 +1,3 @@
+The `-X` option for overriding configuration options for `librdkafka` now works
+the `kafka` saver as well. Previously, the option was only exposed for the
+loader, unlike advertised in the documentation.


### PR DESCRIPTION
This was advertised to exist in the docs, but was actually only implemented for the ´kafka` loader. The fix is mostly a carbon copy of the loader code.

Fixes tenzir/issues#1889