### PR TITLE
Fix excessive CPU usage of `serve`

### DIFF
--- a/changelog/next/bug-fixes/4499--serve-cpu-usage.md
+++ b/changelog/next/bug-fixes/4499--serve-cpu-usage.md
@@ -1,0 +1,1 @@
+The `serve` operator no longer uses an excessive amount of CPU.

--- a/libtenzir/builtins/operators/serve.cpp
+++ b/libtenzir/builtins/operators/serve.cpp
@@ -846,6 +846,10 @@ public:
     co_yield {};
     //  Forward events to the SERVE MANAGER.
     for (auto&& slice : input) {
+      if (slice.rows() == 0) {
+        co_yield {};
+        continue;
+      }
       // Send slice to SERVE MANAGER.
       ctrl.set_waiting(true);
       ctrl.self()


### PR DESCRIPTION
Here's a bad interaction I did not think of before: `ctrl.set_waiting(false)` _immediately_ schedules an operator again so that it can wake itself up from a request response handler. The `serve` operator did not properly dismiss empty events—which are sent directly before an operator starts idling—and thus went into an infinite loop of starting to idle and waking up again.