### PR TITLE
Support bytes inputs in the `buffer` operator

### DIFF
--- a/changelog/next/features/4594--buffer-bytes.md
+++ b/changelog/next/features/4594--buffer-bytes.md
@@ -1,0 +1,2 @@
+The `buffer` operator now works with bytes inputs in addition to the existing
+support for events inputs.

--- a/libtenzir/builtins/operators/buffer.cpp
+++ b/libtenzir/builtins/operators/buffer.cpp
@@ -25,26 +25,28 @@ TENZIR_ENUM(buffer_policy, block, drop);
 
 namespace {
 
+template <class Elements>
 using buffer_actor = caf::typed_actor<
-  // Write events into the buffer.
-  auto(atom::write, table_slice events)->caf::result<void>,
-  // Read events from the buffer.
-  auto(atom::read)->caf::result<table_slice>>;
+  // Write elements into the buffer.
+  auto(atom::write, Elements elements)->caf::result<void>,
+  // Read elements from the buffer.
+  auto(atom::read)->caf::result<Elements>>;
 
+template <class Elements>
 struct buffer_state {
   static constexpr auto name = "buffer";
 
-  buffer_actor::pointer self = {};
+  buffer_actor<Elements>::pointer self = {};
   located<uint64_t> capacity = {};
   buffer_policy policy = {};
   metric_handler metrics_handler = {};
   shared_diagnostic_handler diagnostics_handler = {};
 
   uint64_t buffer_size = {};
-  std::queue<table_slice> buffer = {};
-  caf::typed_response_promise<table_slice> read_rp = {};
+  std::queue<Elements> buffer = {};
+  caf::typed_response_promise<Elements> read_rp = {};
 
-  table_slice blocked_events = {};
+  Elements blocked_elements = {};
   caf::typed_response_promise<void> write_rp = {};
 
   uint64_t num_dropped = {};
@@ -52,26 +54,26 @@ struct buffer_state {
   ~buffer_state() noexcept {
     emit_metrics();
     if (read_rp.pending()) {
-      read_rp.deliver(table_slice{});
+      read_rp.deliver(Elements{});
     }
   }
 
-  auto write(table_slice events) -> caf::result<void> {
+  auto write(Elements elements) -> caf::result<void> {
     if (read_rp.pending()) {
-      read_rp.deliver(std::move(events));
+      read_rp.deliver(std::move(elements));
       return {};
     }
-    if (buffer_size + events.rows() > capacity.inner) {
-      auto [lhs, rhs] = split(events, capacity.inner - buffer_size);
-      if (lhs.rows() > 0) {
-        buffer_size += lhs.rows();
+    if (buffer_size + size(elements) > capacity.inner) {
+      auto [lhs, rhs] = split(elements, capacity.inner - buffer_size);
+      if (const auto lhs_size = size(lhs); lhs_size > 0) {
+        buffer_size += lhs_size;
         buffer.push(std::move(lhs));
       }
-      TENZIR_ASSERT(rhs.rows() > 0);
+      TENZIR_ASSERT(size(rhs) > 0);
       switch (policy) {
         case buffer_policy::drop: {
-          num_dropped += rhs.rows();
-          diagnostic::warning("buffer exceeded capacity and dropped events")
+          num_dropped += size(rhs);
+          diagnostic::warning("buffer exceeded capacity and dropped elements")
             .primary(capacity.source)
             .hint("the configured policy is `{}`; use `{}` to prevent dropping",
                   buffer_policy::drop, buffer_policy::block)
@@ -80,41 +82,41 @@ struct buffer_state {
           return {};
         }
         case buffer_policy::block: {
-          TENZIR_ASSERT(blocked_events.rows() == 0);
+          TENZIR_ASSERT(size(blocked_elements) == 0);
           TENZIR_ASSERT(not write_rp.pending());
-          blocked_events = std::move(rhs);
-          write_rp = self->make_response_promise<void>();
+          blocked_elements = std::move(rhs);
+          write_rp = self->template make_response_promise<void>();
           return write_rp;
         }
       }
     }
-    buffer_size += events.rows();
-    buffer.push(std::move(events));
+    buffer_size += size(elements);
+    buffer.push(std::move(elements));
     return {};
   }
 
-  auto read() -> caf::result<table_slice> {
+  auto read() -> caf::result<Elements> {
     TENZIR_ASSERT(not read_rp.pending());
     if (not buffer.empty()) {
-      auto events = std::move(buffer.front());
-      buffer_size -= events.rows();
+      auto elements = std::move(buffer.front());
+      buffer_size -= size(elements);
       buffer.pop();
       if (write_rp.pending()) {
         TENZIR_ASSERT(policy == buffer_policy::block);
         const auto free_capacity = capacity.inner - buffer_size;
-        auto [lhs, rhs] = split(blocked_events, free_capacity);
-        if (lhs.rows() > 0) {
-          buffer_size += lhs.rows();
+        auto [lhs, rhs] = split(blocked_elements, free_capacity);
+        if (const auto lhs_size = size(lhs); lhs_size > 0) {
+          buffer_size += lhs_size;
           buffer.push(std::move(lhs));
         }
-        blocked_events = std::move(rhs);
-        if (blocked_events.rows() == 0) {
+        blocked_elements = std::move(rhs);
+        if (size(blocked_elements) == 0) {
           write_rp.deliver();
         }
       }
-      return events;
+      return elements;
     }
-    read_rp = self->make_response_promise<table_slice>();
+    read_rp = self->template make_response_promise<Elements>();
     return read_rp;
   }
 
@@ -128,11 +130,14 @@ struct buffer_state {
   }
 };
 
-auto make_buffer(buffer_actor::stateful_pointer<buffer_state> self,
+template <class Elements>
+auto make_buffer(typename buffer_actor<Elements>::template stateful_pointer<
+                   buffer_state<Elements>>
+                   self,
                  located<uint64_t> capacity, buffer_policy policy,
                  metric_handler metrics_handler,
                  shared_diagnostic_handler diagnostics_handler)
-  -> buffer_actor::behavior_type {
+  -> buffer_actor<Elements>::behavior_type {
   self->state.self = self;
   self->state.capacity = capacity;
   self->state.policy = policy;
@@ -148,10 +153,10 @@ auto make_buffer(buffer_actor::stateful_pointer<buffer_state> self,
     self->state.emit_metrics();
   });
   return {
-    [self](atom::write, table_slice& events) -> caf::result<void> {
-      return self->state.write(std::move(events));
+    [self](atom::write, Elements& elements) -> caf::result<void> {
+      return self->state.write(std::move(elements));
     },
-    [self](atom::read) -> caf::result<table_slice> {
+    [self](atom::read) -> caf::result<Elements> {
       return self->state.read();
     },
   };
@@ -165,27 +170,28 @@ public:
   explicit write_buffer_operator(uuid id) : id_{id} {
   }
 
-  auto
-  operator()(generator<table_slice> input, operator_control_plane& ctrl) const
-    -> generator<table_slice> {
+  template <class Elements>
+    requires(detail::is_any_v<Elements, table_slice, chunk_ptr>)
+  auto operator()(generator<Elements> input, operator_control_plane& ctrl) const
+    -> generator<Elements> {
     // The internal-write-buffer operator is spawned after the
     // internal-read-buffer operator, so we can safely get the buffer actor here
     // after the first yield and then just remove it from the registry again.
     co_yield {};
-    auto buffer = ctrl.self().system().registry().get<buffer_actor>(
+    auto buffer = ctrl.self().system().registry().get<buffer_actor<Elements>>(
       fmt::format("tenzir.buffer.{}", id_));
     TENZIR_ASSERT(buffer);
     ctrl.self().link_to(buffer);
     ctrl.self().system().registry().erase(buffer->id());
     // Now, all we need to do is send our inputs to the buffer batch by batch.
-    for (auto&& events : input) {
-      if (events.rows() == 0) {
+    for (auto&& elements : input) {
+      if (size(elements) == 0) {
         co_yield {};
         continue;
       }
       ctrl.set_waiting(true);
       ctrl.self()
-        .request(buffer, caf::infinite, atom::write_v, std::move(events))
+        .request(buffer, caf::infinite, atom::write_v, std::move(elements))
         .then(
           [&]() {
             ctrl.set_waiting(false);
@@ -213,6 +219,9 @@ public:
     if (input.is<table_slice>()) {
       return tag_v<table_slice>;
     }
+    if (input.is<chunk_ptr>()) {
+      return tag_v<chunk_ptr>;
+    }
     return diagnostic::error("`buffer` does not accept {} as input",
                              operator_type_name(input))
       .to_error();
@@ -231,13 +240,25 @@ public:
   read_buffer_operator() = default;
 
   explicit read_buffer_operator(uuid id, located<uint64_t> capacity,
-                                std::optional<buffer_policy> policy)
+                                std::optional<located<buffer_policy>> policy)
     : id_{id}, capacity_{capacity}, policy_{policy} {
   }
 
+  template <class Elements>
   auto policy(operator_control_plane& ctrl) const -> buffer_policy {
-    return policy_.value_or(ctrl.is_hidden() ? buffer_policy::drop
-                                             : buffer_policy::block);
+    if (std::is_same_v<Elements, table_slice>) {
+      if (policy_) {
+        return policy_->inner;
+      }
+      return ctrl.is_hidden() ? buffer_policy::drop : buffer_policy::block;
+    }
+    if (policy_ and policy_->inner == buffer_policy::drop) {
+      diagnostic::error("`drop` policy is unsupported for bytes inputs")
+        .note("use `block` instead")
+        .primary(policy_->source)
+        .emit(ctrl.diagnostics());
+    }
+    return buffer_policy::block;
   }
 
   auto metrics(operator_control_plane& ctrl) const -> metric_handler {
@@ -251,28 +272,30 @@ public:
     });
   }
 
-  auto
-  operator()(generator<table_slice> input, operator_control_plane& ctrl) const
-    -> generator<table_slice> {
+  template <class Elements>
+    requires(detail::is_any_v<Elements, table_slice, chunk_ptr>)
+  auto operator()(generator<Elements> input, operator_control_plane& ctrl) const
+    -> generator<Elements> {
     // The internal-read-buffer operator is spawned before the
     // internal-write-buffer operator, so we spawn the buffer actor here and
     // move it into the registry before the first yield.
-    auto buffer = ctrl.self().spawn<caf::linked>(make_buffer, capacity_,
-                                                 policy(ctrl), metrics(ctrl),
-                                                 ctrl.shared_diagnostics());
+    auto buffer
+      = ctrl.self().spawn<caf::linked>(make_buffer<Elements>, capacity_,
+                                       policy<Elements>(ctrl), metrics(ctrl),
+                                       ctrl.shared_diagnostics());
     ctrl.self().system().registry().put(fmt::format("tenzir.buffer.{}", id_),
                                         buffer);
     co_yield {};
     // Now, we can get batch by batch from the buffer.
-    for (auto&& events : input) {
-      TENZIR_ASSERT(events.rows() == 0);
+    for (auto&& elements : input) {
+      TENZIR_ASSERT(size(elements) == 0);
       ctrl.set_waiting(true);
       ctrl.self()
         .request(buffer, caf::infinite, atom::read_v)
         .then(
-          [&](table_slice& response) {
+          [&](Elements& response) {
             ctrl.set_waiting(false);
-            events = std::move(response);
+            elements = std::move(response);
           },
           [&](caf::error& err) {
             diagnostic::error(err)
@@ -280,7 +303,7 @@ public:
               .emit(ctrl.diagnostics());
           });
       co_yield {};
-      co_yield std::move(events);
+      co_yield std::move(elements);
     }
   }
 
@@ -289,8 +312,8 @@ public:
   }
 
   auto input_independent() const -> bool override {
-    // We only send stub events between the two operators to break the back
-    // pressure and instead use a side channel for transporting events, hence
+    // We only send stub elements between the two operators to break the back
+    // pressure and instead use a side channel for transporting elements, hence
     // the nead to schedule the reading side independently of receiving input.
     return true;
   }
@@ -304,6 +327,9 @@ public:
     -> caf::expected<operator_type> override {
     if (input.is<table_slice>()) {
       return tag_v<table_slice>;
+    }
+    if (input.is<chunk_ptr>()) {
+      return tag_v<chunk_ptr>;
     }
     return diagnostic::error("`buffer` does not accept {} as input",
                              operator_type_name(input))
@@ -319,7 +345,7 @@ public:
 private:
   uuid id_ = {};
   located<uint64_t> capacity_ = {};
-  std::optional<buffer_policy> policy_ = {};
+  std::optional<located<buffer_policy>> policy_ = {};
 };
 
 class buffer_plugin final : public virtual operator_parser_plugin,
@@ -353,14 +379,15 @@ public:
         .primary(capacity.source)
         .throw_();
     }
-    auto policy = std::optional<buffer_policy>{};
+    auto policy = std::optional<located<buffer_policy>>{};
     if (policy_str) {
-      policy = from_string<buffer_policy>(policy_str->inner);
-      if (not policy) {
+      const auto parsed_policy = from_string<buffer_policy>(policy_str->inner);
+      if (not parsed_policy) {
         diagnostic::error("policy must be 'block' or 'drop'")
           .primary(policy_str->source)
           .throw_();
       }
+      policy = {*parsed_policy, policy_str->source};
     }
     const auto id = uuid::random();
     auto result = std::make_unique<pipeline>();
@@ -379,19 +406,26 @@ public:
       .add("policy", policy_str)
       .parse(inv, ctx)
       .ignore();
+    auto failed = false;
     if (capacity.inner == 0) {
       diagnostic::error("capacity must be greater than zero")
         .primary(capacity.source)
         .emit(ctx);
+      failed = true;
     }
-    auto policy = std::optional<buffer_policy>{};
+    auto policy = std::optional<located<buffer_policy>>{};
     if (policy_str) {
-      policy = from_string<buffer_policy>(policy_str->inner);
-      if (not policy) {
+      const auto parsed_policy = from_string<buffer_policy>(policy_str->inner);
+      if (not parsed_policy) {
         diagnostic::error("policy must be 'block' or 'drop'")
           .primary(policy_str->source)
           .emit(ctx);
+        failed = true;
       }
+      policy = {*parsed_policy, policy_str->source};
+    }
+    if (failed) {
+      return failure::promise();
     }
     const auto id = uuid::random();
     auto result = std::make_unique<pipeline>();

--- a/libtenzir/include/tenzir/chunk.hpp
+++ b/libtenzir/include/tenzir/chunk.hpp
@@ -342,6 +342,8 @@ auto split(const chunk_ptr& chunk, size_t partition_point)
 auto split(std::vector<chunk_ptr> chunks, size_t partition_point)
   -> std::pair<std::vector<chunk_ptr>, std::vector<chunk_ptr>>;
 
+auto size(const chunk_ptr& chunk) -> uint64_t;
+
 } // namespace tenzir
 
 namespace fmt {

--- a/libtenzir/include/tenzir/table_slice.hpp
+++ b/libtenzir/include/tenzir/table_slice.hpp
@@ -227,7 +227,6 @@ public:
         TENZIR_ASSERT(x.is_serialized());
         return true;
       };
-
       return f.object(x)
         .pretty_name("tenzir.table_slice")
         .on_load(callback)
@@ -245,6 +244,8 @@ public:
         .fields(f.field("chunk", chunk), f.field("offset", x.offset_));
     }
   }
+
+  friend auto size(const table_slice& slice) -> uint64_t;
 
   // -- operations -------------------------------------------------------------
 

--- a/libtenzir/src/chunk.cpp
+++ b/libtenzir/src/chunk.cpp
@@ -493,4 +493,8 @@ auto split(std::vector<chunk_ptr> chunks, size_t partition_point)
   };
 }
 
+auto size(const chunk_ptr& chunk) -> uint64_t {
+  return chunk ? chunk->size() : 0;
+}
+
 } // namespace tenzir

--- a/libtenzir/src/execution_node.cpp
+++ b/libtenzir/src/execution_node.cpp
@@ -208,14 +208,6 @@ struct exec_node_control_plane final : public operator_control_plane {
   bool is_hidden_ = {};
 };
 
-auto size(const table_slice& slice) -> uint64_t {
-  return slice.rows();
-}
-
-auto size(const chunk_ptr& chunk) -> uint64_t {
-  return chunk ? chunk->size() : 0;
-}
-
 template <class Input, class Output>
 struct exec_node_state {
   exec_node_state() = default;

--- a/libtenzir/src/table_slice.cpp
+++ b/libtenzir/src/table_slice.cpp
@@ -400,6 +400,10 @@ std::span<const std::byte> as_bytes(const table_slice& slice) noexcept {
   return as_bytes(slice.chunk_);
 }
 
+auto size(const table_slice& slice) -> uint64_t {
+  return slice.rows();
+}
+
 // -- operations ---------------------------------------------------------------
 
 table_slice concatenate(std::vector<table_slice> slices) {

--- a/web/docs/operators/buffer.md
+++ b/web/docs/operators/buffer.md
@@ -42,7 +42,7 @@ Specifies what the operator does when the buffer runs full.
   supported for bytes inputs.
 - `block`: Use back pressure to slow down upstream operators.
 
-When buffering events, this option efaults to `block` for pipelines visible on
+When buffering events, this option defaults to `block` for pipelines visible on
 the overview page on [app.tenzir.com](https://app.tenzir.com), and to `drop`
 otherwise. When buffering bytes, this option always defaults to `block`.
 

--- a/web/docs/operators/buffer.md
+++ b/web/docs/operators/buffer.md
@@ -16,8 +16,8 @@ buffer [<capacity>] [--policy <block|drop>]
 
 ## Description
 
-The `buffer` operator buffers up to the specified number of events in an
-in-memory buffer.
+The `buffer` operator buffers up to the specified number of events or bytes in
+an in-memory buffer.
 
 By default, operators in a pipeline run only when their downstream operators
 want to receive input. This mechanism is called back pressure. The `buffer`
@@ -29,7 +29,7 @@ easily.
 
 ### `<capacity>`
 
-The number of events that may be kept at most in the buffer.
+The number of events or bytes that may be kept at most in the buffer.
 
 Note that every operator already buffers up to 254Ki events before it starts
 applying back pressure. Smaller buffers may pessimize performance.
@@ -38,16 +38,18 @@ applying back pressure. Smaller buffers may pessimize performance.
 
 Specifies what the operator does when the buffer runs full.
 
-- `drop`: Drop events that do not fit into the buffer.
+- `drop`: Drop events that do not fit into the buffer. This policy is not
+  supported for bytes inputs.
 - `block`: Use back pressure to slow down upstream operators.
 
-Defaults to `block` for pipelines visible on the overview page on
-[app.tenzir.com](https://app.tenzir.com), and to `drop` otherwise.
+When buffering events, this option efaults to `block` for pipelines visible on
+the overview page on [app.tenzir.com](https://app.tenzir.com), and to `drop`
+otherwise. When buffering bytes, this option always defaults to `block`.
 
 ## Examples
 
-Buffer up to 10M events in a buffer, dropping events if downstream cannot keep
-up.
+Buffer up to 10M events or bytes in a buffer, dropping them if downstream cannot
+keep up.
 
 ```
 buffer 10M --policy drop


### PR DESCRIPTION
This extends the `buffer` operator to support bytes as input in addition to the existing support for events. Note that the `drop` policy is not supported when using bytes as an input, as—unlike for events—dropping parts of a bytes stream can go horribly wrong.

- Fixes tenzir/issues#2153