### PR TITLE
Improve `community_id` diagnostics

### DIFF
--- a/tenzir/integration/data/reference/functions/test_community-2d5fid/step_00.ref
+++ b/tenzir/integration/data/reference/functions/test_community-2d5fid/step_00.ref
@@ -1,5 +1,17 @@
 {"x0": "1:lGqktS6jbUHZ0E3cfwaJiw2aM3g=", "x1": null, "x2": null, "x3": "1:mpczsiJK8HOtVhqo+YaJ3PuQ0nY=", "x4": null, "x5": "1:IYupyQZipmn4+X+/766iaQdMVz0=", "x6": "1:8178KvX8p08bbJ7e45CMJba/ACk=", "x7": "1:X0snYXpgwiv9TZtqg64sgzUn6Dk=", "x8": "1:dGHyGvjMfljg6Bppwm3bg0LO8TY=", "x9": "1:NdobDX8PQNJbAyfkWxhtL2Pqp5w="}
 warning: encountered only `src_port` or `dst_port` but not both
+ --> /dev/stdin:6:73
+  |
+6 | x1 = community_id(src_ip=45.146.166.123, dst_ip=198.71.247.91, src_port=52482, proto="tcp")
+  |                                                                         ~~~~~ 
+  |
+
+warning: encountered only `src_port` or `dst_port` but not both
+ --> /dev/stdin:8:28
+  |
+8 |                   dst_port=749, proto="tcp")
+  |                            ~~~ 
+  |
 
 warning: `proto` must be `tcp`, `udp`, `icmp`, or `icmp6`
   --> /dev/stdin:12:70


### PR DESCRIPTION
This adds source location information to a few more diagnostics emitted by the `community_id` function, and also converts two errors into warnings, as run-time type errors are generally emitted as warnings.