### PR TITLE
Fix a crash when starting `export` on shutdown

### DIFF
--- a/changelog/next/bug-fixes/4530--export-crash.md
+++ b/changelog/next/bug-fixes/4530--export-crash.md
@@ -1,0 +1,4 @@
+We fixed an issue where the `export`, `metrics`, or `diagnostics` operators
+crashed the node when started while the node was shutting down or after an
+unexpected filesystem error occurred. This happened frequently while using the
+Tenzir Platform, which subscribes to metrics and diagnostics automatically.


### PR DESCRIPTION
We've seen a few reports of crashes on main where the `export` operator fails to retrieve the `filesystem` component's actor handle. This cannot happen on startup, as the filesystem is registered before the node has started up, but it can very well happen on shutdown, if the node is tearing down while a new `export` operator is starting up. This fixes the crash by responding with a proper error message instead when a component is not available.

Fixes https://github.com/tenzir/issues/issues/2081