### PR TITLE
Break back pressure in hidden subscribers

### DIFF
--- a/changelog/next/bug-fixes/4399-sub-hidden-back-pressure.md
+++ b/changelog/next/bug-fixes/4399-sub-hidden-back-pressure.md
@@ -1,0 +1,4 @@
+The `subscribe` operator no longer propagates back pressure to its corresponding
+`publish` operators when part of a pipeline that runs in the background, i.e.,
+is not visible on the overview page on app.tenzir.com. An invisible subscriber
+should never be able to slow down a publisher.

--- a/libtenzir/include/tenzir/actors.hpp
+++ b/libtenzir/include/tenzir/actors.hpp
@@ -417,7 +417,7 @@ using node_actor = typed_actor_fwd<
   // Spawn a set of execution nodes for a given pipeline. Does not start the
   // execution nodes.
   auto(atom::spawn, operator_box, operator_type, receiver_actor<diagnostic>,
-       metrics_receiver_actor, int index)
+       metrics_receiver_actor, int index, bool is_hidden)
     ->caf::result<exec_node_actor>>::unwrap;
 
 /// The interface of a PIPELINE EXECUTOR actor.

--- a/libtenzir/include/tenzir/execution_node.hpp
+++ b/libtenzir/include/tenzir/execution_node.hpp
@@ -45,6 +45,7 @@ namespace tenzir {
 /// @param diagnostics_handler The handler asked to spawn diagnostics.
 /// @param metrices_receiver The handler asked to receive and forward metrics.
 /// @param has_terminal True if the operator shall have access to the terminal.
+/// @param is_hidden Whether the operator is run in the background.
 ///
 /// @returns The execution node actor and its output type, or an error.
 /// @pre op != nullptr
@@ -54,7 +55,7 @@ auto spawn_exec_node(caf::scheduled_actor* self, operator_ptr op,
                      operator_type input_type, node_actor node,
                      receiver_actor<diagnostic> diagnostics_handler,
                      metrics_receiver_actor metrics_receiver, int index,
-                     bool has_terminal)
+                     bool has_terminal, bool is_hidden)
   -> caf::expected<std::pair<exec_node_actor, operator_type>>;
 
 } // namespace tenzir

