### PR TITLE
Add bats-assert and bats-support dependencies

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,9 @@
 !/libtenzir/aux/fast_float/
 !/libtenzir/aux/pfs/
 !/libtenzir/aux/simdjson/
+tenzir/integration/lib/bats
+tenzir/integration/lib/bats-assert
+tenzir/integration/lib/bats-support
 CMakeUserPresets.json
 build/
 compile_commands.json

--- a/scripts/debian/install-dev-dependencies.sh
+++ b/scripts/debian/install-dev-dependencies.sh
@@ -4,8 +4,10 @@ set -euo pipefail
 
 apt-get update
 apt-get -y --no-install-recommends install \
-    build-essential \
     bats \
+    bats-assert \
+    bats-support \
+    build-essential \
     ca-certificates \
     ccache \
     cmake-data \


### PR DESCRIPTION
I ran into issues building a Docker image running `docker build . -f Dockerfile --target tenzir-node-de` without these dependencies. 
