### PR TITLE
Add anonymous parsing functions

### DIFF
--- a/libtenzir/include/tenzir/tql2/parser.hpp
+++ b/libtenzir/include/tenzir/tql2/parser.hpp
@@ -9,12 +9,26 @@
 #pragma once
 
 #include "tenzir/diagnostics.hpp"
+#include "tenzir/session.hpp"
 #include "tenzir/tql2/ast.hpp"
 #include "tenzir/tql2/tokens.hpp"
 
 namespace tenzir {
 
-auto parse(std::span<token> tokens, std::string_view source,
-           diagnostic_handler& diag) -> failure_or<ast::pipeline>;
+auto parse(std::span<token> tokens, std::string_view source, session ctx)
+  -> failure_or<ast::pipeline>;
+
+auto parse(std::string_view source, session ctx) -> failure_or<ast::pipeline>;
+
+// TODO: These functions are only a temporary solution.
+auto parse_pipeline_with_bad_diagnostics(std::string_view source, session ctx)
+  -> failure_or<ast::pipeline>;
+auto parse_expression_with_bad_diagnostics(std::string_view source, session ctx)
+  -> failure_or<ast::expression>;
+auto parse_assignment_with_bad_diagnostics(std::string_view source, session ctx)
+  -> failure_or<ast::assignment>;
+auto parse_multiple_assignments_with_bad_diagnostics(std::string_view source,
+                                                     session ctx)
+  -> failure_or<std::vector<ast::assignment>>;
 
 } // namespace tenzir

--- a/libtenzir/include/tenzir/tql2/resolve.hpp
+++ b/libtenzir/include/tenzir/tql2/resolve.hpp
@@ -15,4 +15,6 @@ namespace tenzir {
 
 auto resolve_entities(ast::pipeline& pipe, session ctx) -> failure_or<void>;
 
+auto resolve_entities(ast::expression& expr, session ctx) -> failure_or<void>;
+
 } // namespace tenzir

--- a/libtenzir/include/tenzir/tql2/tokens.hpp
+++ b/libtenzir/include/tenzir/tql2/tokens.hpp
@@ -10,6 +10,7 @@
 
 #include "tenzir/detail/enum.hpp"
 #include "tenzir/diagnostics.hpp"
+#include "tenzir/session.hpp"
 
 #include <string_view>
 
@@ -48,9 +49,15 @@ struct token {
   size_t end;
 };
 
-/// Try to tokenize the source.
+/// Try to tokenize the source. This is a combination of calling:
+/// - validate_utf8
+/// - tokenize_permissive
+/// - verify_tokens
 auto tokenize(std::string_view content,
               session ctx) -> failure_or<std::vector<token>>;
+
+/// Checks that the source is valid UTF-8.
+auto validate_utf8(std::string_view content, session ctx) -> failure_or<void>;
 
 /// Tokenize without emitting errors for error tokens.
 auto tokenize_permissive(std::string_view content) -> std::vector<token>;

--- a/libtenzir/src/tql2/exec.cpp
+++ b/libtenzir/src/tql2/exec.cpp
@@ -184,24 +184,11 @@ auto compile_resolved(ast::pipeline&& pipe, session ctx)
   return tenzir::pipeline{std::move(ops)};
 }
 
-auto validate_utf8(std::string_view content, session ctx) -> failure_or<void> {
-  // TODO: Refactor this.
-  arrow::util::InitializeUTF8();
-  if (arrow::util::ValidateUTF8(content)) {
-    return {};
-  }
-  // TODO: Consider reporting offset.
-  diagnostic::error("found invalid UTF8").emit(ctx);
-  return failure::promise();
-}
-
 } // namespace
 
 auto parse_and_compile(std::string_view source, session ctx)
   -> failure_or<pipeline> {
-  TRY(validate_utf8(source, ctx));
-  TRY(auto tokens, tokenize(source, ctx));
-  TRY(auto ast, parse(tokens, source, ctx));
+  TRY(auto ast, parse(source, ctx));
   return compile(std::move(ast), ctx);
 }
 

--- a/libtenzir/src/tql2/resolve.cpp
+++ b/libtenzir/src/tql2/resolve.cpp
@@ -153,4 +153,10 @@ auto resolve_entities(ast::pipeline& pipe, session ctx) -> failure_or<void> {
   return resolver.get_failure();
 }
 
+auto resolve_entities(ast::expression& expr, session ctx) -> failure_or<void> {
+  auto resolver = entity_resolver{ctx};
+  resolver.visit(expr);
+  return resolver.get_failure();
+}
+
 } // namespace tenzir


### PR DESCRIPTION
This temporary solution makes it possible to parse an AST from a string, but without location information (= without good diagnostics). This is necessary because the diagnostic infrastructure doesn't support multiple source fragments for the same pipeline, and also because we need to parse a list of assignments as part of an upcoming context type. We should revisit this in the future when we built the necessary stuff to deal with this in a better way.