### PR TITLE
Enable azure-blob-storage support in the Docker image

### DIFF
--- a/.github/workflows/tenzir.yaml
+++ b/.github/workflows/tenzir.yaml
@@ -220,7 +220,7 @@ jobs:
           run_if_changed python "python/"
           run_if_changed docs "web/" "python/"
           run_if_changed changelog "changelog/" "web/" "python/"
-          TENZIR_SOURCES=(cmake/ CMakeLists.txt libtenzir/ libtenzir_test/ schema/ tools/ tenzir/ tenzir.yaml.example version.json)
+          TENZIR_SOURCES=(cmake/ CMakeLists.txt libtenzir/ libtenzir_test/ schema/ scripts/ tenzir/ tenzir.yaml.example version.json)
           run_if_changed tenzir "${TENZIR_SOURCES[@]}"
           run_if_changed_default tenzir-plugins $run_tenzir "plugins/" "contrib/tenzir-plugins/"
           # The tenzir-plugins job downloads the Tenzir artifact from GCS, so we

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,9 +75,10 @@ RUN cmake -B build -G Ninja \
       -D TENZIR_ENABLE_MANPAGES:BOOL="OFF" \
       -D TENZIR_ENABLE_PYTHON_BINDINGS_DEPENDENCIES:BOOL="ON" \
       ${TENZIR_BUILD_OPTIONS} && \
-    cmake --build build --parallel
-RUN cmake --build build --target integration
-RUN cmake --install build --strip
+    cmake --build build --parallel && \
+    cmake --build build --target integration && \
+    cmake --install build --strip && \
+    rm -rf build
 
 RUN mkdir -p \
       $PREFIX/etc/tenzir \
@@ -146,7 +147,7 @@ RUN apt-get update && \
       wget && \
     apt-get -y --no-install-recommends install /root/arrow_*.deb && \
     apt-get -y --no-install-recommends install /root/fluent-bit_*.deb && \
