### PR TITLE
Clean up old venvs in the python operator

### DIFF
--- a/changelog/next/bug-fixes/4669--cleanup-python-venvs.md
+++ b/changelog/next/bug-fixes/4669--cleanup-python-venvs.md
@@ -1,0 +1,2 @@
+The node now cleans up old virtual environments created by the `python`
+operator when it restarts.

--- a/changelog/next/bug-fixes/4669--cleanup-python-venvs.md
+++ b/changelog/next/bug-fixes/4669--cleanup-python-venvs.md
@@ -1,2 +1,1 @@
-The node now cleans up old virtual environments created by the `python`
-operator when it restarts.
+The node now wipes its cache directory whenever it restarts.

--- a/libtenzir/builtins/operators/python.cpp
+++ b/libtenzir/builtins/operators/python.cpp
@@ -218,7 +218,8 @@ public:
       auto venv_cleanup = [&] {
         if (config_.create_venvs) {
           TENZIR_ASSERT(venv_base_dir);
-          std::filesystem::create_directories(*venv_base_dir);
+          auto ec = std::error_code{};
+          std::filesystem::create_directories(*venv_base_dir, ec);
           auto venv = fmt::format("{}/uvenv-XXXXXX", venv_base_dir->string());
           if (mkdtemp(venv.data()) == nullptr) {
             diagnostic::error("{}", detail::describe_errno())

--- a/libtenzir/builtins/operators/python.cpp
+++ b/libtenzir/builtins/operators/python.cpp
@@ -468,41 +468,21 @@ public:
 
   auto initialize(const record& plugin_config, const record& global_config)
     -> caf::error override {
-    auto is_node = try_get_or<bool>(global_config, "tenzir.is-node", false);
-    if (!is_node) {
-      return is_node.error();
-    }
     auto create_virtualenv
       = try_get_or<bool>(plugin_config, "create-venvs", true);
     if (!create_virtualenv) {
       return create_virtualenv.error();
     }
-    auto venvs_subdir = is_node ? "venvs" : "client-venvs";
     if (!(*create_virtualenv)) {
       config.venv_base_dir = std::nullopt;
     } else if (const auto* cache_dir = get_if<std::string>(
                  &global_config, "tenzir.cache-directory")) {
       config.venv_base_dir
-        = (std::filesystem::path{*cache_dir} / "python" / venvs_subdir).string();
+        = (std::filesystem::path{*cache_dir} / "python" / "venvs").string();
     } else {
       config.venv_base_dir = (std::filesystem::temp_directory_path() / "tenzir"
-                              / "python" / venvs_subdir)
+                              / "python" / "venvs")
                                .string();
-    }
-    // Cleanup leftover state from older unclean node shutdowns. We know that
-    // `initialize()` is only called once during node startup, so we can remove
-    // the whole directory here without interfering with running pipelines.
-    if (config.venv_base_dir) {
-      auto& dir = *config.venv_base_dir;
-      auto ec = std::error_code{};
-      if (is_node && std::filesystem::exists(dir, ec)) {
-        TENZIR_VERBOSE("python operator removes old state in {}", dir);
-        std::filesystem::remove_all(dir, ec);
-        if (ec) {
-          TENZIR_WARN("python operator failed to clean up old state in {}",
-                      dir);
-        }
-      }
     }
     auto implicit_requirements_default = std::string{
       detail::install_datadir() / "python"

--- a/libtenzir/builtins/operators/python.cpp
+++ b/libtenzir/builtins/operators/python.cpp
@@ -34,7 +34,9 @@
 #include <boost/asio.hpp>
 #include <boost/interprocess/sync/named_semaphore.hpp>
 #include <boost/process.hpp>
+#include <caf/actor_system_config.hpp>
 #include <caf/detail/scope_guard.hpp>
+#include <caf/settings.hpp>
 
 #include <filesystem>
 
@@ -92,7 +94,10 @@ private:
   int64_t pos_ = 0;
 };
 
-auto PYTHON_SCAFFOLD = R"_(
+constexpr auto DEFAULT_IMPLICIT_REQUIREMENTS_TOKEN
+  = std::string_view{"__default_requirements__"};
+
+constexpr auto PYTHON_SCAFFOLD = R"_(
 from tenzir.tools.python_operator_executor import main
 
 main()
@@ -102,8 +107,9 @@ struct config {
   // Implicit arguments passed to every invocation of `pip install`.
   std::string implicit_requirements = {};
 
-  // Base path for virtual environments.
-  std::optional<std::string> venv_base_dir = {};
+  // Whether to create a virtualenv environment for the python
+  // operator.
+  bool create_venvs = true;
 
   template <class Inspector>
   friend auto inspect(Inspector& f, config& x) -> bool {
@@ -112,7 +118,7 @@ struct config {
       = f.object(x)
           .pretty_name("tenzir.plugins.python.config")
           .fields(f.field("implicit-requirements", x.implicit_requirements),
-                  f.field("venv-base-dir", x.venv_base_dir));
+                  f.field("create-venvs", x.create_venvs));
     return result;
   }
 };
@@ -147,6 +153,30 @@ public:
   auto execute(generator<table_slice> input, operator_control_plane& ctrl) const
     -> generator<table_slice> {
     try {
+      // Compute some config values delayed at runtime, because
+      // `detail::install_datadir` and the venv base dir may be different
+      // between the client and node process.
+      auto implicit_requirements = std::string{};
+      if (config_.implicit_requirements
+          == DEFAULT_IMPLICIT_REQUIREMENTS_TOKEN) {
+        implicit_requirements = std::string{
+          detail::install_datadir() / "python"
+          / fmt::format("tenzir-{}.{}.{}-py3-none-any.whl[operator]",
+                        version::major, version::minor, version::patch)};
+      } else {
+        implicit_requirements = config_.implicit_requirements;
+      }
+      auto venv_base_dir = std::optional<std::filesystem::path>{};
+      if (!config_.create_venvs) {
+        venv_base_dir = std::nullopt;
+      } else if (const auto* cache_dir
+                 = get_if<std::string>(&ctrl.self().home_system().config(),
+                                       "tenzir.cache-directory")) {
+        venv_base_dir = std::filesystem::path{*cache_dir} / "python" / "venvs";
+      } else {
+        venv_base_dir = std::filesystem::temp_directory_path() / "tenzir"
+                        / "python" / "venvs";
+      }
       // Creating a pipeline through the API waits until a pipeline has started
       // up succesfully, which requires all individual execution nodes to have
       // started up immediately. This happens once the operator yielded for the
@@ -190,24 +220,22 @@ public:
       // unless disabled by node config.
       auto maybe_venv = std::optional<std::filesystem::path>{};
       auto venv_cleanup = [&] {
-        if (config_.venv_base_dir) {
-          std::filesystem::create_directories(config_.venv_base_dir.value());
-          auto venv
-            = fmt::format("{}/uvenv-XXXXXX", config_.venv_base_dir.value());
+        if (config_.create_venvs) {
+          TENZIR_ASSERT(venv_base_dir);
+          std::filesystem::create_directories(*venv_base_dir);
+          auto venv = fmt::format("{}/uvenv-XXXXXX", venv_base_dir->string());
           if (mkdtemp(venv.data()) == nullptr) {
             diagnostic::error("{}", detail::describe_errno())
               .note("failed to create a unique directory for the python "
                     "virtual environment in {}",
-                    config_.venv_base_dir.value())
+                    *venv_base_dir)
               .throw_();
           }
           auto venv_path = std::filesystem::path{venv};
           maybe_venv = venv_path;
           env["VIRTUAL_ENV"] = venv;
           env["UV_CACHE_DIR"]
-            = (std::filesystem::path{config_.venv_base_dir.value()}.parent_path()
-               / "cache" / "uv")
-                .string();
+            = (venv_base_dir->parent_path() / "cache" / "uv").string();
         }
         return caf::detail::scope_guard([maybe_venv] {
           if (maybe_venv) {
@@ -268,9 +296,9 @@ public:
         };
         // `split` creates an empty token in case the input was entirely
         // empty, but we don't want that so we need an extra guard.
-        if (!config_.implicit_requirements.empty()) {
+        if (!implicit_requirements.empty()) {
           auto implicit_requirements_vec
-            = detail::split_escaped(config_.implicit_requirements, " ", "\\");
+            = detail::split_escaped(implicit_requirements, " ", "\\");
           pip_invocation.insert(pip_invocation.end(),
                                 implicit_requirements_vec.begin(),
                                 implicit_requirements_vec.end());
@@ -466,30 +494,17 @@ class plugin final : public virtual operator_plugin<python_operator>,
 public:
   struct config config = {};
 
-  auto initialize(const record& plugin_config, const record& global_config)
-    -> caf::error override {
+  auto initialize(const record& plugin_config,
+                  const record& /*global_config*/) -> caf::error override {
     auto create_virtualenv
       = try_get_or<bool>(plugin_config, "create-venvs", true);
     if (!create_virtualenv) {
       return create_virtualenv.error();
     }
-    if (!(*create_virtualenv)) {
-      config.venv_base_dir = std::nullopt;
-    } else if (const auto* cache_dir = get_if<std::string>(
-                 &global_config, "tenzir.cache-directory")) {
-      config.venv_base_dir
-        = (std::filesystem::path{*cache_dir} / "python" / "venvs").string();
-    } else {
-      config.venv_base_dir = (std::filesystem::temp_directory_path() / "tenzir"
-                              / "python" / "venvs")
-                               .string();
-    }
-    auto implicit_requirements_default = std::string{
-      detail::install_datadir() / "python"
-      / fmt::format("tenzir-{}.{}.{}-py3-none-any.whl[operator]",
-                    version::major, version::minor, version::patch)};
-    config.implicit_requirements = get_or(
-      plugin_config, "implicit-requirements", implicit_requirements_default);
+    config.create_venvs = *create_virtualenv;
+    config.implicit_requirements
+      = get_or(plugin_config, "implicit-requirements",
+               DEFAULT_IMPLICIT_REQUIREMENTS_TOKEN);
     return {};
   }
 

--- a/libtenzir/src/configuration.cpp
+++ b/libtenzir/src/configuration.cpp
@@ -520,7 +520,14 @@ auto configuration::parse(int argc, char** argv) -> caf::error {
         return caf::make_error(ec::filesystem_error,
                                "failed to determine temp_directory_path");
       }
-      value = tmp / "tenzir" / "cache" / fmt::format("{:}", getuid());
+      auto path = tmp / "tenzir" / "cache" / fmt::format("{:}", getuid());
+      std::filesystem::create_directories(path, ec);
+      if (ec) {
+        return caf::make_error(
+          ec::filesystem_error,
+          fmt::format("failed to create cache directory {}: {}", path, ec));
+      }
+      value = path.string();
     }
   }
   // From here on, we go into CAF land with the goal to put the configuration

--- a/libtenzir/src/spawn_node.cpp
+++ b/libtenzir/src/spawn_node.cpp
@@ -65,7 +65,6 @@ caf::expected<scope_linked<node_actor>> spawn_node(caf::scoped_actor& self) {
   // Remove old VERSION file if it exists. This can be removed once the minimum
   // partition version is >= 3.
   {
-    auto err = std::error_code{};
     std::filesystem::remove(abs_dir / "VERSION", err);
     if (err)
       TENZIR_WARN("failed to remove outdated VERSION file: {}", err.message());
@@ -74,6 +73,16 @@ caf::expected<scope_linked<node_actor>> spawn_node(caf::scoped_actor& self) {
   auto signal_reflector
     = self->system().registry().get<signal_reflector_actor>("signal-reflector");
   self->send(signal_reflector, atom::subscribe_v);
+  // Wipe the old cache directory.
+  {
+    auto cache_directory = get_if<std::string>(&opts, "tenzir.cache-directory");
+    if (cache_directory && std::filesystem::exists(*cache_directory)) {
+      std::filesystem::remove_all(*cache_directory, err);
+      if (err) {
+        TENZIR_WARN("failed to remove cache at {}: {}", *cache_directory, err);
+      }
+    }
+  }
   // Spawn the node.
   TENZIR_DEBUG("{} spawns local node: {}", __func__, id);
   // Pointer to the root command to node.

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -25,16 +25,7 @@ tenzir:
   #   - $PWD/tenzir.db
   #state-directory:
 
-  # The file system path used for persistent state.
-  # Defaults to one of the following paths, selecting the first that is
-  # available:
-  #   - $CACHE_DIRECTORY
-  #   - $XDG_CACHE_HOME/tenzir
-  #   - $HOME/.cache/tenzir (Linux)
-  #   - $HOME/Library/Caches/tenzir (macOS)
-  #cache-directory:
-
-  # The file system path used for persistent state.
+  # The file system path used for recoverable state.
   # In a node process, defaults to the first of the following paths that is
   # available:
   #   - $CACHE_DIRECTORY

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -35,7 +35,7 @@ tenzir:
   #   - $TEMPORARY_DIRECTORY/tenzir/cache/<uid>
   # To determine $TEMPORARY_DIRECTORY, the values of TMPDIR, TMP, TEMP, TEMPDIR are
   # checked in that order, and as a last resort "/tmp" is used.
-  # In a client process, this setting is ignored and `$TEMPORARY_DIRECTORY/tenzir/cache/<uid>`
+  # In a client process, this setting is ignored and `$TEMPORARY_DIRECTORY/tenzir/client-cache/<uid>`
   # is used as cache directory.
   #cache-directory:
 

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -35,15 +35,17 @@ tenzir:
   #cache-directory:
 
   # The file system path used for persistent state.
-  # Defaults to one of the following paths, selecting the first that is
+  # In a node process, defaults to the first of the following paths that is
   # available:
   #   - $CACHE_DIRECTORY
   #   - $XDG_CACHE_HOME
   #   - $XDG_HOME_DIR/.cache/tenzir (linux) or $XDG_HOME_DIR/Libraries/caches/tenzir (mac)
   #   - $HOME/.cache/tenzir (linux) or $HOME/Libraries/caches/tenzir (mac)
-  #   - $TEMPORARY_DIRECTORY/tenzir/cache
+  #   - $TEMPORARY_DIRECTORY/tenzir/cache/<uid>
   # To determine $TEMPORARY_DIRECTORY, the values of TMPDIR, TMP, TEMP, TEMPDIR are
   # checked in that order, and as a last resort "/tmp" is used.
+  # In a client process, this setting is ignored and `$TEMPORARY_DIRECTORY/tenzir/cache/<uid>`
+  # is used as cache directory.
   #cache-directory:
 
   # The file system path used for log files.

--- a/tenzir/tenzir.cpp
+++ b/tenzir/tenzir.cpp
@@ -93,6 +93,7 @@ auto main(int argc, char** argv) -> int {
                           ? app_path
                           : app_path.substr(last_slash + 1);
   bool is_server = (app_name == "tenzir-node");
+  cfg.content["tenzir.is-node"] = is_server;
   // Create log context as soon as we know the correct configuration.
   auto log_context = create_log_context(is_server, *invocation, cfg.content);
   if (!log_context) {


### PR DESCRIPTION
When the node crashes or the the python operator encounters some other bugs, it can happen that the created virtualenv for that instance of the operator gets left behind on disk. Over time, this can accumulate, leading to a large amount of wasted disk space.

To counteract this, we remove all old virtualenvs from previous runs of a tenzir node on the same host whenever we start the node.

This does not solve the problem for virtualenvs created by tenzir client processes, however the intuition is that there the problem is much less severe, because these are created mostly manually and at a much lower frequency.
