### PR TITLE
Add support for named required arguments to TQL2

### DIFF
--- a/libtenzir/include/tenzir/argument_parser2.hpp
+++ b/libtenzir/include/tenzir/argument_parser2.hpp
@@ -65,30 +65,30 @@ public:
 
   // ------------------------------------------------------------------------
 
-  /// @brief Adds a required positional argument
+  /// Adds a required positional argument.
   template <argument_parser_type T>
   auto add(T& x, std::string meta) -> argument_parser2&;
 
-  /// @brief Adds an optional positional argument
+  /// Adds an optional positional argument.
   template <argument_parser_type T>
   auto add(std::optional<T>& x, std::string meta) -> argument_parser2&;
 
   // ------------------------------------------------------------------------
 
-  /// @brief Adds a required named argument
+  /// Adds a required named argument.
   template <argument_parser_type T>
   auto add(std::string name, T& x) -> argument_parser2&;
 
   // ------------------------------------------------------------------------
 
-  /// @brief Adds an optional named argument
+  /// Adds an optional named argument.
   template <argument_parser_type T>
   auto add(std::string name, std::optional<T>& x) -> argument_parser2&;
 
-  /// @brief Adds an optional named argument
+  /// Adds an optional named argument.
   auto add(std::string name, std::optional<location>& x) -> argument_parser2&;
 
-  /// @brief Adds an optional named argument
+  /// Adds an optional named argument.
   auto add(std::string name, bool& x) -> argument_parser2&;
 
   // ------------------------------------------------------------------------

--- a/libtenzir/include/tenzir/argument_parser2.hpp
+++ b/libtenzir/include/tenzir/argument_parser2.hpp
@@ -65,19 +65,30 @@ public:
 
   // ------------------------------------------------------------------------
 
+  /// @brief Adds a required positional argument
   template <argument_parser_type T>
   auto add(T& x, std::string meta) -> argument_parser2&;
 
+  /// @brief Adds an optional positional argument
   template <argument_parser_type T>
   auto add(std::optional<T>& x, std::string meta) -> argument_parser2&;
 
   // ------------------------------------------------------------------------
 
+  /// @brief Adds a required named argument
+  template <argument_parser_type T>
+  auto add(std::string name, T& x) -> argument_parser2&;
+
+  // ------------------------------------------------------------------------
+
+  /// @brief Adds an optional named argument
   template <argument_parser_type T>
   auto add(std::string name, std::optional<T>& x) -> argument_parser2&;
 
+  /// @brief Adds an optional named argument
   auto add(std::string name, std::optional<location>& x) -> argument_parser2&;
 
+  /// @brief Adds an optional named argument
   auto add(std::string name, bool& x) -> argument_parser2&;
 
   // ------------------------------------------------------------------------
@@ -114,6 +125,8 @@ private:
   struct named {
     std::string name;
     caf::detail::tl_apply_t<argument_parser_full_types, setter_variant> set;
+    bool required = false;
+    std::optional<location> found = std::nullopt;
   };
 
   mutable std::string usage_cache_;

--- a/libtenzir/src/argument_parser2.cpp
+++ b/libtenzir/src/argument_parser2.cpp
@@ -225,7 +225,6 @@ auto argument_parser2::parse(const ast::entity& self,
       emit(
         diagnostic::error("required argument `{}` was not provided", arg.name)
           .primary(self.get_location()));
-      result = failure::promise();
     }
   }
   return result;

--- a/libtenzir/src/argument_parser2.cpp
+++ b/libtenzir/src/argument_parser2.cpp
@@ -260,7 +260,7 @@ auto argument_parser2::usage() const -> std::string {
         usage_cache_ += positional.meta;
       }
     }
