### PR TITLE
Make it harder to create a dangling `session_provider`

### DIFF
--- a/libtenzir/include/tenzir/session.hpp
+++ b/libtenzir/include/tenzir/session.hpp
@@ -14,33 +14,25 @@ namespace tenzir {
 
 class session_provider {
 public:
-  static auto make(diagnostic_handler& dh) -> session_provider {
-    return session_provider{dh};
-  }
+  static auto make(diagnostic_handler& dh) -> session_provider;
 
-  auto as_session() -> session;
+  auto as_session() & -> session;
+  auto as_session() && -> session = delete;
 
 private:
   friend class session;
 
   class diagnostic_ctx final : public diagnostic_handler {
   public:
-    explicit diagnostic_ctx(diagnostic_handler& dh) : dh_{dh} {
-    }
+    explicit diagnostic_ctx(diagnostic_handler& dh);
 
-    void emit(diagnostic d) override {
-      if (d.severity == severity::error) {
-        failure_ = failure::promise();
-      }
-      dh_.emit(d);
-    }
+    void emit(diagnostic d) override;
 
     std::optional<failure> failure_;
     diagnostic_handler& dh_;
   };
 
-  explicit session_provider(diagnostic_handler& dh) : dh_{dh} {
-  }
+  explicit session_provider(diagnostic_handler& dh);
 
   diagnostic_ctx dh_;
 };
@@ -48,33 +40,20 @@ private:
 /// This is meant to be used as a value type.
 class session {
 public:
-  explicit session(session_provider& provider) : provider_{provider} {
-  }
+  explicit session(session_provider& provider);
 
-  auto get_failure() const -> std::optional<failure> {
-    return provider_.dh_.failure_;
-  }
+  auto get_failure() const -> std::optional<failure>;
 
-  auto has_failure() const -> bool {
-    return get_failure().has_value();
-  }
+  auto has_failure() const -> bool;
 
   auto reg() -> const registry&;
 
-  auto dh() -> diagnostic_handler& {
-    return provider_.dh_;
-  }
+  auto dh() -> diagnostic_handler&;
 
-  operator diagnostic_handler&() {
-    return dh();
-  }
+  explicit(false) operator diagnostic_handler&();
 
 private:
   session_provider& provider_;
 };
-
-inline auto session_provider::as_session() -> session {
-  return session{*this};
-}
 
 } // namespace tenzir

--- a/libtenzir/src/session.cpp
+++ b/libtenzir/src/session.cpp
@@ -12,9 +12,50 @@
 
 namespace tenzir {
 
+auto session_provider::make(diagnostic_handler& dh) -> session_provider {
+  return session_provider{dh};
+}
+
+auto session_provider::as_session() & -> session {
+  return session{*this};
+}
+
+session_provider::diagnostic_ctx::diagnostic_ctx(diagnostic_handler& dh)
+  : dh_{dh} {
+}
+
+void session_provider::diagnostic_ctx::emit(diagnostic d) {
+  if (d.severity == severity::error) {
+    failure_ = failure::promise();
+  }
+  dh_.emit(d);
+}
+
+session_provider::session_provider(diagnostic_handler& dh) : dh_{dh} {
+}
+
+session::session(session_provider& provider) : provider_{provider} {
+}
+
+auto session::get_failure() const -> std::optional<failure> {
+  return provider_.dh_.failure_;
+}
+
+auto session::has_failure() const -> bool {
+  return get_failure().has_value();
+}
+
 auto session::reg() -> const registry& {
   // TODO: The registry should be attached to a session instead.
   return global_registry();
+}
+
+auto session::dh() -> diagnostic_handler& {
+  return provider_.dh_;
+}
+
+session::operator diagnostic_handler&() {
+  return dh();
 }
 
 } // namespace tenzir

--- a/libtenzir/src/tql2/eval.cpp
+++ b/libtenzir/src/tql2/eval.cpp
@@ -68,15 +68,16 @@ auto resolve(const ast::simple_selector& sel, type ty)
 auto eval(const ast::expression& expr, const table_slice& input,
           diagnostic_handler& dh) -> series {
   // TODO: Do not create a new session here.
-  return evaluator{&input, session_provider::make(dh).as_session()}.eval(expr);
+  auto sp = session_provider::make(dh);
+  return evaluator{&input, sp.as_session()}.eval(expr);
 }
 
 auto const_eval(const ast::expression& expr, diagnostic_handler& dh)
   -> failure_or<data> {
   // TODO: Do not create a new session here.
   try {
-    auto result
-      = evaluator{nullptr, session_provider::make(dh).as_session()}.eval(expr);
+    auto sp = session_provider::make(dh);
+    auto result = evaluator{nullptr, sp.as_session()}.eval(expr);
     TENZIR_ASSERT(result.length() == 1);
     return materialize(value_at(result.type, *result.array, 0));
   } catch (failure fail) {


### PR DESCRIPTION
Ran into this during development of "aggregation" contexts, and figured it'd make sense to just split this out to get it reviewed separately.

I've also used the opportunity to move a few things from header to source files.