### PR TITLE
Fix open partition tracking in the `lookup` operator

### DIFF
--- a/changelog/next/bug-fixes/4363--lookup-crash.md
+++ b/changelog/next/bug-fixes/4363--lookup-crash.md
@@ -1,0 +1,2 @@
+We fixed a rare bug that caused the `lookup` operator to exit unexpectedly when
+using a high value for the operator's `--parallel` option.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "e75eeec968ab53c2c90faeadf351983111451cf6",
+  "rev": "304dddcff6099c17d17d0bc3f9f8e03b66728c30",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
This fixes a bug that could lead to an assertion failure because of a race condition in how parallel retro lookups tracked how many partitions were enqueued.

Fixes tenzir/issues#1968