### PR TITLE
Simplify `// tql2` flag

### DIFF
--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "0e66a725fa68227dd91b5ad85cd1d6e1dc0b14e4",
+  "rev": "ccd43df16b5c9e0fcfc470ae6aa8cd9e9b3e1f30",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
We already have `// experimental-tql2` to enable the new language for the app, configured pipelines, etc. We want to drop the `experimental` prefix. Thus, `// tql2` is the new flag. The longer form is keeps working for compatibility, but should no longer be used.