### PR TITLE
Add a --write-endpoint=<path> option to tenzir-node

### DIFF
--- a/libtenzir/src/application.cpp
+++ b/libtenzir/src/application.cpp
@@ -104,6 +104,7 @@ auto make_start_command() {
     "start", "starts a node",
     opts("?tenzir.start")
       .add<bool>("print-endpoint", "print the client endpoint on stdout")
+      .add<std::string>("write-endpoint", "write the client endpoint to a path")
       .add<caf::config_value::list>("commands", "an ordered list of commands "
                                                 "to run inside the node after "
                                                 "starting")

--- a/libtenzir/src/file.cpp
+++ b/libtenzir/src/file.cpp
@@ -67,16 +67,18 @@ caf::expected<void> file::open(open_mode mode, bool append) {
     flags |= O_APPEND;
   errno = 0;
   std::error_code err{};
-  const auto parent = path_.parent_path();
-  const auto file_exists = std::filesystem::exists(parent, err);
-  if (mode != read_only && !file_exists) {
-    const auto created_directory
-      = std::filesystem::create_directories(parent, err);
-    if (!created_directory) {
-      return caf::make_error(ec::filesystem_error,
-                             fmt::format("failed to create parent directory "
-                                         "{}: {}",
-                                         parent, err.message()));
+  if (path_.has_parent_path()) {
+    const auto parent = path_.parent_path();
+    const auto file_exists = std::filesystem::exists(parent, err);
+    if (mode != read_only && !file_exists) {
+      const auto created_directory
+        = std::filesystem::create_directories(parent, err);
+      if (!created_directory) {
+        return caf::make_error(ec::filesystem_error,
+                               fmt::format("failed to create parent directory "
+                                           "{}: {}",
+                                           parent, err.message()));
+      }
     }
   }
   handle_ = ::open(path_.string().data(), flags, 0644);

--- a/libtenzir/src/io/write.cpp
+++ b/libtenzir/src/io/write.cpp
@@ -20,8 +20,9 @@ namespace tenzir::io {
 caf::error
 write(const std::filesystem::path& filename, std::span<const std::byte> xs) {
   file f{filename};
-  if (!f.open(file::write_only))
-    return caf::make_error(ec::filesystem_error, "failed open file");
+  if (auto result = f.open(file::write_only); !result) {
+    return result.error();
+  }
   return f.write(xs.data(), xs.size());
 }
 

--- a/libtenzir/src/start_command.cpp
+++ b/libtenzir/src/start_command.cpp
@@ -18,6 +18,7 @@
 #include "tenzir/detail/settings.hpp"
 #include "tenzir/endpoint.hpp"
 #include "tenzir/error.hpp"
+#include "tenzir/io/write.hpp"
 #include "tenzir/logger.hpp"
 #include "tenzir/scope_linked.hpp"
 #include "tenzir/spawn_node.hpp"
@@ -135,6 +136,12 @@ auto start_command(const invocation& inv, caf::actor_system& sys)
     TENZIR_INFO("node listens for node-to-node connections on tcp://{}",
                 *listen_endpoint);
     // A single line of output to publish out address for scripts.
+    if (const auto* path = caf::get_if<std::string>(
+          &inv.options, "tenzir.start.write-endpoint")) {
+      if (auto err = io::write(*path, as_bytes(*listen_endpoint))) {
+        TENZIR_WARN("failed to write listen_endpoint to {}: {}", *path, err);
+      }
+    }
     if (caf::get_or(inv.options, "tenzir.start.print-endpoint", false)) {
       // We're not using fmt::print here because it doesn't flush the stream.
       std::cout << *listen_endpoint << std::endl;

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -196,6 +196,12 @@ tenzir:
     # available random port, i.e., when specifying 0 as port value.
     print-endpoint: false
 
+    # Writes the endpoint for clients when the server is ready to accept
+    # connections to the specified destination. This comes in handy when letting
+    # the OS choose an available random port, i.e., when specifying 0 as port
+    # value, and `print-endpoint` is not sufficient.
+    #write-endpoint: /tmp/tenzir-node-endpoint
+
     # An ordered list of commands to run inside the node after starting.
     # As an example, to configure an auto-starting PCAP source that listens
     # on the interface 'en0' and lives inside the Tenzir node, add `spawn


### PR DESCRIPTION
This is useful for `docker compose` setups in conjunction with OS chosen ports. A client instance can read the endpoint from a shared volume path to learn about the listening port.