### PR TITLE
Fix possible crash when one of multiple subscribers disconnects

### DIFF
--- a/changelog/next/bug-fixes/4346--subscriber-crash.md
+++ b/changelog/next/bug-fixes/4346--subscriber-crash.md
@@ -1,0 +1,3 @@
+We fixed a rare crash when one of multiple `subscribe` operators for the same
+topic disconnected while at least one of the other subscribers was overwhelmed
+and asked for corresponding publishers to throttle.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "3a24cbad32665620d078a12599da1e2ba0520e00",
+  "rev": "5220ebb23c9872e355917f445f01b23d72230f5b",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
This fixes a very rare crash in the node through an assertion failure when in an SPMC or MPMC setup one of multiple subscribers to the same topic disconnects, where other subscribers were sent the next batch of events without waiting for them to acknowledge the previous batch.

Fixes tenzir/issues#1941