### PR TITLE
Add an optional `name` argument to the `metrics` operator

### DIFF
--- a/changelog/next/features/4369--metrics-name.md
+++ b/changelog/next/features/4369--metrics-name.md
@@ -1,0 +1,3 @@
+The `metrics` operator now optionally takes a metric name as an argument. For
+example, `metrics cpu` shows only CPU metrics. This is functionally equivalent
+to `metrics | where #schema == "tenzir.metrics.cpu"`.

--- a/changelog/next/features/4369--metrics-name.md
+++ b/changelog/next/features/4369--metrics-name.md
@@ -1,3 +1,3 @@
 The `metrics` operator now optionally takes a metric name as an argument. For
-example, `metrics cpu` shows only CPU metrics. This is functionally equivalent
+example, `metrics cpu` only shows CPU metrics. This is functionally equivalent
 to `metrics | where #schema == "tenzir.metrics.cpu"`.

--- a/web/docs/operators/diagnostics.md
+++ b/web/docs/operators/diagnostics.md
@@ -11,7 +11,7 @@ Retrieves diagnostic events from a Tenzir node.
 ## Synopsis
 
 ```
-diagnostics [--live]
+diagnostics [--live] [--retro]
 ```
 
 ## Description

--- a/web/docs/operators/metrics.md
+++ b/web/docs/operators/metrics.md
@@ -11,7 +11,7 @@ Retrieves metrics events from a Tenzir node.
 ## Synopsis
 
 ```
-metrics [--live]
+metrics [--live] [--retro] [<name>]
 ```
 
 ## Description
@@ -29,6 +29,11 @@ metrics events persisted at a Tenzir node.
 Work on persisted diagnostic events (first), even when `--live` is given.
 
 See [`export` operator](export.md#--retro) for more details.
+
+### `<name>`
+
+Show only metrics with the specified name. For example `metrics cpu` shows only
+CPU metrics.
 
 ## Schemas
 

--- a/web/docs/operators/metrics.md
+++ b/web/docs/operators/metrics.md
@@ -32,7 +32,7 @@ See [`export` operator](export.md#--retro) for more details.
 
 ### `<name>`
 
-Show only metrics with the specified name. For example `metrics cpu` shows only
+Show only metrics with the specified name. For example, `metrics cpu` only shows
 CPU metrics.
 
 ## Schemas


### PR DESCRIPTION
`metrics <name>` is equivalent to `metrics | where #schema == "tenzir.metrics.<name>"`, which is a very common thing to write and a lot easier to type and understand.