### PR TITLE
Implement `eq` and `neq` for `record_type` and `list_type`

### DIFF
--- a/tenzir/integration/data/reference/expression/test_equals_op/step_00.ref
+++ b/tenzir/integration/data/reference/expression/test_equals_op/step_00.ref
@@ -1,0 +1,1 @@
+{"eq1": true, "eq2": true}

--- a/tenzir/integration/tests/expression.bats
+++ b/tenzir/integration/tests/expression.bats
@@ -33,6 +33,10 @@ write_json ndjson=false
 EOF
 }
 
+@test "equals op" {
+  check tenzir --tql2 'from {} | eq1 = {a:1, b:2} == {a:1, b:2} | eq2 = [1,2,3] != [3,2,1]'
+}
+
 @test "record spread" {
   check tenzir -f '/dev/stdin' <<EOF
 from [{}]


### PR DESCRIPTION
Implements `eq` and `neq` for records and list types. These perform strict equality checks, **in-order**. Relaxed out-of-order checks may be implemented in the future.

Additionally, turns off LeakSanitizer for static plugins loaded.

Closes https://github.com/tenzir/issues/issues/2121