### PR TITLE
Fix data parser precedence

### DIFF
--- a/changelog/next/bug-fixes/4523--ip-parsing.md
+++ b/changelog/next/bug-fixes/4523--ip-parsing.md
@@ -1,0 +1,2 @@
+IPv6 addresses with a prefix that is a valid duration, for example `2dff::` with
+the prefix `2d`, now correctly parse as an IP instead of a string.

--- a/libtenzir/builtins/formats/json.cpp
+++ b/libtenzir/builtins/formats/json.cpp
@@ -457,7 +457,7 @@ private:
     if (not raw_ and not builder.is_protected()) {
       // Attempt to parse it as data.
       static constexpr auto parser
-        = parsers::time | parsers::duration | parsers::net | parsers::ip;
+        = parsers::net | parsers::ip | parsers::time | parsers::duration;
       auto result = std::variant<time, duration, subnet, ip>{};
       if (parser(str, result)) {
         return std::visit(
@@ -609,7 +609,7 @@ auto json_to_data(std::string_view string, bool raw)
   -> simdjson::simdjson_result<data> {
   if (not raw) {
     static constexpr auto parser
-      = parsers::time | parsers::duration | parsers::net | parsers::ip;
+      = parsers::net | parsers::ip | parsers::time | parsers::duration;
     auto result = data{};
     if (parser(string, result)) {
       return result;

--- a/libtenzir/include/tenzir/concept/parseable/tenzir/data.hpp
+++ b/libtenzir/include/tenzir/concept/parseable/tenzir/data.hpp
@@ -49,8 +49,8 @@ struct simple_data_parser : parser_base<simple_data_parser> {
 
   template <class Iterator, class Attribute>
   bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
-    static auto p = parsers::time | parsers::duration | parsers::net
-                    | parsers::ip | parsers::number | parsers::boolean;
+    static auto p = parsers::net | parsers::ip | parsers::time
+                    | parsers::duration | parsers::number | parsers::boolean;
     return p(f, l, a);
   }
 };
@@ -90,10 +90,12 @@ private:
         ->* [](record::vector_type&& xs) {
           return record::make_unsafe(std::move(xs));
         };
-    p = parsers::time
-      | parsers::duration
-      | parsers::net
+    // Order matters here: If X is a prefix of Y, then X must come after Y.
+    // For example `3d` is a prefix of `3d::`, hence duration must be after IP.
+    p = parsers::net
       | parsers::ip
+      | parsers::time
+      | parsers::duration
       | parsers::number
       | parsers::boolean
       | parsers::qqstr

--- a/libtenzir/src/data.cpp
+++ b/libtenzir/src/data.cpp
@@ -729,7 +729,7 @@ data parse(const simdjson::dom::element& elem, size_t depth = 0) {
       // Attempt type inference for values that are usually stored in a string
       // when printed as JSON.
       const auto p
-        = parsers::ip | parsers::net | parsers::time | parsers::duration;
+        = parsers::net | parsers::ip | parsers::time | parsers::duration;
       if (p(str, result))
         return result;
       // Take the input as-is if nothing worked.


### PR DESCRIPTION
We previously parsed fields such as `{"x": "2dff::"}` as a string, instead of the IPv6 address `2dff::`. The reason for that is that some places did not account for ordering requirements of the `|` parser combinator. If durations tried first, then the `2d` prefix is parsed as a valid duration, before the completeness check sees that the rest of the string was not consumed, therefore failing the data parsing and keeping it as a string. This PR changes the order, such that parsers that accept a prefix of another parser are ordered after that other parser.