### PR TITLE
Minor changes

### DIFF
--- a/libtenzir/include/tenzir/detail/to_xsv_sep.hpp
+++ b/libtenzir/include/tenzir/detail/to_xsv_sep.hpp
@@ -6,6 +6,8 @@
 // SPDX-FileCopyrightText: (c) 2023 The Tenzir Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+#pragma once
+
 #include <caf/expected.hpp>
 
 #include <string_view>

--- a/libtenzir/include/tenzir/io/read.hpp
+++ b/libtenzir/include/tenzir/io/read.hpp
@@ -6,6 +6,8 @@
 // SPDX-FileCopyrightText: (c) 2020 The Tenzir Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+#pragma once
+
 #include "caf/fwd.hpp"
 #include "tenzir/fwd.hpp"
 

--- a/libtenzir/include/tenzir/io/save.hpp
+++ b/libtenzir/include/tenzir/io/save.hpp
@@ -6,6 +6,8 @@
 // SPDX-FileCopyrightText: (c) 2020 The Tenzir Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+#pragma once
+
 #include "tenzir/fwd.hpp"
 
 #include <cstddef>

--- a/libtenzir/include/tenzir/io/write.hpp
+++ b/libtenzir/include/tenzir/io/write.hpp
@@ -6,6 +6,8 @@
 // SPDX-FileCopyrightText: (c) 2020 The Tenzir Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+#pragma once
+
 #include "tenzir/fwd.hpp"
 
 #include <cstddef>

--- a/libtenzir/include/tenzir/value_ptr.hpp
+++ b/libtenzir/include/tenzir/value_ptr.hpp
@@ -6,6 +6,8 @@
 // SPDX-FileCopyrightText: (c) 2023 The Tenzir Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+#pragma once
+
 #include "tenzir/error.hpp"
 
 #include <memory>

--- a/libtenzir_test/tenzir/test/serialization.hpp
+++ b/libtenzir_test/tenzir/test/serialization.hpp
@@ -6,6 +6,8 @@
 // SPDX-FileCopyrightText: (c) 2023 The Tenzir Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+#pragma once
+
 #include "tenzir/test/test.hpp"
 
 #include <caf/binary_deserializer.hpp>

--- a/shell.nix
+++ b/shell.nix
@@ -10,7 +10,7 @@ in
       nativeBuildInputs =
         [
           pkgs.ccache
-          pkgs.clang-tools_16
+          pkgs.clang-tools
           pkgs.cmake-format
           pkgs.speeve
           pkgs.shfmt
@@ -28,9 +28,9 @@ in
         ] ++ pkgs.tenzir-integration-test-deps
           ++ lib.optionals (!(pkgs.stdenv.hostPlatform.useLLVM or false)) [
           # Make clang available as alternative compiler when it isn't the default.
-          pkgs.clang_16
+          pkgs.clang
           # Bintools come with a wrapped lld for faster linking.
-          pkgs.llvmPackages_16.bintools
+          pkgs.llvmPackages.bintools
         ] # Temporarily only on Linux.
           ++ lib.optionals pkgs.stdenv.isLinux [
           pkgs.pandoc


### PR DESCRIPTION
Added missing #pragma once in some files.
The default llvm toolchain is v17 in nix-pkgs now and there is no need to pin it to a lower version.