### PR TITLE
Refactor TQLv2 execution and expose `parse_and_compile`

### DIFF
--- a/libtenzir/builtins/commands/exec.cpp
+++ b/libtenzir/builtins/commands/exec.cpp
@@ -31,8 +31,7 @@ void dump_diagnostics_to_stdout(std::span<const diagnostic> diagnostics,
 
 auto exec_command_impl(std::string content, diagnostic_handler& dh,
                        const exec_config& cfg, caf::actor_system& sys) -> bool {
-  auto result = exec_pipeline(
-    std::move(content), std::make_unique<diagnostic_handler_ref>(dh), cfg, sys);
+  auto result = exec_pipeline(std::move(content), dh, cfg, sys);
   if (result) {
     return true;
   }

--- a/libtenzir/include/tenzir/exec_pipeline.hpp
+++ b/libtenzir/include/tenzir/exec_pipeline.hpp
@@ -24,12 +24,11 @@ struct exec_config {
   bool tql2 = false;
 };
 
-auto exec_pipeline(std::string content,
-                   std::unique_ptr<diagnostic_handler> diag,
+auto exec_pipeline(std::string content, diagnostic_handler& dh,
                    const exec_config& cfg, caf::actor_system& sys)
   -> caf::expected<void>;
 
-auto exec_pipeline(pipeline pipe, std::unique_ptr<diagnostic_handler> diag,
+auto exec_pipeline(pipeline pipe, diagnostic_handler& dh,
                    const exec_config& cfg, caf::actor_system& sys)
   -> caf::expected<void>;
 

--- a/libtenzir/include/tenzir/tql2/exec.hpp
+++ b/libtenzir/include/tenzir/tql2/exec.hpp
@@ -14,9 +14,12 @@
 
 namespace tenzir {
 
-auto exec2(std::string content, std::unique_ptr<diagnostic_handler> diag,
+auto exec2(std::string_view source, diagnostic_handler& dh,
            const exec_config& cfg, caf::actor_system& sys) -> bool;
 
-auto prepare_pipeline(ast::pipeline&& pipe, session ctx) -> tenzir::pipeline;
+auto compile(ast::pipeline&& pipe, session ctx) -> failure_or<pipeline>;
+
+auto parse_and_compile(std::string_view source, session ctx)
+  -> failure_or<pipeline>;
 
 } // namespace tenzir

--- a/libtenzir/include/tenzir/tql2/parser.hpp
+++ b/libtenzir/include/tenzir/tql2/parser.hpp
@@ -15,6 +15,6 @@
 namespace tenzir {
 
 auto parse(std::span<token> tokens, std::string_view source,
-           diagnostic_handler& diag) -> ast::pipeline;
+           diagnostic_handler& diag) -> failure_or<ast::pipeline>;
 
 } // namespace tenzir

--- a/libtenzir/include/tenzir/tql2/resolve.hpp
+++ b/libtenzir/include/tenzir/tql2/resolve.hpp
@@ -13,6 +13,6 @@
 
 namespace tenzir {
 
-void resolve_entities(ast::pipeline& pipe, session ctx);
+auto resolve_entities(ast::pipeline& pipe, session ctx) -> failure_or<void>;
 
 } // namespace tenzir

--- a/libtenzir/include/tenzir/tql2/tokens.hpp
+++ b/libtenzir/include/tenzir/tql2/tokens.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "tenzir/detail/enum.hpp"
+#include "tenzir/diagnostics.hpp"
 
 #include <string_view>
 
@@ -47,6 +48,15 @@ struct token {
   size_t end;
 };
 
-auto tokenize(std::string_view content) -> std::vector<token>;
+/// Try to tokenize the source.
+auto tokenize(std::string_view content, session ctx)
+  -> failure_or<std::vector<token>>;
+
+/// Tokenize without emitting errors for error tokens.
+auto tokenize_permissive(std::string_view content) -> std::vector<token>;
+
+/// Emit errors for error tokens.
+auto verify_tokens(std::span<token const> tokens, session ctx)
+  -> failure_or<void>;
 
 } // namespace tenzir

--- a/libtenzir/include/tenzir/try.hpp
+++ b/libtenzir/include/tenzir/try.hpp
@@ -111,10 +111,11 @@ struct tenzir::tryable<tenzir::variant<V, E>> {
   decl = tenzir::tryable<decltype(var)>::get_success(std::move(var))
 
 #define TENZIR_TRY_DISCARD(var, expr)                                          \
+  TENZIR_TRY_COMMON(var, expr)                                                 \
   if (false) {                                                                 \
-    (expr); /* trigger [[nodiscard]] */                                        \
-  }                                                                            \
-  TENZIR_TRY_COMMON(var, expr)
+    /* trigger [[nodiscard]] */                                                \
+    tenzir::tryable<decltype(var)>::get_success(std::move(var));               \
+  }
 
 #define TENZIR_TRY_1(expr)                                                     \
   TENZIR_TRY_DISCARD(TENZIR_PP_PASTE2(_try, __COUNTER__), expr)

--- a/libtenzir/src/argument_parser2.cpp
+++ b/libtenzir/src/argument_parser2.cpp
@@ -133,8 +133,12 @@ auto argument_parser2::parse(const ast::entity& self,
             diagnostic::error("expected a pipeline expression").primary(expr));
           return;
         }
-        auto pipe = prepare_pipeline(std::move(pipe_expr->inner), ctx);
-        set(located{std::move(pipe), expr.get_location()});
+        auto pipe = compile(std::move(pipe_expr->inner), ctx);
+        if (pipe.is_error()) {
+          success = false;
+          return;
+        }
+        set(located{std::move(pipe).unwrap(), expr.get_location()});
       });
     ++arg;
   }
