### PR TITLE
Add an operator for partition candidate checks

### DIFF
--- a/changelog/next/features/4329--partitions-operator.md
+++ b/changelog/next/features/4329--partitions-operator.md
@@ -1,0 +1,3 @@
+The `partitions [<expr>]` source operator replaces `show partitions` and now
+supports an optional expression as a positional argument for showing only the
+partitions that would be considered in `export | where <expr>`.

--- a/libtenzir/builtins/operators/show.cpp
+++ b/libtenzir/builtins/operators/show.cpp
@@ -110,6 +110,15 @@ public:
         }
         return std::move(*op);
       }
+      if (aspect->inner == "partitions") {
+        auto op = pipeline::internal_parse_as_operator("partitions");
+        if (not op) {
+          diagnostic::error("failed to parse `partitions` operator: {}",
+                            op.error())
+            .throw_();
+        }
+        return std::move(*op);
+      }
       auto available = std::map<std::string, std::string>{};
       for (const auto& aspect : collect(plugins::get<aspect_plugin>()))
         available.emplace(aspect->aspect_name(), aspect->name());

--- a/libtenzir/include/tenzir/actors.hpp
+++ b/libtenzir/include/tenzir/actors.hpp
@@ -200,8 +200,14 @@ using catalog_actor = typed_actor_fwd<
     ->caf::result<atom::ok>,
   // Merge a set of partition synopses.
   auto(atom::merge, std::vector<partition_synopsis_pair>)->caf::result<atom::ok>,
-  // Get *ALL* partition synopses stored in the catalog.
+  // Get *ALL* partition synopses stored in the catalog, optionally filtered
+  // with an expression to filter the candidate set.
+  // Note that this returns a pointer into the catalog's internal data
+  // structures, which is inherently unsafe to transfer between processes. The
+  // data pointed to must not be mutated. Functionality that depends on this
+  // should instead be moved inside of the catalog itself.
   auto(atom::get)->caf::result<std::vector<partition_synopsis_pair>>,
+  auto(atom::get, expression)->caf::result<std::vector<partition_synopsis_pair>>,
   // Erase a single partition synopsis.
   auto(atom::erase, uuid)->caf::result<atom::ok>,
   // Atomatically replace a set of partititon synopses with another.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "ad51fd0a36f8618690c8aef08c1bfb4608fb935f",
+  "rev": "e4f0bdf9a4e6a2788a6b8c81248ace8d6461ca1d",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/web/docs/operators/partitions.md
+++ b/web/docs/operators/partitions.md
@@ -1,0 +1,82 @@
+---
+sidebar_custom_props:
+  operator:
+    source: true
+---
+
+# partitions
+
+Retrieves metadata about events stored at a node.
+
+## Synopsis
+
+```
+partitions [<expr>]
+```
+
+## Description
+
+The `partitions` operator shows a summary of candidate partitions at a node.
+
+### `<expr>`
+
+Show only partitions which would be considered for pipelines of the form
+`export | where <expr>` instead of returning all data.
+
+## Schemas
+
+Tenzir emits partition information with the following schema:
+
+### `tenzir.partition`
+
+Contains detailed information about a partition.
+
+|Field|Type|Description|
+|:-|:-|:-|
+|`uuid`|`string`|The unique ID of the partition in the UUIDv4 format.|
+|`memusage`|`uint64`|The memory usage of the partition in bytes.|
+|`diskusage`|`uint64`|The disk usage of the partition in bytes.|
+|`events`|`uint64`|The number of events contained in the partition.|
+|`min_import_time`|`time`|The time at which the first event of the partition arrived at the `import` operator.|
+|`max_import_time`|`time`|The time at which the last event of the partition arrived at the `import` operator.|
+|`version`|`uint64`|The version number of the internal partition storage format.|
+|`schema`|`string`|The schema name of the events contained in the partition.|
+|`schema_id`|`string`|A unique identifier for the physical layout of the partition.|
+|`store`|`record`|Resource information about the partition's store.|
+|`indexes`|`record`|Resource information about the partition's indexes.|
+|`sketches`|`record`|Resource information about the partition's sketches.|
+
+The records `store`, `indexes`, and `sketches` have the following schema:
+
+|Field|Type|Description|
+|:-|:-|:-|
+|`url`|`string`|The URL of the resource.|
+|`size`|`uint64`|The size of the resource.|
+
+## Examples
+
+Get an overview of the memory and disk requirements for all stored data sorted
+by schema:
+
+```
+partitions
+| summarize events=sum(events),
+            diskusage=sum(diskusage),
+            memusage=sum(memusage)
+  by schema
+| sort schema
+```
+
+Get an upper bound for the number of events that could contain the IP address
+127.0.0.1:
+
+```
+partitions :ip == 127.0.0.1
+| summarize candidates=sum(events)
+```
+
+See how many partitions contain a non-null value for the field `hostname`:
+
+```
+partitions hostname != null
+```

--- a/web/docs/operators/show.md
+++ b/web/docs/operators/show.md
@@ -30,7 +30,6 @@ Available aspects:
 - `contexts`: shows all available contexts.
 - `formats`: shows all available [formats](../formats.md).
 - `operators`: shows all available [operators](../operators.md).
-- `partitions`: shows all table partitions of a remote node.
 - `pipelines`: shows all managed pipelines of a remote node.
 - `plugins`: shows all loaded plugins.
 
@@ -61,11 +60,10 @@ Show all transformations:
 show operators | where transformation == true
 ```
 
-Show all fields and partitions at a node:
+Show all fields at a node:
 
 ```
 show fields
-show partitions
 ```
 
 Show all aspects of a node:


### PR DESCRIPTION
The `partitions [<expr>]` operator supersedes the `show partitions` operator. The new and optional positional argument is a filter expression for doing a candidate check in the catalog component. This has two primary use cases:
1. Seeing which schemas would be considered for `export | where <expr>` by running `partitions <expr> | deduplicate schema`.
2. Quickly calculating an upper bound for the number of results in `export | where <expr>` by running `partitions <expr> | summarize events=sum(events)`.

Fixes https://github.com/tenzir/issues/issues/1532