### PR TITLE
Emit connection status metrics from the platform

### DIFF
--- a/changelog/next/features/4374--platform-metrics.md
+++ b/changelog/next/features/4374--platform-metrics.md
@@ -1,0 +1,3 @@
+The `tenzir.metrics.platform` metrics records every second whether the
+connection to the Tenzir Platform is working as expected from the node's
+perspective.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "67023a6a32a6833db01541533264f6c6397e5c81",
+  "rev": "438a4ca7e2c2929779edf39615b401abcef224f3",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/web/docs/operators/metrics.md
+++ b/web/docs/operators/metrics.md
@@ -200,6 +200,16 @@ The records `input` and `output` have the following schema:
 |`elements`|`uint64`|Number of elements that were seen during the collection period.|
 |`approx_bytes`|`uint64`|An approximation for the number of bytes transmitted.|
 
+### `tenzir.metrics.platform`
+
+Signals whether the connection to the Tenzir Platform is working from the node's
+perspective. Emitted once per second.
+
+|Field|Type|Description|
+|:-|:-|:-|
+|`timestamp`|`time`|The time at which this metric was recorded.|
+|`connected`|`bool`|The connection status.|
+
 ### `tenzir.metrics.process`
 
 Contains a measurement of the amount of memory used by the `tenzir-node` process.


### PR DESCRIPTION
This adds `metrics platform`—a simple metric emitted once per second that signals whether the connection to the Tenzir Platform is alive and well from the node's perspective.