### PR TITLE
Reduce load in `metrics --live` and `diagnostics --live`

### DIFF
--- a/libtenzir/include/tenzir/actors.hpp
+++ b/libtenzir/include/tenzir/actors.hpp
@@ -228,7 +228,8 @@ using importer_actor = typed_actor_fwd<
   // Register a FLUSH LISTENER actor.
   auto(atom::subscribe, atom::flush, flush_listener_actor)->caf::result<void>,
   // Register a subscriber for table slices.
-  auto(atom::subscribe, receiver_actor<table_slice>)->caf::result<void>,
+  auto(atom::subscribe, receiver_actor<table_slice>, bool internal)
+    ->caf::result<void>,
   // Push buffered slices downstream to make the data available.
   auto(atom::flush)->caf::result<void>,
   // Import a batch of data.

--- a/libtenzir/include/tenzir/importer.hpp
+++ b/libtenzir/include/tenzir/importer.hpp
@@ -88,7 +88,8 @@ struct importer_state {
   accountant_actor accountant;
 
   /// A list of subscribers for incoming events.
-  std::vector<receiver_actor<table_slice>> subscribers = {};
+  std::vector<std::pair<receiver_actor<table_slice>, bool /*internal*/>>
+    subscribers = {};
 
   /// Name of this actor in log events.
   static inline const char* name = "importer";


### PR DESCRIPTION
Before this change, `export --internal --live` (which backs `metrics --live` and `diagnostics --live`) received all imported events, not just internal events. This change makes it so that this the internal attribute is evaluated earlier.

To get a good feel of the reduction, use the following pipelines:

```
export --live
| summarize eps=count(.) timeout 1s
| summarize mean(eps) timeout 1m
```

```
export --live --internal
| summarize eps=count(.) timeout 1s
| summarize mean(eps) timeout 1m
```

Previously, the `export` operators needed to evaluate the sum of the events coming in, now they don't anymore.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made in the pull request description in a way that
   is consumable by everyone, not just developers who know the context of the
   change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://docs.tenzir.com/next/contribute/changelog
3. Provide instructions for the reviewer.
4. Remove this comment so it doesn't show up in the merge commit.
-->
