### PR TITLE
Do not optimize `deduplicate`

### DIFF
--- a/changelog/next/bug-fixes/4379--dedup-order.md
+++ b/changelog/next/bug-fixes/4379--dedup-order.md
@@ -1,0 +1,3 @@
+We fixed a bug that caused `deduplicate <fields...> --distance <distance>` to
+sometimes produce incorrect results when followed by `where <expr>` with an
+expression that filters on the deduplicated fields.


### PR DESCRIPTION
I noticed that this is broken with the following pipeline:

```
metrics platform
| where timestamp > 1w ago
| sort timestamp
| deduplicate connected --distance 1
| where connected == false
| put timestamp, message = "disconnected from platform"
```

The `where connected == false` in this pipeline got pushed through `deduplicate` incorrectly.