--- a/libtenzir/include/tenzir/operator_control_plane.hpp
+++ b/libtenzir/include/tenzir/operator_control_plane.hpp
@@ -44,6 +44,10 @@ struct operator_control_plane {
   /// Returns true if the operator is hosted by process that has a terminal.
   virtual auto has_terminal() const noexcept -> bool = 0;
 
+  /// Returns true if the operator is marked as hidden, i.e., run in the
+  /// background.
+  virtual auto is_hidden() const noexcept -> bool = 0;
+
   /// Suspend or resume the operator's runloop. A suspended operator will not
   /// get resumed after it yielded to the executor.
   virtual auto set_waiting(bool value) noexcept -> void = 0;

--- a/libtenzir/include/tenzir/pipeline_executor.hpp
+++ b/libtenzir/include/tenzir/pipeline_executor.hpp
@@ -38,6 +38,9 @@ struct pipeline_executor_state {
   /// True if the locally-run nodes shall have access to the terminal.
   bool has_terminal = {};
 
+  /// Indicates whether the pipeline is run in the background.
+  bool is_hidden = {};
+
   auto start() -> caf::result<void>;
   auto pause() -> caf::result<void>;
   auto resume() -> caf::result<void>;
@@ -56,7 +59,7 @@ struct pipeline_executor_state {
 auto pipeline_executor(
   pipeline_executor_actor::stateful_pointer<pipeline_executor_state> self,
   pipeline pipe, receiver_actor<diagnostic> diagnostics,
-  metrics_receiver_actor metrics, node_actor node, bool has_terminal)
-  -> pipeline_executor_actor::behavior_type;
+  metrics_receiver_actor metrics, node_actor node, bool has_terminal,
+  bool is_hidden) -> pipeline_executor_actor::behavior_type;
 
 } // namespace tenzir

--- a/libtenzir/src/exec_pipeline.cpp
+++ b/libtenzir/src/exec_pipeline.cpp
@@ -218,7 +218,8 @@ auto exec_pipeline(pipeline pipe, diagnostic_handler& dh,
       self->state.executor = self->spawn<caf::monitored>(
         pipeline_executor, std::move(pipe),
         caf::actor_cast<receiver_actor<diagnostic>>(self),
-        caf::actor_cast<metrics_receiver_actor>(self), node_actor{}, true);
+        caf::actor_cast<metrics_receiver_actor>(self), node_actor{}, true,
+        true);
       self->request(self->state.executor, caf::infinite, atom::start_v)
         .then(
           []() {

--- a/libtenzir/src/node.cpp
+++ b/libtenzir/src/node.cpp
@@ -615,8 +615,8 @@ auto node(node_actor::stateful_pointer<node_state> self, std::string /*name*/,
     },
     [self](atom::spawn, operator_box& box, operator_type input_type,
            const receiver_actor<diagnostic>& diagnostic_handler,
-           const metrics_receiver_actor& metrics_receiver,
-           int index) -> caf::result<exec_node_actor> {
+           const metrics_receiver_actor& metrics_receiver, int index,
+           bool is_hidden) -> caf::result<exec_node_actor> {
       auto op = std::move(box).unwrap();
       if (op->location() == operator_location::local) {
         return caf::make_error(ec::logic_error,
@@ -628,7 +628,7 @@ auto node(node_actor::stateful_pointer<node_state> self, std::string /*name*/,
       auto spawn_result
         = spawn_exec_node(self, std::move(op), input_type,
                           static_cast<node_actor>(self), diagnostic_handler,
-                          metrics_receiver, index, false);
+                          metrics_receiver, index, false, is_hidden);
       if (not spawn_result) {
         return caf::make_error(ec::logic_error,
                                fmt::format("{} failed to spawn execution node "

--- a/libtenzir/src/pipeline.cpp
+++ b/libtenzir/src/pipeline.cpp
@@ -61,6 +61,10 @@ public:
     return false;
   }
 
+  auto is_hidden() const noexcept -> bool override {
+    return true;
+  }
+
   auto set_waiting(bool value) noexcept -> void override {
     (void)value;
     TENZIR_UNIMPLEMENTED();

--- a/libtenzir/src/pipeline_executor.cpp
+++ b/libtenzir/src/pipeline_executor.cpp
@@ -109,7 +109,7 @@ void pipeline_executor_state::spawn_execution_nodes(pipeline pipe) {
       self
         ->request(node, caf::infinite, atom::spawn_v,
                   operator_box{std::move(op)}, input_type, diagnostics, metrics,
-                  op_index)
+                  op_index, is_hidden)
         .then(
           [=, this](exec_node_actor& exec_node) {
             TENZIR_VERBOSE("{} spawned {} remotely", *self, description);
@@ -127,7 +127,7 @@ void pipeline_executor_state::spawn_execution_nodes(pipeline pipe) {
       TENZIR_DEBUG("{} spawns {} locally", *self, description);
       auto spawn_result
         = spawn_exec_node(self, std::move(op), input_type, node, diagnostics,
-                          metrics, op_index, has_terminal);
+                          metrics, op_index, has_terminal, is_hidden);
       if (not spawn_result) {
         abort_start(diagnostic::error(spawn_result.error())
                       .note("failed to spawn {} locally", description)
@@ -264,8 +264,8 @@ auto pipeline_executor_state::resume() -> caf::result<void> {
 auto pipeline_executor(
   pipeline_executor_actor::stateful_pointer<pipeline_executor_state> self,
   pipeline pipe, receiver_actor<diagnostic> diagnostics,
-  metrics_receiver_actor metrics, node_actor node, bool has_terminal)
-  -> pipeline_executor_actor::behavior_type {
+  metrics_receiver_actor metrics, node_actor node, bool has_terminal,
+  bool is_hidden) -> pipeline_executor_actor::behavior_type {
   TENZIR_DEBUG("{} was created", *self);
   self->state.self = self;
   self->state.node = std::move(node);
@@ -275,6 +275,7 @@ auto pipeline_executor(
   self->state.no_location_overrides = caf::get_or(
     self->system().config(), "tenzir.no-location-overrides", false);
   self->state.has_terminal = has_terminal;
+  self->state.is_hidden = is_hidden;
   self->set_down_handler([self](caf::down_msg& msg) {
     const auto exec_node
       = std::find_if(self->state.exec_nodes.begin(),

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "229e9cdfe58fa0762b36de93142ca0fa76d3a708",
+  "rev": "688b87857d1b3727e0fd6b05ea40f64066f3d14a",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/web/docs/operators/subscribe.md
+++ b/web/docs/operators/subscribe.md
@@ -21,6 +21,12 @@ The `subscribe` operator subscribes to events from a channel with the specified
 topic. Multiple `subscribe` operators with the same topic receive the same
 events.
 
+Subscribers propagate back pressure to publishers. If a subscribing pipeline
+fails to keep up, all publishers will slow down as well to a matching speed to
+avoid data loss. This mechanism is disabled for pipelines that are not visible
+on the overview page on [app.tenzir.com](https://app.tenzir.com), which drop
+data rather than slow down their publishers.
+
 ### `<topic>`
 
 An optional topic identifying the channel events are published under.


### PR DESCRIPTION
This change makes it so that `subscribe` no longer propagates back pressure when run as part of a hidden pipeline, i.e., a pipeline that is not visible on the Tenzir Platform.

Without this change, it was surprisingly easy to break publishers by simply subscribing to their topic and piping the data into an operator that did nothing, e.g., `serve` with a very small buffer size.