### PR TITLE
Implement `<record>.has(<string>)`

### DIFF
--- a/tenzir/integration/data/reference/functions/test_has/step_00.ref
+++ b/tenzir/integration/data/reference/functions/test_has/step_00.ref
@@ -1,0 +1,1 @@
+{"key": true, "error": false}

--- a/tenzir/integration/tests/functions.bats
+++ b/tenzir/integration/tests/functions.bats
@@ -35,3 +35,7 @@ x9 = community_id(src_ip=3ffe:507:0:1:260:97ff:fe07:69ea,
                   src_port=3, dst_port=0, proto="icmp6")
 EOF
 }
+
+@test "has" {
+  check tenzir --tql2 'from { key: { field: 1 }, error: { nofield: 1, msg: { field: "None" } } } | key = key.has("field") | error = error.has("field")'
+}


### PR DESCRIPTION
Checks the immediate children of `<record>` for existence of a field named `<string>`. Currently, does not check for nulls.

Closes https://github.com/tenzir/issues/issues/2088