### PR TITLE
Fix `slice 1:-1` for exactly one event

### DIFF
--- a/changelog/next/bug-fixes/4505--slice-regression.md
+++ b/changelog/next/bug-fixes/4505--slice-regression.md
@@ -1,0 +1,3 @@
+The `slice` operator no longer crashes when used with a positive begin and
+negative end value when operating on less events than `-end`, e.g., when working
+on a single event and using `slice 0:-1`.

--- a/libtenzir/builtins/operators/slice.cpp
+++ b/libtenzir/builtins/operators/slice.cpp
@@ -91,7 +91,7 @@ public:
         }
       }
     }
-    TENZIR_ASSERT(num_buffered == -end);
+    TENZIR_ASSERT(num_buffered <= -end);
   }
 
   static auto negative_begin_positive_end(generator<table_slice> input,

--- a/libtenzir/src/detail/assert.cpp
+++ b/libtenzir/src/detail/assert.cpp
@@ -46,7 +46,6 @@ fail_assertion_impl(const char* expr, std::string_view explanation,
     message += ": ";
     message += explanation;
   }
-  message += fmt::format(" @ {}:{}", source.file_name(), source.line());
   panic_impl(std::move(message), source);
 }
 

--- a/tenzir/integration/tests/pipelines_local.bats
+++ b/tenzir/integration/tests/pipelines_local.bats
@@ -254,6 +254,8 @@ setup() {
   # 3 operators are intentionally chosen to slice in the middle of a batch.
   check tenzir "from ${INPUTSDIR}/cef/forcepoint.log read cef | select extension.dvc | head 8 | extend foo=extension.dvc | write json"
   check tenzir "from ${INPUTSDIR}/cef/forcepoint.log read cef | select extension.dvc | tail 3 | extend foo=extension.dvc | write json"
+  # This tests for a regression where slice 1:-1 crashes for exactly one event.
+  check tenzir "from ${INPUTSDIR}/zeek/conn.log.gz read zeek-tsv | head 1 | slice 1:-1"
 }
 
 # bats test_tags=pipelines, zeek


### PR DESCRIPTION
This fixes an invalid assertion failure when `slice` when used with a positive begin and negative end value returned less events than `-end`.

Additionally, this removes a duplicate source location in assertions.