### PR TITLE
Fix bug in `buffer` metrics

### DIFF
--- a/libtenzir/builtins/operators/buffer.cpp
+++ b/libtenzir/builtins/operators/buffer.cpp
@@ -245,7 +245,7 @@ public:
       "tenzir.metrics.buffer",
       record_type{
         {"used", uint64_type{}},
-        {"remaining", uint64_type{}},
+        {"free", uint64_type{}},
         {"dropped", uint64_type{}},
       },
     });


### PR DESCRIPTION
We emitted the field as `free`, but had `remaining` in the schema.