### PR TITLE
Make `tenzir` and `tenzir-node` start faster

### DIFF
--- a/libtenzir/include/tenzir/configuration.hpp
+++ b/libtenzir/include/tenzir/configuration.hpp
@@ -20,21 +20,29 @@
 
 namespace tenzir {
 
+struct config_file {
+  std::filesystem::path path;
+  std::optional<std::string> plugin;
+
+  auto operator==(const config_file& rhs) const -> bool = default;
+  auto operator<=>(const config_file& rhs) const -> std::strong_ordering
+    = default;
+};
+
 /// @returns The config dirs of the application.
 /// @param cfg The actor system config to introspect.
-std::vector<std::filesystem::path>
-config_dirs(const caf::actor_system_config& cfg);
+auto config_dirs(const caf::actor_system_config& cfg)
+  -> std::vector<std::filesystem::path>;
 
 auto config_dirs(const record& cfg) -> std::vector<std::filesystem::path>;
 
 /// @returns The loaded config files of the application.
 /// @note This function is not threadsafe.
-const std::vector<std::filesystem::path>& loaded_config_files();
+auto loaded_config_files() -> const std::vector<config_file>&;
 
 /// @returns The duration value of the given option.
-caf::expected<duration>
-get_or_duration(const caf::settings& options, std::string_view key,
-                duration fallback);
+auto get_or_duration(const caf::settings& options, std::string_view key,
+                     duration fallback) -> caf::expected<duration>;
 
 /// Bundles all configuration parameters of a Tenzir system.
 class configuration : public caf::actor_system_config {
@@ -45,7 +53,7 @@ public:
 
   // -- modifiers --------------------------------------------------------------
 
-  caf::error parse(int argc, char** argv);
+  auto parse(int argc, char** argv) -> caf::error;
 
   // -- configuration options --------------------------------------------------
 
@@ -53,10 +61,10 @@ public:
   std::vector<std::string> command_line = {};
 
   /// The configuration files to load.
-  std::vector<std::filesystem::path> config_files = {};
+  std::vector<config_file> config_files = {};
 
 private:
-  caf::error embed_config(const caf::settings& settings);
+  auto embed_config(const caf::settings& settings) -> caf::error;
 };
 
 } // namespace tenzir


### PR DESCRIPTION
We noticed that flamegraphs show a large amount of time on startup being spent in the function `tenzir::config_dirs(…)`. Apparently, the function was called $`N+1`$ times for $`N`$ plugins and builtins available. That's a bit unnecessary, so I shuffled the code around to only call the function exactly once.

Additionally, this cleans up some code that has been deprecated for over a year now.