### PR TITLE
Fix duration parsing and printing

### DIFF
--- a/libtenzir/include/tenzir/concept/parseable/core/choice.hpp
+++ b/libtenzir/include/tenzir/concept/parseable/core/choice.hpp
@@ -91,7 +91,7 @@ private:
     } else {
       // Parse one element of the variant and assign it to the passed-in
       // attribute.
-      parser_attribute attr;
+      auto attr = parser_attribute{};
       if (!p(f, l, attr))
         return false;
       a = std::move(attr);

--- a/libtenzir/src/tql2/parser.cpp
+++ b/libtenzir/src/tql2/parser.cpp
@@ -603,7 +603,8 @@ private:
     if (auto result = double{}; si_parser<double>{}(token.text, result)) {
       return constant{try_double_to_integer(result), token.location};
     }
-    if (auto result = duration{}; parsers::duration(token.text, result)) {
+    if (auto result = duration{};
+        parsers::simple_duration(token.text, result)) {
       return constant{result, token.location};
     }
     diagnostic::error("could not parse scalar")

--- a/libtenzir/test/time.cpp
+++ b/libtenzir/test/time.cpp
@@ -92,7 +92,7 @@ TEST(compound durations) {
   check_duration("3m42s10ms", 3min + 42s + 10ms);
   check_duration("3s42s10ms", 3s + 42s + 10ms);
   check_duration("42s3m10ms", 3min + 42s + 10ms);
-  check_duration("-10m8ms1ns", -10min + 8ms + 1ns);
+  check_duration("-10m8ms1ns", -(10min + 8ms + 1ns));
   MESSAGE("no intermediate signs");
   auto p = parsers::duration >> parsers::eoi;
   CHECK(!p("-10m-8ms1ns"));


### PR DESCRIPTION
This fixes parsing of negative compound durations and pretty-printing of negative durations.

- Fixes tenzir/issues#2080
- Fixes tenzir/issues#2082