### PR TITLE
Fix double-closing fds in the python operator

### DIFF
--- a/changelog/next/bug-fixes/4646--python-operator-fds.md
+++ b/changelog/next/bug-fixes/4646--python-operator-fds.md
@@ -1,0 +1,2 @@
+Fixed a bug in the python operator that could lead to random valid file
+descriptors in the parent process being closed prematurely.


### PR DESCRIPTION
In boost::process, a pipe's file descriptors are closed in its destructor.

When they were already closed, this results in a harmless "Bad file descriptor" result in the best case when attempting to close an already-closed fd.

In the worst case, the descriptor was already re-opened in the meantime and we close an unrelated file descriptor.
