### PR TITLE
Make `read json --arrays-of-objects` faster

### DIFF
--- a/changelog/next/bug-fixes/4601--faster-arrays-of-objects.md
+++ b/changelog/next/bug-fixes/4601--faster-arrays-of-objects.md
@@ -1,0 +1,3 @@
+We fixed an accidentally quadratic scaling with the number of top-level array
+elements in `read json --arrays-of-objects`. As a result, using this option will
+now be much faster.


### PR DESCRIPTION
Calling `doc_it.source()` resets simdjson's internal data structure, which made `--arrays-of-objects` perform worse the larger the array was.