### PR TITLE
Revamp the `export` operator

### DIFF
--- a/changelog/next/changes/4365--low-prio-export.md
+++ b/changelog/next/changes/4365--low-prio-export.md
@@ -1,0 +1,3 @@
+The previously deprecated `--low-priority` option for the `export` operator no
+longer exists. The new `--parallel <level>` option allows tuning how many
+worker threads the operator uses at most for querying persisted events.

--- a/changelog/next/features/4339--custom-operator-metrics.md
+++ b/changelog/next/features/4339--custom-operator-metrics.md
@@ -1,2 +1,0 @@
-The `publish`, `subscribe`, `import`, `lookup` and `enrich` operators
-deliver their own operator-specific metrics now.

--- a/changelog/next/features/4339-4365--custom-operator-metrics.md
+++ b/changelog/next/features/4339-4365--custom-operator-metrics.md
@@ -1,0 +1,2 @@
+The `publish`, `subscribe`, `import`, `export`, `lookup` and `enrich` operators
+deliver their own, operator-specific metrics now.

--- a/libtenzir/src/argument_parser2.cpp
+++ b/libtenzir/src/argument_parser2.cpp
@@ -171,6 +171,21 @@ auto argument_parser2::parse(const ast::entity& self,
           return;
         }
         auto cast = caf::get_if<T>(&*value);
