### PR TITLE
Implement unstoppable pipelines

### DIFF
--- a/changelog/next/features/4513--unstoppable-pipelines.md
+++ b/changelog/next/features/4513--unstoppable-pipelines.md
@@ -1,0 +1,2 @@
+The new `unstoppable` flag allows for pipelines to run and repeat indefinitely
+without the ability to stop or pause.

--- a/libtenzir/include/tenzir/package.hpp
+++ b/libtenzir/include/tenzir/package.hpp
@@ -79,6 +79,7 @@ struct package_pipeline final {
   std::string definition = {}; // required to be non-empty
   bool disabled = false;
   std::optional<duration> restart_on_error = {};
+  bool unstoppable = false;
 
   auto to_record() const -> record;
 
@@ -91,7 +92,8 @@ struct package_pipeline final {
       .fields(f.field("name", x.name), f.field("description", x.description),
               f.field("definition", x.definition),
               f.field("disabled", x.disabled),
-              f.field("restart-on-error", x.restart_on_error));
+              f.field("restart-on-error", x.restart_on_error),
+              f.field("unstoppable", x.unstoppable));
   }
 };
 

--- a/libtenzir/src/package.cpp
+++ b/libtenzir/src/package.cpp
@@ -249,7 +249,8 @@ auto package_pipeline::parse(const view<record>& data)
     TRY_ASSIGN_STRING_TO_RESULT(definition)
     TRY_ASSIGN_OPTIONAL_STRING_TO_RESULT(name)
     TRY_ASSIGN_OPTIONAL_STRING_TO_RESULT(description)
-    TRY_ASSIGN_BOOL_TO_RESULT(disabled);
+    TRY_ASSIGN_BOOL_TO_RESULT(disabled)
+    TRY_ASSIGN_BOOL_TO_RESULT(unstoppable)
     if (key == "restart-on-error") {
       if (caf::holds_alternative<caf::none_t>(value)) {
         continue;
@@ -422,6 +423,7 @@ auto package_pipeline::to_record() const -> record {
     {"description", description},
     {"definition", definition},
     {"disabled", disabled},
+    {"unstoppable", unstoppable},
   };
   if (restart_on_error) {
     result["restart-on-error"] = restart_on_error;

--- a/libtenzir/src/version.cpp
+++ b/libtenzir/src/version.cpp
@@ -100,6 +100,9 @@ auto tenzir_features() -> std::vector<std::string> {
     // The export, diagnostics, and metrics oeprators support combining live and
     // retro exports.
     "export_live_and_retro",
+    // Pipelines can be unstoppable - they can not be paused or stopped manually,
+    // and run & repeat indefinitely.
+    "unstoppable",
   };
 }
 

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "c1d67436fc62ce061766f678cf12a8aede94c7e4",
+  "rev": "00c6250c6741fcefc9fcb0330cbeee666dba5ab3",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -299,6 +299,12 @@ tenzir:
       # - Set the option to true to enable with the default delay of 1 minute.
       # - Set the option to a valid duration to enable with a custom delay.
       restart-on-error: 1 minute
+      # Pipelines that are unstoppable will run automatically and indefinitely.
+      # They are not able to pause or stop.
+      # If they do complete, they will end up in a failed state.
+      # If `restart-on-error` is enabled, they will restart after the specified
+      # duration.
+      unstoppable: false
 
 
 # The below settings are internal to CAF, and aren't checked by Tenzir directly.

--- a/web/docs/packages.md
+++ b/web/docs/packages.md
@@ -124,6 +124,12 @@ pipelines:
     restart-on-error: 1 minute
     # Disables the pipeline.
     disabled: false
+    # Pipelines that are unstoppable will run automatically and indefinitely.
+    # They are not able to pause or stop.
+    # If they do complete, they will end up in a failed state.
+    # If `restart-on-error` is enabled, they will restart after the specified
+    # duration.
+    unstoppable: true
 
 # Define any number of contexts.
 contexts:

--- a/web/docs/usage/run-pipelines/README.md
+++ b/web/docs/usage/run-pipelines/README.md
@@ -113,4 +113,10 @@ tenzir:
         - Import
       # Disable the pipeline.
       disabled: false
+      # Pipelines that are unstoppable will run automatically and indefinitely.
+      # They are not able to pause or stop.
+      # If they do complete, they will end up in a failed state.
+      # If `restart-on-error` is enabled, they will restart after the specified
+      # duration.
+      unstoppable: true
 ```

--- a/web/openapi/openapi.yaml
+++ b/web/openapi/openapi.yaml
@@ -55,6 +55,13 @@ components:
           description: "A duration string specifying the minimum time between automatic restarts\nof a pipeline when an error occurs. Takes no effect if restarting on\nfailure is disabled.\n"
           default: 1.0m
           example: 500.0ms
+        unstoppable:
+          type: boolean
+          description: |
+            A flag specifying whether this pipeline is unstoppable.
+            Unstoppable pipelines start automatically, fail when they complete, and can not be paused or stopped manually.
+          default: false
+          example: true
     Diagnostic:
       type: object
       properties:
@@ -187,6 +194,12 @@ components:
         definition:
           type: string
           description: The pipeline definition.
+        unstoppable:
+          type: boolean
+          description: |
+            A flag specifying whether this pipeline is unstoppable.
+            Unstoppable pipelines start automatically, fail when they complete, and can not be paused or stopped manually.
+          example: true
         hidden:
           type: bool
           description: Whether this pipeline is hidden. Hidden pipelines are only available through the `show pipelines` operator.
@@ -521,6 +534,12 @@ paths:
                   type: string
                   description: "A duration string specifying the minimum time between automatic restarts\nof a pipeline when an error occurs. Takes no effect if restarting on\nfailure is disabled.\n"
                   example: 500.0ms
+                unstoppable:
+                  type: boolean
+                  description: |
+                    A flag specifying whether this pipeline is unstoppable.
+                    Unstoppable pipelines start automatically, fail when they complete, and can not be paused or stopped manually.
+                  example: true
       responses:
         200:
           description: Success.


### PR DESCRIPTION
This change implements the `unstoppable` flag. Pipelines with that flag enabled automatically start, can not be stopped or paused, and if they do complete, they automatically fail.