### PR TITLE
Remove the zero-size check in the split_at_null() input loop

### DIFF
--- a/changelog/next/bug-fixes/4341--gelf-parser-splitting.md
+++ b/changelog/next/bug-fixes/4341--gelf-parser-splitting.md
@@ -1,0 +1,2 @@
+We fixed a rarely occurring issue in the `gelf` parser that led to parsing
+errors for some events.

--- a/libtenzir/builtins/formats/json.cpp
+++ b/libtenzir/builtins/formats/json.cpp
@@ -107,9 +107,6 @@ inline auto split_at_null(generator<chunk_ptr> input, char split)
         continue;
       }
       const auto size = static_cast<size_t>(current - begin);
-      if (size == 0) {
-        continue;
-      }
       const auto capacity = static_cast<size_t>(end - begin);
       if (buffer.empty() and capacity >= size + simdjson::SIMDJSON_PADDING) {
         co_yield simdjson::padded_string_view{begin, size, capacity};


### PR DESCRIPTION
The zero-size check in the `split_at_null()` input loop was causing the loop to invalidate chunks if the first character was a null character. This is easily triggerable by using the `gelf` parser on `gralog` data. The NDJSON events are separated by null characters, and the parser was ignoring events if such an invalidation occured.
