### PR TITLE
Add list indexing

### DIFF
--- a/libtenzir/include/tenzir/arrow_utils.hpp
+++ b/libtenzir/include/tenzir/arrow_utils.hpp
@@ -28,9 +28,15 @@ template <class T>
 
 template <std::derived_from<arrow::ArrayBuilder> T>
 [[nodiscard]] auto finish(T& x) {
-  using Type = std::conditional_t<std::same_as<arrow::StringBuilder, T>,
-                                  arrow::StringType, typename T::TypeClass>;
-  auto result = std::shared_ptr<typename arrow::TypeTraits<Type>::ArrayType>{};
+  auto result = std::invoke([] {
+    if constexpr (std::same_as<T, arrow::ArrayBuilder>) {
+      return std::shared_ptr<arrow::Array>{};
+    } else {
+      using Type = std::conditional_t<std::same_as<arrow::StringBuilder, T>,
+                                      arrow::StringType, typename T::TypeClass>;
+      return std::shared_ptr<typename arrow::TypeTraits<Type>::ArrayType>{};
+    }
+  });
   check(x.Finish(&result));
   TENZIR_ASSERT(result);
   return result;

--- a/libtenzir/include/tenzir/tql2/eval_impl.hpp
+++ b/libtenzir/include/tenzir/tql2/eval_impl.hpp
@@ -51,6 +51,8 @@ public:
 
   auto eval(const ast::meta& x) -> series;
 
+  auto eval(const ast::index_expr& x) -> series;
+
   template <class T>
   auto eval(const T& x) -> series {
     return not_implemented(x);

--- a/libtenzir/src/tql2/eval_impl.cpp
+++ b/libtenzir/src/tql2/eval_impl.cpp
@@ -177,7 +177,7 @@ auto evaluator::eval(const ast::index_expr& x) -> series {
       if (target < 0) {
         target = length + target;
       }
-      if (target >= length) {
+      if (target < 0 || target >= length) {
         out_of_bounds = true;
         check(b->AppendNull());
         continue;

--- a/libtenzir/src/tql2/eval_impl.cpp
+++ b/libtenzir/src/tql2/eval_impl.cpp
@@ -6,7 +6,9 @@
 // SPDX-FileCopyrightText: (c) 2024 The Tenzir Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+#include <tenzir/arrow_utils.hpp>
 #include <tenzir/detail/enumerate.hpp>
+#include <tenzir/table_slice_builder.hpp>
 #include <tenzir/tql2/eval_impl.hpp>
 
 #include <ranges>
@@ -150,6 +152,48 @@ auto evaluator::eval(const ast::root_field& x) -> series {
     .primary(x.ident)
     .emit(ctx_);
   return null();
+}
+
+auto evaluator::eval(const ast::index_expr& x) -> series {
+  auto value = eval(x.expr);
+  auto index = eval(x.index);
+  if (auto number = index.as<int64_type>()) {
+    auto list = value.as<list_type>();
+    if (not list) {
+      diagnostic::warning("cannot index into `{}` with `{}`", value.type.kind(),
+                          index.type.kind())
+        .primary(x.index)
+        .emit(ctx_);
+      return null();
+    }
+    auto list_values = list->array->values();
+    auto value_type = list->type.value_type();
+    auto b = value_type.make_arrow_builder(arrow::default_memory_pool());
+    check(b->Reserve(list->length()));
+    auto out_of_bounds = false;
+    for (auto i = int64_t{0}; i < list->length(); ++i) {
+      auto target = number->array->Value(i);
+      auto length = list->array->value_length(i);
+      if (target < 0) {
+        target = length + target;
+      }
+      if (target >= length) {
+        out_of_bounds = true;
+        check(b->AppendNull());
+        continue;
+      }
+      auto offset = list->array->value_offset(i);
+      auto value_index = offset + target;
+      check(append_array_slice(*b, value_type, *list_values, value_index, 1));
+    }
+    if (out_of_bounds) {
+      diagnostic::warning("list index out of bounds")
+        .primary(x.index)
+        .emit(ctx_);
+    }
+    return series{value_type, finish(*b)};
+  }
+  return not_implemented(x);
 }
 
 auto evaluator::eval(const ast::meta& x) -> series {

--- a/tenzir/integration/data/reference/expression/test_list_indexing/step_00.ref
+++ b/tenzir/integration/data/reference/expression/test_list_indexing/step_00.ref
@@ -1,0 +1,15 @@
+{"a": [1, 2, 3], "b": 1, "c": 3, "d": 3, "e": 1}
+{"a": [4, 5], "b": 4, "c": null, "d": 5, "e": null}
+warning: list index out of bounds
+ --> /dev/stdin:6:7
+  |
+6 | c = a[2]
+  |       ~ 
+  |
+
+warning: list index out of bounds
+ --> /dev/stdin:8:7
+  |
+8 | e = a[-3]
+  |       ~~ 
+  |

--- a/tenzir/integration/tests/expression.bats
+++ b/tenzir/integration/tests/expression.bats
@@ -42,3 +42,16 @@ z = {...x, ...42, ...y}
 write_json
 EOF
 }
+
+@test "list indexing" {
+  check tenzir -f '/dev/stdin' <<EOF
+source [
+  { a: [1, 2, 3] },
+  { a: [4, 5] },
+]
+b = a[0]
+c = a[2]
+d = a[-1]
+e = a[-3]
+EOF
+}


### PR DESCRIPTION
This PR adds list indexing to TQL2. 


### Example

```
source [
  { x: [1, 2, 3] },
  { x: [4, 5] },
]
y = x[2]
z = x[-1]
```

### Output

```
warning: list index out of bounds
 --> <input>:5:7
  |
5 | y = x[2]
  |       ~ 
  |
{
  "x": [
    1,
    2,
    3
  ],
  "y": 3,
  "z": 3
}
{
  "x": [
    4,
    5
  ],
  "y": null,
  "z": 5
}
```