### PR TITLE
Add an experimental mechanism for inspecting min-max sketches

### DIFF
--- a/libtenzir/builtins/operators/partitions.cpp
+++ b/libtenzir/builtins/operators/partitions.cpp
@@ -9,11 +9,16 @@
 #include <tenzir/actors.hpp>
 #include <tenzir/argument_parser.hpp>
 #include <tenzir/catalog.hpp>
+#include <tenzir/double_synopsis.hpp>
+#include <tenzir/duration_synopsis.hpp>
+#include <tenzir/int64_synopsis.hpp>
 #include <tenzir/node_control.hpp>
 #include <tenzir/partition_synopsis.hpp>
 #include <tenzir/plugin.hpp>
 #include <tenzir/series_builder.hpp>
 #include <tenzir/si_literals.hpp>
+#include <tenzir/time_synopsis.hpp>
+#include <tenzir/uint64_synopsis.hpp>
 
 #include <caf/scoped_actor.hpp>
 
@@ -24,7 +29,10 @@ namespace {
 class partitions_operator final : public crtp_operator<partitions_operator> {
 public:
   partitions_operator() = default;
-  explicit partitions_operator(expression filter) : filter_{std::move(filter)} {
+  explicit partitions_operator(expression filter,
+                               bool experimental_include_ranges)
+    : filter_{std::move(filter)},
+      experimental_include_ranges_{experimental_include_ranges} {
   }
 
   auto operator()(operator_control_plane& ctrl) const
@@ -58,11 +66,10 @@ public:
             .emit(ctrl.diagnostics());
         });
     co_yield {};
-    auto builder = series_builder{};
+    auto builders = std::unordered_map<type, series_builder>{};
     using namespace tenzir::si_literals;
-    constexpr auto max_rows = size_t{8_Ki};
-    for (auto i = 0u; i < synopses.size(); ++i) {
-      auto& synopsis = synopses[i];
+    for (auto& synopsis : synopses) {
+      auto& builder = builders[synopsis.synopsis->schema];
       auto event = builder.record();
       event.field("uuid").data(fmt::to_string(synopsis.uuid));
       event.field("memusage").data(synopsis.synopsis->memusage());
@@ -87,15 +94,53 @@ public:
       add_resource("store", synopsis.synopsis->store_file);
       add_resource("indexes", synopsis.synopsis->indexes_file);
       add_resource("sketches", synopsis.synopsis->sketches_file);
-      if ((i + 1) % max_rows == 0) {
-        for (auto&& result :
-             builder.finish_as_table_slice("tenzir.partition")) {
-          co_yield std::move(result);
+      if (experimental_include_ranges_) {
+        auto ranges = event.field("ranges").record();
+#define X(name)                                                                \
+  do {                                                                         \
+    auto entry = ranges.field(#name).record();                                 \
+    const auto it                                                              \
+      = synopsis.synopsis->type_synopses_.find(type{name##_type{}});           \
+    if (it == synopsis.synopsis->type_synopses_.end()) {                       \
+      entry.field("min").null();                                               \
+      entry.field("max").null();                                               \
+    } else {                                                                   \
+      const auto* syn                                                          \
+        = dynamic_cast<const name##_synopsis*>(it->second.get());              \
+      TENZIR_ASSERT(syn);                                                      \
+      entry.field("min").data(syn->min());                                     \
+      entry.field("max").data(syn->max());                                     \
+    }                                                                          \
+  } while (0)
+        X(time);
+        X(duration);
+        X(uint64);
+        X(int64);
+        X(double);
+#undef X
+        auto fields = ranges.field("fields").record();
+        for (const auto& [qf, synopsis] : synopsis.synopsis->field_synopses_) {
+#define X(name)                                                                \
+  if (const auto* syn                                                          \
+      = dynamic_cast<const name##_synopsis*>(synopsis.get())) {                \
+    auto entry = fields.field(qf.field_name()).record();                       \
+    entry.field("min").data(syn->min());                                       \
+    entry.field("max").data(syn->max());                                       \
+    continue;                                                                  \
+  }
+          X(time);
+          X(duration);
+          X(uint64);
+          X(int64);
+          X(double);
+#undef X
         }
       }
     }
-    for (auto&& result : builder.finish_as_table_slice("tenzir.partition")) {
-      co_yield std::move(result);
+    for (auto& [_, builder] : builders) {
+      for (auto&& result : builder.finish_as_table_slice("tenzir.partition")) {
+        co_yield std::move(result);
+      }
     }
   }
 
@@ -121,11 +166,14 @@ public:
   friend auto inspect(auto& f, partitions_operator& x) -> bool {
     return f.object(x)
       .pretty_name("tenzir.plugins.partitions.partitions_operator")
-      .fields(f.field("filter", x.filter_));
+      .fields(f.field("filter", x.filter_),
+              f.field("experimental_include_ranges",
+                      x.experimental_include_ranges_));
   }
 
 private:
   expression filter_ = trivially_true_expression();
+  bool experimental_include_ranges_ = {};
 };
 
 class plugin final : public virtual operator_plugin<partitions_operator> {
@@ -144,10 +192,18 @@ public:
       "https://docs.tenzir.com/operators/partitions",
     };
     auto expr = std::optional<located<tenzir::expression>>{};
+    auto experimental_include_ranges = std::optional<location>{};
     parser.add(expr, "<expr>");
+    // This option is a temporary workaround to allow for inspecting the min and
+    // max time values of partitions in setups where these values differ from
+    // the import timestamps. A proper solution for this should be implemented
+    // as a standalone operator that takes a field or type extractor and returns
+    // indexes relevant for it.
+    parser.add("--experimental-include-ranges", experimental_include_ranges);
     parser.parse(p);
     if (not expr) {
-      return std::make_unique<partitions_operator>();
+      return std::make_unique<partitions_operator>(
+        trivially_true_expression(), experimental_include_ranges.has_value());
     }
     auto normalized_and_validated = normalize_and_validate(expr->inner);
     if (!normalized_and_validated) {
@@ -157,7 +213,8 @@ public:
         .throw_();
     }
     expr->inner = std::move(*normalized_and_validated);
-    return std::make_unique<partitions_operator>(std::move(expr->inner));
+    return std::make_unique<partitions_operator>(
+      std::move(expr->inner), experimental_include_ranges.has_value());
   }
 };
 


### PR DESCRIPTION
We have a use for this in an environment where running `export | summarize min(:time), max(:time)` is too expensive. This addresses that particular need by enabling `partitions --experimental-include-ranges | summarize min(ranges.time.min), max(ranges.time.max)`.

Note that the option is intentionally undocumented and will be removed again in the future without further notice.