### PR TITLE
Add docs for `top` and `rare`

### DIFF
--- a/web/docs/tql2/operators.md
+++ b/web/docs/tql2/operators.md
@@ -41,11 +41,8 @@ Operator | Description | Example
 [`summarize`](./operators/summarize.md) | Aggregates events with implicit grouping | `summarize name, sum(transaction)`
 [`sort`](./operators/sort.md) | Sorts the events by one or more expressions | `sort name, -abs(transaction)`
 [`reverse`](./operators/reverse.md) | Reverses the event order | `reverse`
-
-<!--
-[`top`](./operators/top.md) | … | `…`
-[`rare`](./operators/rare.md) | … | `…`
--->
+[`top`](./operators/top.md) | Shows the most common values | `top user`
+[`rare`](./operators/rare.md) | Shows the least common values | `rare auth.token`
 
 ## Flow Control
 

--- a/web/docs/tql2/operators/cache.md
+++ b/web/docs/tql2/operators/cache.md
@@ -1,10 +1,10 @@
 # cache
 
-:::warning
-Expert Operator We designed the `cache` operator for under-the-hood
-use of the Tenzir Platform on [app.tenzir.com](https://app.tenzir.com). We
-generally recommend not using the operator by yourself, but rather relying on
-the Tenzir Platform to automatically manage caches for you.
+:::warning Expert Operator
+We designed the `cache` operator for under-the-hood use of the Tenzir Platform
+on [app.tenzir.com](https://app.tenzir.com). We generally recommend not using
+the operator by yourself, but rather relying on the Tenzir Platform to
+automatically manage caches for you.
 :::
 
 An in-memory cache shared between pipelines.

--- a/web/docs/tql2/operators/rare.md
+++ b/web/docs/tql2/operators/rare.md
@@ -21,8 +21,30 @@ The name of the field to find the least common values for.
 
 ## Examples
 
-Find the least common values for field `id.orig_h`.
+Find the least common values for `x`.
+
+```tql
+from [
+  {x: "B"},
+  {x: "A"},
+  {x: "A"},
+  {x: "B"},
+  {x: "A"},
+  {x: "D"},
+  {x: "C"},
+  {x: "C"},
+]
+rare x
+――――――――――――――――――
+{x: "D", count: 1}
+{x: "C", count: 2}
+{x: "B", count: 2}
+{x: "A", count: 3}
+```
+
+Show the five least common values for `id.orig_h`:
 
 ```tql
 rare id.orig_h
+head 5
 ```

--- a/web/docs/tql2/operators/rare.md
+++ b/web/docs/tql2/operators/rare.md
@@ -9,7 +9,13 @@ rare x:field
 ## Description
 
 Shows the least common values for a given field. For each unique value, a new
-event containing its count will be produced.
+event containing its count will be produced. In general, `rare x` is equivalent
+to:
+
+```tql
+summarize x, count=count()
+sort count
+```
 
 :::note Potentially High Memory Usage
 Take care when using this operator with large inputs.

--- a/web/docs/tql2/operators/read_kv.md
+++ b/web/docs/tql2/operators/read_kv.md
@@ -53,7 +53,7 @@ will parse as
 {
   "key2": "value, and more"
 }
-  ```
+```
 
 ### `field_split: str (optional)`
 

--- a/web/docs/tql2/operators/top.md
+++ b/web/docs/tql2/operators/top.md
@@ -8,8 +8,8 @@ top x:field
 
 ## Description
 
-Shows the most common values for a given field. For each unique value, a new
-event containing its count will be produced.
+Shows the most common values for a given field. For each value, a new event
+containing its count will be produced.
 
 :::note Potentially High Memory Usage
 Take care when using this operator with large inputs.
@@ -21,8 +21,30 @@ The field to find the most common values for.
 
 ## Examples
 
-Find the most common values for field `id.orig_h`.
+Find the most common values for `x`.
+
+```tql
+from [
+  {x: "B"},
+  {x: "A"},
+  {x: "A"},
+  {x: "B"},
+  {x: "A"},
+  {x: "D"},
+  {x: "C"},
+  {x: "C"},
+]
+top x
+――――――――――――――――――
+{x: "A", count: 3}
+{x: "B", count: 2}
+{x: "C", count: 2}
+{x: "D", count: 1}
+```
+
+Show the five most common values for `id.orig_h`:
 
 ```tql
 top id.orig_h
+head 5
 ```

--- a/web/docs/tql2/operators/top.md
+++ b/web/docs/tql2/operators/top.md
@@ -9,7 +9,12 @@ top x:field
 ## Description
 
 Shows the most common values for a given field. For each value, a new event
-containing its count will be produced.
+containing its count will be produced. In general, `top x` is equivalent to:
+
+```tql
+summarize x, count=count()
+sort -count
+```
 
 :::note Potentially High Memory Usage
 Take care when using this operator with large inputs.


### PR DESCRIPTION
Some docs were already there, but they were not shown on the overview page, and I also expanded them a bit (plus some small fixes in other docs).

To be merged after #4672.