### PR TITLE
Make it possible to give operators and functions the same name

### DIFF
--- a/libtenzir/builtins/functions/string.cpp
+++ b/libtenzir/builtins/functions/string.cpp
@@ -391,7 +391,8 @@ TENZIR_REGISTER_PLUGIN(trim{"trim_end", "utf8_rtrim"})
 TENZIR_REGISTER_PLUGIN(nullary_method{"capitalize", "utf8_capitalize",
                                       string_type{}})
 TENZIR_REGISTER_PLUGIN(nullary_method{"to_lower", "utf8_lower", string_type{}})
-TENZIR_REGISTER_PLUGIN(nullary_method{"reverse", "utf8_reverse", string_type{}})
+TENZIR_REGISTER_PLUGIN(nullary_method{"tql2.reverse", "utf8_reverse",
+                                      string_type{}})
 TENZIR_REGISTER_PLUGIN(nullary_method{"to_title", "utf8_title", string_type{}})
 TENZIR_REGISTER_PLUGIN(nullary_method{"to_upper", "utf8_upper", string_type{}})
 

--- a/libtenzir/include/tenzir/argument_parser2.hpp
+++ b/libtenzir/include/tenzir/argument_parser2.hpp
@@ -109,6 +109,10 @@ private:
 
   argument_parser2(kind kind, std::string name)
     : kind_{kind}, name_{std::move(name)} {
+    // TODO: Remove this temporary hack once we removed TQL1 plugins.
+    if (name_.starts_with("tql2.")) {
+      name_.erase(0, 5);
+    }
   }
 
   template <class T>

--- a/libtenzir/include/tenzir/tql2/plugin.hpp
+++ b/libtenzir/include/tenzir/tql2/plugin.hpp
@@ -86,6 +86,8 @@ public:
   virtual auto make_function(invocation inv, session ctx) const
     -> failure_or<function_ptr>
     = 0;
+
+  virtual auto function_name() const -> std::string;
 };
 
 class method_plugin : public virtual function_plugin {};

--- a/libtenzir/src/plugin.cpp
+++ b/libtenzir/src/plugin.cpp
@@ -305,6 +305,21 @@ load(const std::vector<std::string>& bundled_plugins,
 
 /// Initialize loaded plugins.
 caf::error initialize(caf::actor_system_config& cfg) {
+  // If everything went well, we should have a strictly-ordered list of plugins.
+  if (auto it = std::ranges::adjacent_find(get(), std::greater_equal{});
+      it != get().end()) {
+    auto name_a = (*it)->name();
+    ++it;
+    auto name_b = (*it)->name();
+    if (name_a == name_b) {
+      TENZIR_ASSERT(false,
+                    fmt::format("found multiple plugins named `{}`", name_a));
+    } else {
+      TENZIR_ASSERT(false, fmt::format("unexpected plugin ordering: found `{}` "
+                                       "before `{}`",
+                                       name_a, name_b));
+    }
+  }
   auto global_config = record{};
   auto global_opts = caf::content(cfg);
   if (auto global_opts_data = to<record>(global_opts)) {

--- a/libtenzir/src/tql2/exec.cpp
+++ b/libtenzir/src/tql2/exec.cpp
@@ -129,11 +129,7 @@ auto compile_resolved(ast::pipeline&& pipe, session ctx)
     stmt.match(
       [&](ast::invocation& x) {
         // TODO: Where do we check that this succeeds?
-        auto def = std::get_if<const operator_factory_plugin*>(
-          &ctx.reg().get(x.op.ref));
-        TENZIR_ASSERT(def);
-        TENZIR_ASSERT(*def);
-        auto op = (*def)->make(
+        auto op = ctx.reg().get(x).make(
           operator_factory_plugin::invocation{
             std::move(x.op),
             std::move(x.args),

--- a/libtenzir/src/tql2/plugin.cpp
+++ b/libtenzir/src/tql2/plugin.cpp
@@ -49,4 +49,13 @@ auto function_use::make(
   return std::make_unique<result>(std::move(f));
 }
 
+auto function_plugin::function_name() const -> std::string {
+  // TODO: Remove this once we removed TQL1 plugins.
+  auto result = name();
+  if (result.starts_with("tql2.")) {
+    result.erase(0, 5);
+  }
+  return result;
+}
+
 } // namespace tenzir

--- a/libtenzir/src/tql2/resolve.cpp
+++ b/libtenzir/src/tql2/resolve.cpp
@@ -36,8 +36,10 @@ public:
       return;
     }
     auto& name = x.path[0].name;
+    auto ns = context_ == context_t::op_name ? entity_ns::op : entity_ns::fn;
     // TODO: We pretend here that every name directly maps to its path.
-    auto entity = reg_.try_get(entity_path{{name}});
+    auto path = entity_path{{name}, ns};
+    auto entity = reg_.try_get(path);
     auto expected = std::invoke([&] {
       switch (context_) {
         case context_t::op_name:
@@ -74,8 +76,8 @@ public:
     }
     // TODO: Check if this entity has right type?
     entity->match(
-      [&](const function_plugin* function) {
-        if (dynamic_cast<const method_plugin*>(function)) {
+      [&](std::reference_wrapper<const function_plugin> function) {
+        if (dynamic_cast<const method_plugin*>(&function.get())) {
           if (context_ != context_t::method_name) {
             diagnostic::error("expected {}, got method", expected)
               .primary(x)
@@ -90,9 +92,9 @@ public:
           result_ = failure::promise();
           return;
         }
-        x.ref = entity_path{{name}};
+        x.ref = std::move(path);
       },
-      [&](const operator_factory_plugin*) {
+      [&](std::reference_wrapper<const operator_factory_plugin>) {
         if (context_ != context_t::op_name) {
           diagnostic::error("expected {}, got operator", expected)
             .primary(x)
@@ -100,7 +102,7 @@ public:
           result_ = failure::promise();
           return;
         }
-        x.ref = entity_path{{name}};
+        x.ref = std::move(path);
       });
   }
 


### PR DESCRIPTION
Plus a few convenience changes and small fixes.

For example, this makes it possible to have both a `reverse` operator (operating on event streams) and a `reverse` function (operating on strings or lists).