### PR TITLE
Add missing integration test timeouts

### DIFF
--- a/tenzir/integration/tests/batching.bats
+++ b/tenzir/integration/tests/batching.bats
@@ -1,5 +1,7 @@
 # shellcheck disable=SC2016
 
+: "${BATS_TEST_TIMEOUT:=60}"
+
 setup() {
   bats_load_library bats-support
   bats_load_library bats-assert

--- a/tenzir/integration/tests/feather.bats
+++ b/tenzir/integration/tests/feather.bats
@@ -1,3 +1,5 @@
+: "${BATS_TEST_TIMEOUT:=60}"
+
 setup() {
   bats_load_library bats-support
   bats_load_library bats-assert

--- a/tenzir/integration/tests/gelf.bats
+++ b/tenzir/integration/tests/gelf.bats
@@ -1,3 +1,5 @@
+: "${BATS_TEST_TIMEOUT:=60}"
+
 setup() {
   bats_load_library bats-support
   bats_load_library bats-assert

--- a/tenzir/integration/tests/leef.bats
+++ b/tenzir/integration/tests/leef.bats
@@ -1,3 +1,5 @@
+: "${BATS_TEST_TIMEOUT:=60}"
+
 setup() {
   bats_load_library bats-support
   bats_load_library bats-assert

--- a/tenzir/integration/tests/time.bats
+++ b/tenzir/integration/tests/time.bats
@@ -1,3 +1,5 @@
+: "${BATS_TEST_TIMEOUT:=60}"
+
 setup() {
   bats_load_library bats-support
   bats_load_library bats-assert

--- a/tenzir/integration/tests/vast_server.bats
+++ b/tenzir/integration/tests/vast_server.bats
@@ -1,3 +1,5 @@
+: "${BATS_TEST_TIMEOUT:=60}"
+
 # BATS ports of our old integration test suite.
 
 # This file contains the subset of tests that were using
@@ -74,29 +76,29 @@ teardown() {
       | select /* and a comment there /**/ timestamp, flow_id, src_ip, dest_ip, src_port
       | sort timestamp
       /**/ /*foo*/"
-  check tenzir "export 
+  check tenzir "export
       | select timestamp, flow_id, src_ip, dest_ip, src_port
       | sort timestamp
       | drop timestamp"
-  check tenzir "export 
+  check tenzir "export
       | select timestamp, flow_id, src_ip, dest_ip, src_port
       | sort timestamp
       | drop timestamp
       | hash --salt=\"abcdefghij12\" flow_id"
-  check tenzir "export 
+  check tenzir "export
       | select timestamp, flow_id, src_ip, dest_ip, src_port
       | sort timestamp
       | drop timestamp
       | hash --salt=\"abcdefghij12\" flow_id
       | drop flow_id"
-  check tenzir "export 
+  check tenzir "export
       | select timestamp, flow_id, src_ip, dest_ip, src_port
       | sort timestamp
       | drop timestamp
       | hash --salt=\"abcdefghij12\" flow_id
       | drop flow_id
       | pseudonymize -m \"crypto-pan\" -s \"123456abcdef\" src_ip, dest_ip"
-  check tenzir "export 
+  check tenzir "export
       | select timestamp, flow_id, src_ip, dest_ip, src_port
       | sort timestamp
       | drop timestamp
@@ -104,7 +106,7 @@ teardown() {
       | drop flow_id
       | pseudonymize -m \"crypto-pan\" -s \"123456abcdef\" src_ip, dest_ip
       | rename source_ip=src_ip"
-  check tenzir "export 
+  check tenzir "export
       | select timestamp, flow_id, src_ip, dest_ip, src_port
       | sort timestamp
       | drop timestamp


### PR DESCRIPTION
CI sometimes hangs in tests without bats timeouts (it can also hang in tests with timeouts, but that seems to happen only under special circumstances). Thus I added timeouts to the remaining test files.