### PR TITLE
Expose `--within <duration>` for `throttle`

### DIFF
--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "ba2fa7e84d583993c0a2dc40ffe6dfc23ede411e",
+  "rev": "5d7cc8ba1d99d1e5e094a181345f1651602ec57a",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/web/docs/operators/azure-log-analytics.md
+++ b/web/docs/operators/azure-log-analytics.md
@@ -19,7 +19,6 @@ azure-log-analytics --tenant-id <tenant-id> --client-id <client-id>
                     --dce <data-collection-endpoint>
                     --dcr <data-collection-rule-id>
                     --table <table-name>
-                    [--batch-size <batch-size>]
 ```
 
 ## Description
@@ -58,16 +57,6 @@ The data collection rule ID, written as `dcr-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`.
 ### `--table <table-name>`
 
 The table to upload events to.
-
-### `--batch-size <batch-size>`
-
-The event batch size for each upload request. The Azure Logs Ingestion API
-[takes at most 500MB per minute][limit], making sensible batching of events a
-necessity.
-
-Defaults to 8192.
-
-[limit]: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/tutorial-logs-ingestion-code?tabs=net#script-returns-error-code-429
 
 ## Examples
 

--- a/web/docs/operators/throttle.md
+++ b/web/docs/operators/throttle.md
@@ -11,18 +11,24 @@ Limits the bandwidth of a pipeline.
 ## Synopsis
 
 ```
-throttle <bandwidth>
+throttle <bandwidth> [--within <duration>]
 ```
 
 ## Description
 
 The `throttle` operator limits the amount of data flowing through it to a
-maximum bandwidth.
+bandwidth.
 
 ### `<bandwidth>`
 
 An unsigned integer giving the maximum bandwidth that is enforced for
-this pipeline, in bytes per second.
+this pipeline, in bytes per the specified interval.
+
+### `--within <duration>`
+
+The duration in which to measure the maximum bandwidth.
+
+Defaults to 1s.
 
 ## Examples
 
@@ -33,12 +39,12 @@ second:
 load tcp://0.0.0.0:4000 | throttle 1
 ```
 
-Load a sample input data file at a speed of at most 1MiB/s and import
-it into the node:
+Load a sample input data file at a speed of at most 1MiB every 10s and import it
+into the node:
 
 ```
 load https://storage.googleapis.com/tenzir-datasets/M57/zeek-all.log.zst
-| throttle 1Mi
+| throttle 1Mi --window 10s
 | decompress zstd
 | read zeek-tsv
 | import


### PR DESCRIPTION
This makes it possible to set the window size over which the bandwidth is restricted. Additionally, this updates `azure-log-analytics` to make use of `throttle` to properly respect the upstream rate limit.