### PR TITLE
Stop using connection timeout to get node components

### DIFF
--- a/changelog/next/bug-fixes/4597--node-connection-timeout.md
+++ b/changelog/next/bug-fixes/4597--node-connection-timeout.md
@@ -1,0 +1,2 @@
+The `import` and `partitions` operators and the `tenzir-ctl rebuild` command no
+longer occasionally fail with request timeouts when the node is under high load.

--- a/libtenzir/include/tenzir/node_control.hpp
+++ b/libtenzir/include/tenzir/node_control.hpp
@@ -45,10 +45,11 @@ auto get_node_components(caf::scoped_actor& self, const node_actor& node)
     std::replace(str.begin(), str.end(), '_', '-');
     return str;
   };
-  const auto timeout = node_connection_timeout(self->config().content);
   auto labels = std::vector<std::string>{
     normalize(caf::type_name_by_id<caf::type_id<Actors>::value>::value)...};
-  self->request(node, timeout, atom::get_v, atom::label_v, labels)
+  self
+    ->request(node, caf::infinite, atom::get_v, atom::label_v,
+              std::move(labels))
     .receive(
       [&](std::vector<caf::actor>& components) {
         result = detail::tuple_map<result_t>(


### PR DESCRIPTION
This is not what the timeout was intended for, and if the node is under high load this can lead to timeout errors that are not handled at all, causing pipelines to fail.