### PR TITLE
Add metrics for select component actors

### DIFF
--- a/changelog/next/features/4668--actor-metrics.md
+++ b/changelog/next/features/4668--actor-metrics.md
@@ -1,0 +1,2 @@
+We added low-level actor metrics that help admins track the system health over
+time.

--- a/libtenzir/include/tenzir/detail/actor_metrics.hpp
+++ b/libtenzir/include/tenzir/detail/actor_metrics.hpp
@@ -1,0 +1,26 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2024 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "tenzir/series_builder.hpp"
+
+namespace tenzir::detail {
+
+auto make_actor_metrics_builder() -> series_builder;
+
+template <class Actor>
+auto generate_actor_metrics(series_builder& builder, Actor self)
+  -> table_slice {
+  auto metric = builder.record();
+  metric.field("timestamp", time::clock::now());
+  metric.field("id", self->id());
+  metric.field("name", self->name());
+  metric.field("inbox_size", uint64_t{self->mailbox().size()});
+  return builder.finish_assert_one_slice();
+}
+
+} // namespace tenzir::detail

--- a/libtenzir/include/tenzir/importer.hpp
+++ b/libtenzir/include/tenzir/importer.hpp
@@ -57,6 +57,9 @@ struct importer_state {
 
   void on_process(const table_slice& slice);
 
+  /// Process a slice and forward it to the index.
+  void handle_slice(table_slice&& slice);
+
   /// The active id block.
   id_block current;
 

--- a/libtenzir/src/detail/actor_metrics.cpp
+++ b/libtenzir/src/detail/actor_metrics.cpp
@@ -1,0 +1,26 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2024 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "tenzir/series_builder.hpp"
+
+namespace tenzir::detail {
+
+auto make_actor_metrics_builder() -> series_builder {
+  return series_builder{type{
+    "tenzir.metrics.actor",
+    record_type{
+      {"timestamp", time_type{}},
+      {"id", string_type{}},
+      {"name", string_type{}},
+      {"inbox_size", uint64_type{}},
+    },
+    {{"internal"}},
+  }};
+}
+
+} // namespace tenzir::detail

--- a/web/docs/operators/metrics.md
+++ b/web/docs/operators/metrics.md
@@ -316,6 +316,17 @@ TCP connection.
 | `bytes_read`    | `uint64` | The number of bytes received since the last metrics.          |
 | `bytes_written` | `uint64` | The number of bytes written since the last metrics.           |
 
+### `tenzir.metrics.actors`
+
+Contains measurements about specific actors.
+
+| Field           | Type     | Description                                                            |
+| :-------------- | :------- | :--------------------------------------------------------------------- |
+| `timestamp`     | `time`   | The time at which this metric was recorded.                            |
+| `actor_id`      | `string` | The internal actor id.                                                 |
+| `actor_name`    | `string` | The name of the actor.                                                 |
+| `num_messages`  | `uint64` | The number of messages in the actor's inbox when the metric was taken. |
+
 ## Examples
 
 Show the CPU usage over the last hour:
@@ -570,6 +581,40 @@ metrics tcp
   "writes": 0,
   "bytes_read": 5148,
   "bytes_written": 0
+}
+```
+
+</details>
+
+Get actor internals:
+
+```c
+metrics actor
+| where timestamp > 1 hour ago
+| sort timestamp
+```
+
+<details>
+<summary>Output</summary>
+
+```json
+{
+  "timestamp": "2024-10-15T12:44:33.234964",
+  "id": "13",
+  "name": "importer",
+  "inbox_size": 1
+}
+{
+  "timestamp": "2024-10-15T12:44:33.234980",
+  "id": "8",
+  "name": "node",
+  "inbox_size": 0
+}
+{
+  "timestamp": "2024-10-15T12:44:33.783078",
+  "id": "12",
+  "name": "index",
+  "inbox_size": 0
 }
 ```
 


### PR DESCRIPTION
The actor metric is a low-level tool to measure the state of an actor over time. It is mostly targeted at component actors and the only measurement right now is the number of messages in the inbox.