### PR TITLE
Add a `trim` method for TQL2

### DIFF
--- a/libtenzir/builtins/functions/string.cpp
+++ b/libtenzir/builtins/functions/string.cpp
@@ -7,7 +7,10 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include <tenzir/arrow_utils.hpp>
+#include <tenzir/tql2/eval.hpp>
 #include <tenzir/tql2/plugin.hpp>
+
+#include <arrow/compute/api.h>
 
 namespace tenzir::plugins::string {
 
@@ -70,16 +73,59 @@ private:
   bool starts_with_;
 };
 
-// TODO: We need better runtime configuration of plugin objects.
-class starts_with final : public virtual starts_or_ends_with {
+class trim : public virtual method_plugin {
 public:
-  starts_with() : starts_or_ends_with(true) {
-  }
-};
+  trim() = default;
 
-class ends_with final : public virtual starts_or_ends_with {
-public:
-  ends_with() : starts_or_ends_with(false) {
+  auto name() const -> std::string override {
+    return "trim";
+  }
+
+  auto make_function(invocation inv, session ctx) const
+    -> failure_or<function_ptr> override {
+    auto subject_expr = ast::expression{};
+    auto characters_expr = std::optional<ast::expression>{};
+    TRY(argument_parser2::method(name())
+          .add(subject_expr, "<string>")
+          .add("chars", characters_expr)
+          .parse(inv, ctx));
+    auto options = arrow::compute::TrimOptions{" \t\n\v\f\r"};
+    if (characters_expr) {
+      TRY(auto characters, const_eval(*characters_expr, ctx));
+      const auto* characters_str = caf::get_if<std::string>(&characters);
+      if (not characters_str) {
+        diagnostic::error("expected string").primary(*characters_expr).emit(ctx);
+        return failure::promise();
+      }
+      options = arrow::compute::TrimOptions{*characters_str};
+    }
+    return function_use::make(
+      [subject_expr = std::move(subject_expr),
+       options = std::move(options)](evaluator eval, session ctx) -> series {
+        auto subject = eval(subject_expr);
+        auto f = detail::overload{
+          [&](const arrow::StringArray& array) {
+            auto trimmed_array
+              = arrow::compute::CallFunction("utf8_trim", {array}, &options);
+            if (not trimmed_array.ok()) {
+              diagnostic::warning("{}", trimmed_array.status().ToString())
+                .primary(subject_expr)
+                .emit(ctx);
+              return series::null(string_type{}, subject.length());
+            }
+            return series{string_type{},
+                          trimmed_array.MoveValueUnsafe().make_array()};
+          },
+          [&](const auto&) {
+            diagnostic::warning("`trim` expected `string`, but got `{}`",
+                                subject.type.kind())
+              .primary(subject_expr)
+              .emit(ctx);
+            return series::null(string_type{}, subject.length());
+          },
+        };
+        return caf::visit(f, *subject.array);
+      });
   }
 };
 
@@ -87,5 +133,6 @@ public:
 
 } // namespace tenzir::plugins::string
 
-TENZIR_REGISTER_PLUGIN(tenzir::plugins::string::starts_with)
-TENZIR_REGISTER_PLUGIN(tenzir::plugins::string::ends_with)
+TENZIR_REGISTER_PLUGIN(tenzir::plugins::string::starts_or_ends_with{true})
+TENZIR_REGISTER_PLUGIN(tenzir::plugins::string::starts_or_ends_with{false})
+TENZIR_REGISTER_PLUGIN(tenzir::plugins::string::trim)


### PR DESCRIPTION
`" \thello, world!\n".trim()` becomes `"hello, world!"`. The `trim` method takes an optional named argument `chars` that must be a constant-evaluated string containing characters to trim.