### PR TITLE
Improve and fix TQLv2 error propagation

### DIFF
--- a/libtenzir/builtins/connectors/file.cpp
+++ b/libtenzir/builtins/connectors/file.cpp
@@ -579,15 +579,16 @@ private:
 
 class load_file_plugin final : public operator_plugin2<load_file_operator> {
 public:
-  auto make(invocation inv, session ctx) const -> operator_ptr override {
+  auto make(invocation inv, session ctx) const
+    -> failure_or<operator_ptr> override {
     auto args = loader_args{};
     auto timeout = std::optional<located<duration>>{};
-    argument_parser2::operator_("load_file")
-      .add(args.path, "<path>")
-      .add("follow", args.follow)
-      .add("mmap", args.mmap)
-      .add("timeout", timeout)
-      .parse(inv, ctx);
+    TRY(argument_parser2::operator_("load_file")
+          .add(args.path, "<path>")
+          .add("follow", args.follow)
+          .add("mmap", args.mmap)
+          .add("timeout", timeout)
+          .parse(inv, ctx));
     if (timeout) {
       args.timeout = located{
         std::chrono::duration_cast<std::chrono::milliseconds>(timeout->inner),
@@ -642,14 +643,15 @@ private:
 
 class save_file_plugin final : public operator_plugin2<save_file_operator> {
 public:
-  auto make(invocation inv, session ctx) const -> operator_ptr override {
+  auto make(invocation inv, session ctx) const
+    -> failure_or<operator_ptr> override {
     auto args = saver_args{};
-    argument_parser2::operator_("save_file")
-      .add(args.path, "<path>")
-      .add("append", args.append)
-      .add("real_time", args.real_time)
-      .add("uds", args.uds)
-      .parse(inv, ctx);
+    TRY(argument_parser2::operator_("save_file")
+          .add(args.path, "<path>")
+          .add("append", args.append)
+          .add("real_time", args.real_time)
+          .add("uds", args.uds)
+          .parse(inv, ctx));
     return std::make_unique<save_file_operator>(std::move(args));
   }
 };

--- a/libtenzir/builtins/formats/grok.cpp
+++ b/libtenzir/builtins/formats/grok.cpp
@@ -560,19 +560,19 @@ public:
   }
 
   auto make_function(invocation inv, session ctx) const
-    -> std::unique_ptr<function_use> override {
+    -> failure_or<function_ptr> override {
     auto input = ast::expression{};
     auto pattern = std::string{};
     auto indexed_captures = false;
     auto include_unnamed = false;
     auto raw = false;
-    argument_parser2::method("grok")
-      .add(input, "<input>")
-      .add(pattern, "<pattern>")
-      .add("indexed_captures", indexed_captures)
-      .add("include_unnamed", include_unnamed)
-      .add("raw", raw)
-      .parse(inv, ctx);
+    TRY(argument_parser2::method("grok")
+          .add(input, "<input>")
+          .add(pattern, "<pattern>")
+          .add("indexed_captures", indexed_captures)
+          .add("include_unnamed", include_unnamed)
+          .add("raw", raw)
+          .parse(inv, ctx));
     auto parser = grok_parser{
       std::move(pattern),
       indexed_captures,

--- a/libtenzir/builtins/functions/int.cpp
+++ b/libtenzir/builtins/functions/int.cpp
@@ -29,11 +29,11 @@ public:
   }
 
   auto make_function(invocation inv, session ctx) const
-    -> std::unique_ptr<function_use> override {
+    -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
-    argument_parser2::function(name())
-      .add(expr, "<string|number>")
-      .parse(inv, ctx);
+    TRY(argument_parser2::function(name())
+          .add(expr, "<string|number>")
+          .parse(inv, ctx));
     return function_use::make([expr = std::move(expr),
                                this](auto eval, session ctx) -> series {
       auto value = eval(expr);

--- a/libtenzir/builtins/functions/misc.cpp
+++ b/libtenzir/builtins/functions/misc.cpp
@@ -20,9 +20,11 @@ public:
   }
 
   auto make_function(invocation inv, session ctx) const
-    -> std::unique_ptr<function_use> override {
+    -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
-    argument_parser2::function("type_id").add(expr, "<value>").parse(inv, ctx);
+    TRY(argument_parser2::function("type_id")
+          .add(expr, "<value>")
+          .parse(inv, ctx));
     return function_use::make(
       [expr = std::move(expr)](evaluator eval, session ctx) -> series {
         TENZIR_UNUSED(ctx);
@@ -47,9 +49,11 @@ public:
   }
 
   auto make_function(invocation inv, session ctx) const
-    -> std::unique_ptr<function_use> override {
+    -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
-    argument_parser2::function("secret").add(expr, "<string>").parse(inv, ctx);
+    TRY(argument_parser2::function("secret")
+          .add(expr, "<string>")
+          .parse(inv, ctx));
     return function_use::make(
       [expr = std::move(expr)](evaluator eval, session ctx) -> series {
         TENZIR_UNUSED(ctx);

--- a/libtenzir/builtins/functions/ocsf.cpp
+++ b/libtenzir/builtins/functions/ocsf.cpp
@@ -22,11 +22,11 @@ public:
   }
 
   auto make_function(invocation inv, session ctx) const
-    -> std::unique_ptr<function_use> override {
+    -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
-    argument_parser2::function("ocsf_category_uid")
-      .add(expr, "<string>")
-      .parse(inv, ctx);
+    TRY(argument_parser2::function("ocsf_category_uid")
+          .add(expr, "<string>")
+          .parse(inv, ctx));
     return function_use::make(
       [expr = std::move(expr)](evaluator eval, session ctx) -> series {
         auto arg = eval(expr);
@@ -89,11 +89,11 @@ public:
   }
 
   auto make_function(invocation inv, session ctx) const
-    -> std::unique_ptr<function_use> override {
+    -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
-    argument_parser2::function("ocsf_category_uid")
-      .add(expr, "<string>")
-      .parse(inv, ctx);
+    TRY(argument_parser2::function("ocsf_category_uid")
+          .add(expr, "<string>")
+          .parse(inv, ctx));
     return function_use::make(
       [expr = std::move(expr)](evaluator eval, session ctx) -> series {
         auto arg = eval(expr);

--- a/libtenzir/builtins/functions/path.cpp
+++ b/libtenzir/builtins/functions/path.cpp
@@ -20,9 +20,11 @@ public:
   }
 
   auto make_function(invocation inv, session ctx) const
-    -> std::unique_ptr<function_use> override {
+    -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
-    argument_parser2::function("file_name").add(expr, "<path>").parse(inv, ctx);
+    TRY(argument_parser2::function("file_name")
+          .add(expr, "<path>")
+          .parse(inv, ctx));
     return function_use::make(
       [expr = std::move(expr)](evaluator eval, session ctx) -> series {
         auto arg = eval(expr);
@@ -71,9 +73,11 @@ public:
   }
 
   auto make_function(invocation inv, session ctx) const
-    -> std::unique_ptr<function_use> override {
+    -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
-    argument_parser2::function("file_name").add(expr, "<path>").parse(inv, ctx);
+    TRY(argument_parser2::function("file_name")
+          .add(expr, "<path>")
+          .parse(inv, ctx));
     return function_use::make(
       [expr = std::move(expr)](evaluator eval, session ctx) -> series {
         auto arg = eval(expr);

--- a/libtenzir/builtins/functions/string.cpp
+++ b/libtenzir/builtins/functions/string.cpp
@@ -23,13 +23,13 @@ public:
   }
 
   auto make_function(invocation inv, session ctx) const
-    -> std::unique_ptr<function_use> override {
+    -> failure_or<function_ptr> override {
     auto subject_expr = ast::expression{};
     auto arg_expr = ast::expression{};
-    argument_parser2::method(name())
-      .add(subject_expr, "<string>")
-      .add(arg_expr, "<string>")
-      .parse(inv, ctx);
+    TRY(argument_parser2::method(name())
+          .add(subject_expr, "<string>")
+          .add(arg_expr, "<string>")
+          .parse(inv, ctx));
     // TODO: This shows the need for some abstraction.
     return function_use::make([subject_expr = std::move(subject_expr),
                                arg_expr = std::move(arg_expr),

--- a/libtenzir/builtins/functions/time.cpp
+++ b/libtenzir/builtins/functions/time.cpp
@@ -23,9 +23,10 @@ public:
   }
 
   auto make_function(invocation inv, session ctx) const
-    -> std::unique_ptr<function_use> override {
+    -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
-    argument_parser2::function("time").add(expr, "<string>").parse(inv, ctx);
+    TRY(
+      argument_parser2::function("time").add(expr, "<string>").parse(inv, ctx));
     return function_use::make(
       [expr = std::move(expr)](evaluator eval, session ctx) -> series {
         auto arg = eval(expr);
@@ -76,9 +77,9 @@ public:
   }
 
   auto make_function(invocation inv, session ctx) const
-    -> std::unique_ptr<function_use> override {
+    -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
-    argument_parser2::function(name()).add(expr, "<time>").parse(inv, ctx);
+    TRY(argument_parser2::function(name()).add(expr, "<time>").parse(inv, ctx));
     return function_use::make([expr = std::move(expr),
                                this](evaluator eval, session ctx) -> series {
       auto arg = eval(expr);
@@ -123,9 +124,11 @@ public:
   }
 
   auto make_function(invocation inv, session ctx) const
-    -> std::unique_ptr<function_use> override {
+    -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
-    argument_parser2::function(name()).add(expr, "<duration>").parse(inv, ctx);
+    TRY(argument_parser2::function(name())
+          .add(expr, "<duration>")
+          .parse(inv, ctx));
     return function_use::make(
       [expr = std::move(expr), this](evaluator eval, session ctx) -> series {
         auto arg = eval(expr);
@@ -171,8 +174,8 @@ public:
   }
 
   auto make_function(invocation inv, session ctx) const
-    -> std::unique_ptr<function_use> override {
-    argument_parser2::function("now").parse(inv, ctx);
+    -> failure_or<function_ptr> override {
+    TRY(argument_parser2::function("now").parse(inv, ctx));
     return function_use::make([](evaluator eval, session ctx) -> series {
       TENZIR_UNUSED(ctx);
       auto result = time{time::clock::now()};

--- a/libtenzir/builtins/operators/batch.cpp
+++ b/libtenzir/builtins/operators/batch.cpp
@@ -154,8 +154,9 @@ public:
       timeout ? timeout->inner : duration::max(), event_order::ordered);
   }
 
-  auto make(invocation inv, session ctx) const -> operator_ptr override {
-    argument_parser2::operator_("batch").parse(inv, ctx);
+  auto make(invocation inv, session ctx) const
+    -> failure_or<operator_ptr> override {
+    argument_parser2::operator_("batch").parse(inv, ctx).ignore();
     return std::make_unique<batch_operator>(defaults::import::table_slice_size,
                                             duration::max(),
                                             event_order::ordered);

--- a/libtenzir/builtins/operators/discard.cpp
+++ b/libtenzir/builtins/operators/discard.cpp
@@ -56,8 +56,9 @@ public:
     return std::make_unique<discard_operator>();
   }
 
-  auto make(invocation inv, session ctx) const -> operator_ptr override {
-    argument_parser2::operator_("discard").parse(inv, ctx);
+  auto make(invocation inv, session ctx) const
+    -> failure_or<operator_ptr> override {
+    argument_parser2::operator_("discard").parse(inv, ctx).ignore();
     return std::make_unique<discard_operator>();
   }
 };

--- a/libtenzir/builtins/operators/drop.cpp
+++ b/libtenzir/builtins/operators/drop.cpp
@@ -222,7 +222,9 @@ private:
 
 class plugin2 final : public virtual operator_plugin2<drop_operator2> {
 public:
-  auto make(invocation inv, session ctx) const -> operator_ptr override {
+  auto make(invocation inv, session ctx) const
+    -> failure_or<operator_ptr> override {
+    auto parser = argument_parser2::operator_("drop");
     auto selectors = std::vector<ast::simple_selector>{};
     for (auto& arg : inv.args) {
       auto selector = ast::simple_selector::try_from(arg);
@@ -232,6 +234,8 @@ public:
         // TODO: Improve error message.
         diagnostic::error("expected simple selector")
           .primary(arg)
+          .usage(parser.usage())
+          .docs(parser.docs())
           .emit(ctx.dh());
       }
     }

--- a/libtenzir/builtins/operators/export.cpp
+++ b/libtenzir/builtins/operators/export.cpp
@@ -323,7 +323,8 @@ public:
       mode, internal);
   }
 
-  auto make(invocation inv, session ctx) const -> operator_ptr override {
+  auto make(invocation inv, session ctx) const
+    -> failure_or<operator_ptr> override {
     auto live = false;
     auto retro = false;
     auto internal = false;
@@ -331,7 +332,8 @@ public:
       .add("live", live)
       .add("retro", retro)
       .add("internal", internal)
-      .parse(inv, ctx);
+      .parse(inv, ctx)
+      .ignore();
     if (not live) {
       // TODO: export live=false, retro=false
       retro = true;

--- a/libtenzir/builtins/operators/fork.cpp
+++ b/libtenzir/builtins/operators/fork.cpp
@@ -85,9 +85,12 @@ private:
 
 class plugin final : public virtual operator_plugin2<fork_operator> {
 public:
-  auto make(invocation inv, session ctx) const -> operator_ptr override {
+  auto make(invocation inv, session ctx) const
+    -> failure_or<operator_ptr> override {
     auto pipe = located<pipeline>{};
-    argument_parser2::operator_("fork").add(pipe, "<pipeline>").parse(inv, ctx);
+    TRY(argument_parser2::operator_("fork")
+          .add(pipe, "<pipeline>")
+          .parse(inv, ctx));
     auto loc = operator_location::anywhere;
     for (auto& op : pipe.inner.operators()) {
       auto op_loc = op->location();

--- a/libtenzir/builtins/operators/head.cpp
+++ b/libtenzir/builtins/operators/head.cpp
@@ -43,9 +43,13 @@ public:
     return std::move(*result);
   }
 
-  auto make(invocation inv, session ctx) const -> operator_ptr override {
+  auto make(invocation inv, session ctx) const
+    -> failure_or<operator_ptr> override {
     auto count = std::optional<uint64_t>{};
-    argument_parser2::operator_("head").add(count, "<count>").parse(inv, ctx);
+    argument_parser2::operator_("head")
+      .add(count, "<count>")
+      .parse(inv, ctx)
+      .ignore();
     auto result = pipeline::internal_parse_as_operator(
       fmt::format("slice :{}", count.value_or(10)));
     if (not result) {

--- a/libtenzir/builtins/operators/import.cpp
+++ b/libtenzir/builtins/operators/import.cpp
@@ -134,8 +134,9 @@ public:
     return std::make_unique<pipeline>(std::move(*pipe));
   }
 
-  auto make(invocation inv, session ctx) const -> operator_ptr override {
-    argument_parser2::operator_("import").parse(inv, ctx);
+  auto make(invocation inv, session ctx) const
+    -> failure_or<operator_ptr> override {
+    argument_parser2::operator_("import").parse(inv, ctx).ignore();
     return std::make_unique<import_operator>();
   }
 };

--- a/libtenzir/builtins/operators/measure.cpp
+++ b/libtenzir/builtins/operators/measure.cpp
@@ -154,13 +154,15 @@ public:
                                               cumulative);
   }
 
-  auto make(invocation inv, session ctx) const -> operator_ptr override {
+  auto make(invocation inv, session ctx) const
+    -> failure_or<operator_ptr> override {
     bool real_time = false;
     bool cumulative = false;
     argument_parser2::operator_("measure")
       .add("real_time", real_time)
       .add("cumulative", cumulative)
-      .parse(inv, ctx);
+      .parse(inv, ctx)
+      .ignore();
     return std::make_unique<measure_operator>(batch_size_, real_time,
                                               cumulative);
   }

--- a/libtenzir/builtins/operators/repeat.cpp
+++ b/libtenzir/builtins/operators/repeat.cpp
@@ -96,9 +96,13 @@ public:
       repetitions.value_or(std::numeric_limits<uint64_t>::max()));
   }
 
-  auto make(invocation inv, session ctx) const -> operator_ptr override {
+  auto make(invocation inv, session ctx) const
+    -> failure_or<operator_ptr> override {
     auto count = std::optional<uint64_t>{};
-    argument_parser2::operator_("repeat").add(count, "<count>").parse(inv, ctx);
+    argument_parser2::operator_("repeat")
+      .add(count, "<count>")
+      .parse(inv, ctx)
+      .ignore();
     return std::make_unique<repeat_operator>(
       count.value_or(std::numeric_limits<uint64_t>::max()));
   }

--- a/libtenzir/builtins/operators/set_select.cpp
+++ b/libtenzir/builtins/operators/set_select.cpp
@@ -15,7 +15,8 @@ namespace {
 
 class set final : public operator_plugin2<set_operator> {
 public:
-  auto make(invocation inv, session ctx) const -> operator_ptr override {
+  auto make(invocation inv, session ctx) const
+    -> failure_or<operator_ptr> override {
     auto usage = "set <path>=<expr>...";
     auto docs = "https://docs.tenzir.com/operators/set";
     auto assignments = std::vector<ast::assignment>{};
@@ -42,7 +43,8 @@ public:
     return "tql2.select";
   }
 
-  auto make(invocation inv, session ctx) const -> operator_ptr override {
+  auto make(invocation inv, session ctx) const
+    -> failure_or<operator_ptr> override {
     auto assignments = std::vector<ast::assignment>{};
     assignments.reserve(1 + inv.args.size());
     assignments.emplace_back(

--- a/libtenzir/builtins/operators/source.cpp
+++ b/libtenzir/builtins/operators/source.cpp
@@ -55,13 +55,12 @@ private:
 
 class plugin final : public operator_plugin2<source_operator> {
 public:
-  auto make(invocation inv, session ctx) const -> operator_ptr override {
+  auto make(invocation inv, session ctx) const
+    -> failure_or<operator_ptr> override {
     auto expr = ast::expression{};
     auto parser
       = argument_parser2::operator_("source").add(expr, "{...} | [...]");
-    if (not parser.parse(inv, ctx)) {
-      return nullptr;
-    }
+    TRY(parser.parse(inv, ctx));
     // TODO: We want to const-eval when the operator is instantiated.
     // For example: `every 1s { source { ts: now() } }`
     auto events = std::vector<record>{};

--- a/libtenzir/builtins/operators/tail.cpp
+++ b/libtenzir/builtins/operators/tail.cpp
@@ -42,16 +42,20 @@ public:
     return std::move(*result);
   }
 
-  auto make(invocation inv, session ctx) const -> operator_ptr override {
+  auto make(invocation inv, session ctx) const
+    -> failure_or<operator_ptr> override {
     auto count = std::optional<uint64_t>{};
-    argument_parser2::operator_("tail").add(count, "<count>").parse(inv, ctx);
+    argument_parser2::operator_("tail")
+      .add(count, "<count>")
+      .parse(inv, ctx)
+      .ignore();
     auto result = pipeline::internal_parse_as_operator(
       fmt::format("slice -{}:", count.value_or(10)));
     if (not result) {
       diagnostic::error("failed to transform `tail` into `slice` operator: {}",
                         result.error())
         .emit(ctx);
-      return nullptr;
+      return failure::promise();
     }
     return std::move(*result);
   }

--- a/libtenzir/builtins/operators/where.cpp
+++ b/libtenzir/builtins/operators/where.cpp
@@ -371,9 +371,11 @@ private:
 
 class plugin2 final : public virtual operator_plugin2<where_operator2> {
 public:
-  auto make(invocation inv, session ctx) const -> operator_ptr override {
+  auto make(invocation inv, session ctx) const
+    -> failure_or<operator_ptr> override {
     auto expr = ast::expression{};
-    argument_parser2::operator_("where").add(expr, "<expr>").parse(inv, ctx);
+    TRY(
+      argument_parser2::operator_("where").add(expr, "<expr>").parse(inv, ctx));
     return std::make_unique<where_operator2>(std::move(expr));
   }
 };

--- a/libtenzir/include/tenzir/argument_parser2.hpp
+++ b/libtenzir/include/tenzir/argument_parser2.hpp
@@ -83,11 +83,12 @@ public:
   // ------------------------------------------------------------------------
 
   auto parse(const operator_factory_plugin::invocation& inv, session ctx)
-    -> bool;
-  auto parse(const ast::function_call& call, session ctx) -> bool;
-  auto parse(const function_plugin::invocation& inv, session ctx) -> bool;
+    -> failure_or<void>;
+  auto parse(const ast::function_call& call, session ctx) -> failure_or<void>;
+  auto parse(const function_plugin::invocation& inv, session ctx)
+    -> failure_or<void>;
   auto parse(const ast::entity& self, std::span<ast::expression const> args,
-             session ctx) -> bool;
+             session ctx) -> failure_or<void>;
 
   auto usage() const -> std::string;
   auto docs() const -> std::string;

--- a/libtenzir/include/tenzir/diagnostics.hpp
+++ b/libtenzir/include/tenzir/diagnostics.hpp
@@ -414,6 +414,10 @@ public:
   using variant<std::conditional_t<std::same_as<T, void>, std::monostate, T>,
                 failure>::variant;
 
+  void ignore() const {
+    // no-op
+  }
+
   explicit operator bool() const {
     return is_success();
   }
@@ -431,6 +435,11 @@ public:
     if constexpr (not std::same_as<T, void>) {
       return std::get<0>(std::move(*this));
     }
+  }
+
+  auto error() const -> failure {
+    TENZIR_ASSERT(is_error());
+    return std::get<1>(*this);
   }
 
   auto operator*() -> reference_type {

--- a/libtenzir/include/tenzir/tql2/eval.hpp
+++ b/libtenzir/include/tenzir/tql2/eval.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "tenzir/data.hpp"
+#include "tenzir/diagnostics.hpp"
 #include "tenzir/tql2/ast.hpp"
 #include "tenzir/type.hpp"
 
@@ -18,7 +19,7 @@ auto eval(const ast::expression& expr, const table_slice& input,
           diagnostic_handler& dh) -> series;
 
 auto const_eval(const ast::expression& expr, diagnostic_handler& dh)
-  -> std::optional<data>;
+  -> failure_or<data>;
 
 struct resolve_error {
   struct field_not_found {};

--- a/libtenzir/src/tql2/eval.cpp
+++ b/libtenzir/src/tql2/eval.cpp
@@ -67,17 +67,20 @@ auto resolve(const ast::simple_selector& sel, type ty)
 
 auto eval(const ast::expression& expr, const table_slice& input,
           diagnostic_handler& dh) -> series {
-  return evaluator{&input, session{dh}}.eval(expr);
+  // TODO: Do not create a new session here.
+  return evaluator{&input, session_provider::make(dh).as_session()}.eval(expr);
 }
 
 auto const_eval(const ast::expression& expr, diagnostic_handler& dh)
-  -> std::optional<data> {
+  -> failure_or<data> {
+  // TODO: Do not create a new session here.
   try {
-    auto result = evaluator{nullptr, session{dh}}.eval(expr);
+    auto result
+      = evaluator{nullptr, session_provider::make(dh).as_session()}.eval(expr);
     TENZIR_ASSERT(result.length() == 1);
     return materialize(value_at(result.type, *result.array, 0));
-  } catch (std::monostate) {
-    return std::nullopt;
+  } catch (failure fail) {
+    return fail;
   }
 }
 

--- a/libtenzir/src/tql2/eval_impl.cpp
+++ b/libtenzir/src/tql2/eval_impl.cpp
@@ -121,7 +121,7 @@ auto evaluator::eval(const ast::function_call& x) -> series {
   if (not func) {
     return series::null(null_type{}, length_);
   }
-  auto result = func->run(function_use::evaluator{this}, ctx_);
+  auto result = (*func)->run(function_use::evaluator{this}, ctx_);
   TENZIR_ASSERT(result.length() == length_);
   return result;
 }
@@ -185,7 +185,7 @@ auto evaluator::input_or_throw(into_location location) -> const table_slice& {
     diagnostic::error("expected a constant expression")
       .primary(location)
       .emit(ctx_);
-    throw std::monostate{};
+    throw failure::promise();
   }
   return *input_;
 }

--- a/libtenzir/src/tql2/plugin.cpp
+++ b/libtenzir/src/tql2/plugin.cpp
@@ -22,12 +22,12 @@ auto function_use::evaluator::operator()(const ast::expression& expr) const
 }
 
 auto aggregation_plugin::make_function(invocation inv, session ctx) const
-  -> std::unique_ptr<function_use> {
+  -> failure_or<function_ptr> {
   // TODO: Consider making this pure-virtual or provide a default implementation.
   diagnostic::error("this function can only be used as an aggregation function")
     .primary(inv.call.fn)
     .emit(ctx);
-  return nullptr;
+  return failure::promise();
 }
 
 auto function_use::make(

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "9571bc330e970cbac70ea90c02d75b2b3dcf002d",
+  "rev": "9a35504b2e7d3f291e3538de6bed8b0001e24538",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
This PR improves error propagation by using `failure_or<T>` in more places, thus statically guaranteeing that an error has been emitted if no `T` is returned. However, functions can also emit an error and _still_ return a `T`, as long as the calling code would be safe to proceed with it. This enables better error messages. Because of this, we need an explicit check before we start the actual execution of a parsed pipeline, since we only want to do that if no errors have been emitted.