### PR TITLE
Fix incorrect context updates count in lookup metrics

### DIFF
--- a/changelog/next/bug-fixes/4655--fix-lookup-metrics.md
+++ b/changelog/next/bug-fixes/4655--fix-lookup-metrics.md
@@ -1,0 +1,3 @@
+We fixed a bug that caused the `context_updates` field in `metrics lookup` to be
+reported once per field specified in the corresponding `lookup` operator instead
+of being reported once per operator in total.

--- a/libtenzir/include/tenzir/fwd.hpp
+++ b/libtenzir/include/tenzir/fwd.hpp
@@ -533,6 +533,7 @@ CAF_BEGIN_TYPE_ID_BLOCK(tenzir_types, first_tenzir_type_id)
     (std::unordered_map<std::string, std::optional<std::string>>))
   TENZIR_ADD_TYPE_ID((std::vector<tenzir::partition_synopsis_pair>))
   TENZIR_ADD_TYPE_ID((std::vector<std::filesystem::path>))
+  TENZIR_ADD_TYPE_ID((std::vector<tenzir::expression>))
 
 CAF_END_TYPE_ID_BLOCK(tenzir_types)
 

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "ab6ca9da1c0e21ec0ca2c0505e490af9d5340059",
+  "rev": "65c36b714f4db3f7913c55911050f7adf21c591b",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
This fixes incorrectly repeated `context_updates` reported in `metrics lookup` when using the `lookup` operator with multiple fields.

- Fixes https://github.com/tenzir/issues/issues/2208