### PR TITLE
Fix minor issues with the diagnostics and metrics collector

### DIFF
--- a/changelog/next/bug-fixes/4326--diagnostics-collector.md
+++ b/changelog/next/bug-fixes/4326--diagnostics-collector.md
@@ -1,0 +1,2 @@
+Fixed an issue where diagnostics where not properly propagated and thus not
+available to the `diagnostics` operator.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "4bac4ba3fba1878864544903d77a05a55a9ec946",
+  "rev": "69d8e39cdb5f4621aff7460427f9436aa86cefb3",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
This PR fixes an issue where diagnostics where not properly propagated and thus not available to the `diagnostics` operator.