### PR TITLE
Add a mechanism for enforcing a node shutdown

### DIFF
--- a/libtenzir/src/application.cpp
+++ b/libtenzir/src/application.cpp
@@ -47,6 +47,9 @@ void add_root_opts(command& cmd) {
   cmd.options.add<std::string>("?tenzir", "console-verbosity",
                                "output verbosity level on the "
                                "console");
+  cmd.options.add<std::string>("?tenzir", "shutdown-grace-period",
+                               "maximum time a clean shutdown may take before "
+                               "a hard kill");
   cmd.options.add<std::string>("?tenzir", "console-format",
                                "format string for logging to the "
                                "console");

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -46,6 +46,10 @@ tenzir:
   # checked in that order, and as a last resort "/tmp" is used.
   #cache-directory:
 
+  # The maximum time a node is allowed to take for its shutdown process until it
+  # shuts down uncleanly. If unset, the node will wait indefinitely.
+  #shutdown-grace-period:
+
   # The file system path used for log files.
   # Defaults to one of the following paths, selecting the first that is
   # available:


### PR DESCRIPTION
This adds a new option `tenzir.shutdown-grace-period` that when set starts a timer when the node starts its shutdown process. If the shutdown does not proceed cleanly in time, the timer causes the process to crash, ensuring that the process does not hang on shutdown.

Additionally, this slightly improves error handling in the metrics-collector component.