### PR TITLE
Revamp package format

### DIFF
--- a/libtenzir/include/tenzir/package.hpp
+++ b/libtenzir/include/tenzir/package.hpp
@@ -40,8 +40,11 @@ struct package_source final {
 
 struct package_config final {
   std::optional<package_source> source = {};
+  std::optional<std::string> version = {};
   detail::flat_map<std::string, std::string> inputs = {};
-  record overrides = {};
+  record metadata
+    = {}; // opaque extra data that can be set when installing the package
+  record overrides = {}; // overrides for fields in the package definition
 
   auto to_record() const -> record;
 
@@ -50,8 +53,8 @@ struct package_config final {
   friend auto inspect(auto& f, package_config& x) -> bool {
     return f.object(x)
       .pretty_name("package_config")
-      .fields(f.field("source", x.source),
-              f.field("inputs", x.inputs),
+      .fields(f.field("source", x.source), f.field("inputs", x.inputs),
+              f.field("version", x.version), f.field("metadata", x.metadata),
               f.field("overrides", x.overrides));
   }
 };

--- a/libtenzir/include/tenzir/package.hpp
+++ b/libtenzir/include/tenzir/package.hpp
@@ -116,18 +116,18 @@ struct package_context final {
   }
 };
 
-struct package_snippet final {
+struct package_example final {
   std::optional<std::string> name = {};
   std::optional<std::string> description = {};
   std::string definition = {}; // required to be non-empty
 
   auto to_record() const -> record;
 
-  static auto parse(const view<record>& data) -> caf::expected<package_snippet>;
+  static auto parse(const view<record>& data) -> caf::expected<package_example>;
 
-  friend auto inspect(auto& f, package_snippet& x) -> bool {
+  friend auto inspect(auto& f, package_example& x) -> bool {
     return f.object(x)
-      .pretty_name("package_snippet")
+      .pretty_name("package_example")
       .fields(f.field("name", x.name), f.field("description", x.description),
               f.field("definition", x.definition));
   }
@@ -151,7 +151,7 @@ struct package_contexts_map
   using super::super;
 };
 
-using package_snippets_list = std::vector<package_snippet>;
+using package_examples_list = std::vector<package_example>;
 
 struct package final {
   std::string id = {};   // required to be non-empty
@@ -164,7 +164,7 @@ struct package final {
   package_inputs_map inputs;
   package_pipelines_map pipelines;
   package_contexts_map contexts;
-  package_snippets_list snippets;
+  package_examples_list examples;
 
   // Packages are kept in the library without a `config`. When installing a
   // package, both the package definition and a config must be available.
@@ -185,7 +185,7 @@ struct package final {
       f.field("package_icon", x.package_icon),
       f.field("author_icon", x.author_icon), f.field("inputs", x.inputs),
       f.field("pipelines", x.pipelines), f.field("contexts", x.contexts),
-      f.field("snippets", x.snippets), f.field("config", x.config));
+      f.field("examples", x.examples), f.field("config", x.config));
   }
 };
 

--- a/libtenzir/include/tenzir/package.hpp
+++ b/libtenzir/include/tenzir/package.hpp
@@ -42,8 +42,7 @@ struct package_config final {
   std::optional<package_source> source = {};
   std::optional<std::string> version = {};
   detail::flat_map<std::string, std::string> inputs = {};
-  record metadata
-    = {}; // opaque extra data that can be set when installing the package
+  record metadata = {};  // opaque extra data that can be set at install time
   record overrides = {}; // overrides for fields in the package definition
 
   auto to_record() const -> record;

--- a/libtenzir/include/tenzir/package.hpp
+++ b/libtenzir/include/tenzir/package.hpp
@@ -41,8 +41,7 @@ struct package_source final {
 struct package_config final {
   std::optional<package_source> source = {};
   detail::flat_map<std::string, std::string> inputs = {};
-  // TODO: Add an `overrides` field.
-  // package_overrides overrides = {};
+  record overrides = {};
 
   auto to_record() const -> record;
 
@@ -51,7 +50,9 @@ struct package_config final {
   friend auto inspect(auto& f, package_config& x) -> bool {
     return f.object(x)
       .pretty_name("package_config")
-      .fields(f.field("source", x.source), f.field("inputs", x.inputs));
+      .fields(f.field("source", x.source),
+              f.field("inputs", x.inputs),
+              f.field("overrides", x.overrides));
   }
 };
 

--- a/libtenzir/src/package.cpp
+++ b/libtenzir/src/package.cpp
@@ -167,7 +167,7 @@ namespace tenzir {
     continue;                                                                  \
   }
 
-#define TRY_ASSIGN_LIST_TO_RESULT(name, inner_type)                            \
+#define TRY_ASSIGN_LIST(name, inner_type, target)                              \
   if (key == #name) {                                                          \
     const auto* item_list = caf::get_if<view<list>>(&value);                   \
     if (not item_list) {                                                       \
@@ -190,11 +190,14 @@ namespace tenzir {
           .note("invalid package definition")                                  \
           .to_error();                                                         \
       }                                                                        \
-      result.name.push_back(*item);                                            \
+      target.push_back(*item);                                                 \
       ++pos;                                                                   \
     }                                                                          \
     continue;                                                                  \
   }
+
+#define TRY_ASSIGN_LIST_TO_RESULT(name, inner_type)                            \
+  TRY_ASSIGN_LIST(name, inner_type, result.name)
 
 auto package_input::parse(const view<record>& data)
   -> caf::expected<package_input> {
@@ -318,9 +321,9 @@ auto package_context::parse(const view<record>& data)
   return result;
 }
 
-auto package_snippet::parse(const view<record>& data)
-  -> caf::expected<package_snippet> {
-  auto result = package_snippet{};
+auto package_example::parse(const view<record>& data)
+  -> caf::expected<package_example> {
+  auto result = package_example{};
   for (const auto& [key, value] : data) {
     TRY_ASSIGN_STRING_TO_RESULT(definition);
     TRY_ASSIGN_OPTIONAL_STRING_TO_RESULT(name);
@@ -332,6 +335,8 @@ auto package_snippet::parse(const view<record>& data)
 
 auto package::parse(const view<record>& data) -> caf::expected<package> {
   auto result = package{};
+  // Briefly support both 'snippets' and 'examples' to enable a smooth transition
+  auto legacy_snippets = std::vector<package_example>{};
   for (const auto& [key, value] : data) {
     TRY_ASSIGN_STRING_TO_RESULT(id);
     TRY_ASSIGN_STRING_TO_RESULT(name);
@@ -343,7 +348,8 @@ auto package::parse(const view<record>& data) -> caf::expected<package> {
     TRY_ASSIGN_MAP_TO_RESULT(pipelines, package_pipeline);
     TRY_ASSIGN_MAP_TO_RESULT(contexts, package_context);
     TRY_ASSIGN_STRUCTURE_TO_RESULT(config, package_config);
-    TRY_ASSIGN_LIST_TO_RESULT(snippets, package_snippet);
+    TRY_ASSIGN_LIST_TO_RESULT(examples, package_example);
+    TRY_ASSIGN_LIST(snippets, package_example, legacy_snippets);
     // Reject unknown keys in the package definition.
     return diagnostic::error("unknown key '{}'", key)
       .note("while trying to parse 'package' entry")
@@ -352,6 +358,14 @@ auto package::parse(const view<record>& data) -> caf::expected<package> {
   }
   REQUIRED_FIELD(id)
   REQUIRED_FIELD(name)
+  if (!legacy_snippets.empty()) {
+    if (!result.examples.empty()) {
+      return diagnostic::error("found both 'snippets' and 'examples'")
+        .note("the 'snippets' key is deprecated, use 'examples' instead")
+        .to_error();
+    }
+    result.examples = std::move(legacy_snippets);
+  }
   if (result.config) {
     for (auto& [name, _] : result.config->inputs) {
       if (!result.inputs.contains(name)) {
@@ -409,7 +423,7 @@ auto package_context::to_record() const -> record {
                 {"disabled", disabled}};
 }
 
-auto package_snippet::to_record() const -> record {
+auto package_example::to_record() const -> record {
   return record{
     {"name", name},
     {"description", description},
@@ -452,12 +466,12 @@ auto package::to_record() const -> record {
     contexts_record[context_id] = context.to_record();
   }
   info_record["contexts"] = std::move(contexts_record);
-  auto snippets_list = list{};
-  snippets_list.reserve(snippets.size());
-  for (auto const& snippet : snippets) {
-    snippets_list.emplace_back(snippet.to_record());
+  auto examples_list = list{};
+  examples_list.reserve(examples.size());
+  for (auto const& example : examples) {
+    examples_list.emplace_back(example.to_record());
   }
-  info_record["snippets"] = std::move(snippets_list);
+  info_record["examples"] = std::move(examples_list);
   auto inputs_record = record{};
   for (auto const& [input_name, input] : inputs) {
     inputs_record[input_name] = input.to_record();

--- a/libtenzir/src/package.cpp
+++ b/libtenzir/src/package.cpp
@@ -237,7 +237,7 @@ auto package_source::parse(const view<record>& data)
     TRY_ASSIGN_STRING_TO_RESULT(directory)
     TRY_ASSIGN_STRING_TO_RESULT(revision)
     return diagnostic::error("unknown key '{}'", key)
-      .note("while trying to parse 'source' entry")
+      .note("while trying to parse `source` entry")
       .note("invalid package source definition")
       .to_error();
   }
@@ -257,7 +257,7 @@ auto package_config::parse(const view<record>& data)
     TRY_ASSIGN_RECORD_TO_RESULT(overrides);
     TRY_ASSIGN_RECORD_TO_RESULT(metadata);
     return diagnostic::error("unknown key '{}'", key)
-      .note("while trying to parse 'config' entry")
+      .note("while trying to parse `config` entry")
       .note("invalid package definition")
       .to_error();
   }
@@ -283,7 +283,7 @@ auto package_pipeline::parse(const view<record>& data)
       if (const auto* as_string = caf::get_if<std::string_view>(&value)) {
         auto inner_value = from_yaml(*as_string);
         if (!inner_value) {
-          return diagnostic::error("failed to parse 'restart-on-error' field")
+          return diagnostic::error("failed to parse `restart-on-error` field")
             .note("error {}", inner_value.error())
             .to_error();
         }
@@ -292,7 +292,7 @@ auto package_pipeline::parse(const view<record>& data)
       const auto* on_off = caf::get_if<bool>(&value_copy);
       const auto* retry_delay = caf::get_if<duration>(&value_copy);
       if (not on_off and not retry_delay) {
-        return diagnostic::error("'restart-on-error' must be a "
+        return diagnostic::error("`restart-on-error` must be a "
                                  "be a "
                                  "bool or a positive duration")
           .note("got '{}'", value)
@@ -307,7 +307,7 @@ auto package_pipeline::parse(const view<record>& data)
       }
       TENZIR_ASSERT(retry_delay);
       if (*retry_delay < duration::zero()) {
-        return diagnostic::error("'restart-on-error' cannot be negative")
+        return diagnostic::error("`restart-on-error` cannot be negative")
           .to_error();
       }
       result.restart_on_error = *retry_delay;
@@ -319,7 +319,7 @@ auto package_pipeline::parse(const view<record>& data)
       continue;
     }
     return diagnostic::error("unknown key '{}'", key)
-      .note("while trying to parse 'pipeline' entry")
+      .note("while trying to parse `pipeline` entry")
       .note("invalid package source definition")
       .to_error();
   }
@@ -371,7 +371,7 @@ auto package::parse(const view<record>& data) -> caf::expected<package> {
     TRY_ASSIGN_LIST(snippets, package_example, legacy_snippets);
     // Reject unknown keys in the package definition.
     return diagnostic::error("unknown key '{}'", key)
-      .note("while trying to parse 'package' entry")
+      .note("while trying to parse `package` entry")
       .note("invalid package definition")
       .to_error();
   }
@@ -379,8 +379,8 @@ auto package::parse(const view<record>& data) -> caf::expected<package> {
   REQUIRED_FIELD(name)
   if (!legacy_snippets.empty()) {
     if (!result.examples.empty()) {
-      return diagnostic::error("found both 'snippets' and 'examples'")
-        .note("the 'snippets' key is deprecated, use 'examples' instead")
+      return diagnostic::error("found both `snippets` and `examples`")
+        .note("the `snippets` key is deprecated, use `examples` instead")
         .to_error();
     }
     result.examples = std::move(legacy_snippets);

--- a/libtenzir/src/package.cpp
+++ b/libtenzir/src/package.cpp
@@ -241,6 +241,15 @@ auto package_config::parse(const view<record>& data)
   for (const auto& [key, value] : data) {
     TRY_ASSIGN_STRUCTURE_TO_RESULT(source, package_source);
     TRY_ASSIGN_STRINGMAP_CONVERSION_TO_RESULT(inputs);
+    if (key == "overrides") {
+      auto const* overrides = caf::get_if<view<record>>(&value);
+      if (not overrides) {
+        return diagnostic::error("'overrides' must be a record")
+          .note("invalid package definition")
+          .to_error();
+      }
+      result.overrides = materialize(*overrides);
+    }
   }
   return result;
 }
@@ -393,6 +402,7 @@ auto package_config::to_record() const -> record {
   }
   auto result = record{
     {"inputs", std::move(inputs_map)},
+    {"overrides", overrides},
   };
   if (source) {
     result["source"] = source->to_record();

--- a/libtenzir/src/version.cpp
+++ b/libtenzir/src/version.cpp
@@ -103,6 +103,9 @@ auto tenzir_features() -> std::vector<std::string> {
     // Pipelines can be unstoppable - they can not be paused or stopped manually,
     // and run & repeat indefinitely.
     "unstoppable",
+    // There is a `packages` operator can display package information in an
+    // extended format.
+    "extended_package_format",
   };
 }
 

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "fdbcf9e29c750c2caed52ac997e3787cc056414f",
+  "rev": "1ab51f2d2ca87ae4312de2751a94b3861cc38e25",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/web/docs/operators/package.md
+++ b/web/docs/operators/package.md
@@ -26,23 +26,29 @@ and user-facing documentation of the package format is still in progress.
 ```
 package add
 package remove <package_id>
+packages [--format=<format>]
 ```
 
 ## Description
 
-The `packages` operator manages packages.
+The `packages` operator show a list of installed packages.
+
+The `package` operator manages packages.
 
 - The `add` command adds a new package on the node by
   running all pipelines and contexts defined in the package.
 
 - The `remove` command removes an existing package.
 
-To get a list of all successfully installed packages, use the [show](./show.md) operator
-by running `show packages`.
-
 ### `<package_id>`
 
 The unique id of the package, as found in the package definition.
+
+### `<format>`
+
+This option controls the output format of the `packages` operator.
+Valid options are `compact` (the default) and `extended`. See the
+`Package List Formats` section below for more details.
 
 ## Examples
 
@@ -68,3 +74,28 @@ Remove the installed package `zeek`:
 ```
 package remove zeek
 ```
+
+## Package List Formats
+
+The output of the `packages` operator can be controlled by the `--format`
+parameter
+
+### Compact Format
+
+The `compact` format consists of one object per installed package
+with keys `id`, `name`, `author` and `description`.
+
+### Extended Format
+
+The `extended` format is mainly intended for use by non-human consumers, like shell
+scripts or frontend code. It consists of an object with four top-level keys:
+
+ 1. `package_definition`: The original package definition object as found in the library.
+ 2. `resolved_package`: The effective package definition that was produced by applying
+    all inputs and overrides from the `config` section and removing all disabled pipelines
+    and contexts.
+ 3. `config`: The user-provided `config` object that was provided when installing the package.
+ 4. `package_status`: Contains additional information about the package provided by the package
+    manager, currently the `install_state` field that can be one of `installing`, `installed` or
+    `zombie` and the `from_configuration` boolean that shows whether a package was added
+    at runtime via the `package add` operator or from a configuration file on the node.

--- a/web/docs/operators/package.md
+++ b/web/docs/operators/package.md
@@ -1,7 +1,7 @@
 ---
 sidebar_custom_props:
   operator:
-    source: true
+    source: false
     transformation: false
     sink: true
 ---
@@ -15,23 +15,14 @@ as a single unit. Most packages are installed from a library, a public
 repository of packages, and contain a collection of thematically related
 pipelines and contexts.
 
-:::note Experimental
-This operator is made available in preparation of the upcoming package
-management support of Tenzir. All interfaces are subject to change,
-and user-facing documentation of the package format is still in progress.
-:::
-
 ## Synopsis
 
 ```
 package add
 package remove <package_id>
-packages [--format=<format>]
 ```
 
 ## Description
-
-The `packages` operator show a list of installed packages.
 
 The `package` operator manages packages.
 
@@ -43,12 +34,6 @@ The `package` operator manages packages.
 ### `<package_id>`
 
 The unique id of the package, as found in the package definition.
-
-### `<format>`
-
-This option controls the output format of the `packages` operator.
-Valid options are `compact` (the default) and `extended`. See the
-`Package List Formats` section below for more details.
 
 ## Examples
 
@@ -74,28 +59,3 @@ Remove the installed package `zeek`:
 ```
 package remove zeek
 ```
-
-## Package List Formats
-
-The output of the `packages` operator can be controlled by the `--format`
-parameter
-
-### Compact Format
-
-The `compact` format consists of one object per installed package
-with keys `id`, `name`, `author` and `description`.
-
-### Extended Format
-
-The `extended` format is mainly intended for use by non-human consumers, like shell
-scripts or frontend code. It consists of an object with four top-level keys:
-
- 1. `package_definition`: The original package definition object as found in the library.
- 2. `resolved_package`: The effective package definition that was produced by applying
-    all inputs and overrides from the `config` section and removing all disabled pipelines
-    and contexts.
- 3. `config`: The user-provided `config` object that was provided when installing the package.
- 4. `package_status`: Contains additional information about the package provided by the package
-    manager, currently the `install_state` field that can be one of `installing`, `installed` or
-    `zombie` and the `from_configuration` boolean that shows whether a package was added
-    at runtime via the `package add` operator or from a configuration file on the node.

--- a/web/docs/operators/packages.md
+++ b/web/docs/operators/packages.md
@@ -24,38 +24,16 @@ The `packages` operator lists all installed packages.
 
 This option controls the output format of the `packages` operator.
 Valid options are `compact` (the default) and `extended`. See the
-`Package List Formats` section below for more details.
+`Schemas` section below for more details.
 
-## Examples
-
-Show a list of installed packages in compact format:
-
-```
-packages
-```
-
-Output:
-```
-{
-  "id": "feodo",
-  "name": "Feodo Abuse Blocklist",
-  "author": "Tenzir",
-  "description": "Feodo Tracker is a project of abuse.ch with the goal of sharing botnet C&C\nservers associated with Dridex, Emotet (aka Heodo), TrickBot, QakBot (aka\nQuakBot / Qbot) and BazarLoader (aka BazarBackdoor). It offers various\nblocklists, helping network owners to protect their users from Dridex and\nEmotet/Heodo.\n",
-  "config": {
-    "inputs": {},
-    "overrides": {}
-  }
-}
-```
-
-## Package List Formats
+## Schemas
 
 The output of the `packages` operator can be controlled by the `--format`
 parameter. There are currently two formats defined, the compact format
 intended for human operators and the extended format intended for use by
 shell scripts and other programs.
 
-### Compact Format
+### `tenzir.package.compact`
 
 The compact format prints the package information according to the following
 schema:
@@ -68,7 +46,7 @@ schema:
 |`description`|`string`|The description of this package.|
 |`config`|`record`|The user-provided package configuration|
 
-### Extended Format
+### `tenzir.package.extended`
 
 The `extended` format is mainly intended for use by non-human consumers,
 like shell scripts or frontend code. It contains all available information
@@ -97,3 +75,25 @@ The `package_status` object has the following schema:
 |:-|:-|:-|
 |`install_state`|`string`|The install state of this package. One of `installing`, `installed`, `removing` or `zombie`.|
 |`from_configuration`|`bool`|Whether the package was installed from the `package add` operator or from a configuration file.|
+
+## Examples
+
+Show a list of installed packages in compact format:
+
+```
+packages
+```
+
+Output:
+```
+{
+  "id": "feodo",
+  "name": "Feodo Abuse Blocklist",
+  "author": "Tenzir",
+  "description": "Feodo Tracker is a project of abuse.ch with the goal of sharing botnet C&C\nservers associated with Dridex, Emotet (aka Heodo), TrickBot, QakBot (aka\nQuakBot / Qbot) and BazarLoader (aka BazarBackdoor). It offers various\nblocklists, helping network owners to protect their users from Dridex and\nEmotet/Heodo.\n",
+  "config": {
+    "inputs": {},
+    "overrides": {}
+  }
+}
+```

--- a/web/docs/operators/packages.md
+++ b/web/docs/operators/packages.md
@@ -1,0 +1,99 @@
+---
+sidebar_custom_props:
+  operator:
+    source: true
+    transformation: false
+    sink: false
+---
+
+# packages
+
+Shows the installed packages.
+
+## Synopsis
+
+```
+packages [--format=<format>]
+```
+
+## Description
+
+The `packages` operator lists all installed packages.
+
+### `<format>`
+
+This option controls the output format of the `packages` operator.
+Valid options are `compact` (the default) and `extended`. See the
+`Package List Formats` section below for more details.
+
+## Examples
+
+Show a list of installed packages in compact format:
+
+```
+packages
+```
+
+Output:
+```
+{
+  "id": "feodo",
+  "name": "Feodo Abuse Blocklist",
+  "author": "Tenzir",
+  "description": "Feodo Tracker is a project of abuse.ch with the goal of sharing botnet C&C\nservers associated with Dridex, Emotet (aka Heodo), TrickBot, QakBot (aka\nQuakBot / Qbot) and BazarLoader (aka BazarBackdoor). It offers various\nblocklists, helping network owners to protect their users from Dridex and\nEmotet/Heodo.\n",
+  "config": {
+    "inputs": {},
+    "overrides": {}
+  }
+}
+```
+
+## Package List Formats
+
+The output of the `packages` operator can be controlled by the `--format`
+parameter. There are currently two formats defined, the compact format
+intended for human operators and the extended format intended for use by
+shell scripts and other programs.
+
+### Compact Format
+
+The compact format prints the package information according to the following
+schema:
+
+|Field|Type|Description|
+|:-|:-|:-|
+|`id`|`string`|The unique package id.|
+|`name`|`string`|The name of this package.|
+|`author`|`string`|The package author.|
+|`description`|`string`|The description of this package.|
+|`config`|`record`|The user-provided package configuration|
+
+### Extended Format
+
+The `extended` format is mainly intended for use by non-human consumers,
+like shell scripts or frontend code. It contains all available information
+about a package.
+
+|Field|Type|Description|
+|:-|:-|:-|
+|`package_definition`|`record`|The original package definition object asa found in the library.|
+|`resolved_package`|`record`|The effective package definition that was produced by applying all inputs and overrides from the `config` section and removing all disabled pipelines and contexts.|
+|`config`|`record`|The user-provided package configuration.|
+|`package_status`|`record`|Run-time information about the package provided the package manager.|
+
+The `config` object has the following schema, where all fields are optional:
+
+|Field|Type|Description|
+|:-|:-|:-|
+|`version`|`string`|The package version.|
+|`source`|`record`|The upstream location of the package definition.|
+|`inputs`|`record`|User-provided values for the package inputs.|
+|`overrides`|`record`|User-provided overrides for fields in the package definition.|
+|`metadata`|`record`|An opaque record that can be set during installation.|
+
+The `package_status` object has the following schema:
+
+|Field|Type|Description|
+|:-|:-|:-|
+|`install_state`|`string`|The install state of this package. One of `installing`, `installed`, `removing` or `zombie`.|
+|`from_configuration`|`bool`|Whether the package was installed from the `package add` operator or from a configuration file.|

--- a/web/docs/packages.md
+++ b/web/docs/packages.md
@@ -16,7 +16,7 @@ A package definition consists of four major parts.
    installation to their environment.
 4. A set of pipelines and contexts that make up the contents of the package.
 
-## Package format
+## Package Format
 
 The following describes the fields of a package definition.
 
@@ -73,12 +73,12 @@ inputs:
 ```
 
 Inputs can be referenced in pipeline and example definitions and in context arguments
-with the synatx `{{ inputs.input-name }}`. The are replaced by their configured values
+with the syntax `{{ inputs.input-name }}`. They are replaced by their configured values
 when installing a package. For example, with the input configured as above the pipeline
 `every {{ inputs.refresh-rate }} { version }` would print the version once per second by default.
 
-To write double curly braces, the syntax `{ '{{' }` can be used to produce the literal
-string enclosed in the single quotes.
+To write double curly braces, use the syntax `{{ '{{' }}` to produce the
+literal string enclosed inside the single quotes.
 
 ### Examples
 
@@ -169,12 +169,11 @@ contexts:
 Start using packages by [installing one](installation/install-a-package.md).
 :::
 
-## User configuration
+## User Configuration
 
-In order to install a package from the library, the user usually has to provide
-their own customization options to adjust the package to his own preferences
-and his local environment. This is done by adding a new key `config` to the
-package definition:
+In order to install a package from the library, you may want to adjust
+the package to your own preferences and local environment. To do this,
+add a new key `config` to the package definition:
 
 ```
 config:
@@ -206,12 +205,12 @@ config:
 
 ### Inputs
 
-Pipeline and context definitions can contain references to user-defined variables,
-as in `from {{ inputs.filename }} version`, that will be replaced by their
+Pipeline and context definitions may contain references to user-defined variables,
+as in `from {{ inputs.filename }} version`, that are replaced by their
 configured value when installing the package.
 
-In order to provide non-default values for the defined inputs, the `config.inputs`
-key is used.
+In order to provide non-default values for the defined inputs, use the `config.inputs`
+key:
 
 ```
 config:
@@ -221,9 +220,9 @@ config:
 
 ### Overrides
 
-The `config.overrides` object can be used to change the value of any field in the
-packag definition. This is intended for fields like `disabled` or `restart-on-error`
-in pipeline definitions to customize them to the users preferences:
+The `config.overrides` object is used to change the value of any field in the
+package definition. This is intended to customize fields like `disabled` or `restart-on-error`
+in pipeline definitions:
 
 ```
 config:


### PR DESCRIPTION
This contains two updates to the package format:

* Support a `config.overrides` field in the package definition that can be used to modify other fields of the package
* Rename 'snippets' to 'examples'
* Add a new optional `config.version` key that can be set to any string by the user to indicate the package version
* Add a new optional 'config.metadata` key that can be used to store arbitrary opaque data
* Add a new `packages` operator that can show the installed package information in an extended format more suited to consumption by the app