### PR TITLE
Restore Python 3.9 compatibility

### DIFF
--- a/python/tenzir/tools/python_operator_executor.py
+++ b/python/tenzir/tools/python_operator_executor.py
@@ -13,6 +13,7 @@ from typing import (
     Dict,
     Generator,
     Iterable,
+    Optional,
     SupportsIndex,
     Tuple,
     TypeVar,
@@ -44,7 +45,7 @@ def log(*args):
     print(y, file=sys.stderr)
 
 
-def add_note(e: BaseException | None, msg: str) -> None:
+def add_note(e: Optional[BaseException], msg: str) -> None:
     if e is None:
         return
     if sys.version_info >= (3, 11):


### PR DESCRIPTION
We cannot use the `|` type union syntax yet.
This also contains a fix for the python operator cleanup logic.