### PR TITLE
Port the `api` operator to TQL2

### DIFF
--- a/libtenzir/include/tenzir/arrow_utils.hpp
+++ b/libtenzir/include/tenzir/arrow_utils.hpp
@@ -15,21 +15,30 @@
 #include <arrow/result.h>
 #include <arrow/type_traits.h>
 
+#include <source_location>
+
 namespace tenzir {
 
-inline void check(const arrow::Status& status) {
-  TENZIR_ASSERT(status.ok(), status.ToString());
+inline void
+check(const arrow::Status& status, std::source_location location
+                                   = std::source_location::current()) {
+  if (not status.ok()) [[unlikely]] {
+    detail::panic_impl(status.ToString(), location);
+  }
 }
 
 template <class T>
-[[nodiscard]] auto check(arrow::Result<T> result) -> T {
-  check(result.status());
+[[nodiscard]] auto
+check(arrow::Result<T> result, std::source_location location
+                               = std::source_location::current()) -> T {
+  check(result.status(), location);
   return result.MoveValueUnsafe();
 }
 
 template <std::derived_from<arrow::ArrayBuilder> T>
-[[nodiscard]] auto finish(T& x) {
-  auto array = check(x.Finish());
+[[nodiscard]] auto
+finish(T& x, std::source_location location = std::source_location::current()) {
+  auto array = check(x.Finish(), location);
   auto cast
     = std::dynamic_pointer_cast<type_to_arrow_array_t<type_from_arrow_t<T>>>(
       std::move(array));

--- a/libtenzir/src/error.cpp
+++ b/libtenzir/src/error.cpp
@@ -73,25 +73,27 @@ void render_default_ctx(std::ostringstream& oss, const caf::message& ctx) {
     oss << ":";
     for (size_t i = 0; i < size; ++i) {
       oss << ' ';
-      if (ctx.match_element<std::string>(i))
+      if (ctx.match_element<std::string>(i)) {
         oss << ctx.get_as<std::string>(i);
-      else
+      } else {
         oss << to_string(ctx);
+      }
     }
   }
 }
 
 } // namespace
 
-const char* to_string(ec x) {
+auto to_string(ec x) -> const char* {
   auto index = static_cast<size_t>(x);
   TENZIR_ASSERT(index < sizeof(descriptions));
   return descriptions[index];
 }
 
-std::string render(caf::error err, bool pretty_diagnostics) {
-  if (!err)
+auto render(const caf::error& err, bool pretty_diagnostics) -> std::string {
+  if (!err) {
     return "";
+  }
   std::ostringstream oss;
   auto category = err.category();
   if (category == caf::type_id_v<tenzir::ec>
@@ -154,8 +156,9 @@ std::string render(caf::error err, bool pretty_diagnostics) {
 }
 
 auto add_context_impl(const caf::error& error, std::string str) -> caf::error {
-  if (!error)
+  if (!error) {
     return error;
+  }
   if (error.category() == caf::type_id_v<tenzir::ec>
       && static_cast<tenzir::ec>(error.code()) == ec::diagnostic) {
     auto ctx = error.context();


### PR DESCRIPTION
For example:

```
// tql2
api "/pipeline/update", {
  id: "1e6b6d7c-4b7f-4cbf-bf65-115a7fc27145",
  action: "stop",
}
```

- Fixes https://github.com/tenzir/issues/issues/2091