### PR TITLE
Remove the `use_simple_format` option for `/serve`

### DIFF
--- a/changelog/next/changes/4411--serve-simple-format-only.md
+++ b/changelog/next/changes/4411--serve-simple-format-only.md
@@ -1,0 +1,2 @@
+The `/serve` endpoint now always uses the simple output format for schema
+definitions. The option `use_simple_format` is now ignored.

--- a/libtenzir/builtins/aspects/schemas.cpp
+++ b/libtenzir/builtins/aspects/schemas.cpp
@@ -58,7 +58,7 @@ public:
     co_yield {};
     auto builder = series_builder{};
     for (const auto& schema : schemas) {
-      builder.data(schema.to_definition2());
+      builder.data(schema.to_definition());
       co_yield builder.finish_assert_one_slice(
         fmt::format("tenzir.schema.{}", schema.make_fingerprint()));
     }

--- a/libtenzir/include/tenzir/type.hpp
+++ b/libtenzir/include/tenzir/type.hpp
@@ -293,11 +293,9 @@ public:
   [[nodiscard]] data construct() const noexcept;
 
   /// Converts the type into its type definition.
-  /// @param expand Render the definition in its expanded form.
   /// @pre *this
-  [[nodiscard]] auto to_definition(bool expand = false) const noexcept -> data;
-  [[nodiscard]] auto to_definition2(std::optional<std::string> field_name = {},
-                                    offset parent_path = {}) const noexcept
+  [[nodiscard]] auto to_definition(std::optional<std::string> field_name = {},
+                                   offset parent_path = {}) const noexcept
     -> record;
 
   /// Creates a type from an Arrow DataType, Field, or Schema.