+        if constexpr (std::same_as<T, uint64_t>) {
+          if (not cast) {
+            auto other = caf::get_if<int64_t>(&*value);
+            if (other) {
+              if (*other < 0) {
+                emit(diagnostic::error("expected positive integer, got `{}`",
+                                       *other)
+                       .primary(expr));
+                return;
+              }
+              value = static_cast<uint64_t>(*other);
+              cast = caf::get_if<T>(&*value);
+            }
+          }
+        }
         if (not cast) {
           // TODO: Attempt conversion.
           emit(diagnostic::error("expected argument of type `{}`, but got `{}`",

--- a/web/docs/operators/export.md
+++ b/web/docs/operators/export.md
@@ -11,7 +11,7 @@ Retrieves events from a Tenzir node. The dual to [`import`](import.md).
 ## Synopsis
 
 ```
-export [--live] [--retro] [--internal] [--paralllel <level>]
+export [--live] [--retro] [--internal] [--parallel <level>]
 ```
 
 ## Description

--- a/web/docs/operators/export.md
+++ b/web/docs/operators/export.md
@@ -11,7 +11,7 @@ Retrieves events from a Tenzir node. The dual to [`import`](import.md).
 ## Synopsis
 
 ```
-export [--live] [--internal] [--low-priority]
+export [--live] [--retro] [--internal] [--paralllel <level>]
 ```
 
 ## Description
@@ -40,10 +40,12 @@ Export internal events, such as metrics or diagnostics, instead. By default,
 `export` only returns events that were previously imported with `import`. In
 contrast, `export --internal` exports internal events such as operator metrics.
 
-### `--low-priority`
+### `--parallel <level>`
 
-Treat this export with a lower priority, causing it to interfere less with
-regular priority exports at the cost of potentially running slower.
+The parallel level controls how many worker threads the operator uses at most
+for querying historical events.
+
+Defaults to 3.
 
 ## Examples
 

--- a/web/docs/operators/metrics.md
+++ b/web/docs/operators/metrics.md
@@ -40,6 +40,7 @@ Contains a measurement of CPU utilization.
 
 |Field|Type|Description|
 |:-|:-|:-|
+|`timestamp`|`time`|The time at which this metric was recorded.|
 |`loadavg_1m`|`double`|The load average over the last minute.|
 |`loadavg_5m`|`double`|The load average over the last 5 minutes.|
 |`loadavg_15m`|`double`|The load average over the last 15 minutes.|
@@ -50,6 +51,7 @@ Contains a measurement of disk space usage.
 
 |Field|Type|Description|
 |:-|:-|:-|
+|`timestamp`|`time`|The time at which this metric was recorded.|
 |`path`|`string`|The byte measurements below refer to the filesystem on which this path is located.|
 |`total_bytes`|`uint64`|The total size of the volume, in bytes.|
 |`used_bytes`|`uint64`|The number of bytes occupied on the volume.|
@@ -64,11 +66,28 @@ Contains a measurement the `enrich` operator, emitted once every second.
 |`pipeline_id`|`string`|The ID of the pipeline where the associated operator is from.|
 |`run`|`uint64`|The number of the run, starting at 1 for the first run.|
 |`hidden`|`bool`|True if the pipeline is running for the explorer.|
-|`timestamp`|`time`|The time when this event was emitted.|
+|`timestamp`|`time`|The time at which this metric was recorded.|
 |`operator_id`|`uint64`|The ID of the `enrich` operator in the pipeline.|
 |`context`|`string`|The name of the context the associated operator is using.|
 |`events`|`uint64`|The amount of input events that entered the `enrich` operator since the last metric.|
 |`hits`|`uint64`|The amount of successfully enriched events since the last metric.|
+
+### `tenzir.metrics.export`
+
+Contains a measurement the `export` operator, emitted once every second per
+schema. Note that internal events like metrics or diagnostics to not emit
+metrics themselves.
+
+|Field|Type|Description|
+|:-|:-|:-|
+|`pipeline_id`|`string`|The ID of the pipeline where the associated operator is from.|
+|`run`|`uint64`|The number of the run, starting at 1 for the first run.|
+|`hidden`|`bool`|True if the pipeline is running for the explorer.|
+|`timestamp`|`time`|The time at which this metric was recorded.|
+|`operator_id`|`uint64`|The ID of the `export` operator in the pipeline.|
+|`schema`|`string`|The schema name of the batch.|
+|`schema_id`|`string`|The schema ID of the batch.|
+|`events`|`uint64`|The amount of events that were imported.|
 
 ### `tenzir.metrics.import`
 
@@ -81,7 +100,7 @@ metrics themselves.
 |`pipeline_id`|`string`|The ID of the pipeline where the associated operator is from.|
 |`run`|`uint64`|The number of the run, starting at 1 for the first run.|
 |`hidden`|`bool`|True if the pipeline is running for the explorer.|
-|`timestamp`|`time`|The time when this event was emitted.|
+|`timestamp`|`time`|The time at which this metric was recorded.|
 |`operator_id`|`uint64`|The ID of the `import` operator in the pipeline.|
 |`schema`|`string`|The schema name of the batch.|
 |`schema_id`|`string`|The schema ID of the batch.|
@@ -96,7 +115,7 @@ Contains a measurement of the `lookup` operator, emitted once every second.
 |`pipeline_id`|`string`|The ID of the pipeline where the associated operator is from.|
 |`run`|`uint64`|The number of the run, starting at 1 for the first run.|
 |`hidden`|`bool`|True if the pipeline is running for the explorer.|
-|`timestamp`|`time`|The time when this event was emitted.|
+|`timestamp`|`time`|The time at which this metric was recorded.|
 |`operator_id`|`uint64`|The ID of the `lookup` operator in the pipeline.|
 |`context`|`string`|The name of the context the associated operator is using.|
 |`live`|`record`|Information about the live lookup.|
@@ -124,6 +143,7 @@ Contains a measurement of the available memory on the host.
 
 |Field|Type|Description|
 |:-|:-|:-|
+|`timestamp`|`time`|The time at which this metric was recorded.|
 |`total_bytes`|`uint64`|The total available memory, in bytes.|
 |`used_bytes`|`uint64`|The amount of memory used, in bytes.|
 |`free_bytes`|`uint64`|The amount of free memory, in bytes.|
@@ -167,6 +187,7 @@ Contains a measurement of the amount of memory used by the `tenzir-node` process
 
 |Field|Type|Description|
 |:-|:-|:-|
+|`timestamp`|`time`|The time at which this metric was recorded.|
 |`current_memory_usage`|`uint64`|The memory currently used by this process.|
 |`peak_memory_usage`|`uint64`|The peak amount of memory, in bytes.|
 |`swap_space_usage`|`uint64`|The amount of swap space, in bytes. Only available on Linux systems.|
@@ -182,7 +203,7 @@ schema.
 |`pipeline_id`|`string`|The ID of the pipeline where the associated operator is from.|
 |`run`|`uint64`|The number of the run, starting at 1 for the first run.|
 |`hidden`|`bool`|True if the pipeline is running for the explorer.|
-|`timestamp`|`time`|The time when this event was emitted.|
+|`timestamp`|`time`|The time at which this metric was recorded.|
 |`operator_id`|`uint64`|The ID of the `publish` operator in the pipeline.|
 |`topic`|`string`|The topic name.|
 |`schema`|`string`|The schema name of the batch.|
@@ -199,7 +220,7 @@ per schema.
 |`pipeline_id`|`string`|The ID of the pipeline where the associated operator is from.|
 |`run`|`uint64`|The number of the run, starting at 1 for the first run.|
 |`hidden`|`bool`|True if the pipeline is running for the explorer.|
-|`timestamp`|`time`|The time when this event was emitted.|
+|`timestamp`|`time`|The time at which this metric was recorded.|
 |`operator_id`|`uint64`|The ID of the `subscribe` operator in the pipeline.|
 |`topic`|`string`|The topic name.|
 |`schema`|`string`|The schema name of the batch.|


### PR DESCRIPTION
This is a complete rewrite of the `export` operator that brings a few changes:
1. The operator is no longer detached, but rather cooperatively scheduled. This makes the operator cheaper to start.
2. The operator now emits metrics with the name `tenzir.metrics.export` once per second and on shutdown.
3. The operator now schedules up to three partitions at once for retroactive queries, pipelining them for an improved performance, especially when using smaller partitions. A new `--parallel <level>` option allows for overriding this setting.
4. The gap between retro and live exports is now drastically reduced, as the live export starts immediately and no longer waits for the retro export to finish. Note that this doesn't eliminate the gap window entirely, as there is still a gap between the importer and passive partitions being ack'd by the catalog.
5. The previously deprecated `--low-priority` option for the operator no longer exists. The option was a no-op for quite some time now.