### PR TITLE
Raise the default and max timeouts for `/serve`

### DIFF
--- a/changelog/next/changes/4370--serve-timeouts.md
+++ b/changelog/next/changes/4370--serve-timeouts.md
@@ -1,0 +1,2 @@
+We raised the default and maximum long-polling timeouts for `/serve` from 2s and
+5s to 5s and 10s, respectively.

--- a/libtenzir/builtins/operators/serve.cpp
+++ b/libtenzir/builtins/operators/serve.cpp
@@ -81,7 +81,7 @@ constexpr auto SPEC_V0 = R"_(
 /serve:
   post:
     summary: Return data from a pipeline
-    description: "Returns events from an existing pipeline. The pipeline definition must include a serve operator. By default, the endpoint performs long polling (`timeout: 2s`) and returns events as soon as they are available (`min_events: 1`)."
+    description: "Returns events from an existing pipeline. The pipeline definition must include a serve operator. By default, the endpoint performs long polling (`timeout: 5s`) and returns events as soon as they are available (`min_events: 1`)."
     requestBody:
       description: Body for the serve endpoint
       required: true
@@ -111,9 +111,9 @@ constexpr auto SPEC_V0 = R"_(
                 description: Wait for this number of events before returning.
               timeout:
                 type: string
-                example: "2000ms"
-                default: "2000ms"
-                description: The maximum amount of time spent on the request. Hitting the timeout is not an error. The timeout must not be greater than 5 seconds.
+                example: "200ms"
+                default: "5s"
+                description: The maximum amount of time spent on the request. Hitting the timeout is not an error. The timeout must not be greater than 10 seconds.
               use_simple_format:
                 type: bool
                 example: true

--- a/libtenzir/include/tenzir/defaults.hpp
+++ b/libtenzir/include/tenzir/defaults.hpp
@@ -178,11 +178,10 @@ inline constexpr uint64_t max_events = 1024;
 
 /// The maximum amount of time to wait for additional having at least
 /// `min_events`.
-inline constexpr std::chrono::milliseconds timeout
-  = std::chrono::milliseconds{2000};
+inline constexpr auto timeout = std::chrono::seconds{5};
 
 /// The maximum timeout that can be requested by the client.
-inline constexpr std::chrono::seconds max_timeout = std::chrono::seconds{5};
+inline constexpr std::chrono::seconds max_timeout = std::chrono::seconds{10};
 
 } // namespace serve
 


### PR DESCRIPTION
This brings up the default and maximum long-polling timeouts for `/serve` from 2s and 5s to 5s and 10s, respectively.

I've made this change because we've started polling a lot of metrics and diagnostics from the app, and this drastically reduces the load on the API when there are no diagnostics.

We can't really raise it much higher because of AWS' lambda and websocket gateway timeouts, but this I think we can safely do.