--- a/libtenzir/test/type.cpp
+++ b/libtenzir/test/type.cpp
@@ -42,8 +42,6 @@ TEST(null_type) {
   CHECK_EQUAL(*lt.to_arrow_type(), *arrow::list(arrow::null()));
   CHECK_EQUAL(*ln.to_arrow_type(), *arrow::list(arrow::null()));
   CHECK_EQUAL(*ltn.to_arrow_type(), *arrow::list(arrow::null()));
-  const auto expected_definition = data{};
-  CHECK_EQUAL(tn.to_definition(), expected_definition);
 }
 
 TEST(bool_type) {
@@ -63,8 +61,6 @@ TEST(bool_type) {
   CHECK(caf::holds_alternative<bool_type>(bt));
   const auto lbt = type::from_legacy_type(legacy_bool_type{});
   CHECK(caf::holds_alternative<bool_type>(lbt));
-  const auto expected_definition = data{"bool"};
-  CHECK_EQUAL(bt.to_definition(), expected_definition);
 }
 
 TEST(int64_type) {
@@ -84,8 +80,6 @@ TEST(int64_type) {
   CHECK(caf::holds_alternative<int64_type>(it));
   const auto lit = type::from_legacy_type(legacy_integer_type{});
   CHECK(caf::holds_alternative<int64_type>(lit));
-  const auto expected_definition = data{"int64"};
-  CHECK_EQUAL(it.to_definition(), expected_definition);
 }
 
 TEST(uint64_type) {
@@ -105,8 +99,6 @@ TEST(uint64_type) {
   CHECK(caf::holds_alternative<uint64_type>(ct));
   const auto lct = type::from_legacy_type(legacy_count_type{});
   CHECK(caf::holds_alternative<uint64_type>(lct));
-  const auto expected_definition = data{"uint64"};
-  CHECK_EQUAL(ct.to_definition(), expected_definition);
 }
 
 TEST(double_type) {
@@ -126,8 +118,6 @@ TEST(double_type) {
   CHECK(caf::holds_alternative<double_type>(rt));
   const auto lrt = type::from_legacy_type(legacy_real_type{});
   CHECK(caf::holds_alternative<double_type>(lrt));
-  const auto expected_definition = data{"double"};
-  CHECK_EQUAL(rt.to_definition(), expected_definition);
 }
 
 TEST(duration_type) {
@@ -147,8 +137,6 @@ TEST(duration_type) {
   CHECK(caf::holds_alternative<duration_type>(dt));
   const auto ldt = type::from_legacy_type(legacy_duration_type{});
   CHECK(caf::holds_alternative<duration_type>(ldt));
-  const auto expected_definition = data{"duration"};
-  CHECK_EQUAL(dt.to_definition(), expected_definition);
 }
 
 TEST(time_type) {
@@ -168,8 +156,6 @@ TEST(time_type) {
   CHECK(caf::holds_alternative<time_type>(tt));
   const auto ltt = type::from_legacy_type(legacy_time_type{});
   CHECK(caf::holds_alternative<time_type>(ltt));
-  const auto expected_definition = data{"time"};
-  CHECK_EQUAL(tt.to_definition(), expected_definition);
 }
 
 TEST(string_type) {
@@ -189,8 +175,6 @@ TEST(string_type) {
   CHECK(caf::holds_alternative<string_type>(st));
   const auto lst = type::from_legacy_type(legacy_string_type{});
   CHECK(caf::holds_alternative<string_type>(lst));
-  const auto expected_definition = data{"string"};
-  CHECK_EQUAL(st.to_definition(), expected_definition);
 }
 
 TEST(ip_type) {
@@ -210,8 +194,6 @@ TEST(ip_type) {
   CHECK(caf::holds_alternative<ip_type>(at));
   const auto lat = type::from_legacy_type(legacy_address_type{});
   CHECK(caf::holds_alternative<ip_type>(lat));
-  const auto expected_definition = data{"ip"};
-  CHECK_EQUAL(at.to_definition(), expected_definition);
 }
 
 TEST(subnet_type) {
@@ -231,8 +213,6 @@ TEST(subnet_type) {
   CHECK(caf::holds_alternative<subnet_type>(st));
   const auto lst = type::from_legacy_type(legacy_subnet_type{});
   CHECK(caf::holds_alternative<subnet_type>(lst));
-  const auto expected_definition = data{"subnet"};
-  CHECK_EQUAL(st.to_definition(), expected_definition);
 }
 
 TEST(enumeration_type) {
@@ -263,9 +243,6 @@ TEST(enumeration_type) {
   CHECK_EQUAL(caf::get<enumeration_type>(let).field(1), "second");
   CHECK_EQUAL(caf::get<enumeration_type>(let).field(2), "third");
   CHECK_EQUAL(caf::get<enumeration_type>(let).field(3), "");
-  const auto expected_definition
-    = data{record{{"enum", list{"first", "third", "fourth"}}}};
-  CHECK_EQUAL(et.to_definition(), expected_definition);
 }
 
 TEST(list_type) {
@@ -289,8 +266,6 @@ TEST(list_type) {
     = type::from_legacy_type(legacy_list_type{legacy_bool_type{}});
   CHECK(caf::holds_alternative<list_type>(llbt));
   CHECK_EQUAL(caf::get<list_type>(llbt).value_type(), type{bool_type{}});
-  const auto expected_definition = data{record{{"list", "int64"}}};
-  CHECK_EQUAL(tlit.to_definition(), expected_definition);
 }
 
 TEST(map_type) {
@@ -316,9 +291,6 @@ TEST(map_type) {
   CHECK(caf::holds_alternative<map_type>(lmabt));
   CHECK_EQUAL(caf::get<map_type>(lmabt).key_type(), type{ip_type{}});
   CHECK_EQUAL(caf::get<map_type>(lmabt).value_type(), type{bool_type{}});
-  const auto expected_definition
-    = data{record{{"map", record{{"key", "string"}, {"value", "int64"}}}}};
-  CHECK_EQUAL(tmsit.to_definition(), expected_definition);
 }
 
 TEST(record_type) {
@@ -347,40 +319,6 @@ TEST(record_type) {
   CHECK_EQUAL(r.field({1, 1}).type, ip_type{});
   CHECK_EQUAL(r.field({3, 0}).name, "s");
   CHECK_EQUAL(flatten(rt), type{flatten(r)});
-  const auto expected_definition = data{record{
-    {"record",
-     list{
-       record{{"i", "int64"}},
-       record{
-         {"r1",
-          record{
-            {
-              "record",
-              list{
-                record{
-                  {"p",
-                   record{
-                     {"port", "int64"},
-                   }},
-                },
-                record{{"a", "ip"}},
-              },
-            },
-          }},
-       },
-       record{{"b", "bool"}},
-       record{
-         {"r2",
-          record{
-            {"record",
-             list{
-               record{{"s", "subnet"}},
-             }},
-          }},
-       },
-     }},
-  }};
-  CHECK_EQUAL(rt.to_definition(), expected_definition);
 }
 
 TEST(record_type name resolving) {
@@ -844,44 +782,6 @@ TEST(aliases) {
   CHECK_EQUAL(aliases[2], t3);
   CHECK_EQUAL(aliases[3], t2);
   CHECK_EQUAL(aliases[4], t1);
-  const auto expected_definition = data{record{
-    {"foo",
-     record{
-       {"type",
-        record{
-          {"bar",
-           record{
-             {"type",
-              record{
-                {"baz",
-                 record{
-                   {"qux",
-                    record{
-                      {"type",
-                       record{
-                         {"quux", "bool"},
-                       }},
-                      {"attributes",
-                       record{
-                         {"first", caf::none},
-                       }},
-                    }},
-                 }},
-              }},
-             {"attributes",
-              record{
-                {"second", caf::none},
-                {"third", caf::none},
-              }},
-           }},
-        }},
-       {"attributes",
-        record{
-          {"fourth", caf::none},
-        }},
-     }},
-  }};
-  CHECK_EQUAL(t7.to_definition(), expected_definition);
 }
 
 TEST(metadata layer merging) {

--- a/web/openapi/openapi.yaml
+++ b/web/openapi/openapi.yaml
@@ -548,7 +548,7 @@ paths:
   /serve:
     post:
       summary: Return data from a pipeline
-      description: "Returns events from an existing pipeline. The pipeline definition must include a serve operator. By default, the endpoint performs long polling (`timeout: 2s`) and returns events as soon as they are available (`min_events: 1`)."
+      description: "Returns events from an existing pipeline. The pipeline definition must include a serve operator. By default, the endpoint performs long polling (`timeout: 5s`) and returns events as soon as they are available (`min_events: 1`)."
       requestBody:
         description: Body for the serve endpoint
         required: true
@@ -579,14 +579,9 @@ paths:
                   description: Wait for this number of events before returning.
                 timeout:
                   type: string
-                  example: 2.0s
-                  default: 2.0s
-                  description: The maximum amount of time spent on the request. Hitting the timeout is not an error. The timeout must not be greater than 5 seconds.
-                use_simple_format:
-                  type: bool
-                  example: true
-                  default: false
-                  description: Use an experimental, more simple format for the contained schema, and render durations as numbers representing seconds as opposed to human-readable strings.
+                  example: 200.0ms
+                  default: 5.0s
+                  description: The maximum amount of time spent on the request. Hitting the timeout is not an error. The timeout must not be greater than 10 seconds.
       responses:
         200:
           description: Success.
@@ -614,11 +609,32 @@ paths:
                     example:
                       - schema_id: c631d301e4b18f4
                         definition:
-                          record:
-                            - timestamp: time
-                              schema: string
-                              schema_id: string
-                              events: uint64
+                          - name: tenzir.summarize
+                            kind: record
+                            type: tenzir.summarize
+                            attributes:
+                              {}
+                            path:
+                              []
+                            fields:
+                              - name: severity
+                                kind: string
+                                type: string
+                                attributes:
+                                  {}
+                                path:
+                                  - 0
+                                fields:
+                                  []
+                              - name: pipeline_id
+                                kind: string
+                                type: string
+                                attributes:
+                                  {}
+                                path:
+                                  - 1
+                                fields:
+                                  []
                   events:
                     type: array
                     items:


### PR DESCRIPTION
This is now always the default. We've had it for quite some time now, and we've used it in the app from the very day we added it.

Fixes tenzir/issues#1706