### PR TITLE
Implement `load_tcp` for TQL2

### DIFF
--- a/libtenzir/builtins/connectors/tcp.cpp
+++ b/libtenzir/builtins/connectors/tcp.cpp
@@ -49,7 +49,6 @@ struct tcp_metrics {
       return;
     }
     metric_handler.emit({
-      {"port", port},
       {"handle", handle},
       {"reads", reads},
       {"writes", writes},
@@ -506,7 +505,6 @@ public:
                                           ctrl.metrics({
                                             "tenzir.metrics.tcp",
                                             record_type{
-                                              {"port", uint64_type{}},
                                               {"handle", string_type{}},
                                               {"reads", uint64_type{}},
                                               {"writes", uint64_type{}},
@@ -622,7 +620,6 @@ public:
       = ctrl.self().spawn(make_tcp_bridge, ctrl.metrics({
                                              "tenzir.metrics.tcp",
                                              record_type{
-                                               {"port", uint64_type{}},
                                                {"handle", string_type{}},
                                                {"reads", uint64_type{}},
                                                {"writes", uint64_type{}},

--- a/libtenzir/builtins/operators/load_tcp.cpp
+++ b/libtenzir/builtins/operators/load_tcp.cpp
@@ -663,7 +663,7 @@ struct connection_manager_state {
           write_rp.deliver();
         }
       }
-      return std::move(elements);
+      return elements;
     }
     read_rp = self->template make_response_promise<Elements>();
     return read_rp;

--- a/libtenzir/builtins/operators/load_tcp.cpp
+++ b/libtenzir/builtins/operators/load_tcp.cpp
@@ -299,6 +299,9 @@ struct connection_manager_state {
     std::optional<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&>>
       tls_socket = {};
     pipeline_executor_actor pipeline_executor = {};
+
+    // The mutex is protecting the queue of chunks and the response promise, as
+    // they're both used from the Asio-managed thread pool.
     mutable std::mutex mutex = {};
     std::queue<chunk_ptr> chunks = {};
     caf::typed_response_promise<chunk_ptr> rp = {};

--- a/libtenzir/builtins/operators/load_tcp.cpp
+++ b/libtenzir/builtins/operators/load_tcp.cpp
@@ -70,7 +70,7 @@ struct endpoint {
 };
 
 struct load_tcp_args {
-  located<endpoint> endpoint = {};
+  located<struct endpoint> endpoint = {};
   located<uint64_t> parallel = {};
   std::optional<location> connect = {};
   std::optional<location> tls = {};
@@ -101,7 +101,7 @@ auto set_close_on_exec(boost::asio::ip::tcp::socket::native_handle_type handle)
 }
 
 auto resolve_endpoint(boost::asio::io_context& io_ctx,
-                      const located<endpoint>& endpoint)
+                      const located<struct endpoint>& endpoint)
   -> caf::expected<boost::asio::ip::tcp::endpoint> {
   auto ec = boost::system::error_code{};
   auto resolver = boost::asio::ip::tcp::resolver{io_ctx};

--- a/libtenzir/builtins/operators/load_tcp.cpp
+++ b/libtenzir/builtins/operators/load_tcp.cpp
@@ -374,7 +374,7 @@ struct connection_manager_state {
 
   auto connect() -> caf::expected<void> {
     TENZIR_ASSERT(args.connect);
-    // FIXME: Implement support for connect=true.
+    // TODO: Implement support for connect=true.
     TENZIR_UNIMPLEMENTED();
     return {};
   }
@@ -416,8 +416,6 @@ struct connection_manager_state {
   }
 
   auto handle_connection(boost::asio::ip::tcp::socket peer) -> void {
-    // FIXME: all diagnostics for peers should be warnings
-    // Now, set up the shared connection state.
     TENZIR_ASSERT(not connections.contains(peer.native_handle()));
     auto& connection = connections[peer.native_handle()];
     TENZIR_ASSERT(not connection.socket);

--- a/libtenzir/builtins/operators/load_tcp.cpp
+++ b/libtenzir/builtins/operators/load_tcp.cpp
@@ -161,7 +161,7 @@ public:
     }
   }
 
-  auto location() const -> operator_location {
+  auto location() const -> operator_location override {
     return operator_location::local;
   }
 
@@ -226,7 +226,7 @@ public:
     }
   }
 
-  auto location() const -> operator_location {
+  auto location() const -> operator_location override {
     return operator_location::anywhere;
   }
 
@@ -799,7 +799,7 @@ public:
     }
   }
 
-  auto location() const -> operator_location {
+  auto location() const -> operator_location override {
     return operator_location::local;
   }
 

--- a/libtenzir/builtins/operators/load_tcp.cpp
+++ b/libtenzir/builtins/operators/load_tcp.cpp
@@ -494,6 +494,7 @@ struct connection_manager_state {
         .primary(args.endpoint.source)
         .to_error();
     }
+    // TODO: Consider moving this up so that it happens as early as possible.
     TRY(set_close_on_exec(acceptor->native_handle()));
     if (acceptor->listen(boost::asio::socket_base::max_connections, ec)) {
       return diagnostic::error("{}", ec.message())

--- a/libtenzir/builtins/operators/load_tcp.cpp
+++ b/libtenzir/builtins/operators/load_tcp.cpp
@@ -950,6 +950,8 @@ public:
         return failure::promise();
       },
       [&](tag<chunk_ptr>) -> failure_or<operator_ptr> {
+        // TODO: Consider emitting a warning if there are multiple parallel
+        // connections when the nested pipeline returns bytes.
         return std::make_unique<load_tcp_operator<chunk_ptr>>(std::move(args));
       },
       [&](tag<table_slice>) -> failure_or<operator_ptr> {

--- a/libtenzir/builtins/operators/load_tcp.cpp
+++ b/libtenzir/builtins/operators/load_tcp.cpp
@@ -1,0 +1,864 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2024 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <tenzir/actors.hpp>
+#include <tenzir/config.hpp>
+#include <tenzir/detail/assert.hpp>
+#include <tenzir/detail/posix.hpp>
+#include <tenzir/detail/weak_run_delayed.hpp>
+#include <tenzir/error.hpp>
+#include <tenzir/fwd.hpp>
+#include <tenzir/location.hpp>
+#include <tenzir/pipeline.hpp>
+#include <tenzir/pipeline_executor.hpp>
+#include <tenzir/plugin.hpp>
+#include <tenzir/scope_linked.hpp>
+#include <tenzir/tql2/plugin.hpp>
+#include <tenzir/try.hpp>
+
+#include <boost/asio.hpp>
+#include <boost/asio/ssl.hpp>
+#include <caf/typed_event_based_actor.hpp>
+#include <caf/typed_response_promise.hpp>
+
+#include <algorithm>
+#include <exception>
+#include <iterator>
+#include <netdb.h>
+#include <queue>
+#include <utility>
+
+namespace tenzir::plugins::load_tcp {
+
+namespace {
+
+// -- actor interfaces ---------------------------------------------------------
+
+using connection_actor = caf::typed_actor<
+  // Read bytes from a connection buffer.
+  auto(atom::read, boost::asio::ip::tcp::socket::native_handle_type handle)
+    ->caf::result<chunk_ptr>>;
+
+template <class Elements>
+using connection_manager_actor = caf::typed_actor<
+  // Write elements into the buffer.
+  auto(atom::write, Elements elements)->caf::result<void>,
+  // Read elements from the buffer.
+  auto(atom::read)->caf::result<Elements>>
+  // Support reading from a connection.
+  ::template extend_with<connection_actor>
+  // Handle metrics of the nested pipelines.
+  ::template extend_with<metrics_receiver_actor>
+  // Handle diagnostics of the nested pipelines.
+  ::template extend_with<receiver_actor<diagnostic>>;
+
+// -- helper structs -----------------------------------------------------------
+
+struct endpoint {
+  std::string hostname = {};
+  std::string port = {};
+
+  friend auto inspect(auto& f, endpoint& x) -> bool {
+    return f.object(x).fields(f.field("hostname", x.hostname),
+                              f.field("port", x.port));
+  }
+};
+
+struct load_tcp_args {
+  located<endpoint> endpoint = {};
+  located<uint64_t> parallel = {};
+  std::optional<location> connect = {};
+  std::optional<location> tls = {};
+  std::optional<located<std::string>> certfile = {};
+  std::optional<located<std::string>> keyfile = {};
+  std::optional<located<class pipeline>> pipeline = {};
+
+  friend auto inspect(auto& f, load_tcp_args& x) -> bool {
+    return f.object(x).fields(
+      f.field("endpoint", x.endpoint), f.field("parallel", x.parallel),
+      f.field("connect", x.connect), f.field("tls", x.tls),
+      f.field("certfile", x.certfile), f.field("keyfile", x.keyfile),
+      f.field("pipeline", x.pipeline));
+  }
+};
+
+// -- helper functions ---------------------------------------------------------
+
+auto set_close_on_exec(boost::asio::ip::tcp::socket::native_handle_type handle)
+  -> caf::expected<void> {
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
+  if (::fcntl(handle, F_SETFD, FD_CLOEXEC) != 0) {
+    return diagnostic::error("{}", detail::describe_errno())
+      .note("failed to configure socket to close on exec")
+      .to_error();
+  }
+  return {};
+}
+
+auto resolve_endpoint(boost::asio::io_context& io_ctx,
+                      const located<endpoint>& endpoint)
+  -> caf::expected<boost::asio::ip::tcp::endpoint> {
+  auto ec = boost::system::error_code{};
+  auto resolver = boost::asio::ip::tcp::resolver{io_ctx};
+  auto endpoints
+    = resolver.resolve(endpoint.inner.hostname, endpoint.inner.port, ec);
+  if (ec) {
+    return diagnostic::error("{}", ec.message())
+      .note("failed to resolve endpoint")
+      .primary(endpoint.source)
+      .to_error();
+  }
+  if (endpoints.empty()) {
+    return diagnostic::error("no endpoints found")
+      .primary(endpoint.source)
+      .to_error();
+  }
+  return *endpoints.begin();
+}
+
+// -- load_tcp_source operator -------------------------------------------------
+
+class load_tcp_source_operator final
+  : public crtp_operator<load_tcp_source_operator> {
+public:
+  load_tcp_source_operator() = default;
+
+  explicit load_tcp_source_operator(
+    const connection_actor& connection,
+    boost::asio::ip::tcp::socket::native_handle_type handle)
+    : connection_{connection}, handle_{handle} {
+  }
+
+  auto operator()(operator_control_plane& ctrl) const -> generator<chunk_ptr> {
+    auto connection = connection_.lock();
+    TENZIR_ASSERT(connection);
+    while (true) {
+      auto result = chunk_ptr{};
+      ctrl.set_waiting(true);
+      ctrl.self()
+        .request(connection, caf::infinite, atom::read_v, handle_)
+        .then(
+          [&](chunk_ptr chunk) {
+            ctrl.set_waiting(false);
+            result = std::move(chunk);
+          },
+          [&](const caf::error& err) {
+            diagnostic::error(err)
+              .note("failed to read from TCP connection with handle {}",
+                    handle_)
+              .emit(ctrl.diagnostics());
+          });
+      co_yield {};
+      if (size(result) == 0) {
+        break;
+      }
+      co_yield std::move(result);
+    }
+  }
+
+  auto name() const -> std::string override {
+    return "internal-load-tcp-source-bytes";
+  }
+
+  auto optimize(const expression& filter, event_order order) const
+    -> optimize_result override {
+    TENZIR_UNUSED(filter, order);
+    return do_not_optimize(*this);
+  }
+
+  auto infer_type_impl(operator_type input) const
+    -> caf::expected<operator_type> override {
+    TENZIR_ASSERT(input.is<void>());
+    return tag_v<chunk_ptr>;
+  }
+
+  friend auto inspect(auto& f, load_tcp_source_operator& x) -> bool {
+    return f.object(x).fields(f.field("connection", x.connection_),
+                              f.field("handle", x.handle_));
+  }
+
+private:
+  detail::weak_handle<connection_actor> connection_ = {};
+  boost::asio::ip::tcp::socket::native_handle_type handle_ = {};
+};
+
+// -- load_tcp_sink operator ---------------------------------------------------
+
+template <class Elements>
+class load_tcp_sink_operator final
+  : public crtp_operator<load_tcp_sink_operator<Elements>> {
+public:
+  load_tcp_sink_operator() = default;
+
+  explicit load_tcp_sink_operator(
+    const connection_manager_actor<Elements>& connection_manager)
+    : connection_manager_{connection_manager} {
+  }
+
+  auto operator()(generator<Elements> input, operator_control_plane& ctrl) const
+    -> generator<std::monostate> {
+    auto connection_manager = connection_manager_.lock();
+    TENZIR_ASSERT(connection_manager);
+    for (auto&& elements : input) {
+      ctrl.set_waiting(true);
+      ctrl.self()
+        .request(connection_manager, caf::infinite, atom::write_v,
+                 std::move(elements))
+        .then(
+          [&]() {
+            ctrl.set_waiting(false);
+          },
+          [&](const caf::error& err) {
+            diagnostic::error(err)
+              .note("failed to read from TCP connection")
+              .emit(ctrl.diagnostics());
+          });
+      co_yield {};
+    }
+  }
+
+  auto name() const -> std::string override {
+    return fmt::format("internal-load-tcp-sink-{}",
+                       operator_type_name<Elements>());
+  }
+
+  auto optimize(const expression& filter, event_order order) const
+    -> optimize_result override {
+    TENZIR_UNUSED(filter, order);
+    return do_not_optimize(*this);
+  }
+
+  auto infer_type_impl(operator_type input) const
+    -> caf::expected<operator_type> override {
+    TENZIR_ASSERT(input.is<Elements>());
+    return tag_v<void>;
+  }
+
+  friend auto inspect(auto& f, load_tcp_sink_operator& x) -> bool {
+    return f.apply(x.connection_manager_);
+  }
+
+private:
+  detail::weak_handle<connection_manager_actor<Elements>> connection_manager_
+    = {};
+};
+
+// -- connection-manager actor -------------------------------------------------
+
+template <class Elements>
+struct connection_manager_state {
+  [[maybe_unused]] static constexpr auto name = "connection-manager";
+
+  connection_manager_actor<Elements>::pointer self = {};
+  load_tcp_args args = {};
+  shared_diagnostic_handler diagnostics = {};
+
+  // Everything required for the I/O worker.
+  std::vector<std::thread> io_workers = {};
+  std::shared_ptr<boost::asio::io_context> io_ctx = {};
+  std::optional<boost::asio::ip::tcp::socket> socket = {};
+
+  // Everything required for listening for connections.
+  std::optional<boost::asio::ip::tcp::acceptor> acceptor = {};
+
+  // Everything needed for back pressure handling.
+  static constexpr auto max_buffered_batches = size_t{20};
+  std::queue<Elements> buffer = {};
+  caf::typed_response_promise<Elements> read_rp = {};
+  std::queue<caf::typed_response_promise<void>> write_rps = {};
+
+  // State we need to keep for each peer.
+  struct connection_state {
+    static constexpr auto max_queued_chunks = size_t{10};
+    static constexpr auto read_buffer_size = size_t{65'536};
+
+    std::optional<boost::asio::ip::tcp::socket> socket = {};
+    std::optional<boost::asio::ssl::context> ssl_ctx = {};
+    std::optional<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&>>
+      tls_socket = {};
+    pipeline_executor_actor pipeline_executor = {};
+    std::vector<char> read_buffer = {};
+    mutable std::mutex mutex = {};
+    std::queue<chunk_ptr> chunks = {};
+    caf::typed_response_promise<chunk_ptr> rp = {};
+
+    auto async_read(connection_manager_actor<Elements>::pointer self) -> void {
+      auto on_read = [this, self](boost::system::error_code ec, size_t length) {
+        if (ec and ec != boost::asio::error::eof) {
+          TENZIR_ASSERT(length == 0);
+          // FIXME: Handle unexpected connection errors by emitting a
+          // warning diagnostic and then letting the nested pipeline end
+          // naturally to drop as few results as possible.
+          TENZIR_UNIMPLEMENTED();
+        }
+        TENZIR_ASSERT(length > 0 or ec == boost::asio::error::eof);
+        read_buffer.resize(length);
+        auto chunk = chunk::make(std::exchange(read_buffer, {}));
+        auto should_read = false;
+        {
+          auto lock = std::unique_lock{mutex};
+          if (rp.pending()) {
+            caf::anon_send(
+              caf::actor_cast<caf::actor>(self),
+              caf::make_action([this, chunk = std::move(chunk)]() mutable {
+                auto lock = std::unique_lock{mutex};
+                rp.deliver(std::move(chunk));
+              }));
+            TENZIR_ASSERT(chunks.empty());
+            should_read = true;
+          } else {
+            chunks.push(std::move(chunk));
+            TENZIR_ASSERT(chunks.size() <= max_queued_chunks);
+            should_read = chunks.size() < max_queued_chunks;
+          }
+        }
+        if (should_read) {
+          async_read(self);
+        }
+      };
+      read_buffer.resize(read_buffer_size);
+      auto asio_buffer = boost::asio::buffer(read_buffer, read_buffer_size);
+      if (tls_socket) {
+        tls_socket->async_read_some(asio_buffer, std::move(on_read));
+      } else {
+        socket->async_read_some(asio_buffer, std::move(on_read));
+      }
+    }
+  };
+  std::unordered_map<boost::asio::ip::tcp::socket::native_handle_type,
+                     connection_state>
+    connections = {};
+
+  // Everything required for spawning the nested pipeline.
+  static constexpr auto has_terminal = false;
+  bool is_hidden = {};
+  node_actor node = {};
+
+  connection_manager_state() = default;
+  connection_manager_state(const connection_manager_state&) = delete;
+  connection_manager_state(connection_manager_state&&) = delete;
+  auto operator=(const connection_manager_state&)
+    -> connection_manager_state& = delete;
+  auto operator=(connection_manager_state&&)
+    -> connection_manager_state& = delete;
+
+  ~connection_manager_state() noexcept {
+    io_ctx->stop();
+    for (auto& io_worker : io_workers) {
+      io_worker.join();
+    }
+  }
+
+  auto start() -> caf::expected<void> {
+    TENZIR_ASSERT(not io_ctx);
+    io_ctx = std::make_shared<boost::asio::io_context>();
+    io_workers.reserve(args.parallel.inner);
+    std::ranges::generate_n(
+      std::back_inserter(io_workers), args.parallel.inner, [this] {
+        return std::thread{[this] {
+          const auto guard = boost::asio::make_work_guard(*io_ctx);
+          io_ctx->run();
+        }};
+      });
+    socket.emplace(*io_ctx);
+    return args.connect ? connect() : listen();
+  }
+
+  auto connect() -> caf::expected<void> {
+    TENZIR_ASSERT(args.connect);
+    // FIXME: Implement support for connect=true.
+    TENZIR_UNIMPLEMENTED();
+    return {};
+  }
+
+  auto listen() -> caf::expected<void> {
+    TENZIR_ASSERT(not args.connect);
+    TENZIR_ASSERT(not acceptor);
+    TRY(auto endpoint, resolve_endpoint(*io_ctx, args.endpoint));
+    acceptor.emplace(*io_ctx);
+    auto ec = boost::system::error_code{};
+    if (acceptor->open(endpoint.protocol(), ec)) {
+      return diagnostic::error("{}", ec.message())
+        .note("failed to open acceptor")
+        .primary(args.endpoint.source)
+        .to_error();
+    }
+    if (acceptor->set_option(boost::asio::socket_base::reuse_address{true},
+                             ec)) {
+      return diagnostic::error("{}", ec.message())
+        .note("failed to enable reuse address")
+        .primary(args.endpoint.source)
+        .to_error();
+    }
+    if (acceptor->bind(endpoint, ec)) {
+      return diagnostic::error("{}", ec.message())
+        .note("failed to bind to endpoint")
+        .primary(args.endpoint.source)
+        .to_error();
+    }
+    TRY(set_close_on_exec(acceptor->native_handle()));
+    if (acceptor->listen(boost::asio::socket_base::max_connections, ec)) {
+      return diagnostic::error("{}", ec.message())
+        .note("failed to start listening")
+        .primary(args.endpoint.source)
+        .to_error();
+    }
+    async_accept();
+    return {};
+  }
+
+  auto handle_connection(boost::asio::ip::tcp::socket peer)
+    -> caf::expected<void> {
+    // FIXME: all diagnostics for peers should be warnings
+    // Now, set up the shared connection state.
+    TENZIR_ASSERT(not connections.contains(peer.native_handle()));
+    auto& connection = connections[peer.native_handle()];
+    TENZIR_ASSERT(not connection.socket);
+    connection.socket.emplace(std::move(peer));
+    TRY(set_close_on_exec(connection.socket->native_handle()));
+    if (args.tls) {
+      TENZIR_ASSERT(not connection.ssl_ctx);
+      connection.ssl_ctx.emplace(boost::asio::ssl::context::tls_server);
+      auto ec = boost::system::error_code{};
+      if (args.certfile) {
+        if (connection.ssl_ctx->use_certificate_chain_file(args.certfile->inner,
+                                                           ec)) {
+          return diagnostic::error("{}", ec.message())
+            .note("failed to load certificate chain file")
+            .primary(args.certfile->source)
+            .to_error();
+        }
+      }
+      if (args.keyfile) {
+        if (connection.ssl_ctx->use_private_key_file(
+              args.keyfile->inner, boost::asio::ssl::context::pem, ec)) {
+          return diagnostic::error("{}", ec.message())
+            .note("failed to load private key file")
+            .primary(args.certfile->source)
+            .to_error();
+        }
+      }
+      if (connection.ssl_ctx->set_verify_mode(boost::asio::ssl::verify_none,
+                                              ec)) {
+        return diagnostic::error("{}", ec.message())
+          .note("failed to disable peer certificate verification")
+          .primary(*args.tls)
+          .to_error();
+      }
+      TENZIR_ASSERT(not connection.tls_socket);
+      connection.tls_socket.emplace(*connection.socket, *connection.ssl_ctx);
+      if (connection.tls_socket->handshake(
+            boost::asio::ssl::stream<boost::asio::ip::tcp::socket>::server,
+            ec)) {
+        return diagnostic::error("{}", ec.message())
+          .note("failed to perform TLS handshake")
+          .primary(*args.tls)
+          .to_error();
+      }
+    }
+    // Set up and spawn the nested pipeline.
+    auto pipeline = args.pipeline->inner;
+    auto source = std::make_unique<load_tcp_source_operator>(
+      connection_actor{self}, connection.socket->native_handle());
+    pipeline.prepend(std::move(source));
+    auto sink = std::make_unique<load_tcp_sink_operator<Elements>>(
+      connection_manager_actor<Elements>{self});
+    pipeline.append(std::move(sink));
+    TENZIR_ASSERT(pipeline.is_closed());
+    TENZIR_ASSERT(not connection.pipeline_executor);
+    connection.pipeline_executor = self->template spawn<caf::monitored>(
+      pipeline_executor, std::move(pipeline), receiver_actor<diagnostic>{self},
+      metrics_receiver_actor{self}, node, has_terminal, is_hidden);
+    self->request(connection.pipeline_executor, caf::infinite, atom::start_v)
+      .then(
+        [this, handle = connection.socket->native_handle()]() {
+          // Start the async read loop for this connection.
+          auto connection = connections.find(handle);
+          TENZIR_ASSERT(connection != connections.end());
+          connection->second.async_read(self);
+        },
+        [](const caf::error& err) {
+          // FIXME: Emit a diagnostic
+          TENZIR_WARN("failed to start: {}", err);
+        });
+    return {};
+  }
+
+  auto async_accept() -> void {
+    acceptor->async_accept(
+      [this, handle = caf::actor_cast<caf::actor>(self)](
+        boost::system::error_code ec, boost::asio::ip::tcp::socket socket) {
+        auto action = [this, ec, socket = std::move(socket)]() mutable {
+          // Always start accepting the next connection.
+          async_accept();
+          // If there's an error accepting connections, then we just warn about
+          // it but continue to accept new ones.
+          if (ec) {
+            diagnostic::warning("{}", ec.message())
+              .note("failed to accept connection")
+              .primary(args.endpoint.source)
+              .emit(diagnostics);
+            return;
+          }
+          const auto ok = handle_connection(std::move(socket));
+          if (not ok) {
+            diagnostic::warning(ok.error()).emit(diagnostics);
+          }
+        };
+        caf::anon_send(handle, caf::make_action(std::move(action)));
+      });
+  }
+
+  auto
+  read_from_connection(boost::asio::ip::tcp::socket::native_handle_type handle)
+    -> caf::result<chunk_ptr> {
+    auto connection = connections.find(handle);
+    TENZIR_ASSERT(connection != connections.end());
+    auto chunk = chunk_ptr{};
+    auto should_read = false;
+    {
+      auto lock = std::unique_lock{connection->second.mutex};
+      if (connection->second.chunks.empty()) {
+        TENZIR_ASSERT(not connection->second.rp.pending());
+        connection->second.rp
+          = self->template make_response_promise<chunk_ptr>();
+        return connection->second.rp;
+      }
+      should_read = connection->second.chunks.size()
+                    == connection_state::max_queued_chunks;
+      chunk = std::move(connection->second.chunks.front());
+      connection->second.chunks.pop();
+    }
+    if (should_read) {
+      connection->second.async_read(self);
+    }
+    return chunk;
+  }
+
+  auto write_elements(Elements elements) -> caf::result<void> {
+    if (read_rp.pending()) {
+      TENZIR_ASSERT(buffer.empty());
+      read_rp.deliver(std::move(elements));
+    }
+    buffer.push(std::move(elements));
+    if (buffer.size() < max_buffered_batches) {
+      return {};
+    }
+    return write_rps.emplace(self->template make_response_promise<void>());
+  }
+
+  auto read_elements() -> caf::result<Elements> {
+    TENZIR_ASSERT(not read_rp.pending());
+    if (not buffer.empty()) {
+      auto elements = std::move(buffer.front());
+      buffer.pop();
+      while (buffer.size() < max_buffered_batches and not write_rps.empty()) {
+        auto write_rp = std::move(write_rps.front());
+        write_rps.pop();
+        TENZIR_ASSERT(write_rp.pending());
+        write_rp.deliver();
+      }
+      return std::move(elements);
+    }
+    read_rp = self->template make_response_promise<Elements>();
+    return read_rp;
+  }
+
+  auto handle_down_msg(const caf::down_msg& msg) -> void {
+    const auto connection
+      = std::ranges::find_if(connections, [&](const auto& connection) {
+          return connection.second.pipeline_executor.address() == msg.source;
+        });
+    TENZIR_ASSERT(connection != connections.end());
+    // FIXME: It is only safe to erase this connection _after_ there is no more
+    // in-flight async read for it. Otherwise, acquiring the mutex in it can
+    // throw an exception. The connections map likely has to point to shared
+    // pointers because of this.
+    connections.erase(connection);
+    if (not msg.reason) {
+      return;
+    }
+    // FIXME: Emit a diagnostic when a nested pipeline shuts down with an
+    // unexpected error.
+  }
+};
+
+template <class Elements>
+auto make_connection_manager(
+  typename connection_manager_actor<Elements>::template stateful_pointer<
+    connection_manager_state<Elements>>
+    self,
+  const load_tcp_args& args, const shared_diagnostic_handler& diagnostics,
+  bool is_hidden, const node_actor& node)
+  -> connection_manager_actor<Elements>::behavior_type {
+  self->state.self = self;
+  self->state.args = args;
+  self->state.diagnostics = diagnostics;
+  self->state.is_hidden = is_hidden;
+  self->state.node = node;
+  if (auto ok = self->state.start(); not ok) {
+    self->quit(std::move(ok.error()));
+    return connection_manager_actor<
+      Elements>::behavior_type::make_empty_behavior();
+  }
+  self->set_down_handler([self](const caf::down_msg& msg) {
+    self->state.handle_down_msg(msg);
+  });
+  return {
+    [self](atom::read, boost::asio::ip::tcp::socket::native_handle_type handle)
+      -> caf::result<chunk_ptr> {
+      return self->state.read_from_connection(handle);
+    },
+    [self](atom::write, Elements& elements) -> caf::result<void> {
+      return self->state.write_elements(std::move(elements));
+    },
+    [self](atom::read) -> caf::result<Elements> {
+      return self->state.read_elements();
+    },
+    [self](uint64_t op_index, uint64_t metric_index,
+           const type& schema) -> caf::result<void> {
+      (void)self;
+      // FIXME: Figure out how we can somehow forward custom metrics from the
+      // nested operator.
+      TENZIR_UNUSED(metric_index, schema);
+      TENZIR_WARN("register metric {}/{}: {}", op_index, metric_index, schema);
+      return {};
+    },
+    [self](uint64_t op_index, uint64_t metric_index,
+           const record& metric) -> caf::result<void> {
+      (void)self;
+      TENZIR_UNUSED(op_index, metric_index, metric);
+      TENZIR_WARN("deliver metric {}/{}: {}", op_index, metric_index, metric);
+      return {};
+    },
+    [self](const operator_metric& op_metric) -> caf::result<void> {
+      (void)self;
+      TENZIR_UNUSED(op_metric);
+      return {};
+    },
+    [self](const diagnostic& diagnostic) -> caf::result<void> {
+      (void)self;
+      // FIXME: Forward diagnostics from the nested pipeline as warnings.
+      TENZIR_UNUSED(diagnostic);
+      TENZIR_WARN("deliver diagnostic {:?}", diagnostic);
+      return {};
+    },
+  };
+}
+
+// -- load_tcp operator --------------------------------------------------------
+
+template <class Elements>
+class load_tcp_operator final
+  : public crtp_operator<load_tcp_operator<Elements>> {
+public:
+  load_tcp_operator() = default;
+
+  load_tcp_operator(load_tcp_args args) : args_{std::move(args)} {
+  }
+
+  auto operator()(operator_control_plane& ctrl) const -> generator<Elements> {
+    const auto connection_manager_actor = scope_linked{
+      ctrl.self().spawn<caf::linked>(make_connection_manager<Elements>, args_,
+                                     ctrl.shared_diagnostics(),
+                                     ctrl.is_hidden(), ctrl.node())};
+    while (true) {
+      auto result = Elements{};
+      ctrl.set_waiting(true);
+      ctrl.self()
+        .request(connection_manager_actor.get(), caf::infinite, atom::read_v)
+        .then(
+          [&](Elements& elements) {
+            ctrl.set_waiting(false);
+            result = std::move(elements);
+          },
+          [&](const caf::error& err) {
+            diagnostic::error(err).emit(ctrl.diagnostics());
+          });
+      co_yield {};
+      co_yield std::move(result);
+    }
+  }
+
+  auto name() const -> std::string override {
+    return fmt::format("internal-load-tcp-{}", operator_type_name<Elements>());
+  }
+
+  auto optimize(const expression& filter, event_order order) const
+    -> optimize_result override {
+    if (not args_.pipeline) {
+      return {filter, order, this->copy()};
+    }
+    auto result = args_.pipeline->inner.optimize(filter, order);
+    if (not result.replacement) {
+      return result;
+    }
+    auto args = args_;
+    args.pipeline->inner = pipeline{};
+    args.pipeline->inner.append(std::move(result.replacement));
+    result.replacement
+      = std::make_unique<load_tcp_operator<Elements>>(std::move(args));
+    return result;
+  }
+
+  friend auto inspect(auto& f, load_tcp_operator& x) -> bool {
+    return f.apply(x.args_);
+  }
+
+private:
+  load_tcp_args args_ = {};
+};
+
+// -- plugins ------------------------------------------------------------------
+
+class load_tcp_plugin final : public virtual operator_factory_plugin {
+public:
+  auto name() const -> std::string override {
+    return "load_tcp";
+  }
+
+  auto make(invocation inv, session ctx) const
+    -> failure_or<operator_ptr> override {
+    auto url = located<std::string>{};
+    auto parallel = std::optional<located<uint64_t>>{};
+    auto tls = std::optional<located<bool>>{};
+    auto args = load_tcp_args{};
+    auto parser = argument_parser2::operator_("load_tcp");
+    parser.add(url, "<url>");
+    parser.add("connect", args.connect);
+    parser.add("parallel", parallel);
+    parser.add("tls", tls);
+    parser.add("certfile", args.certfile);
+    parser.add("keyfile", args.keyfile);
+    parser.add(args.pipeline, "{ ... }");
+    parser.parse(inv, ctx).ignore();
+    auto failed = false;
+    if (url.inner.starts_with("tcp://")) {
+      url.inner = url.inner.substr(6);
+      url.source.begin += 6;
+    }
+    if (const auto splits = detail::split(url.inner, ":", 1);
+        splits.size() != 2) {
+      diagnostic::error("malformed URL")
+        .primary(url.source)
+        .hint("syntax: tcp://<hostname>:<port>")
+        .usage(parser.usage())
+        .docs(parser.docs())
+        .emit(ctx);
+      failed = true;
+    } else {
+      args.endpoint.inner.hostname = std::string{splits[0]};
+      args.endpoint.inner.port = std::string{splits[1]};
+      args.endpoint.source = url.source;
+    }
+    if (parallel) {
+      args.parallel = *parallel;
+      if (args.parallel.inner == 0
+          or args.parallel.inner > std::thread::hardware_concurrency()) {
+        diagnostic::error("`parallel` must be between 1 and {}",
+                          std::thread::hardware_concurrency())
+          .primary(parallel->source)
+          .usage(parser.usage())
+          .docs(parser.docs())
+          .emit(ctx);
+        failed = true;
+      }
+      if (args.connect and args.parallel.inner != 1) {
+        diagnostic::warning("`parallel` is ignored when `connect` is set")
+          .primary(*args.connect)
+          .primary(parallel->source)
+          .usage(parser.usage())
+          .docs(parser.docs())
+          .emit(ctx);
+      }
+    } else {
+      args.parallel = {1, inv.self.get_location()};
+    }
+    if (tls and not tls->inner) {
+      if (args.certfile) {
+        diagnostic::error("conflicting option: `certfile` requires `tls`")
+          .primary(tls->source)
+          .primary(args.certfile->source)
+          .usage(parser.usage())
+          .docs(parser.docs())
+          .emit(ctx);
+        failed = true;
+      }
+      if (args.keyfile) {
+        diagnostic::error("conflicting option: `keyfile` requires `tls`")
+          .primary(tls->source)
+          .primary(args.keyfile->source)
+          .usage(parser.usage())
+          .docs(parser.docs())
+          .emit(ctx);
+        failed = true;
+      }
+    }
+    if (tls) {
+      args.tls.emplace(tls->source);
+    } else if (args.certfile or args.keyfile) {
+      args.tls.emplace(inv.self.get_location());
+    }
+    if (not args.pipeline) {
+      // If the user does not provide a pipeline, we fall back to just an empty
+      // pipeline, i.e., pass the bytes for all connections through.
+      args.pipeline.emplace(pipeline{}, inv.self.get_location());
+    }
+    const auto output_type = args.pipeline->inner.infer_type(tag_v<chunk_ptr>);
+    if (not output_type) {
+      diagnostic::error(output_type.error())
+        .note("failed to infer output type of nested pipeline")
+        .primary(args.pipeline->source)
+        .usage(parser.usage())
+        .docs(parser.docs())
+        .emit(ctx);
+      failed = true;
+    }
+    if (failed) {
+      return failure::promise();
+    }
+    return output_type->match(
+      [&](tag<void>) -> failure_or<operator_ptr> {
+        diagnostic::error("nested pipeline must return bytes or events")
+          .primary(args.pipeline->source)
+          .usage(parser.usage())
+          .docs(parser.docs())
+          .emit(ctx);
+        return failure::promise();
+      },
+      [&](tag<chunk_ptr>) -> failure_or<operator_ptr> {
+        return std::make_unique<load_tcp_operator<chunk_ptr>>(std::move(args));
+      },
+      [&](tag<table_slice>) -> failure_or<operator_ptr> {
+        return std::make_unique<load_tcp_operator<table_slice>>(
+          std::move(args));
+      });
+  }
+};
+
+using load_tcp_bytes_plugin
+  = operator_inspection_plugin<load_tcp_operator<chunk_ptr>>;
+using load_tcp_events_plugin
+  = operator_inspection_plugin<load_tcp_operator<table_slice>>;
+using load_tcp_source_bytes_plugin
+  = operator_inspection_plugin<load_tcp_source_operator>;
+using load_tcp_sink_bytes_plugin
+  = operator_inspection_plugin<load_tcp_sink_operator<chunk_ptr>>;
+using load_tcp_sink_events_plugin
+  = operator_inspection_plugin<load_tcp_sink_operator<table_slice>>;
+
+} // namespace
+
+} // namespace tenzir::plugins::load_tcp
+
+TENZIR_REGISTER_PLUGIN(tenzir::plugins::load_tcp::load_tcp_plugin)
+TENZIR_REGISTER_PLUGIN(tenzir::plugins::load_tcp::load_tcp_bytes_plugin)
+TENZIR_REGISTER_PLUGIN(tenzir::plugins::load_tcp::load_tcp_events_plugin)
+TENZIR_REGISTER_PLUGIN(tenzir::plugins::load_tcp::load_tcp_source_bytes_plugin)
+TENZIR_REGISTER_PLUGIN(tenzir::plugins::load_tcp::load_tcp_sink_bytes_plugin)
+TENZIR_REGISTER_PLUGIN(tenzir::plugins::load_tcp::load_tcp_sink_events_plugin)

--- a/libtenzir/builtins/operators/load_tcp.cpp
+++ b/libtenzir/builtins/operators/load_tcp.cpp
@@ -161,6 +161,10 @@ public:
     }
   }
 
+  auto location() const -> operator_location {
+    return operator_location::local;
+  }
+
   auto name() const -> std::string override {
     return "internal-load-tcp-source-bytes";
   }
@@ -220,6 +224,10 @@ public:
           });
       co_yield {};
     }
+  }
+
+  auto location() const -> operator_location {
+    return operator_location::anywhere;
   }
 
   auto name() const -> std::string override {
@@ -784,6 +792,10 @@ public:
       co_yield {};
       co_yield std::move(result);
     }
+  }
+
+  auto location() const -> operator_location {
+    return operator_location::local;
   }
 
   auto name() const -> std::string override {

--- a/libtenzir/builtins/operators/tcp-listen.cpp
+++ b/libtenzir/builtins/operators/tcp-listen.cpp
@@ -160,7 +160,6 @@ struct connection_state {
 
   auto emit_metrics() -> void {
     metric_handler.emit({
-      {"port", socket->local_endpoint().port()},
       {"handle", fmt::to_string(socket->native_handle())},
       {"reads", reads},
       {"writes", 0ull},
@@ -211,7 +210,6 @@ auto make_connection(connection_actor::stateful_pointer<connection_state> self,
   self->state.metric_handler = self->state.ctrl->metrics({
     "tenzir.metrics.tcp",
     record_type{
-      {"port", uint64_type{}},
       {"handle", string_type{}},
       {"reads", uint64_type{}},
       {"writes", uint64_type{}},

--- a/libtenzir/include/tenzir/fwd.hpp
+++ b/libtenzir/include/tenzir/fwd.hpp
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include "tenzir/config.hpp" // IWYU pragma: export
-#include "tenzir/tql/fwd.hpp"
+#include "tenzir/config.hpp"  // IWYU pragma: export
+#include "tenzir/tql/fwd.hpp" // IWYU pragma: export
 
 #include <arrow/util/config.h>
 #include <caf/config.hpp>
@@ -108,11 +108,12 @@ namespace caf {
 template <class Slot>
 struct inspector_access<inbound_stream_slot<Slot>> {
   template <class Inspector, class T>
-  static auto apply(Inspector& f, inbound_stream_slot<T>& x) {
+  static auto apply(Inspector& f, inbound_stream_slot<T>& x) -> bool {
     auto val = x.value();
     auto result = f.apply(val);
-    if constexpr (Inspector::is_loading)
+    if constexpr (Inspector::is_loading) {
       x = inbound_stream_slot<T>{val};
+    }
     return result;
   }
 };
@@ -120,12 +121,20 @@ struct inspector_access<inbound_stream_slot<Slot>> {
 template <>
 struct inspector_access<std::filesystem::path> {
   template <class Inspector>
-  static auto apply(Inspector& f, std::filesystem::path& x) {
+  static auto apply(Inspector& f, std::filesystem::path& x) -> bool {
     auto str = x.string();
     auto result = f.apply(str);
-    if constexpr (Inspector::is_loading)
+    if constexpr (Inspector::is_loading) {
       x = {str};
+    }
     return result;
+  }
+};
+
+template <>
+struct inspector_access<std::monostate> {
+  static auto apply(auto&, std::monostate&) -> bool {
+    return true;
   }
 };
 
@@ -175,7 +184,6 @@ class parser_interface;
 class passive_store;
 class pattern;
 class pipeline;
-class pipeline;
 class plugin_ptr;
 class plugin;
 class port;
@@ -213,7 +221,6 @@ struct disjunction;
 struct extract_query_context;
 struct field_extractor;
 struct flow;
-struct identifier;
 struct index_state;
 struct invocation;
 struct legacy_address_type;
@@ -451,6 +458,7 @@ constexpr inline caf::type_id_t first_tenzir_type_id = 800;
 
 CAF_BEGIN_TYPE_ID_BLOCK(tenzir_types, first_tenzir_type_id)
 
+  TENZIR_ADD_TYPE_ID((std::monostate))
   TENZIR_ADD_TYPE_ID((tenzir::bitmap))
   TENZIR_ADD_TYPE_ID((tenzir::blob))
   TENZIR_ADD_TYPE_ID((tenzir::chunk_ptr))

--- a/libtenzir/include/tenzir/fwd.hpp
+++ b/libtenzir/include/tenzir/fwd.hpp
@@ -131,13 +131,6 @@ struct inspector_access<std::filesystem::path> {
   }
 };
 
-template <>
-struct inspector_access<std::monostate> {
-  static auto apply(auto&, std::monostate&) -> bool {
-    return true;
-  }
-};
-
 namespace detail {
 
 class stringification_inspector;
@@ -458,7 +451,6 @@ constexpr inline caf::type_id_t first_tenzir_type_id = 800;
 
 CAF_BEGIN_TYPE_ID_BLOCK(tenzir_types, first_tenzir_type_id)
 
-  TENZIR_ADD_TYPE_ID((std::monostate))
   TENZIR_ADD_TYPE_ID((tenzir::bitmap))
   TENZIR_ADD_TYPE_ID((tenzir::blob))
   TENZIR_ADD_TYPE_ID((tenzir::chunk_ptr))

--- a/libtenzir/include/tenzir/try.hpp
+++ b/libtenzir/include/tenzir/try.hpp
@@ -96,7 +96,7 @@ struct tenzir::tryable<caf::expected<void>> {
   }
 
   static auto get_error(caf::expected<void>&& x) -> caf::error {
-    return std::move(x.error());
+    return x.error();
   }
 };
 

--- a/libtenzir/include/tenzir/try.hpp
+++ b/libtenzir/include/tenzir/try.hpp
@@ -85,6 +85,21 @@ struct tenzir::tryable<caf::expected<T>> {
   }
 };
 
+template <>
+struct tenzir::tryable<caf::expected<void>> {
+  static auto is_success(const caf::expected<void>& x) -> bool {
+    return !!x;
+  }
+
+  static void get_success(caf::expected<void>&& x) {
+    TENZIR_UNUSED(x);
+  }
+
+  static auto get_error(caf::expected<void>&& x) -> caf::error {
+    return std::move(x.error());
+  }
+};
+
 template <class V, class E>
 struct tenzir::tryable<tenzir::variant<V, E>> {
   static auto is_success(const tenzir::variant<V, E>& x) -> bool {

--- a/libtenzir/src/argument_parser2.cpp
+++ b/libtenzir/src/argument_parser2.cpp
@@ -71,9 +71,13 @@ auto argument_parser2::parse(const ast::entity& self,
       x);
   };
   auto arg = args.begin();
-  for (auto [idx, positional] : detail::enumerate(positional_)) {
+  auto positional_idx = size_t{0};
+  // for (auto [positional_idx, positional] : detail::enumerate(positional_)) {
+  for (auto it = positional_.begin(); it != positional_.end();
+       ++it, ++positional_idx) {
+    auto& positional = *it;
     if (arg == args.end()) {
-      if (first_optional_ && idx >= *first_optional_) {
+      if (first_optional_ && positional_idx >= *first_optional_) {
         break;
       }
       emit(diagnostic::error("expected additional positional argument `{}`",
@@ -83,12 +87,12 @@ auto argument_parser2::parse(const ast::entity& self,
     }
     auto& expr = *arg;
     if (std::holds_alternative<ast::assignment>(*expr.kind)) {
-      if (first_optional_ && idx >= *first_optional_) {
-        break;
-      }
-      emit(diagnostic::error("expected positional argument `{}` first",
-                             positional.meta)
-             .primary(expr));
+      // if (first_optional_ && idx >= *first_optional_) {
+      //   break;
+      // }
+      // emit(diagnostic::error("expected positional argument `{}` first",
+      //                        positional.meta)
+      //        .primary(expr));
       break;
     }
     positional.set.match(
@@ -152,88 +156,110 @@ auto argument_parser2::parse(const ast::entity& self,
     ++arg;
   }
   for (; arg != args.end(); ++arg) {
-    auto assignment = std::get_if<ast::assignment>(&*arg->kind);
-    if (not assignment) {
-      emit(diagnostic::error("did not expect more positional arguments")
-             .primary(*arg));
-      continue;
-    }
-    auto sel = std::get_if<ast::simple_selector>(&assignment->left);
-    if (not sel || sel->has_this() || sel->path().size() != 1) {
-      emit(diagnostic::error("invalid name").primary(assignment->left));
-      continue;
-    }
-    auto& name = sel->path()[0].name;
-    auto it = std::ranges::find(named_, name, &named::name);
-    if (it == named_.end()) {
-      emit(diagnostic::error("named argument `{}` does not exist", name)
-             .primary(assignment->left));
-      continue;
-    }
-    if (it->found) {
-      emit(diagnostic::error("duplicate named argument `{}`", name)
-             .primary(*it->found)
-             .primary(arg->get_location()));
-      continue;
-    }
-    it->found = arg->get_location();
-    auto& expr = assignment->right;
-    it->set.match(
-      [&]<data_type T>(setter<located<T>>& set) {
-        auto value = const_eval(expr, ctx);
-        if (not value) {
-          result = value.error();
+    arg->match(
+      [&](ast::assignment assignment) {
+        auto sel = std::get_if<ast::simple_selector>(&assignment.left);
+        if (not sel || sel->has_this() || sel->path().size() != 1) {
+          emit(diagnostic::error("invalid name").primary(assignment.left));
           return;
         }
-        auto cast = caf::get_if<T>(&*value);
-        if constexpr (std::same_as<T, uint64_t>) {
-          if (not cast) {
-            auto other = caf::get_if<int64_t>(&*value);
-            if (other) {
-              if (*other < 0) {
-                emit(diagnostic::error("expected positive integer, got `{}`",
-                                       *other)
-                       .primary(expr));
-                return;
-              }
-              value = static_cast<uint64_t>(*other);
-              cast = caf::get_if<T>(&*value);
+        auto& name = sel->path()[0].name;
+        auto it = std::ranges::find(named_, name, &named::name);
+        if (it == named_.end()) {
+          emit(diagnostic::error("named argument `{}` does not exist", name)
+                 .primary(assignment.left));
+          return;
+        }
+        if (it->found) {
+          emit(diagnostic::error("duplicate named argument `{}`", name)
+                 .primary(*it->found)
+                 .primary(arg->get_location()));
+          return;
+        }
+        it->found = arg->get_location();
+        auto& expr = assignment.right;
+        it->set.match(
+          [&]<data_type T>(setter<located<T>>& set) {
+            auto value = const_eval(expr, ctx);
+            if (not value) {
+              result = value.error();
+              return;
             }
-          }
-        }
-        if (not cast) {
-          // TODO: Attempt conversion.
-          emit(diagnostic::error("expected argument of type `{}`, but got `{}`",
-                                 type_kind::of<data_to_type_t<T>>, kind(*value))
-                 .primary(expr));
-          return;
-        }
-        set(located{std::move(*cast), expr.get_location()});
+            auto cast = caf::get_if<T>(&*value);
+            if constexpr (std::same_as<T, uint64_t>) {
+              if (not cast) {
+                auto other = caf::get_if<int64_t>(&*value);
+                if (other) {
+                  if (*other < 0) {
+                    emit(diagnostic::error(
+                           "expected positive integer, got `{}`", *other)
+                           .primary(expr));
+                    return;
+                  }
+                  value = static_cast<uint64_t>(*other);
+                  cast = caf::get_if<T>(&*value);
+                }
+              }
+            }
+            if (not cast) {
+              // TODO: Attempt conversion.
+              emit(diagnostic::error(
+                     "expected argument of type `{}`, but got `{}`",
+                     type_kind::of<data_to_type_t<T>>, kind(*value))
+                     .primary(expr));
+              return;
+            }
+            set(located{std::move(*cast), expr.get_location()});
+          },
+          [&](setter<ast::expression>& set) {
+            set(expr);
+          },
+          [&](setter<ast::simple_selector>& set) {
+            auto sel = ast::simple_selector::try_from(expr);
+            if (not sel) {
+              emit(diagnostic::error("expected a selector").primary(expr));
+              return;
+            }
+            set(std::move(*sel));
+          },
+          [&](setter<located<pipeline>>& set) {
+            auto pipe_expr = std::get_if<ast::pipeline_expr>(&*expr.kind);
+            if (not pipe_expr) {
+              emit(diagnostic::error("expected a pipeline expression")
+                     .primary(expr));
+              return;
+            }
+            auto pipe = compile(std::move(pipe_expr->inner), ctx);
+            if (pipe.is_error()) {
+              result = pipe.error();
+              return;
+            }
+            set(located{std::move(pipe).unwrap(), expr.get_location()});
+          });
       },
-      [&](setter<ast::expression>& set) {
-        set(expr);
+      [&](ast::pipeline_expr pipe_expr) {
+        if (positional_idx == positional_.size()) {
+          emit(diagnostic::error("did not expect more positional arguments")
+                 .primary(*arg));
+        }
+        positional_[positional_idx].set.match(
+          [&](setter<located<pipeline>>& set) {
+            auto pipe = compile(std::move(pipe_expr.inner), ctx);
+            if (pipe.is_error()) {
+              result = pipe.error();
+              return;
+            }
+            set(located{std::move(pipe).unwrap(), pipe_expr.get_location()});
+          },
+          [&](auto&) {
+            TENZIR_UNREACHABLE();
+          });
+        ++positional_idx;
       },
-      [&](setter<ast::simple_selector>& set) {
-        auto sel = ast::simple_selector::try_from(expr);
-        if (not sel) {
-          emit(diagnostic::error("expected a selector").primary(expr));
-          return;
+      [&](auto&) {
+        if (positional_idx == positional_.size()) {
+          emit(diagnostic::error("unexpected argument").primary(*arg));
         }
-        set(std::move(*sel));
-      },
-      [&](setter<located<pipeline>>& set) {
-        auto pipe_expr = std::get_if<ast::pipeline_expr>(&*expr.kind);
-        if (not pipe_expr) {
-          emit(
-            diagnostic::error("expected a pipeline expression").primary(expr));
-          return;
-        }
-        auto pipe = compile(std::move(pipe_expr->inner), ctx);
-        if (pipe.is_error()) {
-          result = pipe.error();
-          return;
-        }
-        set(located{std::move(pipe).unwrap(), expr.get_location()});
       });
   }
   for (const auto& arg : named_) {

--- a/libtenzir/src/argument_parser2.cpp
+++ b/libtenzir/src/argument_parser2.cpp
@@ -87,12 +87,6 @@ auto argument_parser2::parse(const ast::entity& self,
     }
     auto& expr = *arg;
     if (std::holds_alternative<ast::assignment>(*expr.kind)) {
-      // if (first_optional_ && idx >= *first_optional_) {
-      //   break;
-      // }
-      // emit(diagnostic::error("expected positional argument `{}` first",
-      //                        positional.meta)
-      //        .primary(expr));
       break;
     }
     positional.set.match(

--- a/libtenzir/src/argument_parser2.cpp
+++ b/libtenzir/src/argument_parser2.cpp
@@ -72,7 +72,6 @@ auto argument_parser2::parse(const ast::entity& self,
   };
   auto arg = args.begin();
   auto positional_idx = size_t{0};
-  // for (auto [positional_idx, positional] : detail::enumerate(positional_)) {
   for (auto it = positional_.begin(); it != positional_.end();
        ++it, ++positional_idx) {
     auto& positional = *it;

--- a/web/docs/operators/metrics.md
+++ b/web/docs/operators/metrics.md
@@ -310,12 +310,11 @@ TCP connection.
 | `hidden`        | `bool`   | True if the pipeline is running for the explorer.             |
 | `timestamp`     | `time`   | The time at which this metric was recorded.                   |
 | `operator_id`   | `uint64` | The ID of the `publish` operator in the pipeline.             |
-| `port`          | `uint64` | The TCP port number.                                          |
 | `native`        | `string` | The native handle of the connection (unix: file descriptor).  |
 | `reads`         | `uint64` | The number of attempted reads since the last metric.          |
-| `writes`        | `uint64` | The number of attempted writes since the last metric.          |
+| `writes`        | `uint64` | The number of attempted writes since the last metric.         |
 | `bytes_read`    | `uint64` | The number of bytes received since the last metrics.          |
-| `bytes_written` | `uint64` | The number of bytes written since the last metrics.          |
+| `bytes_written` | `uint64` | The number of bytes written since the last metrics.           |
 
 ## Examples
 


### PR DESCRIPTION
This is an all-new `load_tcp` for TQL2, and our first operator to support a fully nested pipeline.

The operator has the following synopsis:

```
load_tcp <url> { ... }?,
  connect=<bool>?,
  parallel=<uint64>?,
  tls=<bool>?,
  certfile=<string>?,
  keyfile=<string>?
```

The nested pipeline runs once per connection, joining the output (either events or bytes) at the end of the `load_tcp` operator.