### PR TITLE
Add a simpler way to install packages

### DIFF
--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "dbfac2a17d4b2f740f0f87baf9fac017a0a0f9e0",
+  "rev": "87814454d67532082df5ff46f2f386755864a690",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/web/docs/installation/install-a-package.md
+++ b/web/docs/installation/install-a-package.md
@@ -20,21 +20,17 @@ operator](../operators/package.md):
 
 ```tql
 // tql2
-load_file "package.yaml"
-read_yaml
-package_add
+package_add "package.yaml"
 ```
 
 To set package inputs, set the values in the pipeline:
 
 ```tql
 // tql2
-load_file "package.yaml"
-read_yaml
-// Adjust inputs
-config.inputs.endpoint = "localhost:42000"
-config.inputs.policy = "block"
-package_add
+package_add "package.yaml", inputs={
+  endpoint: "localhost:42000",
+  policy: "block",
+}
 ```
 
 Your package should now show when listing all installed packages:
@@ -83,9 +79,9 @@ The node search path for packages consists of the following locations:
 2. All directories specified in the `tenzir.package-dirs` configuration option.
 
 As an alternative way to specify inputs visually in the app, or setting them
-explicitly prior to calling `package_add`, you can add a `config.yaml` file next
-to the `package.yaml` file. Here is an example that sets the keys
-`config.inputs.endpoint` and `config.inputs.policy`:
+explicitly as part of calling `package_add`, you can add a `config.yaml` file
+next to the `package.yaml` file. Here is an example that sets the inputs
+`endpoint` and `policy`:
 
 ```yaml
 inputs:

--- a/web/docs/operators/package.md
+++ b/web/docs/operators/package.md
@@ -44,18 +44,23 @@ from https://github.com/tenzir/library/raw/main/feodo/package.yaml
 | package add
 ```
 
+Add a package from the [Community Library](https://github.com/tenzir/library):
+
+```
+// tql2
+package_add "suricata-ocsf",
+```
+
 Add a package with required inputs:
 
 ```
-// experimental-tql2
-load "https://github.com/tenzir/library/raw/main/zeek/package.yaml"
-read_yaml
-config.inputs.format = "tsv"
-config.inputs["log-directory"] = "/opt/tenzir/logs"
-package_add
+// tql2
+package_add "https://github.com/tenzir/library/raw/main/zeek/package.yaml",
+  inputs={format: "tsv", "log-directory": "/opt/tenzir/logs"}
 ```
 
 Remove the installed package `zeek`:
+
 ```
 package remove zeek
 ```

--- a/web/docs/write-a-package.md
+++ b/web/docs/write-a-package.md
@@ -262,9 +262,7 @@ file is easiest with the [`package_add`](operators/package.md) operator, since
 a package is just data:
 
 ```tql
-load_file "/path/to/package.yaml"
-read_yaml
-package_add
+package_add "/path/to/package.yaml"
 ```
 
 This fails with the following error:
@@ -276,18 +274,13 @@ error: failed to add package
 ```
 
 Doh, we didn't substitute the template `{{ inputs.refresh-interval }}`. We can
-do this with one extra statement, though:
+do this by passing one additional argument:
 
 ```tql
-load_file "/path/to/package.yaml"
-read_yaml
-config.inputs["refresh-interval"] = 1h
-package_add
+package_add "/path/to/package.yaml", inputs={
+  "refresh-interval": 1h
+}
 ```
-
-NB: We have to access the field `refresh-interval` in `config.inputs` via `[]`
-because `config.inputs.refresh-interval` would be parsed as a subtraction
-between two fields.
 
 The package should show up in the list of packages after installation:
 


### PR DESCRIPTION
This adds two new, optional parameters to TQL2's `package_add`:
- A positional argument that may either be a package identifier or a path to a package, and
- a named argument `inputs` that is a record used for setting package inputs.

A few examples:

```
// tql2
package_add "slack", inputs={"webhook-url": "…"}
package_add "path/to/package.yaml", inputs={ … }
package_add "https://raw.githubusercontent.com/tenzir/library/main/feodo/package.yaml"
from … | package_add inputs={ … }
```