### PR TITLE
Lift the restriction on combining `raw` and `merge` for parsers

### DIFF
--- a/libtenzir/src/multi_series_builder.cpp
+++ b/libtenzir/src/multi_series_builder.cpp
@@ -118,12 +118,16 @@ auto object_generator::data_unparsed(std::string_view s) -> void {
       if (not writable()) {
         return;
       }
-      auto res = msb_->builder_raw_.parser_(s, nullptr);
-      auto& [value, diag] = res;
-      if (value) {
-        b.data(std::move(*value));
-      } else {
+      if (msb_->settings_.raw) {
         b.data(s);
+      } else {
+        auto res = msb_->builder_raw_.parser_(s, nullptr);
+        auto& [value, diag] = res;
+        if (value) {
+          b.data(std::move(*value));
+        } else {
+          b.data(s);
+        }
       }
     },
     [&](raw_pointer raw) {
@@ -142,12 +146,16 @@ auto object_generator::data_unparsed(std::string s) -> void {
       if (not writable()) {
         return;
       }
-      auto res = msb_->builder_raw_.parser_(s, nullptr);
-      auto& [value, diag] = res;
-      if (value) {
-        b.data(std::move(*value));
-      } else {
+      if (msb_->settings_.raw) {
         b.data(s);
+      } else {
+        auto res = msb_->builder_raw_.parser_(s, nullptr);
+        auto& [value, diag] = res;
+        if (value) {
+          b.data(std::move(*value));
+        } else {
+          b.data(s);
+        }
       }
     },
     [&](raw_pointer raw) {
@@ -247,12 +255,16 @@ auto list_generator::data_unparsed(std::string_view s) -> void {
       if (not writable()) {
         return;
       }
-      auto res = msb_->builder_raw_.parser_(s, nullptr);
-      auto& [value, diag] = res;
-      if (value) {
-        b.data(std::move(*value));
-      } else {
+      if (msb_->settings_.raw) {
         b.data(s);
+      } else {
+        auto res = msb_->builder_raw_.parser_(s, nullptr);
+        auto& [value, diag] = res;
+        if (value) {
+          b.data(std::move(*value));
+        } else {
+          b.data(s);
+        }
       }
     },
     [&](raw_pointer raw) {
@@ -271,12 +283,16 @@ auto list_generator::data_unparsed(std::string s) -> void {
       if (not writable()) {
         return;
       }
-      auto res = msb_->builder_raw_.parser_(s, nullptr);
-      auto& [value, diag] = res;
-      if (value) {
-        b.data(std::move(*value));
-      } else {
+      if (msb_->settings_.raw) {
         b.data(s);
+      } else {
+        auto res = msb_->builder_raw_.parser_(s, nullptr);
+        auto& [value, diag] = res;
+        if (value) {
+          b.data(std::move(*value));
+        } else {
+          b.data(s);
+        }
       }
     },
     [&](raw_pointer raw) {

--- a/libtenzir/src/multi_series_builder.cpp
+++ b/libtenzir/src/multi_series_builder.cpp
@@ -119,14 +119,20 @@ auto object_generator::data_unparsed(std::string_view s) -> void {
         return;
       }
       if (msb_->settings_.raw) {
-        b.data(s);
+        if (not b.try_data(s)) {
+          b.null();
+        }
       } else {
         auto res = msb_->builder_raw_.parser_(s, nullptr);
         auto& [value, diag] = res;
         if (value) {
-          b.data(std::move(*value));
+          if (not b.try_data(std::move(*value))) {
+            b.null();
+          }
         } else {
-          b.data(s);
+          if (not b.try_data(s)) {
+            b.null();
+          }
         }
       }
     },
@@ -147,14 +153,20 @@ auto object_generator::data_unparsed(std::string s) -> void {
         return;
       }
       if (msb_->settings_.raw) {
-        b.data(s);
+        if (not b.try_data(s)) {
+          b.null();
+        }
       } else {
         auto res = msb_->builder_raw_.parser_(s, nullptr);
         auto& [value, diag] = res;
         if (value) {
-          b.data(std::move(*value));
+          if (not b.try_data(std::move(*value))) {
+            b.null();
+          }
         } else {
-          b.data(s);
+          if (not b.try_data(s)) {
+            b.null();
+          }
         }
       }
     },
@@ -256,14 +268,20 @@ auto list_generator::data_unparsed(std::string_view s) -> void {
         return;
       }
       if (msb_->settings_.raw) {
-        b.data(s);
+        if (not b.try_data(s)) {
+          b.null();
+        }
       } else {
         auto res = msb_->builder_raw_.parser_(s, nullptr);
         auto& [value, diag] = res;
         if (value) {
-          b.data(std::move(*value));
+          if (not b.try_data(std::move(*value))) {
+            b.null();
+          }
         } else {
-          b.data(s);
+          if (not b.try_data(s)) {
+            b.null();
+          }
         }
       }
     },

--- a/libtenzir/src/multi_series_builder_argument_parser.cpp
+++ b/libtenzir/src/multi_series_builder_argument_parser.cpp
@@ -153,21 +153,6 @@ auto multi_series_builder_argument_parser::get_settings(diagnostic_handler& dh)
     }
     settings_.unnest_separator = unnest_->inner;
   }
-  if (raw_ and schema_ and merge_) {
-    // In merging mode, we directly write into a series builder
-    // this means that data needs to be parsed to the correct type before
-    // writing to the builder however, when calling
-    // `field_generator::data_unparsed`, we dont know the schema
-    // TODO technically its only an issue with *known* schemas. For unknown
-    // schemas there is no type issue [ ] This could also be resolved by having
-    // the merging mode keep track of the type at non-trivial cost
-    diagnostic::error("`--merge --schema` and `--raw` are incompatible")
-      .primary(*raw_)
-      .primary(*schema_)
-      .primary(*merge_)
-      .emit(dh);
-    return false;
-  }
   settings_.raw = raw_.has_value();
   return true;
 }

--- a/libtenzir/test/multi_series_builder.cpp
+++ b/libtenzir/test/multi_series_builder.cpp
@@ -185,7 +185,7 @@ TEST(merging records) {
   check_outcome(res2, expected_result2);
 }
 
-TEST(merging records with seed and reset) {
+TEST(merging records with seed) {
   const type seed_schema = {
     "seed",
     record_type{
@@ -231,6 +231,114 @@ TEST(merging records with seed and reset) {
         {"0", caf::none},
         {"1", caf::none},
         {"2", uint64_t{0}},
+      },
+    },
+  };
+  check_outcome(res, expected_result);
+
+  {
+    auto r = b.record();
+    r.exact_field("1").data(0.0);
+  }
+  const auto res2 = b.finalize();
+  CHECK_EQUAL(res2.front().type, seed_schema);
+
+  const vvr expected_result2 = {
+    {
+      {
+        {"0", caf::none},
+        {"1", 0.0},
+      },
+    },
+  };
+  check_outcome(res2, expected_result2);
+}
+
+TEST(merging records with seed and raw) {
+  const type seed_schema = {
+    "seed",
+    record_type{
+      {"0", int64_type{}},
+      {"1", double_type{}},
+    },
+  };
+  multi_series_builder b{
+    multi_series_builder::policy_schema{
+      .seed_schema = "seed",
+    },
+    multi_series_builder::settings_type{
+      .merge = true,
+      .raw = true,
+    },
+    dh,
+    {seed_schema},
+  };
+
+  {
+    auto r = b.record();
+    r.exact_field("0").data(int64_t{0});
+  }
+  {
+    auto r = b.record();
+    r.exact_field("1").data(1.0);
+  }
+  {
+    auto r = b.record();
+    r.exact_field("0").data_unparsed("-2"sv);
+    r.exact_field("1").data_unparsed("2.0"sv);
+  }
+  {
+    auto r = b.record();
+    r.exact_field("0").data(int64_t{-3});
+    r.exact_field("not_in_schema").data_unparsed("3.0"sv);
+  }
+
+  {
+    auto r = b.record();
+    r.exact_field("0").data_unparsed("this is not an integer"sv);
+  }
+
+  const auto res = b.finalize();
+  CHECK_EQUAL(res.size(),
+              std::size_t{1}); // merging should produce exactly one series here
+
+  const type expected_type{
+    "seed",
+    record_type{
+      {"0", int64_type{}},
+      {"1", double_type{}},
+      {"not_in_schema", string_type{}},
+    },
+  };
+
+  CHECK_EQUAL(res.front().type, expected_type);
+
+  const vvr expected_result = {
+    {
+      {
+        {"0", int64_t{0}},
+        {"1", caf::none},
+        {"not_in_schema", caf::none},
+      },
+      {
+        {"0", caf::none},
+        {"1", 1.0},
+        {"not_in_schema", caf::none},
+      },
+      {
+        {"0", int64_t{-2}},
+        {"1", 2.0},
+        {"not_in_schema", caf::none},
+      },
+      {
+        {"0", int64_t{-3}},
+        {"1", caf::none},
+        {"not_in_schema", "3.0"},
+      },
+      {
+        {"0", caf::none},
+        {"1", caf::none},
+        {"not_in_schema", caf::none},
       },
     },
   };

--- a/web/docs/formats.md
+++ b/web/docs/formats.md
@@ -62,8 +62,6 @@ to huge schemas filled with nulls and imprecise results. Use with caution.
 
 \*: In selector mode, only events with the same selector are merged.
 
-This option can not be combined with `--raw --schema`.
-
 ### `--schema <schema>` (Parsers)
 
 Explicitly set the output schema.
@@ -76,7 +74,7 @@ can be used to reject fields that are not in the schema.
 
 If the given schema does not exist, this option instead assigns the output schema name only.
 
-This option can not be combined with `--selector` or `--raw --merge`.
+This option can not be combined with `--selector`.
 
 ### `--selector <field>[:<prefix>]` (Parsers)
 
@@ -142,8 +140,6 @@ to be parsed as strings, unless the field is specified to be an IP address by th
 JSON however has numeric types, so those would be parsed.
 
 Use with caution.
-
-This option can not be combined with `--merge --schema`.
 
 ## MIME Types
 


### PR DESCRIPTION
Originally, we disallowed combining `--raw --merge --schema=schema` for technical reasons.

However, since then a refactor in the multi series builder actually made that easily possible, so we are now lifting that restriction.

The TQL2 docs already document the state after this PR.