### PR TITLE
Unify types in list expressions

### DIFF
--- a/libtenzir/include/tenzir/type.hpp
+++ b/libtenzir/include/tenzir/type.hpp
@@ -468,6 +468,13 @@ std::strong_ordering operator<=>(const T& lhs, const U& rhs) noexcept {
 caf::error
 replace_if_congruent(std::initializer_list<type*> xs, const module& with);
 
+/// Attempts to unify two types.
+///
+/// Every type can be unified with `null_type`. Records can be unified if their
+/// overlapping fields can be unified, and lists can be unified if their value
+/// type can be unified.
+auto unify(const type& a, const type& b) -> std::optional<type>;
+
 // -- null_type ---------------------------------------------------------------
 
 /// A monostate value that is always `null`.

--- a/tenzir/integration/data/reference/expression/test_list_construction/step_00.ref
+++ b/tenzir/integration/data/reference/expression/test_list_construction/step_00.ref
@@ -1,0 +1,112 @@
+{
+  "x0": [],
+  "x1": [
+    null
+  ],
+  "x2": [
+    null,
+    null
+  ],
+  "x3": [
+    null,
+    42
+  ],
+  "x4": [
+    42,
+    null
+  ],
+  "x5": [
+    {},
+    {}
+  ],
+  "x6": [
+    {
+      "a": 42
+    },
+    {
+      "a": 42
+    }
+  ],
+  "x7": [
+    {
+      "a": 42,
+      "b": null
+    },
+    {
+      "a": null,
+      "b": 42
+    }
+  ],
+  "x8": [
+    {
+      "a": null,
+      "b": null
+    },
+    {
+      "a": 42,
+      "b": 42
+    }
+  ],
+  "x9": [
+    [],
+    []
+  ],
+  "x10": [
+    [],
+    [
+      42
+    ]
+  ],
+  "x11": [
+    [
+      {
+        "x": 42,
+        "y": null
+      }
+    ],
+    [
+      {
+        "x": null,
+        "y": 42
+      }
+    ]
+  ],
+  "x12": [
+    {},
+    null
+  ],
+  "x13": [
+    123,
+    null
+  ],
+  "x14": [
+    [
+      {
+        "x": 123
+      }
+    ],
+    null
+  ]
+}
+warning: type clash in list, using `null` instead
+  --> /dev/stdin:14:13
+   |
+14 |   x12: [{}, []],
+   |             ~~ 
+   |
+   = note: expected `record` but got `list`
+
+warning: type clash in list, using `null` instead
+  --> /dev/stdin:15:14
+   |
+15 |   x13: [123, "abc"],
+   |              ~~~~~ 
+   |
+   = note: expected `int64` but got `string`
+
+warning: type clash in list, using `null` instead
+  --> /dev/stdin:16:21
+   |
+16 |   x14: [[{x: 123}], [{x: "abc"}]],
+   |                     ~~~~~~~~~~~~ 
+   |

--- a/tenzir/integration/tests/expression.bats
+++ b/tenzir/integration/tests/expression.bats
@@ -67,3 +67,26 @@ x = a.length()
 y = b.length()
 EOF
 }
+
+@test "list construction" {
+  check tenzir -f '/dev/stdin' <<EOF
+source {
+  x0: [],
+  x1: [null],
+  x2: [null, null],
+  x3: [null, 42],
+  x4: [42, null],
+  x5: [{}, {}],
+  x6: [{a: 42}, {a: 42}],
+  x7: [{a: 42}, {b: 42}],
+  x8: [{a: null}, {b: 42, a: 42}],
+  x9: [[], []],
+  x10: [[], [42]],
+  x11: [[{x: 42}], [{y: 42}]],
+  x12: [{}, []],
+  x13: [123, "abc"],
+  x14: [[{x: 123}], [{x: "abc"}]],
+}
+write_json
+EOF
+}


### PR DESCRIPTION
Previously, item types of a `[...]` expression had to match exactly (ignoring top-level `null` values). This PR relaxes that restriction to generally allow unifyable types, so that things like `[{x: 42}, {x: null}]` or `[{x: 42}, {y: 42}]` are valid.