### PR TITLE
Handle queries, fragments, etc. in the to_hive operator

### DIFF
--- a/libtenzir/CMakeLists.txt
+++ b/libtenzir/CMakeLists.txt
@@ -101,7 +101,7 @@ endif ()
 
 # -- boost --------------------------------------------------------------------
 
-find_package(Boost REQUIRED COMPONENTS headers filesystem)
+find_package(Boost REQUIRED COMPONENTS headers filesystem url)
 
 # -- re2 ----------------------------------------------------------------------
 
@@ -364,9 +364,9 @@ target_link_libraries(libtenzir PUBLIC ${ARROW_LIBRARY})
 dependency_summary("Apache Arrow" ${ARROW_LIBRARY} "Dependencies")
 
 # Link against Boost.
-target_link_libraries(libtenzir PUBLIC Boost::headers Boost::filesystem)
+target_link_libraries(libtenzir PUBLIC Boost::headers Boost::filesystem Boost::url)
 string(APPEND TENZIR_FIND_DEPENDENCY_LIST
-       "\nfind_package(Boost REQUIRED COMPONENTS headers filesystem)")
+       "\nfind_package(Boost REQUIRED COMPONENTS headers filesystem url)")
 dependency_summary("Boost" Boost::headers "Dependencies")
 
 # Link against re2.


### PR DESCRIPTION
This is a leftover from Friday's demo preparations, in particular we wanted to implement a way to use urls like `s3://bucket/key?root_url=https://s3.local/` in combination with partitioning.

Adding a `boost::url` dependency for this seems like overkill, however Arrow's `util::Uri` class is read-only and doesn't allow modifying url components, and the platform plugin already depends on `boost::url` so hopefully this won't make a difference in any of our CI environments in practice.

Example (of the success case):
```
$ ./bin/tenzir --tql2 'version | to_hive "http://user:pass@tenzir.example.org:32/foo/#asdf?foo=bar", partition_by=[major], format="json"'
error: failed to upload chunk to http://user:pass@tenzir.example.org:32/foo/major=4/0.json#asdf?foo=bar
 = note: !! unspecified: curl: Couldn't resolve host name

```