### PR TITLE
Improve idle detection of operators

### DIFF
--- a/libtenzir/builtins/operators/buffer.cpp
+++ b/libtenzir/builtins/operators/buffer.cpp
@@ -311,11 +311,11 @@ public:
     return "internal-read-buffer";
   }
 
-  auto input_independent() const -> bool override {
+  auto idle_after() const -> duration override {
     // We only send stub elements between the two operators to break the back
     // pressure and instead use a side channel for transporting elements, hence
     // the nead to schedule the reading side independently of receiving input.
-    return true;
+    return duration::max();
   }
 
   auto optimize(expression const& filter, event_order order) const

--- a/libtenzir/builtins/operators/cache.cpp
+++ b/libtenzir/builtins/operators/cache.cpp
@@ -520,12 +520,12 @@ public:
     return "read_cache";
   }
 
-  auto input_independent() const -> bool override {
+  auto idle_after() const -> duration override {
     // We only send stub events between the two operators to break the back
     // pressure and instead use a side channel for transporting events, hence
     // the need to schedule the reading side independently of receiving input if
     // we're not a source.
-    return not source_;
+    return source_ ? duration::zero() : duration::max();
   }
 
   auto optimize(const expression& filter, event_order order) const

--- a/libtenzir/builtins/operators/every_cron.cpp
+++ b/libtenzir/builtins/operators/every_cron.cpp
@@ -190,10 +190,9 @@ public:
     return pipe_.operators().empty() ? false : pipe_.operators()[0]->internal();
   }
 
-  auto input_independent() const -> bool override {
-    return pipe_.operators().empty()
-             ? false
-             : pipe_.operators()[0]->input_independent();
+  auto idle_after() const -> duration override {
+    return pipe_.operators().empty() ? duration::zero()
+                                     : pipe_.operators()[0]->idle_after();
   }
 
   auto infer_type_impl(operator_type input) const

--- a/libtenzir/builtins/operators/from_load_read.cpp
+++ b/libtenzir/builtins/operators/from_load_read.cpp
@@ -111,6 +111,10 @@ public:
     };
   }
 
+  auto idle_after() const -> duration override {
+    return defaults::import::batch_timeout;
+  }
+
   friend auto inspect(auto& f, read_operator& x) -> bool {
     return plugin_inspect(f, x.parser_);
   }

--- a/libtenzir/builtins/operators/local_remote.cpp
+++ b/libtenzir/builtins/operators/local_remote.cpp
@@ -82,8 +82,8 @@ public:
     return op_->internal();
   }
 
-  auto input_independent() const -> bool override {
-    return op_->input_independent();
+  auto idle_after() const -> duration override {
+    return op_->idle_after();
   }
 
   auto infer_type_impl(operator_type input) const

--- a/libtenzir/builtins/operators/shell.cpp
+++ b/libtenzir/builtins/operators/shell.cpp
@@ -314,9 +314,9 @@ public:
     return true;
   }
 
-  auto input_independent() const -> bool override {
+  auto idle_after() const -> duration override {
     // We may produce results without receiving any further input.
-    return true;
+    return duration::max();
   }
 
   auto name() const -> std::string override {

--- a/libtenzir/builtins/operators/summarize.cpp
+++ b/libtenzir/builtins/operators/summarize.cpp
@@ -789,13 +789,13 @@ public:
     return "summarize";
   }
 
-  auto input_independent() const -> bool override {
-    // Returning false here is technically incorrect when using summarize with
+  auto idle_after() const -> duration override {
+    // Returning zero here is technically incorrect when using summarize with
     // timeouts. However, the handling of input-independent non-source operators
     // in the execution nodes is so bad, that we accept a potential delay here
     // over excess CPU usage.
     // TODO: Fix this properly in the execution nodes.
-    return false;
+    return duration::zero();
   }
 
   auto optimize(expression const& filter, event_order order) const

--- a/libtenzir/builtins/operators/unordered.cpp
+++ b/libtenzir/builtins/operators/unordered.cpp
@@ -54,8 +54,8 @@ public:
     return op_->internal();
   }
 
-  auto input_independent() const -> bool override {
-    return op_->input_independent();
+  auto idle_after() const -> duration override {
+    return op_->idle_after();
   }
 
   auto infer_type_impl(operator_type input) const

--- a/libtenzir/include/tenzir/pipeline.hpp
+++ b/libtenzir/include/tenzir/pipeline.hpp
@@ -373,11 +373,12 @@ public:
     return false;
   }
 
-  /// Returns whether the operator can produce output independently from
-  /// receiving input. Set to true to cause operators to be polled rather than
-  /// pulled from. Operators without a source are always polled from.
-  virtual auto input_independent() const -> bool {
-    return false;
+  /// Returns the time after which the operator is considered idle if it does
+  /// not produce any output. Must be a positive duration. If the operator can
+  /// produce output independently from receiving input, return
+  /// `duration::max()` to cause the operator to be polled.
+  virtual auto idle_after() const -> duration {
+    return duration::zero();
   }
 
   /// Retrieve the output type of this operator for a given input.
@@ -533,8 +534,8 @@ public:
     detail::panic("pipeline::internal() must not be called");
   }
 
-  auto input_independent() const -> bool override {
-    detail::panic("pipeline::input_independent() must not be called");
+  auto idle_after() const -> duration override {
+    detail::panic("pipeline::idle_after() must not be called");
   }
 
   auto instantiate(operator_input input, operator_control_plane& control) const


### PR DESCRIPTION
This replaces the `input_independent` property of operators with a smarter `idle_after` property, and makes use of it in the `read` operator to improve scheduling of the operator when is not yet finished but has no demand, and the `read` operators parser has events "stuck" in its generator's state, e.g., in a series builder's internal buffer.