### PR TITLE
Prevent unbounded memory usage in `export --live`

### DIFF
--- a/changelog/next/bug-fixes/4396--exprt-live-overflow.md
+++ b/changelog/next/bug-fixes/4396--exprt-live-overflow.md
@@ -1,0 +1,2 @@
+We fixed a bug that caused a potentially unbounded memory usage in `export
+--live`, `metrics --live`, and `diagnostics --live`.

--- a/changelog/next/changes/4396--export-queued-events.md
+++ b/changelog/next/changes/4396--export-queued-events.md
@@ -1,0 +1,2 @@
+`metrics export` now includes an additional field that shows the number of
+queued events in the pipeline.

--- a/web/docs/operators/export.md
+++ b/web/docs/operators/export.md
@@ -23,6 +23,10 @@ The `export` operator retrieves events from a Tenzir node.
 Work on all events that are imported with `import` operators in real-time
 instead of on events persisted at a Tenzir node.
 
+Note that live exports may drop events if the following pipeline fails to keep
+up. To connect pipelines with back pressure, use the [`publish`](publish.md) and
+[`subscribe`](subscribe.md) operators.
+
 ### `--retro`
 
 Export persistent events at a Tenzir node. Unless `--live` is given, this is

--- a/web/docs/operators/metrics.md
+++ b/web/docs/operators/metrics.md
@@ -110,6 +110,7 @@ metrics themselves.
 |`schema`|`string`|The schema name of the batch.|
 |`schema_id`|`string`|The schema ID of the batch.|
 |`events`|`uint64`|The amount of events that were imported.|
+|`queued_events`|`uint64`|The total amount of events that are enqueued in the export.|
 
 ### `tenzir.metrics.import`
 


### PR DESCRIPTION
Before this change, a backpressure-blocked pipeline with `export --live` was able to use potentially use infinite amounts of memory.

This also adds the `queued_events` field to export metrics.