### PR TITLE
Handle URL params in loader and add `load_http` for TQLv2

### DIFF
--- a/libtenzir/test/http.cpp
+++ b/libtenzir/test/http.cpp
@@ -106,6 +106,22 @@ TEST(HTTP request items - urlencoded) {
   CHECK_EQUAL(request.body, "foo=42&bar=true");
 }
 
+TEST(HTTP request items - URL param) {
+  auto request = http::request{};
+  auto items = std::vector<http::request_item>{
+    make_item("foo==42"),
+    make_item("bar==true"),
+  };
+  request.uri = "https://example.org/";
+  auto err = apply(items, request);
+  CHECK_EQUAL(err, caf::none);
+  CHECK_EQUAL(request.uri, "https://example.org/?foo=42&bar=true");
+  request.uri = "https://example.org/?";
+  err = apply(items, request);
+  CHECK_EQUAL(err, caf::none);
+  CHECK_EQUAL(request.uri, "https://example.org/?foo=42&bar=true");
+}
+
 TEST(HTTP response) {
   http::response r;
   r.status_code = 200;


### PR DESCRIPTION
This adds supports for adding URL parameters `?foo=42&bar=43` as `http::request_item` and also adds a TQLv2 version of the HTTP loader: 

```
load_http <url>, method=<string>, params=<record>, headers=<record>
```

Example:

```python
load_http(
  "http://api.example.org", 
  params={foo: "test", bar: "baz"}, 
  headers={"My-Custom-Header": "Example"},
)
```