### PR TITLE
Fix a potentially uncaught exception in `shell`

### DIFF
--- a/changelog/next/bug-fixes/4508--uncaught-exception.md
+++ b/changelog/next/bug-fixes/4508--uncaught-exception.md
@@ -1,0 +1,7 @@
+We fixed a bug in the `shell` operator that could cause the process to crash
+when breaking its pipe. Now, the operator shuts down with an error diagnostic
+instead.
+
+Pipelines with the `python` operator now deploy more quickly, as their
+deployment no longer waits for the virtual environment to be set up
+successfully.


### PR DESCRIPTION
This follows up on a mysterious segfault from an uncaught exception we've seen in a production deployment. The exception was thrown by some Boost.Process API, so it could've only been the `shell` or `python` operator, and since execution nodes have an exception handler installed it couldn't be from the operator's run loop directly. This led me directly to this manually spawned thread int he `shell` operator.

Additionally, this change makes the `python` operator signal its startup quicker. It doesn't make it actually initialize the venv any faster, but it makes it so that starting a pipeline doesn't wait for it anymore.