### PR TITLE
Add new expert-only options to control demand

### DIFF
--- a/changelog/next/changes/4447--memory-control.md
+++ b/changelog/next/changes/4447--memory-control.md
@@ -1,0 +1,11 @@
+We've made some changes that optimize Tenzir's memory usage. Pipeline operators
+that emit very small batches of events or bytes at a high frequency now use less
+memory. The `serve` operator's internal buffer is now soft-capped at 1Ki instead
+of 64Ki events, aligning the buffer size with the default upper limit for the
+number of events that can be fetched at once from `/serve`. The `export`,
+`metrics`, and `diagnostics` operators now handle back pressure better and
+utilize less memory in situations where the node has many small partitions. For
+expert users, the new `tenzir.demand` configuration section allows for
+controlling how eagerly operators demand input from their upstream operators.
+Lowering the demand reduces the peak memory usage of pipelines at some
+performance cost.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "d44d55ea62137f9f127644c7cf8a6eb36457d67b",
+  "rev": "7de8bbdd76b5d9688887b06bb8f8896e252dde38",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -136,7 +136,7 @@ tenzir:
 
   # The size of an index shard, expressed in number of events. This should
   # be a power of 2.
-  max-partition-size: 4194304
+  max-partition-size: 4Mi
 
   # Timeout after which an active partition is forcibly flushed, regardless of
   # its size.
@@ -152,6 +152,26 @@ tenzir:
 
   # Zstd compression level applied to the Feather store backend.
   # zstd-compression-level: <default>
+
+  # Control how operator's calculate demand from their upstream operator. Note
+  # that this is an expert feature and should only be changed if you know what
+  # you are doing. All values may either be set to a number, or to a record
+  # containing `bytes` and `events` fields with numbers depending on the
+  # operator's input type.
+  demand:
+    # Issue demand only if room for at least this many elements is available.
+    # Must be greater than zero.
+    min-elements:
+      bytes: 128Ki
+      events: 8Ki
+    # Controls how many elements may be buffered until the operator stops
+    # issuing demand. Must be greater or equal to min-elements.
+    max-elements:
+      bytes: 4Mi
+      events: 254Ki
+    # Controls how many batches of elements may be buffered until the operator
+    # stops issuing demand. Must be greater than zero.
+    max-batches: 20
 
   # Context configured as part of the configuration that are always available.
   contexts:

--- a/web/docs/installation/tune-performance/README.md
+++ b/web/docs/installation/tune-performance/README.md
@@ -7,6 +7,28 @@ sidebar_position: 5
 This section describes tuning knobs that have a notable effect on system
 performance.
 
+## Demand
+
+Tenzir schedules operators asynchronously. Within a pipeline, every operator
+sends elements (events or bytes) downstream to the next operator, and demand
+upstream to the previous operator. If an operator has no downstream demand,
+Tenzir's pipeline execution engine stops scheduling the operator.
+
+The configuration section `tenzir.demand` controls how operators issue demand to
+their upstream operators. See the [example configuration][example-configuration]
+for all available options.
+
+For example, to minimize memory usage of pipelines at the cost of performance,
+set the following option:
+
+```yaml
+tenzir:
+  demand:
+    max-batches: 1
+```
+
+[example-configuration]: ../../configuration.md#example-configuration
+
 ## Batching
 
 Tenzir processes events in batches. Because the structured data has the shape of

--- a/web/docs/operators/serve.md
+++ b/web/docs/operators/serve.md
@@ -31,7 +31,7 @@ The buffer size specifies the maximum number of events to keep in the `serve`
 operator to make them instantly available in the corresponding endpoint before
 throttling the pipeline execution.
 
-Defaults to `64Ki`.
+Defaults to `1Ki`.
 
 ### `<serve-id>`
 


### PR DESCRIPTION
The new `tenzir.demand` configuration section is an expert-only configuration section that lets users control how eagerly operators demand input from their upstream operators.