### PR TITLE
Upload Docker images for major and major.minor version

### DIFF
--- a/.github/workflows/tenzir.yaml
+++ b/.github/workflows/tenzir.yaml
@@ -256,7 +256,10 @@ jobs:
           elif [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
             tags=('main' "${{ github.sha }}")
           elif [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
-            tags=('latest' "${{ github.sha }}" "${{ steps.configure.outputs.release-version }}")
+            major_minor_patch='${{ steps.configure.outputs.release-version }}'
+            major_minor=$(echo $major_minor_patch | sed 's/\(v[0-9]*\.[0-9]*\)\..*/\1/')
+            major=$(echo $major_minor_patch | sed 's/\(v[0-9]*\)\..*/\1/')
+            tags=('latest' "${{ github.sha }}" "${major_minor_patch}" "${major_minor}" "${major}")
           else
             echo "::error unexpected github.event_name: \"${GITHUB_EVENT_NAME}\""
             exit 1


### PR DESCRIPTION
This makes it so that on the next release, we will upload not just `v4.19.0`, but also `v4.19` and `v4` images.

Fixes tenzir/issues#1977