### PR TITLE
Split at null bytes in TQL2 gelf parser

### DIFF
--- a/libtenzir/builtins/formats/json.cpp
+++ b/libtenzir/builtins/formats/json.cpp
@@ -1196,7 +1196,7 @@ public:
     auto result = parser.parse(inv, ctx);
     TRY(result);
     auto args = parser_args{"gelf"};
-
+    args.split_mode = split_at::null;
     TRY(args.builder_options, msb_parser.get_options(ctx.dh()));
     return std::make_unique<parser_adapter<json_parser>>(
       json_parser{std::move(args)});


### PR DESCRIPTION
Without this fix, trying to ingest gelf data from a file in a TQL2 pipeline would fail with the following error:

```
error: gelf parser: SCALAR_DOCUMENT_AS_VALUE: A JSON document made of a scalar (number, Boolean, null or string) is treated as a value. Use get_bool(), get_double(), etc. on the document instead. 
 = note: skips invalid JSON '{"version":"1.1","timestamp":1.71146624E9,"host":"192.1 ... (truncated 1048522 bytes)
```