### PR TITLE
Prefer recent partitions for retro lookups

### DIFF
--- a/changelog/next/changes/4636--lookup-prefer-recent.md
+++ b/changelog/next/changes/4636--lookup-prefer-recent.md
@@ -1,0 +1,2 @@
+The `lookup` operator now prefers recent data in searches for lookups against
+historical data instead of using the order in which context updates arrive.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "bf79af08257584ec93b7a1ad3b2acc3821931fe6",
+  "rev": "7e2d7d1c206d70ac6e91d5dd59f6429bb78616bf",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
This changes the `lookup` operator to unconditionally prefer recent newer persisted events across context updates in favor of going by the order in which context updates arrive.