### PR TITLE
Fix crash for heterogeneous subnet lookup tables

### DIFF
--- a/changelog/next/bug-fixes/4531--context-inspect-crash.md
+++ b/changelog/next/bug-fixes/4531--context-inspect-crash.md
@@ -1,0 +1,2 @@
+`context inspect <ctx>` no longer crashes for lookup table contexts with
+values of multiple schemas when using subnets as keys.

--- a/libtenzir/builtins/contexts/lookup_table.cpp
+++ b/libtenzir/builtins/contexts/lookup_table.cpp
@@ -381,8 +381,10 @@ public:
       row.field("key", data{key});
       row.field("value", value->raw_data);
       if (entry_builder.length() >= context::dump_batch_size_limit) {
-        co_yield entry_builder.finish_assert_one_slice(
-          fmt::format("tenzir.{}.info", context_type()));
+        for (auto&& slice : entry_builder.finish_as_table_slice(
+               fmt::format("tenzir.{}.info", context_type()))) {
+          co_yield std::move(slice);
+        }
       }
     }
     for (const auto& [key, value] : context_entries) {


### PR DESCRIPTION
This fixes a crash resulting from invalid API usage when running `context inspect <ctx>` for a `lookup-table` context with heterogeneous values using subnets as keys.
