### PR TITLE
Fix diagnostic newline printing

### DIFF
--- a/changelog/next/changes/4348--deduplicate-diagnostics.md
+++ b/changelog/next/changes/4348--deduplicate-diagnostics.md
@@ -1,0 +1,2 @@
+Diagnostics from managed pipelines are now deduplicated, showing each diagnostic
+at most once for each run.

--- a/libtenzir/src/diagnostics.cpp
+++ b/libtenzir/src/diagnostics.cpp
@@ -75,7 +75,7 @@ public:
 
   void emit(diagnostic diag) override {
     if (not std::exchange(first, false)) {
-      fmt::print("\n");
+      fmt::print(stream_, "\n");
     }
     // TODO: Do not print the same line multiple times. Merge annotations instead.
     fmt::print(stream_, "{}{}{}{}: {}{}\n", bold, color(diag.severity),


### PR DESCRIPTION
The newline is currently always printed to `stdout` instead of the target stream. This mostly "works" when using `tenzir` directly from the terminal, but obviously doesn't in many other cases.