-    const auto append_option = [&](const named& opt) {
+    const auto append_named_option = [&](const named& opt) {
       if (opt.name.starts_with("_")) {
         // This denotes an internal/unstable option.
         return;
@@ -279,20 +279,19 @@ auto argument_parser2::usage() const -> std::string {
           return "{ ... }";
         });
       auto txt = fmt::format("{}={}", opt.name, meta);
+      usage_cache_ += txt;
       if (not opt.required) {
-        usage_cache_ += "[" + txt + "]";
-      } else {
-        usage_cache_ += txt;
+        usage_cache_ += "?";
       }
     };
     for (const auto& opt : named_) {
       if (opt.required) {
-        append_option(opt);
+        append_named_option(opt);
       }
     }
     for (const auto& opt : named_) {
       if (not opt.required) {
-        append_option(opt);
+        append_named_option(opt);
       }
     }
 

--- a/tenzir/integration/data/reference/functions/test_community-2d5fid/step_01.ref
+++ b/tenzir/integration/data/reference/functions/test_community-2d5fid/step_01.ref
@@ -1,0 +1,8 @@
+error: required argument `proto` was not provided
+ --> <input>:1:16
+  |
+1 | from {} | x0 = community_id( src_ip=null, dst_ip=null )
+  |                ^^^^^^^^^^^^ 
+  |
+  = usage: community_id(src_ip=<expr>, dst_ip=<expr>, proto=<expr>, [src_port=<expr>], [dst_port=<expr>], [seed=<expr>])
+  = docs: https://docs.tenzir.com/functions/community_id

--- a/tenzir/integration/data/reference/functions/test_community-2d5fid/step_01.ref
+++ b/tenzir/integration/data/reference/functions/test_community-2d5fid/step_01.ref
@@ -4,5 +4,5 @@ error: required argument `proto` was not provided
 1 | from {} | x0 = community_id( src_ip=null, dst_ip=null )
   |                ^^^^^^^^^^^^ 
   |
-  = usage: community_id(src_ip=<expr>, dst_ip=<expr>, proto=<expr>, [src_port=<expr>], [dst_port=<expr>], [seed=<expr>])
+  = usage: community_id(src_ip=<expr>, dst_ip=<expr>, proto=<expr>, src_port=<expr>?, dst_port=<expr>?, seed=<expr>?)
   = docs: https://docs.tenzir.com/functions/community_id

--- a/tenzir/integration/data/reference/functions/test_community-2d5fid/step_02.ref
+++ b/tenzir/integration/data/reference/functions/test_community-2d5fid/step_02.ref
@@ -4,5 +4,5 @@ error: required argument `dst_ip` was not provided
 1 | from {} | x0 = community_id( src_ip=null, proto=null )
   |                ^^^^^^^^^^^^ 
   |
-  = usage: community_id(src_ip=<expr>, dst_ip=<expr>, proto=<expr>, [src_port=<expr>], [dst_port=<expr>], [seed=<expr>])
+  = usage: community_id(src_ip=<expr>, dst_ip=<expr>, proto=<expr>, src_port=<expr>?, dst_port=<expr>?, seed=<expr>?)
   = docs: https://docs.tenzir.com/functions/community_id

--- a/tenzir/integration/data/reference/functions/test_community-2d5fid/step_02.ref
+++ b/tenzir/integration/data/reference/functions/test_community-2d5fid/step_02.ref
@@ -1,0 +1,8 @@
+error: required argument `dst_ip` was not provided
+ --> <input>:1:16
+  |
+1 | from {} | x0 = community_id( src_ip=null, proto=null )
+  |                ^^^^^^^^^^^^ 
+  |
+  = usage: community_id(src_ip=<expr>, dst_ip=<expr>, proto=<expr>, [src_port=<expr>], [dst_port=<expr>], [seed=<expr>])
+  = docs: https://docs.tenzir.com/functions/community_id

--- a/tenzir/integration/data/reference/functions/test_community-2d5fid/step_03.ref
+++ b/tenzir/integration/data/reference/functions/test_community-2d5fid/step_03.ref
@@ -1,0 +1,8 @@
+error: required argument `src_ip` was not provided
+ --> <input>:1:16
+  |
+1 | from {} | x0 = community_id( dst_ip=null, proto=null )
+  |                ^^^^^^^^^^^^ 
+  |
+  = usage: community_id(src_ip=<expr>, dst_ip=<expr>, proto=<expr>, [src_port=<expr>], [dst_port=<expr>], [seed=<expr>])
+  = docs: https://docs.tenzir.com/functions/community_id

--- a/tenzir/integration/data/reference/functions/test_community-2d5fid/step_03.ref
+++ b/tenzir/integration/data/reference/functions/test_community-2d5fid/step_03.ref
@@ -4,5 +4,5 @@ error: required argument `src_ip` was not provided
 1 | from {} | x0 = community_id( dst_ip=null, proto=null )
   |                ^^^^^^^^^^^^ 
   |
-  = usage: community_id(src_ip=<expr>, dst_ip=<expr>, proto=<expr>, [src_port=<expr>], [dst_port=<expr>], [seed=<expr>])
+  = usage: community_id(src_ip=<expr>, dst_ip=<expr>, proto=<expr>, src_port=<expr>?, dst_port=<expr>?, seed=<expr>?)
   = docs: https://docs.tenzir.com/functions/community_id

--- a/tenzir/integration/tests/functions.bats
+++ b/tenzir/integration/tests/functions.bats
@@ -34,6 +34,9 @@ x9 = community_id(src_ip=3ffe:507:0:1:260:97ff:fe07:69ea,
                   dst_ip=3ffe:507:0:1:200:86ff:fe05:80da,
                   src_port=3, dst_port=0, proto="icmp6")
 EOF
+  check ! tenzir 'from {} | x0 = community_id( src_ip=null, dst_ip=null )'
+  check ! tenzir 'from {} | x0 = community_id( src_ip=null, proto=null )'
+  check ! tenzir 'from {} | x0 = community_id( dst_ip=null, proto=null )'
 }
 
 @test "has" {


### PR DESCRIPTION
It is now possible to add named, required arguments to an `argument_parser2`:

```
auto s = std::string{};
parser.add( "name", s );
```

The argument parser will check ensure that all named required arguments were present and return a failure otherwise.

In the synopsis, named required arguments will be listed after the positional arguments, before non-required named arguments. Non-required named arguments now have a trailing `?` to signal that they are optional.

Fixes https://github.com/tenzir/issues/issues/2146