### PR TITLE
Perform individual catalog lookups in `lookup`

### DIFF
--- a/changelog/next/bug-fixes/4535--retro-queued-events.md
+++ b/changelog/next/bug-fixes/4535--retro-queued-events.md
@@ -1,0 +1,2 @@
+We fixed a bug that sometimes caused the `retro.queued_events` value in `lookup`
+metrics to stop going down again.

--- a/changelog/next/features/4535--faster-lookup.md
+++ b/changelog/next/features/4535--faster-lookup.md
@@ -1,0 +1,3 @@
+The `lookup` operator is now smarter about retroactive lookups for frequently
+updated contexts and avoids loading data from disk multiple times for context
+updates that arrive shortly after one another.

--- a/libtenzir/builtins/contexts/bloom_filter.cpp
+++ b/libtenzir/builtins/contexts/bloom_filter.cpp
@@ -31,7 +31,6 @@
 #include <arrow/type.h>
 #include <caf/error.hpp>
 
-#include <chrono>
 #include <memory>
 #include <string>
 
@@ -90,7 +89,8 @@ public:
   }
 
   auto dump() -> generator<table_slice> override {
-    auto ptr = reinterpret_cast<const std::byte*>(bloom_filter_.data().data());
+    const auto* ptr
+      = reinterpret_cast<const std::byte*>(bloom_filter_.data().data());
     auto size = bloom_filter_.data().size();
     auto data = std::basic_string<std::byte>{ptr, size};
     auto entry_builder = series_builder{};
@@ -156,11 +156,10 @@ public:
       bloom_filter_.add(materialized_key);
       key_values_list.emplace_back(std::move(materialized_key));
     }
-    auto query_f
-      = [key_values_list = std::move(key_values_list)](
-          parameter_map,
-          const std::vector<std::string>& fields) -> caf::expected<expression> {
-      auto result = disjunction{};
+    auto query_f = [key_values_list = std::move(key_values_list)](
+                     parameter_map, const std::vector<std::string>& fields)
+      -> caf::expected<std::vector<expression>> {
+      auto result = std::vector<expression>{};
       result.reserve(fields.size());
       for (const auto& field : fields) {
         auto lhs = to<operand>(field);
@@ -173,8 +172,10 @@ public:
       }
       return result;
     };
-    return update_result{.update_info = show(),
-                         .make_query = std::move(query_f)};
+    return update_result{
+      .update_info = show(),
+      .make_query = std::move(query_f),
+    };
   }
 
   auto make_query() -> make_query_type override {

--- a/libtenzir/builtins/contexts/lookup_table.cpp
+++ b/libtenzir/builtins/contexts/lookup_table.cpp
@@ -528,11 +528,10 @@ public:
       ++context_it;
     }
     TENZIR_ASSERT(context_it == context_values.end());
-    auto query_f
-      = [key_values_list = std::move(key_values_list)](
-          parameter_map,
-          const std::vector<std::string>& fields) -> caf::expected<expression> {
-      auto result = disjunction{};
+    auto query_f = [key_values_list = std::move(key_values_list)](
+                     parameter_map, const std::vector<std::string>& fields)
+      -> caf::expected<std::vector<expression>> {
+      auto result = std::vector<expression>{};
       result.reserve(fields.size());
       for (const auto& field : fields) {
         auto lhs = to<operand>(field);
@@ -561,23 +560,22 @@ public:
       }
       entry.first.populate_snapshot_data(key_values_list);
     }
-    return
-      [key_values_list = std::move(key_values_list)](
-        parameter_map,
-        const std::vector<std::string>& fields) -> caf::expected<expression> {
-        auto result = disjunction{};
-        result.reserve(fields.size());
-        for (const auto& field : fields) {
-          auto lhs = to<operand>(field);
-          TENZIR_ASSERT(lhs);
-          result.emplace_back(predicate{
-            *lhs,
-            relational_operator::in,
-            data{key_values_list},
-          });
-        }
-        return result;
-      };
+    return [key_values_list = std::move(key_values_list)](
+             parameter_map, const std::vector<std::string>& fields)
+             -> caf::expected<std::vector<expression>> {
+      auto result = std::vector<expression>{};
+      result.reserve(fields.size());
+      for (const auto& field : fields) {
+        auto lhs = to<operand>(field);
+        TENZIR_ASSERT(lhs);
+        result.emplace_back(predicate{
+          *lhs,
+          relational_operator::in,
+          data{key_values_list},
+        });
+      }
+      return result;
+    };
   }
 
   auto reset() -> caf::expected<void> override {

--- a/libtenzir/include/tenzir/plugin.hpp
+++ b/libtenzir/include/tenzir/plugin.hpp
@@ -657,16 +657,6 @@ private:
              std::span<const std::byte> header) const final;
 };
 
-// -- lookup table plugin -----------
-
-class lookup_table_plugin : public virtual plugin {
-public:
-  virtual auto apply_lookup(std::vector<table_slice> slices,
-                            std::unordered_set<std::string> fields,
-                            record indicators) const -> std::vector<table_slice>
-    = 0;
-};
-
 // -- context plugin -----------------------------------------------------------
 
 class context {
@@ -676,7 +666,7 @@ public:
   using make_query_type
     = std::function<auto(parameter_map parameters,
                          const std::vector<std::string>& fields)
-                      ->caf::expected<expression>>;
+                      ->caf::expected<std::vector<expression>>>;
 
   static constexpr auto dump_batch_size_limit = 65536;
 

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "7c2306c06af441980e312c602f2f690efd00219f",
+  "rev": "ecedeae5e4bb42bda4628cca4ddb0e1592e9d8d0",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
This makes `lookup` faster by performing one catalog lookup per event in the context update, as opposed to one catalog lookup per batch of events. This may seem a bit counterintuitive, but the large disjunction of expressions for batched updates caused a lot of false positives. This new approach has less of them, but on the other hand may cause duplicate results to be returned from the catalog. To offset this, the `lookup` operator now merges expressions into a disjunction when it notices repeat partitions being returned as candidates.

This also fixes an issue where a failed catalog lookup caused the `retro.queued_events` metric to miscount until after the node restarted.

- Fixes tenzir/issues#2055
- Fixes tenzir/issues#2056