### PR TITLE
Fix two concurrency issues related to child process creation

### DIFF
--- a/changelog/next/bug-fixes/4333--fix-bad-file-descriptor-in-python-operator.md
+++ b/changelog/next/bug-fixes/4333--fix-bad-file-descriptor-in-python-operator.md
@@ -1,0 +1,2 @@
+We fixed a bug that caused a "Bad file descriptor" error from the python
+operator, when multiple instances of it were started simultaneously.

--- a/libtenzir/builtins/operators/python.cpp
+++ b/libtenzir/builtins/operators/python.cpp
@@ -242,7 +242,7 @@ public:
           if (bp::system(python_executable, "-m", "venv", venv,
                          bp::std_err > std_err,
                          detail::preserved_fds{{STDERR_FILENO}},
-                         boost::process::limit_handles)
+                         bp::detail::limit_handles_{})
               != 0) {
             auto venv_error = drain_pipe(std_err);
             // We need to delete the potentially broken venv here to make sure
@@ -286,7 +286,7 @@ public:
                          fmt::join(pip_invocation, "' '"));
           if (bp::system(pip_invocation, env, bp::std_err > std_err,
                          detail::preserved_fds{{STDOUT_FILENO, STDERR_FILENO}},
-                         boost::process::limit_handles)
+                         bp::detail::limit_handles_{})
               != 0) {
             auto pip_error = drain_pipe(std_err);
             diagnostic::error("{}", pip_error)
@@ -316,7 +316,7 @@ public:
         detail::preserved_fds{{STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO,
                                codepipe.pipe().native_source(),
                                errpipe.pipe().native_sink()}},
-        boost::process::limit_handles};
+        bp::detail::limit_handles_{}};
       if (code.empty()) {
         // The current implementation always expects a non-empty input.
         // Otherwise, it blocks forever on a `read` call.

--- a/libtenzir/builtins/operators/python.cpp
+++ b/libtenzir/builtins/operators/python.cpp
@@ -178,7 +178,7 @@ public:
       bp::pipe std_in;
       bp::ipstream std_err;
       auto python_executable = bp::search_path("python3");
-      auto env = boost::this_process::environment();
+      auto env = bp::environment{boost::this_process::environment()};
       // Automatically create a virtualenv with all requirements preinstalled,
       // unless disabled by node config.
       if (config_.venv_base_dir) {

--- a/libtenzir/builtins/operators/python.cpp
+++ b/libtenzir/builtins/operators/python.cpp
@@ -332,8 +332,7 @@ public:
           auto python_error = drain_pipe(errpipe);
           diagnostic::error("{}", python_error)
             .note("python process exited with error")
-            .emit(ctrl.diagnostics());
-          co_return;
+            .throw_();
         }
         if (slice.rows() == 0) {
           co_yield {};

--- a/libtenzir/builtins/operators/shell.cpp
+++ b/libtenzir/builtins/operators/shell.cpp
@@ -60,7 +60,7 @@ public:
             bp::std_in < bp::close,
             bp::on_exit(exit_handler),
             detail::preserved_fds{{STDOUT_FILENO, STDERR_FILENO}},
-            boost::process::limit_handles,
+            bp::detail::limit_handles_{},
           };
           break;
         case stdin_mode::inherit:
@@ -71,7 +71,7 @@ public:
             bp::std_out > result.stdout_,
             bp::on_exit(exit_handler),
             detail::preserved_fds{{STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO}},
-            boost::process::limit_handles,
+            bp::detail::limit_handles_{},
           };
           break;
         case stdin_mode::pipe:
@@ -83,7 +83,7 @@ public:
             bp::std_in < result.stdin_,
             bp::on_exit(exit_handler),
             detail::preserved_fds{{STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO}},
-            boost::process::limit_handles,
+            bp::detail::limit_handles_{},
           };
           break;
       }


### PR DESCRIPTION
This fixes "Bad file descriptor" errors from the python operator and shell operators.
Additionally, a thread-safety issue in the python operators environment cloning routine is worked around.