### PR TITLE
Introduce API metrics

### DIFF
--- a/changelog/next/features/4368--api-metrics.md
+++ b/changelog/next/features/4368--api-metrics.md
@@ -1,0 +1,2 @@
+The new `tenzir.metrics.api` metrics record every API call made to a Tenzir
+Node.

--- a/libtenzir/include/tenzir/node.hpp
+++ b/libtenzir/include/tenzir/node.hpp
@@ -9,8 +9,8 @@
 #pragma once
 
 #include "tenzir/actors.hpp"
-#include "tenzir/command.hpp"
 #include "tenzir/component_registry.hpp"
+#include "tenzir/series_builder.hpp"
 
 #include <caf/actor.hpp>
 #include <caf/stateful_actor.hpp>
@@ -18,7 +18,6 @@
 
 #include <chrono>
 #include <filesystem>
-#include <map>
 #include <string>
 #include <unordered_map>
 
@@ -65,6 +64,9 @@ struct node_state {
 
   /// Counters for multi-instance components.
   std::unordered_map<std::string, uint64_t> label_counters = {};
+
+  /// Builder for API metrics.
+  std::unordered_map<std::string, series_builder> api_metrics_builders = {};
 
   /// Startup timestamp.
   time start_time = time::clock::now();

--- a/web/docs/operators/metrics.md
+++ b/web/docs/operators/metrics.md
@@ -34,6 +34,20 @@ See [`export` operator](export.md#--retro) for more details.
 
 Tenzir collects metrics with the following schemas.
 
+### `tenzir.metrics.api`
+
+Contains information about all accessed API endpoints, emitted once per second.
+
+|Field|Type|Description|
+|:-|:-|:-|
+|`timestamp`|`time`|The time at which this metric was recorded.|
+|`method`|`double`|The HTTP method used to access the API.|
+|`path`|`double`|The path of the accessed API endpoint.|
+|`params`|`record`|The API endpoints parameters passed inused.|
+
+The schema of the record `params` depends on the API endpoint used. Refer to the
+[API documentation](/api) to see the available parameters per endpoint.
+
 ### `tenzir.metrics.cpu`
 
 Contains a measurement of CPU utilization.


### PR DESCRIPTION
> [!NOTE]
> This depends on the actor registry changes made in #4365.

The new `tenzir.metrics.api` metrics record every single interaction with a Tenzir Node through its API.

For example, this shows how often each endpoint is used per minute:

```
metrics --live
| where #schema == "tenzir.metrics.api"
| summarize count=count(.) by path timeout 1m
| write lines
```

```
/pipeline/reset-ttl 1
/pipeline/launch 19
/pipeline/update 44
/serve 81
```

This shows the most commonly started pipeline through the app in the last hour:

```
metrics
| where #schema == "tenzir.metrics.api" and path == "/pipeline/launch"
| top params.definition
| head 1
| write lines
```

```
"diagnostics |\nwhere pipeline_id == \"load-test-1\" | where run == 15\n| sort timestamp asc" 10
```