### PR TITLE
Guard against empty events in the catalog

### DIFF
--- a/libtenzir/builtins/operators/import.cpp
+++ b/libtenzir/builtins/operators/import.cpp
@@ -48,6 +48,12 @@ public:
         co_yield {};
         continue;
       }
+      // The current catalog assumes that all events have at least one field.
+      // This check guards against that. We should remove it once we get to
+      // rewriting our catalog.
+      if (caf::get<record_type>(slice.schema()).num_fields() == 0) {
+        continue;
+      }
       if (not slice.schema().attribute("internal").has_value()) {
         metric_handler.emit({
           {"schema", std::string{slice.schema().name()}},


### PR DESCRIPTION
I don't think anyone's ever run into this, but I just happened to do so while trying to reproduce something else. It's a workaround, not a fix, but I think that's good enough for now.