### PR TITLE
Prepare repository for Tenzir v4.17.3

### DIFF
--- a/changelog/next/bug-fixes/4330--fix-deletion-of-configured-contexts.md
+++ b/changelog/next/bug-fixes/4330--fix-deletion-of-configured-contexts.md
@@ -1,3 +1,0 @@
-We fixed a bug that caused the deletion of the on-disk state of all configured
-context at startup. This bug was introduced with
-[#4325](https://github.com/tenzir/tenzir/pull/4325) (Tenzir v4.17.2).

--- a/changelog/next/features/4329--partitions-operator.md
+++ b/changelog/next/features/4329--partitions-operator.md
@@ -1,3 +1,0 @@
-The `partitions [<expr>]` source operator replaces `show partitions` and now
-supports an optional expression as a positional argument for showing only the
-partitions that would be considered in `export | where <expr>`.

--- a/changelog/v4.17.3/bug-fixes/4330.md
+++ b/changelog/v4.17.3/bug-fixes/4330.md
@@ -1,0 +1,2 @@
+We fixed a bug in Tenzir v4.17.2 that sometimes caused the deletion of on-disk
+state of configured contexts on startup.

--- a/changelog/v4.17.3/features/4329.md
+++ b/changelog/v4.17.3/features/4329.md
@@ -1,0 +1,3 @@
+The `partitions [<expr>]` source operator supersedes `show partitions` (now
+deprecated) and supports an optional expression as a positional argument for
+showing only the partitions that would be considered in `export | where <expr>`.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tenzir"
-version = "4.17.2"
+version = "4.17.3"
 description = "A security telemetry engine for detection and response"
 authors = ["Tenzir <engineering@tenzir.com>"]
 maintainers = ["Tenzir <engineering@tenzir.com>"]

--- a/version.json
+++ b/version.json
@@ -4,7 +4,7 @@
     "annotated git tag without the leading 'v'.",
     "This value gets updated automatically by `scripts/prepare-release`."
   ],
-  "tenzir-version": "4.17.2",
+  "tenzir-version": "4.17.3",
   "tenzir-partition-version_COMMENT": [
     "The partition version. This number must be bumped alongside the release",
     "version for releases that contain major format changes to the on-disk",

--- a/web/versioned_docs/version-v4.17/operators/partitions.md
+++ b/web/versioned_docs/version-v4.17/operators/partitions.md
@@ -1,0 +1,82 @@
+---
+sidebar_custom_props:
+  operator:
+    source: true
+---
+
+# partitions
+
+Retrieves metadata about events stored at a node.
+
+## Synopsis
+
+```
+partitions [<expr>]
+```
+
+## Description
+
+The `partitions` operator shows a summary of candidate partitions at a node.
+
+### `<expr>`
+
+Show only partitions which would be considered for pipelines of the form
+`export | where <expr>` instead of returning all data.
+
+## Schemas
+
+Tenzir emits partition information with the following schema:
+
+### `tenzir.partition`
+
+Contains detailed information about a partition.
+
+|Field|Type|Description|
+|:-|:-|:-|
+|`uuid`|`string`|The unique ID of the partition in the UUIDv4 format.|
+|`memusage`|`uint64`|The memory usage of the partition in bytes.|
+|`diskusage`|`uint64`|The disk usage of the partition in bytes.|
+|`events`|`uint64`|The number of events contained in the partition.|
+|`min_import_time`|`time`|The time at which the first event of the partition arrived at the `import` operator.|
+|`max_import_time`|`time`|The time at which the last event of the partition arrived at the `import` operator.|
+|`version`|`uint64`|The version number of the internal partition storage format.|
+|`schema`|`string`|The schema name of the events contained in the partition.|
+|`schema_id`|`string`|A unique identifier for the physical layout of the partition.|
+|`store`|`record`|Resource information about the partition's store.|
+|`indexes`|`record`|Resource information about the partition's indexes.|
+|`sketches`|`record`|Resource information about the partition's sketches.|
+
+The records `store`, `indexes`, and `sketches` have the following schema:
+
+|Field|Type|Description|
+|:-|:-|:-|
+|`url`|`string`|The URL of the resource.|
+|`size`|`uint64`|The size of the resource.|
+
+## Examples
+
+Get an overview of the memory and disk requirements for all stored data sorted
+by schema:
+
+```
+partitions
+| summarize events=sum(events),
+            diskusage=sum(diskusage),
+            memusage=sum(memusage)
+  by schema
+| sort schema
+```
+
+Get an upper bound for the number of events that could contain the IP address
+127.0.0.1:
+
+```
+partitions :ip == 127.0.0.1
+| summarize candidates=sum(events)
+```
+
+See how many partitions contain a non-null value for the field `hostname`:
+
+```
+partitions hostname != null
+```

--- a/web/versioned_docs/version-v4.17/operators/show.md
+++ b/web/versioned_docs/version-v4.17/operators/show.md
@@ -30,7 +30,6 @@ Available aspects:
 - `contexts`: shows all available contexts.
 - `formats`: shows all available [formats](../formats.md).
 - `operators`: shows all available [operators](../operators.md).
-- `partitions`: shows all table partitions of a remote node.
 - `pipelines`: shows all managed pipelines of a remote node.
 - `plugins`: shows all loaded plugins.
 
@@ -61,11 +60,10 @@ Show all transformations:
 show operators | where transformation == true
 ```
 
-Show all fields and partitions at a node:
+Show all fields at a node:
 
 ```
 show fields
-show partitions
 ```
 
 Show all aspects of a node:


### PR DESCRIPTION
This commit was created with `/scripts/prepare-release`.

Here is a high-level summary of the changes:

* Updated `/version.json` to `v4.17.3`.
* Generated a new entry in the docs version selector list.
* Removed the docs for the previous release candidate.
* Moved all changelog entries from `/changelog/next` to `/changelog/v4.17.3`.
* Updated the python bindings version in `/python/pyproject.toml` to `v4.17.3`.