### PR TITLE
Introduce `TENZIR_TOKEN`

### DIFF
--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "74550f5b7cede31ae293c59ac5556d5d7f4e9693",
+  "rev": "27d854b880eaf961a27e7f1f2fdb769e2e03255b",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
This adds two new configuration options for Tenzir Nodes: `TENZIR_TOKEN` and `TENZIR_PLATFORM_CONTROL_ENDPOINT`.

The token supersedes the tenant id and api key in the existing platform configuration file. The platform control endpoint supersedes the control endpoint option in the existing platform configuration file, but is no longer required and defaults to `wss://ws.tenzir.app/production`.

The token's format is computed from the tenant id and the api key. Take for example a platform configuration file like this:

```
# ~/.config/tenzir/plugin/platform.yaml
api-key: jjyKtVVv5XKZmTXS0luIfb3aqTSJELiMIHllI5h59f4
tenant-id: t-8w5man4n
control-endpoint: wss://ws.tenzir.app/production
```

Instead of needing to create this file, users can now simply set the following environment variable for the node:

```bash
TENZIR_TOKEN=tnz_8w5man4njjyKtVVv5XKZmTXS0luIfb3aqTSJELiMIHllI5h59f4
```

The token is simply the tenant id and the api key concatenaded, with the fixed `t-` prefix of the tenant id removed. Instead, there is a fixed `tnz_` prefix to make it easy to spot accidentally leaked tokens at a glance.

Only Sovereign Edition users or developers with access to staging deployments must set the `TENZIR_PLATFORM_CONTROL_ENDPOINT` variable. The new name for this option exactly matches the variable used to configure the endpoint for the Tenzir Platform itself.

This change is entirely backwards compatible. The new options take precedence over the old ones.