@@ -184,8 +188,12 @@ auto argument_parser2::parse(const ast::entity& self,
             diagnostic::error("expected a pipeline expression").primary(expr));
           return;
         }
-        auto pipe = prepare_pipeline(std::move(pipe_expr->inner), ctx);
-        set(located{std::move(pipe), expr.get_location()});
+        auto pipe = compile(std::move(pipe_expr->inner), ctx);
+        if (pipe.is_error()) {
+          success = false;
+          return;
+        }
+        set(located{std::move(pipe).unwrap(), expr.get_location()});
       });
   }
   return success;

--- a/libtenzir/src/tql2/parser.cpp
+++ b/libtenzir/src/tql2/parser.cpp
@@ -65,7 +65,8 @@ public:
   using tk = token_kind;
 
   static auto parse_file(std::span<token> tokens, std::string_view source,
-                         diagnostic_handler& diag) -> ast::pipeline {
+                         diagnostic_handler& diag)
+    -> failure_or<ast::pipeline> {
     try {
       auto self = parser{tokens, source, diag};
       auto pipe = self.parse_pipeline();
@@ -74,8 +75,9 @@ public:
       }
       return pipe;
     } catch (diagnostic& d) {
+      TENZIR_ASSERT(d.severity == severity::error);
       diag.emit(std::move(d));
-      return ast::pipeline{{}};
+      return failure::promise();
     }
   }
 
@@ -929,7 +931,7 @@ private:
 } // namespace
 
 auto parse(std::span<token> tokens, std::string_view source,
-           diagnostic_handler& diag) -> ast::pipeline {
+           diagnostic_handler& diag) -> failure_or<ast::pipeline> {
   return parser::parse_file(tokens, source, diag);
 }
 

--- a/tenzir/integration/data/reference/lexer/test_invalid_utf-2d8/step_00.ref
+++ b/tenzir/integration/data/reference/lexer/test_invalid_utf-2d8/step_00.ref
@@ -1,6 +1,1 @@
-error: invalid UTF8
- --> /dev/stdin:1:1
-  |
-1 | "aÿb" + 42
-  | ^^^^^ 
-  |
+error: found invalid UTF8


### PR DESCRIPTION
This PR improves multiple APIs with a new `failure_or<T>` return value (that returns a `failure` when a `diagnostic::error` was emitted) and uses this to refactor quite a few functions. It also exposes a `parse_and_compile` function for a follow-up PR that will be used to integrate TQLv2 into the pipeline manager. 