### PR TITLE
Allow immediate restarts of the TCP listen connector

### DIFF
--- a/changelog/next/bug-fixes/4367--tcp-reuseaddr.md
+++ b/changelog/next/bug-fixes/4367--tcp-reuseaddr.md
@@ -1,0 +1,2 @@
+The `tcp` connector no longer fails in listen mode when you try to restart it
+directly after stopping it.

--- a/libtenzir/builtins/operators/tcp-listen.cpp
+++ b/libtenzir/builtins/operators/tcp-listen.cpp
@@ -361,6 +361,8 @@ auto make_connection_manager(
   self->state.endpoint = endpoints.begin()->endpoint();
   self->state.acceptor = boost::asio::ip::tcp::acceptor(*self->state.io_context,
                                                         *self->state.endpoint);
+  boost::asio::ip::tcp::acceptor::reuse_address reuse_address(true);
+  self->state.acceptor->set_option(reuse_address);
   self->state.acceptor->listen(boost::asio::socket_base::max_connections);
   self->state.socket = boost::asio::ip::tcp::socket(*self->state.io_context);
 #if TENZIR_LINUX

--- a/libtenzir/builtins/operators/tcp-listen.cpp
+++ b/libtenzir/builtins/operators/tcp-listen.cpp
@@ -361,7 +361,7 @@ auto make_connection_manager(
   self->state.endpoint = endpoints.begin()->endpoint();
   self->state.acceptor = boost::asio::ip::tcp::acceptor(*self->state.io_context,
                                                         *self->state.endpoint);
-  boost::asio::ip::tcp::acceptor::reuse_address reuse_address(true);
+  auto reuse_address = boost::asio::ip::tcp::acceptor::reuse_address{true};
   self->state.acceptor->set_option(reuse_address);
   self->state.acceptor->listen(boost::asio::socket_base::max_connections);
   self->state.socket = boost::asio::ip::tcp::socket(*self->state.io_context);


### PR DESCRIPTION
A pipeline with `from tcp://...` could not be restarted seamlessly because the listening port was blocked for a certain amount of time after the pipeline was stopped.

This change adds the necessary flags so the port can be reused immediately.
