### PR TITLE
Add new package fields to support upgrade workflow

### DIFF
--- a/libtenzir/include/tenzir/package.hpp
+++ b/libtenzir/include/tenzir/package.hpp
@@ -21,9 +21,10 @@
 namespace tenzir {
 
 struct package_source final {
-  std::string repository = {};
-  std::string directory = {};
-  std::string revision = {};
+  std::string repository = {}; // Must be non-empty
+  std::string directory = {};  // Must be non-empty
+  std::string revision = {};   // Must be non-empty
+  std::optional<std::string> version = {};
 
   auto to_record() const -> record;
 
@@ -34,13 +35,15 @@ struct package_source final {
       .pretty_name("package_source")
       .fields(f.field("repository", x.repository),
               f.field("directory", x.directory),
-              f.field("revision", x.revision));
+              f.field("revision", x.revision), f.field("version", x.version));
   }
 };
 
 struct package_config final {
+  std::optional<time> install_time = {};
   std::optional<package_source> source = {};
   detail::flat_map<std::string, std::string> inputs = {};
+
   // TODO: Add an `overrides` field.
   // package_overrides overrides = {};
 
@@ -51,7 +54,9 @@ struct package_config final {
   friend auto inspect(auto& f, package_config& x) -> bool {
     return f.object(x)
       .pretty_name("package_config")
-      .fields(f.field("source", x.source), f.field("inputs", x.inputs));
+      .fields(f.field("source", x.source),
+              f.field("install_time", x.install_time),
+              f.field("inputs", x.inputs));
   }
 };
 

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "e94be1465ae155370263d507e8d165c791c9353e",
+  "rev": "bf024b0f4e84c7c59c502950007ad7c19a959546",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
Add new fields to assist the frontend in comparing a locally installed package against the one available in the library:

 * `version` - A field that can be used by the frontend to enter a package-defined version number or a computed hash of the package definition
 * `install_time` - A field that can be set to mark the original time the package was installed. The package manager sets this to the current system time if no value is provided by the frontend.
