### PR TITLE
Slightly optimize the partitions operator

### DIFF
--- a/libtenzir/builtins/operators/partitions.cpp
+++ b/libtenzir/builtins/operators/partitions.cpp
@@ -69,7 +69,9 @@ public:
     auto builders = std::unordered_map<type, series_builder>{};
     using namespace tenzir::si_literals;
     for (auto& synopsis : synopses) {
-      auto& builder = builders[synopsis.synopsis->schema];
+      auto& builder
+        = builders[experimental_include_ranges_ ? synopsis.synopsis->schema
+                                                : type{}];
       auto event = builder.record();
       event.field("uuid").data(fmt::to_string(synopsis.uuid));
       event.field("memusage").data(synopsis.synopsis->memusage());


### PR DESCRIPTION
Achieving a factor 100 speedup on my admittedly pathological catalog with >80000 unique schemas.