### PR TITLE
Rename `null=bool` option for TQL2's `read_lines`

### DIFF
--- a/libtenzir/builtins/formats/lines.cpp
+++ b/libtenzir/builtins/formats/lines.cpp
@@ -276,7 +276,7 @@ class read_lines final
     auto args = parser_args{};
     argument_parser2::operator_(name())
       .add("skip_empty", args.skip_empty)
-      .add("null", args.null)
+      .add("split_at_null", args.null)
       .parse(inv, ctx)
       .ignore();
     return std::make_unique<parser_adapter<lines_parser>>(


### PR DESCRIPTION
Because options in TQL2's argument parser are just assignment expressions, we cannot use a constant on the left-hand side, and thus also not as an argument name.

I renamed the option to `split_at_null=bool` instead, which is a better name in any case.

- Fixes https://github.com/tenzir/issues/issues/2234