### PR TITLE
Add the `request_id` to API metrics

### DIFF
--- a/libtenzir/builtins/operators/api.cpp
+++ b/libtenzir/builtins/operators/api.cpp
@@ -32,8 +32,9 @@ public:
       .json_body = request_body_,
     };
     auto response = std::optional<rest_response>{};
+    const auto request_id = std::string{};
     ctrl.self()
-      .request(ctrl.node(), caf::infinite, atom::proxy_v, request)
+      .request(ctrl.node(), caf::infinite, atom::proxy_v, request, request_id)
       .await(
         [&](rest_response& value) {
           response = std::move(value);

--- a/libtenzir/include/tenzir/actors.hpp
+++ b/libtenzir/include/tenzir/actors.hpp
@@ -407,7 +407,8 @@ using node_actor = typed_actor_fwd<
   // Note that nodes connected via CAF trust each other completely,
   // so this skips all authorization and access control mechanisms
   // that come with HTTP(s).
-  auto(atom::proxy, http_request_description)->caf::result<rest_response>,
+  auto(atom::proxy, http_request_description, std::string)
+    ->caf::result<rest_response>,
   // Retrieve components by their label from the component registry.
   auto(atom::get, atom::label, std::vector<std::string>)
     ->caf::result<std::vector<caf::actor>>,

--- a/libtenzir/src/node.cpp
+++ b/libtenzir/src/node.cpp
@@ -515,10 +515,10 @@ auto node(node_actor::stateful_pointer<node_state> self, std::string /*name*/,
     }
   });
   return {
-    [self](atom::proxy,
-           http_request_description& desc) -> caf::result<rest_response> {
-      TENZIR_VERBOSE("{} proxying request to {} with {}", *self,
-                     desc.canonical_path, desc.json_body);
+    [self](atom::proxy, http_request_description& desc,
+           std::string& request_id) -> caf::result<rest_response> {
+      TENZIR_VERBOSE("{} proxying request with id {} to {} with {}", *self,
+                     request_id, desc.canonical_path, desc.json_body);
       auto [handler, endpoint] = self->state.get_endpoint_handler(desc);
       if (!handler) {
         auto canonical_paths = std::unordered_set<std::string>{};
@@ -548,36 +548,39 @@ auto node(node_actor::stateful_pointer<node_state> self, std::string /*name*/,
                                          params.error());
       auto rp = self->make_response_promise<rest_response>();
       auto deliver = [rp, self, desc, params, endpoint,
+                      request_id = std::move(request_id),
                       start_time = std::chrono::steady_clock::now()](
                        caf::expected<rest_response> response) mutable {
-        {
-          auto it = self->state.api_metrics_builders.find(desc.canonical_path);
-          if (it == self->state.api_metrics_builders.end()) {
-            auto builder = series_builder{type{
-              "tenzir.metrics.api",
-              record_type{
-                {"timestamp", time_type{}},
-                {"method", string_type{}},
-                {"path", string_type{}},
-                {"response_time", duration_type{}},
-                {"status_code", uint64_type{}},
-                {"params", endpoint.params.value_or(record_type{})},
-              },
-              {{"internal"}},
-            }};
-            it = self->state.api_metrics_builders.emplace_hint(
-              it, desc.canonical_path, std::move(builder));
-          }
-          auto metric = it->second.record();
-          metric.field("timestamp", time::clock::now());
-          metric.field("method", fmt::to_string(endpoint.method));
-          metric.field("path", endpoint.path);
-          metric.field("response_time",
-                       duration{std::chrono::steady_clock::now() - start_time});
-          metric.field("status_code",
-                       response ? uint64_t{response->code()} : uint64_t{500});
-          metric.field("params", *params);
+        auto it = self->state.api_metrics_builders.find(desc.canonical_path);
+        if (it == self->state.api_metrics_builders.end()) {
+          auto builder = series_builder{type{
+            "tenzir.metrics.api",
+            record_type{
+              {"timestamp", time_type{}},
+              {"request_id", string_type{}},
+              {"method", string_type{}},
+              {"path", string_type{}},
+              {"response_time", duration_type{}},
+              {"status_code", uint64_type{}},
+              {"params", endpoint.params.value_or(record_type{})},
+            },
+            {{"internal"}},
+          }};
+          it = self->state.api_metrics_builders.emplace_hint(
+            it, desc.canonical_path, std::move(builder));
         }
+        auto metric = it->second.record();
+        metric.field("timestamp", time::clock::now());
+        if (not request_id.empty()) {
+          metric.field("request_id", request_id);
+        }
+        metric.field("method", fmt::to_string(endpoint.method));
+        metric.field("path", endpoint.path);
+        metric.field("response_time",
+                     duration{std::chrono::steady_clock::now() - start_time});
+        metric.field("status_code",
+                     response ? uint64_t{response->code()} : uint64_t{500});
+        metric.field("params", *params);
         if (not response) {
           rp.deliver(
             rest_response::make_error(500, "internal error", response.error()));

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "e9143131fa0c2db44cc7c11ab58afacaeba1249c",
+  "rev": "5e4b41ecb41747a71642de763b6efa64ba816ba3",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/web/docs/operators/metrics.md
+++ b/web/docs/operators/metrics.md
@@ -46,6 +46,7 @@ Contains information about all accessed API endpoints, emitted once per second.
 |Field|Type|Description|
 |:-|:-|:-|
 |`timestamp`|`time`|The time at which the API request was received.|
+|`request_id`|`string`|The unique request ID assigned by the Tenzir Platform.|
 |`method`|`double`|The HTTP method used to access the API.|
 |`path`|`double`|The path of the accessed API endpoint.|
 |`response_time`|`duration`|The time the API endpoint took to respond.|


### PR DESCRIPTION
End-to-end request tracing, who thought this'd ever be a thing?