### PR TITLE
Always render the source location for panics

### DIFF
--- a/libtenzir/include/tenzir/detail/assert.hpp
+++ b/libtenzir/include/tenzir/detail/assert.hpp
@@ -17,13 +17,15 @@
 
 namespace tenzir::detail {
 
-[[noreturn]] void panic(std::string message);
+[[noreturn]] void
+panic_impl(std::string message, std::source_location source
+                                = std::source_location::current());
 
 template <class... Ts>
-  requires(sizeof...(Ts) > 0)
 [[noreturn]] TENZIR_NO_INLINE void
-panic(fmt::format_string<Ts...> str, Ts&&... xs) {
-  panic(fmt::format(str, std::forward<Ts>(xs)...));
+panic(fmt::format_string<Ts...> str, Ts&&... xs,
+      std::source_location source = std::source_location::current()) {
+  panic_impl(fmt::format(str, std::forward<Ts>(xs)...), source);
 }
 
 [[noreturn]] void

--- a/libtenzir/include/tenzir/detail/narrow.hpp
+++ b/libtenzir/include/tenzir/detail/narrow.hpp
@@ -44,8 +44,8 @@ auto narrow(U y, std::source_location source = std::source_location::current())
   T x = narrow_cast<T>(y);
   if (static_cast<U>(x) != y
       && (is_same_signedness<T, U>::value || (x < T{}) != (y < U{}))) {
-    detail::panic("cannot narrow {} to {} @ {}:{}", y, typeid(T).name(),
-                  source.file_name(), source.line());
+    detail::panic_impl(
+      fmt::format("cannot narrow {} to {}", y, typeid(T).name()), source);
   }
   return x;
 }

--- a/libtenzir/src/detail/assert.cpp
+++ b/libtenzir/src/detail/assert.cpp
@@ -17,13 +17,14 @@
 
 namespace tenzir::detail {
 
-void panic(std::string message) {
+void panic_impl(std::string message, std::source_location source) {
   // TODO: Ideally, we would capture a stacktrace here and print it after some
   // post-processing, potentially only after being caught. The exception type
   // should be change to a special panic exception.
   backtrace();
   TENZIR_ERROR("panic: {}", message);
   TENZIR_ERROR("version: {}", version::version);
+  TENZIR_ERROR("source: {}:{}", source.file_name(), source.line());
   TENZIR_ERROR("this is a bug, we would appreciate a report - thank you!");
   // TODO: Consider making this available through the normal configuration
   // mechanism.
@@ -33,6 +34,7 @@ void panic(std::string message) {
     std::this_thread::sleep_for(std::chrono::milliseconds{100});
     std::_Exit(1);
   }
+  message += fmt::format(" @ {}:{}", source.file_name(), source.line());
   throw std::runtime_error(message);
 }
 
@@ -45,7 +47,7 @@ fail_assertion_impl(const char* expr, std::string_view explanation,
     message += explanation;
   }
   message += fmt::format(" @ {}:{}", source.file_name(), source.line());
-  panic(std::move(message));
+  panic_impl(std::move(message), source);
 }
 
 } // namespace tenzir::detail


### PR DESCRIPTION
Before:

```
error: todo
 = note: unhandled exception in exec-node tql2.summarize
```

After:

```
error: todo @ /__w/tenzir/libtenzir/builtins/functions/numeric.cpp:266
 = note: unhandled exception in exec-node tql2.summarize
```