### PR TITLE
Emit metrics for events that get emitted as part of push() in the subscribe operator

### DIFF
--- a/changelog/next/bug-fixes/4439--consistent-subscribe-metrics.md
+++ b/changelog/next/bug-fixes/4439--consistent-subscribe-metrics.md
@@ -1,0 +1,1 @@
+The `subscribe` operator now delivers metrics more consistently.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "0285c1ee2276b19986497930fec044d19dd199dc",
+  "rev": "0b08b8589a8c81495110df4f4a5c0bbce90a79ee",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
Events that the `subscribe` operator receives while the buffer is empty and `buffer_rp` is pending get delivered via `buffer_rp` - but the metrics were missing. This change adds metrics for those events.
