### PR TITLE
Keep from tcp pipelines running on connection failures

### DIFF
--- a/changelog/next/bug-fixes/4602--graceful-tcp-connection-errors.md
+++ b/changelog/next/bug-fixes/4602--graceful-tcp-connection-errors.md
@@ -1,0 +1,2 @@
+Pipelines starting with `from tcp` no longer enter the failed state when an
+error occurrs in one of the connections.


### PR DESCRIPTION
Pipelines starting with `from tcp` no longer go into the failed state when a single connection fails.