### PR TITLE
Allow disabling node-to-node connections

### DIFF
--- a/changelog/next/features/4380--disable-node-to-node-conns.md
+++ b/changelog/next/features/4380--disable-node-to-node-conns.md
@@ -1,0 +1,3 @@
+Setting the `tenzir.endpoint` option to `false` now causes the node not to
+listen for node-to-node connections. Previously, the port was always exposed for
+other nodes or `tenzir` processes to connect.

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -4,8 +4,11 @@
 
 # Options that concern Tenzir.
 tenzir:
-  # The host and port to listen at and connect to.
-  endpoint: "localhost:5158"
+  # The host and port to listen at for node-to-node connections to in the form
+  # `<host>:<port>`. Host or port may be emitted to use their defaults, which
+  # are localhost and 5158, respectively. Set the port to zero to automatically
+  # choose a port. Set to false to disable exposing an endpoint.
+  endpoint: localhost:5158
 
   # The timeout for connecting to a Tenzir server. Set to 0 seconds to wait
   # indefinitely.

--- a/web/docs/setup-guides/deploy-a-node.md
+++ b/web/docs/setup-guides/deploy-a-node.md
@@ -137,15 +137,22 @@ tenzir-node
 
           v4.0.0-rc6-0-gf193b51f1f
 Visit https://app.tenzir.com to get started.
+
+[16:50:26.741] node listens for node-to-node connections on tcp://127.0.0.1:5158
+[16:50:26.982] node connected to platform via wss://ws.tenzir.app:443/production
 ```
 
-This will spawn a blocking process that listens by default on the TCP endpoint
-`127.0.0.1:5158`. Select a different endpoint via `--endpoint`, e.g., bind to an
-IPv6 address:
+This will spawn a blocking process that listens by default for node-to-node
+connections on the TCP endpoint `127.0.0.1:5158`. Select a different endpoint
+via the `tenzir.endpoint` option, e.g., bind to an IPv6 address:
 
 ```bash
 tenzir-node --endpoint=[::1]:42000
 ```
+
+Set `tenzir.endpoint` to `false` to disable the endpoint, making the node
+exclusively accessible through the Tenzir Platform. This effectively prevents
+connections from other `tenzir` or `tenzir-node` processes.
 
 ## Stop a node
 


### PR DESCRIPTION
This change makes it so that setting the value `false` for the `tenzir.endpoint` option causes the node not to expose the node as a remote actor for `tenzir` processes or other nodes to connect to it.