### PR TITLE
Don't terminate `export` when used with `every`

### DIFF
--- a/changelog/next/bug-fixes/4382--fix-every-export.md
+++ b/changelog/next/bug-fixes/4382--fix-every-export.md
@@ -1,0 +1,2 @@
+Pipelines that use the `every` modifier with the `export` operator no longer
+terminate after the first run.

--- a/libtenzir/builtins/operators/export.cpp
+++ b/libtenzir/builtins/operators/export.cpp
@@ -339,9 +339,13 @@ public:
       },
     });
     auto diagnostics_handler = ctrl.shared_diagnostics();
-    auto bridge = ctrl.self().spawn<caf::linked>(
-      make_bridge, expr_, mode_, std::move(filesystem),
-      std::move(metrics_handler), std::move(diagnostics_handler));
+    auto bridge
+      = ctrl.self().spawn(make_bridge, expr_, mode_, std::move(filesystem),
+                          std::move(metrics_handler),
+                          std::move(diagnostics_handler));
+    auto bridge_guard = caf::detail::make_scope_guard([&]() {
+      ctrl.self().send_exit(bridge, caf::exit_reason::normal);
+    });
     co_yield {};
     while (true) {
       auto result = table_slice{};


### PR DESCRIPTION
<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made in the pull request description in a way that
   is consumable by everyone, not just developers who know the context of the
   change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://docs.tenzir.com/next/contribute/changelog
3. Provide instructions for the reviewer.
4. Remove this comment so it doesn't show up in the merge commit.
-->
