### PR TITLE
Send a hard shutdown to the export bridge

### DIFF
--- a/changelog/next/bug-fixes/4389--fix-every-export-again.md
+++ b/changelog/next/bug-fixes/4389--fix-every-export-again.md
@@ -1,0 +1,1 @@
+We fixed a memory leak in `export` that was introduced with `v4.18.1`.

--- a/libtenzir/builtins/operators/export.cpp
+++ b/libtenzir/builtins/operators/export.cpp
@@ -346,7 +346,7 @@ public:
                           std::move(metrics_handler),
                           std::move(diagnostics_handler));
     auto bridge_guard = caf::detail::make_scope_guard([&]() {
-      ctrl.self().send_exit(bridge, caf::exit_reason::normal);
+      ctrl.self().send_exit(bridge, caf::exit_reason::user_shutdown);
     });
     co_yield {};
     while (true) {


### PR DESCRIPTION
The previous `exit_reason::normal` did not cause the export bridge actor to exit because the `importer` still held a strong handle.
