### PR TITLE
Enable azure-blob-storage in the DEB and RPM packages

### DIFF
--- a/libtenzir/CMakeLists.txt
+++ b/libtenzir/CMakeLists.txt
@@ -361,11 +361,6 @@ dependency_summary("libmaxminddb" maxminddb::maxminddb "Dependencies")
 
 # Link against Apache Arrow.
 target_link_libraries(libtenzir PUBLIC ${ARROW_LIBRARY})
-if (TENZIR_ENABLE_STATIC_EXECUTABLE)
-  target_link_libraries(
-    libtenzir PUBLIC Azure::azure-identity Azure::azure-storage-blobs
-                     Azure::azure-storage-files-datalake)
-endif ()
 dependency_summary("Apache Arrow" ${ARROW_LIBRARY} "Dependencies")
 
 # Link against Boost.

--- a/libtenzir/CMakeLists.txt
+++ b/libtenzir/CMakeLists.txt
@@ -88,9 +88,15 @@ string(
   "\n Snappy_LIB"
   "\n ZSTD_LIB)")
 if (BUILD_SHARED_LIBS)
-  set(ARROW_LIBRARY arrow_shared)
+  set(ARROW_LIBRARY Arrow::arrow_shared)
 else ()
-  set(ARROW_LIBRARY arrow_static)
+  set(ARROW_LIBRARY Arrow::arrow_static)
+  # TODO: Missing dependency upstream. Check if still needed when updating
+  # Arrow.
+  target_link_libraries(
+    Arrow::arrow_static
+    INTERFACE Azure::azure-identity Azure::azure-storage-blobs
+              Azure::azure-storage-files-datalake)
 endif ()
 
 # -- boost --------------------------------------------------------------------
@@ -261,7 +267,8 @@ target_link_libraries(libtenzir PUBLIC PkgConfig::PC_CURL)
 # The static curl library we use on macOS depends on SystemConfiguration, but
 # that dependency is missing from the pkg-config file, so we insert it here as a
 # work around.
