### PR TITLE
Add the `aggregation` context type

### DIFF
--- a/libtenzir/builtins/aggregation-functions/all.cpp
+++ b/libtenzir/builtins/aggregation-functions/all.cpp
@@ -85,7 +85,7 @@ public:
     caf::visit(f, *arg.array);
   }
 
-  auto finish() -> data override {
+  auto get() const -> data override {
     switch (state_) {
       case state::none:
         return all_;

--- a/libtenzir/builtins/aggregation-functions/any.cpp
+++ b/libtenzir/builtins/aggregation-functions/any.cpp
@@ -85,7 +85,7 @@ public:
     caf::visit(f, *arg.array);
   }
 
-  auto finish() -> data override {
+  auto get() const -> data override {
     switch (state_) {
       case state::none:
         return any_;

--- a/libtenzir/builtins/aggregation-functions/collect.cpp
+++ b/libtenzir/builtins/aggregation-functions/collect.cpp
@@ -74,7 +74,7 @@ public:
     }
   }
 
-  auto finish() -> data override {
+  auto get() const -> data override {
     return result_;
   }
 

--- a/libtenzir/builtins/aggregation-functions/count_distinct.cpp
+++ b/libtenzir/builtins/aggregation-functions/count_distinct.cpp
@@ -23,13 +23,13 @@ template <concrete_type Type>
 struct heterogeneous_data_hash {
   using is_transparent = void;
 
-  [[nodiscard]] auto
-  operator()(view<type_to_data_t<Type>> value) const -> size_t {
+  [[nodiscard]] auto operator()(view<type_to_data_t<Type>> value) const
+    -> size_t {
     return hash(value);
   }
 
-  [[nodiscard]] auto
-  operator()(const type_to_data_t<Type>& value) const -> size_t
+  [[nodiscard]] auto operator()(const type_to_data_t<Type>& value) const
+    -> size_t
     requires(!std::is_same_v<view<type_to_data_t<Type>>, type_to_data_t<Type>>)
   {
     return hash(make_view(value));
@@ -105,7 +105,7 @@ public:
     }
   }
 
-  auto finish() -> data override {
+  auto get() const -> data override {
     return data{uint64_t{distinct_.size()}};
   }
 

--- a/libtenzir/builtins/aggregation-functions/distinct.cpp
+++ b/libtenzir/builtins/aggregation-functions/distinct.cpp
@@ -23,8 +23,8 @@ template <concrete_type Type>
 struct heterogeneous_data_hash {
   using is_transparent = void;
 
-  [[nodiscard]] auto
-  operator()(view<type_to_data_t<Type>> value) const -> size_t {
+  [[nodiscard]] auto operator()(view<type_to_data_t<Type>> value) const
+    -> size_t {
     return hash(value);
   }
 
@@ -112,7 +112,7 @@ public:
     }
   }
 
-  auto finish() -> data override {
+  auto get() const -> data override {
     return list{distinct_.begin(), distinct_.end()};
   }
 

--- a/libtenzir/builtins/aggregation-functions/max.cpp
+++ b/libtenzir/builtins/aggregation-functions/max.cpp
@@ -132,7 +132,7 @@ public:
     caf::visit(f, *arg.array);
   }
 
-  auto finish() -> data override {
+  auto get() const -> data override {
     if (max_) {
       return max_->match([](auto max) {
         return data{max};

--- a/libtenzir/builtins/aggregation-functions/mean.cpp
+++ b/libtenzir/builtins/aggregation-functions/mean.cpp
@@ -130,7 +130,7 @@ public:
     caf::visit(f, *arg.array);
   }
 
-  auto finish() -> data override {
+  auto get() const -> data override {
     switch (state_) {
       case state::none:
       case state::failed:

--- a/libtenzir/builtins/aggregation-functions/min.cpp
+++ b/libtenzir/builtins/aggregation-functions/min.cpp
@@ -128,7 +128,7 @@ public:
     caf::visit(f, *arg.array);
   }
 
-  auto finish() -> data override {
+  auto get() const -> data override {
     if (min_) {
       return min_->match([](auto min) {
         return data{min};

--- a/libtenzir/builtins/aggregation-functions/sample.cpp
+++ b/libtenzir/builtins/aggregation-functions/sample.cpp
@@ -75,7 +75,7 @@ public:
     }
   }
 
-  auto finish() -> data override {
+  auto get() const -> data override {
     return sample_;
   }
 

--- a/libtenzir/builtins/aggregation-functions/stddev_variance.cpp
+++ b/libtenzir/builtins/aggregation-functions/stddev_variance.cpp
@@ -160,7 +160,7 @@ public:
     caf::visit(f, *arg.array);
   }
 
-  auto finish() -> data override {
+  auto get() const -> data override {
     if (count_ == 0) {
       return data{};
     }

--- a/libtenzir/builtins/aggregation-functions/sum.cpp
+++ b/libtenzir/builtins/aggregation-functions/sum.cpp
@@ -159,7 +159,7 @@ public:
     caf::visit(f, *s.array);
   }
 
-  auto finish() -> data override {
+  auto get() const -> data override {
     if (sum_) {
       return sum_->match([](auto sum) {
         return data{sum};

--- a/libtenzir/builtins/contexts/bloom_filter.cpp
+++ b/libtenzir/builtins/contexts/bloom_filter.cpp
@@ -172,10 +172,6 @@ public:
     };
   }
 
-  auto make_query() -> make_query_type override {
-    return {};
-  }
-
   auto reset() -> caf::expected<void> override {
     auto params = bloom_filter_.parameters();
     TENZIR_ASSERT(params.n && params.p);

--- a/libtenzir/builtins/contexts/bloom_filter.cpp
+++ b/libtenzir/builtins/contexts/bloom_filter.cpp
@@ -173,7 +173,8 @@ public:
     };
   }
 
-  auto reset() -> caf::expected<void> override {
+  auto reset(session ctx) -> failure_or<void> override {
+    TENZIR_UNUSED(ctx);
     auto params = bloom_filter_.parameters();
     TENZIR_ASSERT(params.n && params.p);
     bloom_filter_ = dcso_bloom_filter{*params.n, *params.p};

--- a/libtenzir/builtins/contexts/bloom_filter.cpp
+++ b/libtenzir/builtins/contexts/bloom_filter.cpp
@@ -21,6 +21,7 @@
 #include <tenzir/plugin.hpp>
 #include <tenzir/series.hpp>
 #include <tenzir/series_builder.hpp>
+#include <tenzir/session.hpp>
 #include <tenzir/table_slice.hpp>
 #include <tenzir/table_slice_builder.hpp>
 #include <tenzir/type.hpp>
@@ -54,15 +55,15 @@ public:
   }
 
   /// Emits context information for every event in `slice` in order.
-  auto apply(series array, bool replace)
-    -> caf::expected<std::vector<series>> override {
-    (void)replace;
+  auto apply(series array, bool replace, session ctx)
+    -> failure_or<std::vector<series>> override {
+    TENZIR_UNUSED(ctx);
     auto builder = series_builder{};
     for (const auto& value : array.values()) {
       if (bloom_filter_.lookup(value)) {
         builder.data(true);
       } else {
-        builder.null();
+        replace ? builder.data(value) : builder.null();
       }
     }
     return builder.finish();

--- a/libtenzir/builtins/contexts/geoip.cpp
+++ b/libtenzir/builtins/contexts/geoip.cpp
@@ -493,10 +493,6 @@ public:
                            "geoip context can not be updated with events");
   }
 
-  auto make_query() -> make_query_type override {
-    return {};
-  }
-
   auto reset() -> caf::expected<void> override {
     return {};
   }

--- a/libtenzir/builtins/contexts/geoip.cpp
+++ b/libtenzir/builtins/contexts/geoip.cpp
@@ -493,7 +493,8 @@ public:
                            "geoip context can not be updated with events");
   }
 
-  auto reset() -> caf::expected<void> override {
+  auto reset(session ctx) -> failure_or<void> override {
+    TENZIR_UNUSED(ctx);
     return {};
   }
 

--- a/libtenzir/builtins/contexts/lookup_table.cpp
+++ b/libtenzir/builtins/contexts/lookup_table.cpp
@@ -23,6 +23,7 @@
 #include <tenzir/plugin.hpp>
 #include <tenzir/series.hpp>
 #include <tenzir/series_builder.hpp>
+#include <tenzir/session.hpp>
 #include <tenzir/table_slice.hpp>
 #include <tenzir/table_slice_builder.hpp>
 #include <tenzir/type.hpp>
@@ -266,8 +267,9 @@ public:
     return caf::visit(match, value);
   };
 
-  auto apply(series array, bool replace)
-    -> caf::expected<std::vector<series>> override {
+  auto apply(series array, bool replace, session ctx)
+    -> failure_or<std::vector<series>> override {
+    TENZIR_UNUSED(ctx);
     auto builder = series_builder{};
     const auto now = time::clock::now();
     for (auto value : array.values()) {

--- a/libtenzir/builtins/contexts/lookup_table.cpp
+++ b/libtenzir/builtins/contexts/lookup_table.cpp
@@ -106,7 +106,8 @@ public:
       data_(from_data(std::move(d))) {
   }
 
-  friend auto operator==(const key_data& a, const key_data& b) -> bool {
+  [[maybe_unused]] friend auto operator==(const key_data& a, const key_data& b)
+    -> bool {
     return a.data_ == b.data_;
   }
 
@@ -511,7 +512,8 @@ public:
     };
   }
 
-  auto reset() -> caf::expected<void> override {
+  auto reset(session ctx) -> failure_or<void> override {
+    TENZIR_UNUSED(ctx);
     context_entries.clear();
     subnet_entries.clear();
     return {};

--- a/libtenzir/builtins/formats/pcap.cpp
+++ b/libtenzir/builtins/formats/pcap.cpp
@@ -507,8 +507,8 @@ public:
             }
           }
         } else {
-          diagnostic::warning("received unprocessable schema")
-            .note("cannot handle", slice.schema().name())
+          diagnostic::error("event cannot be rendered as PCAP")
+            .note("got `{}`", slice.schema().name())
             .emit(ctrl.diagnostics());
           co_yield {};
           co_return;

--- a/libtenzir/builtins/functions/numeric.cpp
+++ b/libtenzir/builtins/functions/numeric.cpp
@@ -137,8 +137,8 @@ public:
     return "tql2.round";
   }
 
-  auto make_function(invocation inv,
-                     session ctx) const -> failure_or<function_ptr> override {
+  auto make_function(invocation inv, session ctx) const
+    -> failure_or<function_ptr> override {
     auto value = ast::expression{};
     auto spec = std::optional<located<duration>>{};
     TRY(argument_parser2::function("round")
@@ -161,8 +161,8 @@ public:
     return "tql2.sqrt";
   }
 
-  auto make_function(invocation inv,
-                     session ctx) const -> failure_or<function_ptr> override {
+  auto make_function(invocation inv, session ctx) const
+    -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
     TRY(
       argument_parser2::function("sqrt").add(expr, "<number>").parse(inv, ctx));
@@ -230,8 +230,8 @@ public:
     return "tql2.random";
   }
 
-  auto make_function(invocation inv,
-                     session ctx) const -> failure_or<function_ptr> override {
+  auto make_function(invocation inv, session ctx) const
+    -> failure_or<function_ptr> override {
     argument_parser2::function("random").parse(inv, ctx).ignore();
     return function_use::make([](evaluator eval, session ctx) -> series {
       TENZIR_UNUSED(ctx);
@@ -262,7 +262,7 @@ public:
     count_ += arg.array->length() - arg.array->null_count();
   }
 
-  auto finish() -> data override {
+  auto get() const -> data override {
     return count_;
   }
 
@@ -349,7 +349,7 @@ public:
     caf::visit(f, arg.type);
   }
 
-  auto finish() -> data override {
+  auto get() const -> data override {
     switch (state_) {
       case state::none:
       case state::failed:

--- a/libtenzir/builtins/operators/summarize.cpp
+++ b/libtenzir/builtins/operators/summarize.cpp
@@ -110,8 +110,9 @@ struct group_by_key_view : std::vector<data_view> {
   friend group_by_key materialize(const group_by_key_view& views) {
     auto result = group_by_key{};
     result.reserve(views.size());
-    for (const auto& view : views)
+    for (const auto& view : views) {
       result.push_back(materialize(view));
+    }
     return result;
   }
 };
@@ -121,15 +122,17 @@ struct group_by_key_view : std::vector<data_view> {
 struct group_by_key_hash {
   size_t operator()(const group_by_key& x) const noexcept {
     auto hasher = xxh64{};
-    for (const auto& value : x)
+    for (const auto& value : x) {
       hash_append(hasher, make_view(value));
+    }
     return hasher.finish();
   }
 
   size_t operator()(const group_by_key_view& x) const noexcept {
     auto hasher = xxh64{};
-    for (const auto& value : x)
+    for (const auto& value : x) {
       hash_append(hasher, value);
+    }
     return hasher.finish();
   }
 };
@@ -479,8 +482,9 @@ public:
     for (auto row = int64_t{1}; row < detail::narrow<int64_t>(slice.rows());
          ++row) {
       auto* bucket = find_or_create_bucket(row);
-      if (bucket == first_bucket)
+      if (bucket == first_bucket) {
         continue;
+      }
       update_bucket(*first_bucket, first_row, row - first_row);
       first_row = row;
       first_bucket = bucket;
@@ -1030,7 +1034,7 @@ public:
       for (auto index : cfg_.indices) {
         if (index >= 0) {
           auto& dest = cfg_.aggregates[index].dest;
-          auto value = group->aggregations[index]->finish();
+          auto value = group->aggregations[index]->get();
           if (dest) {
             emplace(result, *dest, value);
           } else {

--- a/libtenzir/include/tenzir/plugin.hpp
+++ b/libtenzir/include/tenzir/plugin.hpp
@@ -697,8 +697,8 @@ public:
   /// @param array The values to look up in the context.
   /// @param replace If true, return the input values for missing fields rather
   /// than nulls.
-  virtual auto apply(series array, bool replace)
-    -> caf::expected<std::vector<series>>
+  virtual auto apply(series array, bool replace, session ctx)
+    -> failure_or<std::vector<series>>
     = 0;
 
   /// Inspects the context.

--- a/libtenzir/include/tenzir/plugin.hpp
+++ b/libtenzir/include/tenzir/plugin.hpp
@@ -122,8 +122,8 @@ public:
   /// @param global_config The entire Tenzir configuration for potential access
   /// to global options.
   [[nodiscard]] virtual auto
-  initialize(const record& plugin_config,
-             const record& global_config) -> caf::error {
+  initialize(const record& plugin_config, const record& global_config)
+    -> caf::error {
     (void)plugin_config;
     (void)global_config;
     return {};
@@ -186,8 +186,9 @@ template <class Base>
 class serialization_plugin : public virtual plugin {
 public:
   /// @pre `x.name() == name()`
-  [[nodiscard]] virtual auto
-  serialize(serializer f, const Base& x) const -> bool = 0;
+  [[nodiscard]] virtual auto serialize(serializer f, const Base& x) const
+    -> bool
+    = 0;
 
   /// @post `!x || x->name() == name()`
   virtual void deserialize(deserializer f, std::unique_ptr<Base>& x) const = 0;
@@ -339,7 +340,8 @@ public:
   virtual auto name() const -> std::string = 0;
 
   virtual auto instantiate(operator_control_plane& ctrl) const
-    -> std::optional<generator<chunk_ptr>> = 0;
+    -> std::optional<generator<chunk_ptr>>
+    = 0;
 
   virtual auto default_parser() const -> std::string {
     return "json";
@@ -353,8 +355,9 @@ public:
 /// @see operator_parser_plugin
 class loader_parser_plugin : public virtual plugin {
 public:
-  virtual auto
-  parse_loader(parser_interface& p) const -> std::unique_ptr<plugin_loader> = 0;
+  virtual auto parse_loader(parser_interface& p) const
+    -> std::unique_ptr<plugin_loader>
+    = 0;
 
   virtual auto supported_uri_schemes() const -> std::vector<std::string>;
 };
@@ -379,7 +382,8 @@ public:
 
   virtual auto
   instantiate(generator<chunk_ptr> input, operator_control_plane& ctrl) const
-    -> std::optional<generator<table_slice>> = 0;
+    -> std::optional<generator<table_slice>>
+    = 0;
 
   /// Apply the parser to an array of strings.
   ///
@@ -387,9 +391,9 @@ public:
   /// for every single string.
   ///
   /// @post `input->length() == result_array->length()`
-  virtual auto
-  parse_strings(std::shared_ptr<arrow::StringArray> input,
-                operator_control_plane& ctrl) const -> std::vector<series>;
+  virtual auto parse_strings(std::shared_ptr<arrow::StringArray> input,
+                             operator_control_plane& ctrl) const
+    -> std::vector<series>;
 
   /// Implement ordering optimization for parsers. See
   /// `operator_base::optimize(...)` for details. The default implementation
@@ -403,8 +407,9 @@ public:
 /// @see operator_parser_plugin
 class parser_parser_plugin : public virtual plugin {
 public:
-  virtual auto
-  parse_parser(parser_interface& p) const -> std::unique_ptr<plugin_parser> = 0;
+  virtual auto parse_parser(parser_interface& p) const
+    -> std::unique_ptr<plugin_parser>
+    = 0;
 };
 
 using parser_serialization_plugin = serialization_plugin<plugin_parser>;
@@ -458,7 +463,8 @@ public:
   /// should expect a heterogeneous input instead.
   virtual auto
   instantiate(type input_schema, operator_control_plane& ctrl) const
-    -> caf::expected<std::unique_ptr<printer_instance>> = 0;
+    -> caf::expected<std::unique_ptr<printer_instance>>
+    = 0;
 
   /// Returns whether the printer allows for joining output streams into a
   /// single saver.
@@ -472,9 +478,9 @@ public:
 /// @see operator_parser_plugin
 class printer_parser_plugin : public virtual plugin {
 public:
-  virtual auto
-  parse_printer(parser_interface& p) const -> std::unique_ptr<plugin_printer>
-                                              = 0;
+  virtual auto parse_printer(parser_interface& p) const
+    -> std::unique_ptr<plugin_printer>
+    = 0;
 };
 
 using printer_serialization_plugin = serialization_plugin<plugin_printer>;
@@ -502,7 +508,8 @@ public:
 
   virtual auto
   instantiate(operator_control_plane& ctrl, std::optional<printer_info> info)
-    -> caf::expected<std::function<void(chunk_ptr)>> = 0;
+    -> caf::expected<std::function<void(chunk_ptr)>>
+    = 0;
 
   /// Returns true if the saver joins the output from its preceding printer. If
   /// so, `instantiate()` will only be called once.
@@ -520,8 +527,9 @@ public:
 /// @see operator_parser_plugin
 class saver_parser_plugin : public virtual plugin {
 public:
-  virtual auto
-  parse_saver(parser_interface& p) const -> std::unique_ptr<plugin_saver> = 0;
+  virtual auto parse_saver(parser_interface& p) const
+    -> std::unique_ptr<plugin_saver>
+    = 0;
 
   virtual auto supported_uri_schemes() const -> std::vector<std::string>;
 };
@@ -566,27 +574,29 @@ public:
   ///          OpenAPI spec.
   [[nodiscard]] virtual auto
   openapi_endpoints(api_version version = api_version::latest) const -> record
-                                                                        = 0;
+    = 0;
 
   /// OpenAPI description of the schemas used by the plugin endpoints, if any.
   /// @returns A record containing entries for the `schemas` element of an
   ///          OpenAPI spec. The record may be empty if the plugin defines
   ///          no custom schemas.
-  [[nodiscard]] virtual auto openapi_schemas(
-    api_version /*version*/ = api_version::latest) const -> record {
+  [[nodiscard]] virtual auto
+  openapi_schemas(api_version /*version*/ = api_version::latest) const
+    -> record {
     return record{};
   }
 
   /// List of API endpoints provided by this plugin.
-  [[nodiscard]] virtual auto
-  rest_endpoints() const -> const std::vector<rest_endpoint>& = 0;
+  [[nodiscard]] virtual auto rest_endpoints() const
+    -> const std::vector<rest_endpoint>& = 0;
 
   /// Actor that will handle this endpoint.
   //  TODO: This should get some integration with component_plugin so that
   //  the component can be used to answer requests directly.
   [[nodiscard]] virtual auto
-  handler(caf::actor_system& system,
-          node_actor node) const -> rest_handler_actor = 0;
+  handler(caf::actor_system& system, node_actor node) const
+    -> rest_handler_actor
+    = 0;
 };
 
 // -- store plugin ------------------------------------------------------------
@@ -687,8 +697,9 @@ public:
   /// @param array The values to look up in the context.
   /// @param replace If true, return the input values for missing fields rather
   /// than nulls.
-  virtual auto
-  apply(series array, bool replace) -> caf::expected<std::vector<series>> = 0;
+  virtual auto apply(series array, bool replace)
+    -> caf::expected<std::vector<series>>
+    = 0;
 
   /// Inspects the context.
   virtual auto show() const -> record = 0;
@@ -697,18 +708,15 @@ public:
   virtual auto dump() -> generator<table_slice> = 0;
 
   /// Updates the context.
-  virtual auto
-  update(table_slice events,
-         parameter_map parameters) -> caf::expected<update_result> = 0;
+  virtual auto update(table_slice events, parameter_map parameters)
+    -> caf::expected<update_result>
+    = 0;
 
   /// Clears the context state, with optional parameters.
   virtual auto reset() -> caf::expected<void> = 0;
 
   /// Serializes a context for persistence.
   virtual auto save() const -> caf::expected<save_result> = 0;
-
-  /// Returns a callback for retroactive lookups.
-  virtual auto make_query() -> make_query_type = 0;
 };
 
 class context_loader {
@@ -717,9 +725,9 @@ public:
 
   virtual auto version() const -> int = 0;
 
-  virtual auto
-  load(chunk_ptr serialized) const -> caf::expected<std::unique_ptr<context>>
-                                      = 0;
+  virtual auto load(chunk_ptr serialized) const
+    -> caf::expected<std::unique_ptr<context>>
+    = 0;
 };
 
 class context_plugin : public virtual plugin {
@@ -727,12 +735,13 @@ public:
   /// Create a context.
   [[nodiscard]] virtual auto
   make_context(context::parameter_map parameters) const
-    -> caf::expected<std::unique_ptr<context>> = 0;
+    -> caf::expected<std::unique_ptr<context>>
+    = 0;
 
   [[nodiscard]] auto get_latest_loader() const -> const context_loader&;
 
-  [[nodiscard]] auto
-  get_versioned_loader(int version) const -> const context_loader*;
+  [[nodiscard]] auto get_versioned_loader(int version) const
+    -> const context_loader*;
 
   [[nodiscard]] virtual auto context_name() const -> std::string {
     return name();
@@ -762,8 +771,8 @@ public:
   /// Create a metrics collector.
   /// Plugins may return an error if the collector is not supported on the
   /// platform the node is currently running on.
-  [[nodiscard]] virtual auto
-  make_collector() const -> caf::expected<collector> = 0;
+  [[nodiscard]] virtual auto make_collector() const -> caf::expected<collector>
+    = 0;
 
   /// Returns the frequency for collecting the metrics, expressed as the
   /// interval between calls to the collector.
@@ -781,8 +790,9 @@ public:
   virtual auto aspect_name() const -> std::string;
 
   /// Produces the data to show.
-  virtual auto
-  show(operator_control_plane& ctrl) const -> generator<table_slice> = 0;
+  virtual auto show(operator_control_plane& ctrl) const
+    -> generator<table_slice>
+    = 0;
 };
 
 // -- plugin_ptr ---------------------------------------------------------------
@@ -1030,8 +1040,8 @@ extern const char* TENZIR_PLUGIN_VERSION;
 // type for the lambda on each invocation. While every lambda is supposed to
 // be a unique type according to the C++ standard, empirically we noticed here
 // that it is not across different translation units. So now we use a lambda
-// for distinguishing instances within the same translation unit and the decltype
-// expression for distinguishing across translation units.
+// for distinguishing instances within the same translation unit and the
+// decltype expression for distinguishing across translation units.
 #  define TENZIR_REGISTER_PLUGIN(...)                                          \
     template <auto>                                                            \
     struct auto_register_plugin;                                               \
@@ -1085,8 +1095,8 @@ extern const char* TENZIR_PLUGIN_VERSION;
       /* NOLINTNEXTLINE(cppcoreguidelines-owning-memory) */                    \
       return new __VA_ARGS__;                                                  \
     }                                                                          \
-    extern "C" auto tenzir_plugin_destroy(                                     \
-      class ::tenzir::plugin* plugin) -> void {                                \
+    extern "C" auto tenzir_plugin_destroy(class ::tenzir::plugin* plugin)      \
+      -> void {                                                                \
       /* NOLINTNEXTLINE(cppcoreguidelines-owning-memory) */                    \
       delete plugin;                                                           \
     }                                                                          \

--- a/libtenzir/include/tenzir/session.hpp
+++ b/libtenzir/include/tenzir/session.hpp
@@ -18,7 +18,8 @@ public:
     return session_provider{dh};
   }
 
-  auto as_session() -> session;
+  auto as_session() & -> session;
+  auto as_session() && -> session = delete;
 
 private:
   friend class session;
@@ -73,7 +74,7 @@ private:
   session_provider& provider_;
 };
 
-inline auto session_provider::as_session() -> session {
+inline auto session_provider::as_session() & -> session {
   return session{*this};
 }
 

--- a/libtenzir/include/tenzir/tql2/plugin.hpp
+++ b/libtenzir/include/tenzir/tql2/plugin.hpp
@@ -98,7 +98,7 @@ public:
 
   virtual void update(const table_slice& input, session ctx) = 0;
 
-  virtual auto finish() -> data = 0;
+  virtual auto get() const -> data = 0;
 };
 
 class aggregation_plugin : public virtual function_plugin {

--- a/libtenzir/src/tql2/eval.cpp
+++ b/libtenzir/src/tql2/eval.cpp
@@ -68,15 +68,16 @@ auto resolve(const ast::simple_selector& sel, type ty)
 auto eval(const ast::expression& expr, const table_slice& input,
           diagnostic_handler& dh) -> series {
   // TODO: Do not create a new session here.
-  return evaluator{&input, session_provider::make(dh).as_session()}.eval(expr);
+  auto sp = session_provider::make(dh);
+  return evaluator{&input, sp.as_session()}.eval(expr);
 }
 
 auto const_eval(const ast::expression& expr, diagnostic_handler& dh)
   -> failure_or<data> {
   // TODO: Do not create a new session here.
   try {
-    auto result
-      = evaluator{nullptr, session_provider::make(dh).as_session()}.eval(expr);
+    auto sp = session_provider::make(dh);
+    auto result = evaluator{nullptr, sp.as_session()}.eval(expr);
     TENZIR_ASSERT(result.length() == 1);
     return materialize(value_at(result.type, *result.array, 0));
   } catch (failure fail) {

--- a/libtenzir/src/tql2/parser.cpp
+++ b/libtenzir/src/tql2/parser.cpp
@@ -745,8 +745,8 @@ public:
     }
   }
 
-  auto parse_function_call(std::optional<ast::expression> subject,
-                           entity fn) -> function_call {
+  auto parse_function_call(std::optional<ast::expression> subject, entity fn)
+    -> function_call {
     expect(tk::lpar);
     auto scope = ignore_newlines(true);
     auto args = std::vector<ast::expression>{};

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "f61b743e67109578426d338da7534b3c58723764",
+  "rev": "eea63f9f021603da553e0dc0c57fa0d7560b1361",
   "submodules": true,
   "shallow": true,
   "allRefs": true

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "0626eb7092247b4e9f4cb7dd39398f7976db29d9",
+  "rev": "b617e0489528de0d5155bea2fb0991d5ccf701ef",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "b617e0489528de0d5155bea2fb0991d5ccf701ef",
+  "rev": "f61b743e67109578426d338da7534b3c58723764",
   "submodules": true,
   "shallow": true,
   "allRefs": true


### PR DESCRIPTION
This implements a new `aggregation` context type. It functions much like a `lookup-table` context, except that it takes as a required argument a list of assignments of aggregation function calls.

When updating the context, the provided key field is used to identify which set of aggregations to update based on the data. When enriching with the context, the aggregation instances are used to create the enrichment.

Here's an example. Consider a context like this:

```yaml
contexts:
  users:
    type: aggregation
    arguments:
      fields:
        first_seen: min(timestamp)
        last_seen: max(timestamp)
        ips: distinct(ip_address)
```

You update the context from a stream of events like this:

```json
{
  "username": "dominiklohmann",
  "timestamp": "2024-10-15T16:07:00.843514",
  "ip": "1.2.3.4"
}
```

In another pipeline, you can now enrich usernames with this information, automatically adding the `first_seen`, `last_seen`, and `ips` fields defined in the context based on all previous context updates.

> [!NOTE]
> This also makes three somewhat related adjustments to surrounding code:
> - We now forbid creating a `session` from a temporary `session_provider`, as that is inherently unsafe.
> - `context::make_query` no longer exists. It was effectively dead code since the removal of `lookup --snapshot`.
> - Getting the result of an `aggregation_instance` may no longer modify the instance to guarantee that it is safe to get an intermediate result.