### PR TITLE
Ensure plugins are always in the right order

### DIFF
--- a/libtenzir/builtins/connectors/s3.cpp
+++ b/libtenzir/builtins/connectors/s3.cpp
@@ -248,6 +248,11 @@ private:
 class plugin final : public virtual loader_plugin<s3_loader>,
                      public virtual saver_plugin<s3_saver> {
 public:
+  ~plugin() noexcept override {
+    const auto finalized = arrow::fs::FinalizeS3();
+    TENZIR_ASSERT(finalized.ok(), finalized.ToString().c_str());
+  }
+
   auto initialize(const record& plugin_config, const record& global_config)
     -> caf::error override {
     (void)global_config;
@@ -287,14 +292,6 @@ public:
         .to_error();
     }
     return {};
-  }
-
-  virtual auto deinitialize() -> void override {
-    auto finalized = arrow::fs::FinalizeS3();
-    if (not finalized.ok()) {
-      TENZIR_ERROR("failed to close Arrow S3 filesystem: {}",
-                   finalized.ToString());
-    }
   }
 
   auto parse_loader(parser_interface& p) const

--- a/libtenzir/include/tenzir/plugin.hpp
+++ b/libtenzir/include/tenzir/plugin.hpp
@@ -1066,13 +1066,16 @@ extern const char* TENZIR_PLUGIN_VERSION;
       }                                                                        \
       static auto init() -> bool {                                             \
         /* NOLINTBEGIN(cppcoreguidelines-owning-memory) */                     \
-        ::tenzir::plugins::get_mutable().push_back(TENZIR_MAKE_PLUGIN(         \
+        auto plugin = TENZIR_MAKE_PLUGIN(                                      \
           new __VA_ARGS__,                                                     \
           +[](::tenzir::plugin* plugin) noexcept {                             \
             delete plugin;                                                     \
           },                                                                   \
-          TENZIR_PLUGIN_VERSION));                                             \
+          TENZIR_PLUGIN_VERSION);                                              \
         /* NOLINTEND(cppcoreguidelines-owning-memory) */                       \
+        const auto it = std::ranges::upper_bound(                              \
+          ::tenzir::plugins::get_mutable(), plugin);                           \
+        ::tenzir::plugins::get_mutable().insert(it, std::move(plugin));        \
         return true;                                                           \
       }                                                                        \
       inline static auto flag = init();                                        \

--- a/libtenzir/include/tenzir/plugin.hpp
+++ b/libtenzir/include/tenzir/plugin.hpp
@@ -129,10 +129,6 @@ public:
     return {};
   }
 
-  // Deinitializes a plugin.
-  virtual auto deinitialize() -> void {
-  }
-
   /// Returns the unique name of the plugin.
   [[nodiscard]] virtual std::string name() const = 0;
 };

--- a/libtenzir_test/src/main.cpp
+++ b/libtenzir_test/src/main.cpp
@@ -86,14 +86,7 @@ int main(int argc, char** argv) {
 
   // Make sure to deinitialize all plugins at the end.
   auto plugin_guard = caf::detail::make_scope_guard([]() noexcept {
-    // Ideally, we would not have this deinitialize function at all and could
-    // just call `plugins::get_mutable().clear()`, but that has a race condition
-    // in that some detached actors may still be alive that are owned by
-    // plugins, which then often dereference a nullptr through the global actor
-    // system config.
-    for (auto& plugin : tenzir::plugins::get_mutable()) {
-      plugin->deinitialize();
-    }
+    tenzir::plugins::get_mutable().clear();
   });
   caf::settings log_settings;
   put(log_settings, "tenzir.console-verbosity", tenzir_loglevel);

--- a/plugins/zmq/src/plugin.cpp
+++ b/plugins/zmq/src/plugin.cpp
@@ -479,15 +479,15 @@ private:
 class plugin final : public virtual loader_plugin<zmq_loader>,
                      public virtual saver_plugin<zmq_saver> {
 public:
+  ~plugin() noexcept override {
+    // Destroy the singleton.
+    context.reset();
+  }
+
   auto initialize(const record&, const record&) -> caf::error override {
     // Create the singleton.
     context = std::make_shared<::zmq::context_t>();
     return {};
-  }
-
-  auto deinitialize() -> void override {
-    // Destroy the singleton.
-    context.reset();
   }
 
   auto parse_loader(parser_interface& p) const

--- a/tenzir/tenzir.cpp
+++ b/tenzir/tenzir.cpp
@@ -83,6 +83,12 @@ auto main(int argc, char** argv) -> int {
                           ? app_path
                           : app_path.substr(last_slash + 1);
   bool is_server = (app_name == "tenzir-node");
+  // Make sure to deinitialize all plugins at the end. This has to be done
+  // before we create the log context, as that must be cleared before we clear
+  // the plugins.
+  auto plugin_guard = caf::detail::make_scope_guard([&]() noexcept {
+    plugins::get_mutable().clear();
+  });
   // Create log context as soon as we know the correct configuration.
   auto log_context = create_log_context(is_server, *invocation, cfg.content);
   if (!log_context)
@@ -95,17 +101,6 @@ auto main(int argc, char** argv) -> int {
   // Print the plugins that were loaded, and errors that occured during loading.
   for (const auto& file : *loaded_plugin_paths)
     TENZIR_DEBUG("loaded plugin: {}", file);
-  // Make sure to deinitialize all plugins at the end.
-  auto plugin_guard = caf::detail::make_scope_guard([]() noexcept {
-    // Ideally, we would not have this deinitialize function at all and could
-    // just call `plugins::get_mutable().clear()`, but that has a race condition
-    // in that some detached actors may still be alive that are owned by
-    // plugins, which then often dereference a nullptr through the global actor
-    // system config.
-    for (auto& plugin : plugins::get_mutable()) {
-      plugin->deinitialize();
-    }
-  });
   // Initialize successfully loaded plugins.
   if (auto err = plugins::initialize(cfg)) {
     TENZIR_ERROR("failed to initialize plugins: {}", err);


### PR DESCRIPTION
This fixes a rather obscure bug that I've been trying to hunt down for quite some time, where some plugins are not stored sorted by name. Turns out this was only happening for builtins and depended on the order of static initialization. Plugins may bundle further builtins, which then get added once the plugin is loaded.

This also removes `plugin::deinitialize()`—I finally figured out what the issue was.