### PR TITLE
Reduce log verbosity of the node

### DIFF
--- a/libtenzir/src/evaluator.cpp
+++ b/libtenzir/src/evaluator.cpp
@@ -93,7 +93,7 @@ evaluator_state::evaluator_state(
 }
 
 void evaluator_state::handle_result(const offset& position, const ids& result) {
-  TENZIR_DEBUG("{} got {} new hits for predicate at position {}", *self,
+  TENZIR_TRACE("{} got {} new hits for predicate at position {}", *self,
                rank(result), position);
   auto ptr = hits_for(position);
   TENZIR_ASSERT(ptr != nullptr);
@@ -126,7 +126,7 @@ void evaluator_state::handle_no_indexer(const offset& position) {
 
 void evaluator_state::evaluate() {
   auto expr_hits = caf::visit(ids_evaluator{predicate_hits}, expr);
-  TENZIR_DEBUG("{} got predicate_hits: {} expr_hits: {}", *self, predicate_hits,
+  TENZIR_TRACE("{} got predicate_hits: {} expr_hits: {}", *self, predicate_hits,
                expr_hits);
   hits |= expr_hits;
 }

--- a/libtenzir/src/index.cpp
+++ b/libtenzir/src/index.cpp
@@ -680,12 +680,10 @@ void index_state::handle_slice(table_slice x) {
     }
     active_partition = *part;
   } else if (x.rows() > active_partition->second.capacity) {
-    TENZIR_DEBUG("{} exceeds active capacity by {} rows", *self,
-                 x.rows() - active_partition->second.capacity);
-    TENZIR_VERBOSE("{} flushes active partition {} with {}/{} events", *self,
-                   schema,
-                   partition_capacity - active_partition->second.capacity,
-                   partition_capacity);
+    TENZIR_DEBUG("{} flushes active partition {} with {} rows and {}/{} events",
+                 *self, schema, x.rows(),
+                 partition_capacity - active_partition->second.capacity,
+                 partition_capacity);
     decommission_active_partition(schema, {});
     flush_to_disk();
     auto part = create_active_partition(schema);
@@ -734,11 +732,10 @@ index_state::create_active_partition(const type& schema) {
       // If the partition was already rotated then there's nothing to do for us.
       return;
     }
-    TENZIR_VERBOSE("{} flushes active partition {} with {}/{} {} events "
-                   "after {} timeout",
-                   *self, it->second.id,
-                   partition_capacity - it->second.capacity, partition_capacity,
-                   schema, data{active_partition_timeout});
+    TENZIR_DEBUG("{} flushes active partition {} with {}/{} {} events "
+                 "after {} timeout",
+                 *self, it->second.id, partition_capacity - it->second.capacity,
+                 partition_capacity, schema, data{active_partition_timeout});
     decommission_active_partition(schema, [this, schema,
                                            id](const caf::error& err) mutable {
       if (err) {
@@ -767,12 +764,12 @@ void index_state::decommission_active_partition(
   // Persist active partition asynchronously.
   const auto part_path = partition_path(id);
   const auto synopsis_path = partition_synopsis_path(id);
-  TENZIR_DEBUG("{} persists active partition {} to {}", *self, schema,
+  TENZIR_TRACE("{} persists active partition {} to {}", *self, schema,
                part_path);
   self->request(actor, caf::infinite, atom::persist_v, part_path, synopsis_path)
     .then(
       [=, this](partition_synopsis_ptr& ps) {
-        TENZIR_DEBUG("{} successfully persisted partition {} {}", *self, schema,
+        TENZIR_TRACE("{} successfully persisted partition {} {}", *self, schema,
                      id);
         // The catalog expects to own the partition synopsis it receives,
         // so we make a copy for the listeners.
@@ -782,7 +779,7 @@ void index_state::decommission_active_partition(
         self->request(catalog, caf::infinite, atom::merge_v, std::move(apsv))
           .then(
             [=, this](atom::ok) {
-              TENZIR_DEBUG("{} inserted partition {} {} to the catalog", *self,
+              TENZIR_TRACE("{} inserted partition {} {} to the catalog", *self,
                            schema, id);
               for (auto& listener : partition_creation_listeners)
                 self->send(listener, atom::update_v,
@@ -1141,7 +1138,6 @@ index(index_actor::stateful_pointer<index_state> self,
       self->send(importer,
                  detail::generate_actor_metrics(actor_metrics_builder, self));
     });
-  // Clean up unpersisted events every second.
   return {
     [self](atom::done, uuid partition_id) {
       TENZIR_DEBUG("{} queried partition {} successfully", *self, partition_id);

--- a/libtenzir/src/node.cpp
+++ b/libtenzir/src/node.cpp
@@ -490,8 +490,8 @@ auto node(node_actor::stateful_pointer<node_state> self, std::string /*name*/,
   return {
     [self](atom::proxy, http_request_description& desc,
            std::string& request_id) -> caf::result<rest_response> {
-      TENZIR_VERBOSE("{} proxying request with id {} to {} with {}", *self,
-                     request_id, desc.canonical_path, desc.json_body);
+      TENZIR_DEBUG("{} proxying request with id {} to {} with {}", *self,
+                   request_id, desc.canonical_path, desc.json_body);
       auto [handler, endpoint] = self->state.get_endpoint_handler(desc);
       if (!handler) {
         auto canonical_paths = std::unordered_set<std::string>{};

--- a/libtenzir/src/posix_filesystem.cpp
+++ b/libtenzir/src/posix_filesystem.cpp
@@ -168,7 +168,6 @@ posix_filesystem(filesystem_actor::stateful_pointer<posix_filesystem_state> self
     },
     [self](atom::erase,
            const std::filesystem::path& filename) -> caf::result<atom::done> {
-      TENZIR_DEBUG("{} got request to erase {}", *self, filename);
       const auto path
         = filename.is_absolute() ? filename : self->state.root / filename;
       auto err = std::error_code{};

--- a/libtenzir/src/store.cpp
+++ b/libtenzir/src/store.cpp
@@ -76,7 +76,7 @@ handle_query(const auto& self, const query_context& query_context) {
         .then(
           [self, issuer = query_context.issuer, query_id = query_context.id,
            rp]() mutable {
-            TENZIR_DEBUG("{} finished working on extract query {}", *self,
+            TENZIR_TRACE("{} finished working on extract query {}", *self,
                          query_id);
             auto it = self->state.running_extractions.find(query_id);
             if (it == self->state.running_extractions.end()) {
@@ -175,7 +175,6 @@ default_passive_store_actor::behavior_type default_passive_store(
   return {
     [self](atom::query,
            const query_context& query_context) -> caf::result<uint64_t> {
-      TENZIR_DEBUG("{} starts working on query {}", *self, query_context.id);
       return handle_query<default_passive_store_actor>(self, query_context);
     },
     [self](atom::erase, const ids& selection) -> caf::result<uint64_t> {
@@ -201,7 +200,7 @@ default_passive_store_actor::behavior_type default_passive_store(
     },
     [self](atom::internal, atom::extract,
            const uuid& query_id) -> caf::result<void> {
-      TENZIR_DEBUG("{} continuous working on extract query {}", *self,
+      TENZIR_TRACE("{} continuous working on extract query {}", *self,
                    query_id);
       auto it = self->state.running_extractions.find(query_id);
       if (it == self->state.running_extractions.end())

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "0626eb7092247b4e9f4cb7dd39398f7976db29d9",
+  "rev": "6429d2c27d9c1542c0a3e5cdb85c43cff6e8ce61",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
As a band-aid fix for the increasingly overwhelming log sizes of the node, I went through some of the most verbose log messages and made a judgement call on each whether to keep, demote or remove that log message.