### PR TITLE
Move `head` and `tail` operators to slice.cpp

### DIFF
--- a/libtenzir/builtins/operators/head.cpp
+++ b/libtenzir/builtins/operators/head.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2023 The Tenzir Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#include "tenzir/tql2/plugin.hpp"
-
 #include <tenzir/argument_parser.hpp>
 #include <tenzir/pipeline.hpp>
 #include <tenzir/plugin.hpp>
@@ -16,8 +14,7 @@ namespace tenzir::plugins::head {
 
 namespace {
 
-class plugin final : public virtual operator_parser_plugin,
-                     public virtual operator_factory_plugin {
+class plugin final : public virtual operator_parser_plugin {
 public:
   auto name() const -> std::string override {
     return "head";
@@ -39,24 +36,6 @@ public:
       diagnostic::error("failed to transform `head` into `slice` operator: {}",
                         result.error())
         .throw_();
-    }
-    return std::move(*result);
-  }
-
-  auto make(invocation inv, session ctx) const
-    -> failure_or<operator_ptr> override {
-    auto count = std::optional<uint64_t>{};
-    argument_parser2::operator_("head")
-      .add(count, "<count>")
-      .parse(inv, ctx)
-      .ignore();
-    auto result = pipeline::internal_parse_as_operator(
-      fmt::format("slice :{}", count.value_or(10)));
-    if (not result) {
-      diagnostic::error("failed to transform `head` into `slice` operator: {}",
-                        result.error())
-        .emit(ctx);
-      return nullptr;
     }
     return std::move(*result);
   }

--- a/libtenzir/builtins/operators/tail.cpp
+++ b/libtenzir/builtins/operators/tail.cpp
@@ -9,14 +9,12 @@
 #include <tenzir/argument_parser.hpp>
 #include <tenzir/pipeline.hpp>
 #include <tenzir/plugin.hpp>
-#include <tenzir/tql2/plugin.hpp>
 
 namespace tenzir::plugins::tail {
 
 namespace {
 
-class plugin final : public virtual operator_parser_plugin,
-                     public virtual operator_factory_plugin {
+class plugin final : public virtual operator_parser_plugin {
 public:
   auto name() const -> std::string override {
     return "tail";
@@ -38,24 +36,6 @@ public:
       diagnostic::error("failed to transform `tail` into `slice` operator: {}",
                         result.error())
         .throw_();
-    }
-    return std::move(*result);
-  }
-
-  auto make(invocation inv, session ctx) const
-    -> failure_or<operator_ptr> override {
-    auto count = std::optional<uint64_t>{};
-    argument_parser2::operator_("tail")
-      .add(count, "<count>")
-      .parse(inv, ctx)
-      .ignore();
-    auto result = pipeline::internal_parse_as_operator(
-      fmt::format("slice -{}:", count.value_or(10)));
-    if (not result) {
-      diagnostic::error("failed to transform `tail` into `slice` operator: {}",
-                        result.error())
-        .emit(ctx);
-      return failure::promise();
     }
     return std::move(*result);
   }


### PR DESCRIPTION
Moves `head` and `tail` operators to slice.cpp removing the need for `pipeline::internal_parse_as_operator()`.