### PR TITLE
Tie pipeline autocreation & autodeletion to the hidden flag

### DIFF
--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "9657c308985ca38891450bc704a3af8ddc5f21a1",
+  "rev": "12e905387cd650e8aae5bf25aa54656b94bd61f2",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/web/openapi/openapi.yaml
+++ b/web/openapi/openapi.yaml
@@ -38,7 +38,7 @@ components:
           example: zeek-monitoring-pipeline
         hidden:
           type: boolean
-          description: "A flag specifying whether this pipeline is hidden.\nHidden pipelines are not persisted and will not show up in the /pipeline/list endpoint response.\n"
+          description: "A flag specifying whether this pipeline is hidden.\nHidden pipelines start automatically, are not persisted, and will not show up in the /pipeline/list endpoint response.\n"
           default: false
           example: false
         ttl:


### PR DESCRIPTION
This change tightens the enforcement of requirements for `hidden` pipelines. They must always start automatically, and autodelete in all stopping cases. Instead of making the user enforce that (and even missing an enforcement for `autodeletion` flags), we simply overwrite the flags in the request.