-    rm /root/fluent-bit_*.deb /root/arrow_*.deb && \
+    rm /root/arrow_*.deb /root/fluent-bit_*.deb && \
     rm -rf /var/lib/apt/lists/* && \
     echo "/opt/aws-sdk-cpp/lib" > /etc/ld.so.conf.d/aws-cpp-sdk.conf && \
     ldconfig
@@ -177,36 +178,39 @@ COPY contrib/tenzir-plugins ./contrib/tenzir-plugins
 
 FROM plugins-source AS azure-log-analytics-plugin
 
-RUN cmake -S contrib/tenzir-plugins/azure-log-analytics \
-      -B build-azure-log-analytics -G Ninja \
+RUN cmake -S contrib/tenzir-plugins/azure-log-analytics -B build-azure-log-analytics -G Ninja \
       -D CMAKE_INSTALL_PREFIX:STRING="$PREFIX" && \
-    cmake --build build-azure-log-analytics --parallel
-RUN cmake --build build-azure-log-analytics --target integration
-RUN DESTDIR=/plugin/azure-log-analytics cmake --install build-azure-log-analytics --strip --component Runtime
+      cmake --build build-azure-log-analytics --parallel && \
+      cmake --build build-azure-log-analytics --target integration && \
+      DESTDIR=/plugin/azure-log-analytics cmake --install build-azure-log-analytics --strip --component Runtime && \
+      rm -rf build-build-azure-log-analytics
 
 FROM plugins-source AS compaction-plugin
 
 RUN cmake -S contrib/tenzir-plugins/compaction -B build-compaction -G Ninja \
       -D CMAKE_INSTALL_PREFIX:STRING="$PREFIX" && \
-    cmake --build build-compaction --parallel
-RUN cmake --build build-compaction --target integration
-RUN DESTDIR=/plugin/compaction cmake --install build-compaction --strip --component Runtime
+      cmake --build build-compaction --parallel && \
+      cmake --build build-compaction --target integration && \
+      DESTDIR=/plugin/compaction cmake --install build-compaction --strip --component Runtime && \
+      rm -rf build-compaction
 
 FROM plugins-source AS context-plugin
 
 RUN cmake -S contrib/tenzir-plugins/context -B build-context -G Ninja \
       -D CMAKE_INSTALL_PREFIX:STRING="$PREFIX" && \
-    cmake --build build-context --parallel
-RUN cmake --build build-context --target integration
-RUN DESTDIR=/plugin/context cmake --install build-context --strip --component Runtime
+      cmake --build build-context --parallel && \
+      cmake --build build-context --target integration && \
+      DESTDIR=/plugin/context cmake --install build-context --strip --component Runtime && \
+      rm -rf build-context
 
 FROM plugins-source AS pipeline-manager-plugin
 
 RUN cmake -S contrib/tenzir-plugins/pipeline-manager -B build-pipeline-manager -G Ninja \
       -D CMAKE_INSTALL_PREFIX:STRING="$PREFIX" && \
-    cmake --build build-pipeline-manager --parallel
-RUN cmake --build build-pipeline-manager --target integration
-RUN DESTDIR=/plugin/pipeline-manager cmake --install build-pipeline-manager --strip --component Runtime
+      cmake --build build-pipeline-manager --parallel && \
+      cmake --build build-pipeline-manager --target integration && \
+      DESTDIR=/plugin/pipeline-manager cmake --install build-pipeline-manager --strip --component Runtime && \
+      rm -rf build-pipeline-manager
 
 FROM plugins-source AS packages-plugin
 
@@ -214,24 +218,27 @@ FROM plugins-source AS packages-plugin
 # they require the context and pipeline-manager plugins to be available.
 RUN cmake -S contrib/tenzir-plugins/packages -B build-packages -G Ninja \
       -D CMAKE_INSTALL_PREFIX:STRING="$PREFIX" && \
-    cmake --build build-packages --parallel
-RUN DESTDIR=/plugin/packages cmake --install build-packages --strip --component Runtime
+      cmake --build build-packages --parallel && \
+      DESTDIR=/plugin/packages cmake --install build-packages --strip --component Runtime && \
+      rm -rf build-packages
 
 FROM plugins-source AS platform-plugin
 
 RUN cmake -S contrib/tenzir-plugins/platform -B build-platform -G Ninja \
       -D CMAKE_INSTALL_PREFIX:STRING="$PREFIX" && \
-    cmake --build build-platform --parallel
-RUN cmake --build build-platform --target integration
-RUN DESTDIR=/plugin/platform cmake --install build-platform --strip --component Runtime
+      cmake --build build-platform --parallel && \
+      cmake --build build-platform --target integration && \
+      DESTDIR=/plugin/platform cmake --install build-platform --strip --component Runtime && \
+      rm -rf build-platform
 
 FROM plugins-source AS vast-plugin
 
 RUN cmake -S contrib/tenzir-plugins/vast -B build-vast -G Ninja \
       -D CMAKE_INSTALL_PREFIX:STRING="$PREFIX" && \
-    cmake --build build-vast --parallel
-RUN cmake --build build-vast --target integration
-RUN DESTDIR=/plugin/vast cmake --install build-vast --strip --component Runtime
+      cmake --build build-vast --parallel && \
+      cmake --build build-vast --target integration && \
+      DESTDIR=/plugin/vast cmake --install build-vast --strip --component Runtime && \
+      rm -rf build-vast
 
 # -- tenzir-ce -------------------------------------------------------------------
 

--- a/scripts/debian/build-arrow.sh
+++ b/scripts/debian/build-arrow.sh
@@ -1,0 +1,68 @@
+#! /usr/bin/env bash
+# This script creates an arrow package that is tailored to Tenzir's needs.
+# This is required because as of Arrow 17 the official debian packages lack
+# support for the Azure filesystem integration.
+
+set -euo pipefail
+
+apt-get -qq update
+apt-get install --no-install-recommends -y \
+  bison \
+  build-essential \
+  ca-certificates \
+  checkinstall \
+  cmake \
+  libcurl4-openssl-dev \
+  dh-make \
+  flex \
+  libminizip-dev \
+  libsasl2-dev \
+  libssl-dev \
+  libabsl-dev \
+  libyaml-dev \
+  make \
+  pkg-config \
+  unzip \
+  wget \
+  zlib1g-dev
+apt-get install -y --reinstall \
+  lsb-base \
+  lsb-release
+
+mkdir -p source
+pushd source
+curl -L 'https://github.com/apache/arrow/archive/refs/tags/apache-arrow-17.0.0.tar.gz' | tar -xz --strip-components=1
+cd cpp
+cmake -B build -S . \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX=/usr \
+  -DCMAKE_INSTALL_SYSCONFDIR=/etc \
+  -DARROW_FILESYSTEM=ON \
+  -DARROW_AZURE=ON \
+  -DARROW_GCS=ON \
+  -DARROW_COMPUTE=ON \
+  -DARROW_S3=ON \
+  -DARROW_PARQUET=ON \
+  -DARROW_WITH_BROTLI=ON \
+  -DARROW_WITH_BZ2=ON \
+  -DARROW_WITH_LZ4=ON \
+  -DARROW_WITH_SNAPPY=ON \
+  -DARROW_WITH_ZLIB=ON \
+  -DARROW_WITH_ZSTD=ON
+cmake --build build --parallel "$(nproc --all)"
+cmake --install build
+cd build
+checkinstall \
+  --pakdir / \
+  --pkgsource="https://github.com/raboof/nethogs/" \
+  --pkglicense="ASL2.0" \
+  --deldesc=no \
+  --nodoc \
+  --pkgversion="17.0.0" \
+  --pkgrelease="TENZIR" \
+  --pkgname=arrow \
+  --requires="libc6,libcurl4,libgcc1,libssl3,libstdc++6,libxml2,zlib1g" \
+  make install
+popd
+rm -rf source
+ls -l /

--- a/scripts/debian/build-arrow.sh
+++ b/scripts/debian/build-arrow.sh
@@ -34,6 +34,7 @@ pushd source
 curl -L 'https://github.com/apache/arrow/archive/refs/tags/apache-arrow-17.0.0.tar.gz' | tar -xz --strip-components=1
 cd cpp
 cmake -B build -S . \
+  -G "Unix Makefiles" \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=/usr \
   -DCMAKE_INSTALL_SYSCONFDIR=/etc \
@@ -54,7 +55,7 @@ cmake --install build
 cd build
 checkinstall \
   --pakdir / \
-  --pkgsource="https://github.com/raboof/nethogs/" \
+  --pkgsource="https://github.com/apache/arrow" \
   --pkglicense="ASL2.0" \
   --deldesc=no \
   --nodoc \

--- a/scripts/debian/install-aws-sdk.sh
+++ b/scripts/debian/install-aws-sdk.sh
@@ -35,3 +35,5 @@ cmake -B build \
 cmake --build build --parallel
 cmake --install build --strip
 rm -rf "${SOURCE_TREE}"
+echo "/opt/aws-sdk-cpp/lib" > /etc/ld.so.conf.d/aws-cpp-sdk.conf
+ldconfig

--- a/scripts/debian/install-dev-dependencies.sh
+++ b/scripts/debian/install-dev-dependencies.sh
@@ -61,19 +61,8 @@ apt-get -y --no-install-recommends install \
     wget \
     yara
 
-codename="$(lsb_release --codename --short)"
-
-# Apache Arrow
-wget "https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-${codename}.deb"
-apt-get -y --no-install-recommends install ./"apache-arrow-apt-source-latest-${codename}.deb"
-apt-get update
-# The apt download sometimes fails with a 403. We employ a similar workaround as
-# arrow itself: https://github.com/apache/arrow/pull/36836.
-# See also: https://github.com/apache/arrow/issues/35292.
-apt-get -y --no-install-recommends install libarrow-dev=15.0.2-1 libprotobuf-dev libparquet-dev=15.0.2-1 || \
-  apt-get -y --no-install-recommends install libarrow-dev=15.0.2-1 libprotobuf-dev libparquet-dev=15.0.2-1 || \
-  apt-get -y --no-install-recommends install libarrow-dev=15.0.2-1 libprotobuf-dev libparquet-dev=15.0.2-1
-rm ./"apache-arrow-apt-source-latest-${codename}.deb"
+dir=$(dirname "$(readlink -f "$0")")
+"${dir}"/build-arrow.sh
 
 # Node 18.x and Yarn
 NODE_MAJOR=18


### PR DESCRIPTION
The official Arrow packages for Debian do not include support for the Azure filesystem module. For this reason we now build a customized Arrow config as part of the dependency installation setup step, so the connector is available in the Docker images.

Note:
This now also builds arrow in the regular Debian CI, and that'll cause some noticeably longer CI runtimes. We may consider not building the `azure-blob-storage` plugin in that mode to reduce the impact on end-to-end runtimes.