### PR TITLE
Fix `/pipeline/launch` when no cache is provided

### DIFF
--- a/changelog/next/bug-fixes/4554--launch-hotfix.md
+++ b/changelog/next/bug-fixes/4554--launch-hotfix.md
@@ -1,0 +1,2 @@
+We fixed a regression introduced with Tenzir v4.20 that sometimes caused the
+Tenzir Platform to fail to fetch results from pipelines.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "949a6c9cd50db76279d5c05492e2e8d348b7b1c6",
+  "rev": "af874e3cdb106423ef5b2f9cca5374738521b55f",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
This fixes a case with a missing test—calling `/pipeline/launch` for a pipeline that has no sink, and configuring the implicit sink to be just `serve` without `cache`.