### PR TITLE
Push expressions into `subscribe` for better metrics

### DIFF
--- a/changelog/next/bug-fixes/4349--export-live-where.md
+++ b/changelog/next/bug-fixes/4349--export-live-where.md
@@ -1,0 +1,2 @@
+Pipelines of the form `export --live | where <expr>` failed to filter with
+type extractors or concepts. This now works as expected.

--- a/changelog/next/changes/4349--subscribe-metrics.md
+++ b/changelog/next/changes/4349--subscribe-metrics.md
@@ -1,0 +1,2 @@
+Pipeline activity for pipelines starting with `subscribe | where <expr>` will no
+longer report ingress that does not match the provided filter expression.

--- a/libtenzir/builtins/operators/export.cpp
+++ b/libtenzir/builtins/operators/export.cpp
@@ -54,7 +54,12 @@ caf::behavior make_bridge(caf::stateful_actor<bridge_state>* self,
           });
   return {
     [self](table_slice slice) {
-      auto filtered = filter(std::move(slice), self->state.expr);
+      auto bound_expr = tailor(self->state.expr, slice.schema());
+      if (not bound_expr) {
+        // failing to bind is not an error.
+        return;
+      }
+      auto filtered = filter(std::move(slice), *bound_expr);
       if (not filtered) {
         return;
       }

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "93e5ffe5b63cc8892ef14eafa202d6601b67c5dd",
+  "rev": "83dcc1a3c83ebf531275b3d0a80cb219e02a49f8",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
… and a small bug fix for `export --live | where … ` when using type extractors or concepts.