### PR TITLE
Fix macOS CI warnings

### DIFF
--- a/scripts/macOS/install-dev-dependencies.sh
+++ b/scripts/macOS/install-dev-dependencies.sh
@@ -23,11 +23,8 @@ brew install --overwrite \
     llvm@17 \
     ninja \
     nmap \
-    openssl \
     pandoc \
     parallel \
-    pipx \
-    pkg-config \
     poetry \
     protobuf \
     rabbitmq-c \


### PR DESCRIPTION
These dependencies are pre-installed on the macOS runners, so there's no need to attempt to install them again.
