### PR TITLE
Fix regression in `azure-log-analytics`

### DIFF
--- a/changelog/next/bug-fixes/4516--azure-fix.md
+++ b/changelog/next/bug-fixes/4516--azure-fix.md
@@ -1,0 +1,2 @@
+We fixed a regression introduced in Tenzir v4.19.2 in the `azure-log-analytics`
+operator that prevented it from starting correctly.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "e94be1465ae155370263d507e8d165c791c9353e",
+  "rev": "51506c50bd7cc952552011f5c9ebe4e34351974b",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
This fixes a regression introduced in Tenzir v4.19.2 in the `azure-log-analytics` operator that prevented it from starting correctly.
