### PR TITLE
Remove `context::make_query()`

### DIFF
--- a/libtenzir/builtins/contexts/bloom_filter.cpp
+++ b/libtenzir/builtins/contexts/bloom_filter.cpp
@@ -172,10 +172,6 @@ public:
     };
   }
 
-  auto make_query() -> make_query_type override {
-    return {};
-  }
-
   auto reset() -> caf::expected<void> override {
     auto params = bloom_filter_.parameters();
     TENZIR_ASSERT(params.n && params.p);

--- a/libtenzir/builtins/contexts/geoip.cpp
+++ b/libtenzir/builtins/contexts/geoip.cpp
@@ -493,10 +493,6 @@ public:
                            "geoip context can not be updated with events");
   }
 
-  auto make_query() -> make_query_type override {
-    return {};
-  }
-
   auto reset() -> caf::expected<void> override {
     return {};
   }

--- a/libtenzir/builtins/contexts/lookup_table.cpp
+++ b/libtenzir/builtins/contexts/lookup_table.cpp
@@ -508,34 +508,6 @@ public:
     };
   }
 
-  auto make_query() -> make_query_type override {
-    auto key_values_list = list{};
-    key_values_list.reserve(context_entries.size());
-    const auto now = time::clock::now();
-    for (const auto& entry : context_entries) {
-      if (entry.second.is_expired(now)) {
-        continue;
-      }
-      entry.first.populate_snapshot_data(key_values_list);
-    }
-    return [key_values_list = std::move(key_values_list)](
-             parameter_map, const std::vector<std::string>& fields)
-             -> caf::expected<std::vector<expression>> {
-      auto result = std::vector<expression>{};
-      result.reserve(fields.size());
-      for (const auto& field : fields) {
-        auto lhs = to<operand>(field);
-        TENZIR_ASSERT(lhs);
-        result.emplace_back(predicate{
-          *lhs,
-          relational_operator::in,
-          data{key_values_list},
-        });
-      }
-      return result;
-    };
-  }
-
   auto reset() -> caf::expected<void> override {
     context_entries.clear();
     subnet_entries.clear();

--- a/libtenzir/include/tenzir/detail/weak_handle.hpp
+++ b/libtenzir/include/tenzir/detail/weak_handle.hpp
@@ -31,9 +31,9 @@ template <class Handle>
 struct weak_handle : caf::weak_actor_ptr {
   weak_handle() noexcept = default;
   weak_handle(const weak_handle&) noexcept = default;
-  weak_handle& operator=(const weak_handle&) noexcept = default;
+  auto operator=(const weak_handle&) noexcept -> weak_handle& = default;
   weak_handle(weak_handle&&) noexcept = default;
-  weak_handle& operator=(weak_handle&&) noexcept = default;
+  auto operator=(weak_handle&&) noexcept -> weak_handle& = default;
   ~weak_handle() noexcept = default;
 
   explicit(false) weak_handle(const Handle& handle) noexcept
@@ -41,7 +41,7 @@ struct weak_handle : caf::weak_actor_ptr {
     // nop
   }
 
-  Handle lock() const noexcept {
+  auto lock() const noexcept -> Handle {
     return caf::actor_cast<Handle>(weak_ptr_.lock());
   }
 

--- a/libtenzir/include/tenzir/plugin.hpp
+++ b/libtenzir/include/tenzir/plugin.hpp
@@ -706,9 +706,6 @@ public:
 
   /// Serializes a context for persistence.
   virtual auto save() const -> caf::expected<save_result> = 0;
-
-  /// Returns a callback for retroactive lookups.
-  virtual auto make_query() -> make_query_type = 0;
 };
 
 class context_loader {

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "3c6b212219238f6b6d8c3fa997aa996f70622fc1",
+  "rev": "024fb29aa2f79bb69c7161a6240fa19e4b80293c",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
This is a leftover from the "snapshot" feature of the `lookup` operator that was dead code now, so we were able to just remove it.

- Fixes https://github.com/tenzir/issues/issues/2251