-if (CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND PC_CURL_CFLAGS MATCHES ".*CURL_STATICLIB.*")
+if (CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND PC_CURL_CFLAGS MATCHES
+                                            ".*CURL_STATICLIB.*")
   find_library(SystemConfiguration SystemConfiguration REQUIRED)
   mark_as_advanced(SystemConfiguration)
   string(APPEND TENZIR_FIND_DEPENDENCY_LIST
@@ -354,6 +361,11 @@ dependency_summary("libmaxminddb" maxminddb::maxminddb "Dependencies")
 
 # Link against Apache Arrow.
 target_link_libraries(libtenzir PUBLIC ${ARROW_LIBRARY})
+if (TENZIR_ENABLE_STATIC_EXECUTABLE)
+  target_link_libraries(
+    libtenzir PUBLIC Azure::azure-identity Azure::azure-storage-blobs
+                     Azure::azure-storage-files-datalake)
+endif ()
 dependency_summary("Apache Arrow" ${ARROW_LIBRARY} "Dependencies")
 
 # Link against Boost.
@@ -475,7 +487,8 @@ endif ()
 
 if (DEFINED TENZIR_VERSION_BUILD_METADATA_BACKUP)
   set(set_tenzir_version_build_metadata
-    "set(TENZIR_VERSION_BUILD_METADATA \"${TENZIR_VERSION_BUILD_METADATA_BACKUP}\")")
+      "set(TENZIR_VERSION_BUILD_METADATA \"${TENZIR_VERSION_BUILD_METADATA_BACKUP}\")"
+  )
 endif ()
 
 file(

--- a/nix/azure-sdk-for-cpp/default.nix
+++ b/nix/azure-sdk-for-cpp/default.nix
@@ -1,0 +1,142 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  curl,
+  libxml2,
+  mbedtls_2,
+  openssl
+}:
+let
+  azure-macro-utils-c = stdenv.mkDerivation {
+    pname = "azure-macro-utils-c";
+    version = "unstable-2019-10-17";
+
+    src = fetchFromGitHub {
+      owner = "Azure";
+      repo = "macro-utils-c";
+      rev = "5926caf4e42e98e730e6d03395788205649a3ada";
+      hash = "sha256-K5G+g+Jnzf7qfb/4+rVOpVgSosoEtNV3Joct1y1Xcdw=";
+    };
+
+    nativeBuildInputs = [ cmake ];
+
+    meta = {
+      homepage = "https://github.com/Azure/macro-utils-c";
+      description = "A C header file that contains a multitude of very useful C macros";
+      sourceProvenance = [ lib.sourceTypes.fromSource ];
+      license = lib.licenses.mit;
+      maintainers = [ lib.maintainers.tobim ];
+      platforms = lib.platforms.all;
+    };
+  };
+
+  azure-c-shared-utility = stdenv.mkDerivation {
+    pname = "azure-c-shared-utility";
+    version = "unstable-2023-09-05";
+
+    src = fetchFromGitHub {
+      owner = "Azure";
+      repo = "azure-c-shared-utility";
+      rev = "55bb392cd220e6b369336a7bd42e2a2a47507b2b";
+      hash = "sha256-RezVUPsG8TP2UxUa65jRl4on8RfrPRWoZdqsSVDGZ1Q=";
+    };
+
+    nativeBuildInputs = [ cmake ninja ];
+    buildInputs = [
+      azure-macro-utils-c
+      curl
+      mbedtls_2
+      umock-c
+    ] ++ lib.optionals stdenv.hostPlatform.isStatic [
+      openssl
+    ];
+
+    cmakeFlags = [
+      "-Duse_default_uuid=ON"
+      "-Duse_installed_dependencies=ON"
+      "-Duse_mbedtls=ON"
+      "-Duse_openssl=OFF"
+    ];
+
+    env = {
+      # From `pkg-config --libs libcurl`.
+      NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isStatic "-lnghttp2 -lidn2 -lunistring -lssh2 -lpsl -lssl -lcrypto -lssl -lcrypto -ldl -lzstd -lz -lidn2 -lunistring";
+    };
+
+    postInstall = ''
+      mkdir $out/include/azureiot
+    '';
+
+  };
+
+  umock-c = stdenv.mkDerivation {
+    pname = "azure-sdk-for-cpp";
+    version = "unstable-2020-";
+
+    src = fetchFromGitHub {
+      owner = "Azure";
+      repo = "umock-c";
+      rev = "504193e65d1c2f6eb50c15357167600a296df7ff";
+      hash = "sha256-oeqsy63G98c4HWT6NtsYzC6/YxgdROvUe9RAdmElbCM=";
+    };
+
+    nativeBuildInputs = [ cmake ninja ];
+    buildInputs = [
+      azure-macro-utils-c
+    ];
+
+    cmakeFlags = [
+      "-Duse_installed_dependencies=ON"
+    ];
+
+  };
+
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "azure-sdk-for-cpp";
+  version = "1.13.0";
+
+  src = fetchFromGitHub {
+    owner = "Azure";
+    repo = "azure-sdk-for-cpp";
+    rev = "azure-core_1.13.0";
+    hash = "sha256-+drodBren44VLC84gYTjKaAJ2YU1CoUPr0FTVxdVIa4=";
+  };
+
+  #postPatch = ''
+  #  substituteInPlace sdk/core/azure-core-amqp/CMakeLists.txt \
+  #    --replace-fail "VENDOR_UAMQP ON" "VENDOR_UAMQP OFF"
+  #'';
+
+  nativeBuildInputs = [ cmake ninja ];
+
+  buildInputs = [
+    #abseil-cpp
+    azure-c-shared-utility
+    azure-macro-utils-c
+    curl
+    libxml2
+    umock-c
+  ];
+
+  env = {
+    AZURE_SDK_DISABLE_AUTO_VCPKG = 1;
+  };
+
+  cmakeFlags = [
+    "-DDISABLE_AZURE_CORE_OPENTELEMETRY=ON"
+    "-DWARNINGS_AS_ERRORS=OFF"
+  ];
+
+  meta = {
+    homepage = "https://azure.github.io/azure-sdk-for-cpp";
+    description = "Next generation multi-platform command line experience for Azure";
+    sourceProvenance = [ lib.sourceTypes.fromSource ];
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.tobim ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -60,9 +60,11 @@ in {
       aws-sdk-cpp-arrow = final.aws-sdk-cpp-tenzir;
     };
     arrow-cpp'' = arrow-cpp'.overrideAttrs (orig: {
+      nativeBuildInputs = orig.nativeBuildInputs ++ [
+        prev.buildPackages.pkg-config
+      ];
       buildInputs = orig.buildInputs ++ [
         final.azure-sdk-for-cpp
-        final.libxml2
       ];
       cmakeFlags = orig.cmakeFlags ++ [
         "-DARROW_AZURE=ON"

--- a/nix/tenzir/default.nix
+++ b/nix/tenzir/default.nix
@@ -17,6 +17,7 @@
     libpcap,
     arrow-cpp,
     aws-sdk-cpp-tenzir,
+    azure-sdk-for-cpp,
     fast_float,
     flatbuffers,
     fluent-bit,
@@ -57,6 +58,7 @@
     bundledPlugins =
       [
         "plugins/amqp"
+        "plugins/azure-blob-storage"
         "plugins/gcs"
         "plugins/fluent-bit"
         "plugins/kafka"
@@ -129,6 +131,8 @@
           cppzmq
           re2
           restinio
+        ] ++ lib.optionals isStatic [
+          azure-sdk-for-cpp
         ] ++ lib.optionals stdenv.isLinux [
           pfs
         ] ++ lib.optionals (!(stdenv.isDarwin && isStatic)) [

--- a/plugins/azure-blob-storage/CMakeLists.txt
+++ b/plugins/azure-blob-storage/CMakeLists.txt
@@ -7,9 +7,12 @@ project(
 
 find_package(Arrow QUIET REQUIRED CONFIG)
 if (NOT ARROW_AZURE OR NOT ${ARROW_CS} STREQUAL "ON")
-  message(WARNING "Disabling Azure Blob Storage plugin because the ARROW_AZURE flag is not found/enabled. You probably need to enable ARROW_AZURE when installing Apache Arrow.")
+  message(
+    WARNING
+      "Disabling Azure Blob Storage plugin because the ARROW_AZURE flag is not found/enabled. You probably need to enable ARROW_AZURE when installing Apache Arrow."
+  )
   return()
-endif()
+endif ()
 
 include(CTest)
 
@@ -21,3 +24,8 @@ TenzirRegisterPlugin(
   INCLUDE_DIRECTORIES include
   BUILTINS GLOB "${CMAKE_CURRENT_SOURCE_DIR}/builtins/*.cpp")
 
+if (TENZIR_ENABLE_STATIC_EXECUTABLE)
+  target_link_libraries(
+    azure-blob-storage PUBLIC Azure::azure-identity Azure::azure-storage-blobs
+                              Azure::azure-storage-files-datalake)
+endif ()

--- a/plugins/azure-blob-storage/include/saver.hpp
+++ b/plugins/azure-blob-storage/include/saver.hpp
@@ -75,7 +75,7 @@ public:
         = output_stream.ValueUnsafe()->Write(chunk->data(), chunk->size());
       if (not output_stream.ok()) {
         diagnostic::error("{}", status.ToString())
-          .note("failed to write to stream for URI `{}`", uri)
+          .note("failed to write to stream for URI `{}`", uri.inner)
           .emit(ctrl.diagnostics());
         return;
       }

--- a/plugins/azure-blob-storage/src/plugin.cpp
+++ b/plugins/azure-blob-storage/src/plugin.cpp
@@ -35,8 +35,9 @@ public:
     auto out = std::string{};
     auto opts = arrow::fs::AzureOptions::FromUri(uri.inner, &out);
     if (auto s = opts.status(); s != arrow::Status::OK()) {
-      throw diagnostic::error("Failed to parse URI {}", s.ToString())
-        .primary(uri);
+      diagnostic::error("Failed to parse URI {}", s.ToString())
+        .primary(uri)
+        .throw_();
     }
     return std::make_unique<abs_saver>(std::move(uri));
   }
@@ -51,8 +52,9 @@ public:
     auto out = std::string{};
     auto opts = arrow::fs::AzureOptions::FromUri(uri.inner, &out);
     if (auto s = opts.status(); s != arrow::Status::OK()) {
-      throw diagnostic::error("Failed to parse URI {}", s.ToString())
-        .primary(uri);
+      diagnostic::error("Failed to parse URI {}", s.ToString())
+        .primary(uri)
+        .throw_();
     }
     return std::make_unique<abs_loader>(std::move(uri));
   }


### PR DESCRIPTION
This adds support for the `azure-blob-storage` operator to all packages built on the static binary build.