### PR TITLE
Add support for `min(<time>)` and `max(<time>)`

### DIFF
--- a/libtenzir/builtins/aggregation-functions/max.cpp
+++ b/libtenzir/builtins/aggregation-functions/max.cpp
@@ -52,7 +52,7 @@ private:
 // TODO: Probably merge this with min
 class max_instance final : public aggregation_instance {
 public:
-  using max_t = variant<caf::none_t, int64_t, uint64_t, double, duration>;
+  using max_t = variant<caf::none_t, int64_t, uint64_t, double, duration, time>;
   explicit max_instance(ast::expression expr) : expr_{std::move(expr)} {
   }
 
@@ -105,15 +105,17 @@ public:
           }
         }
       },
-      [&](const arrow::DurationArray& array) {
-        for (auto i = int64_t{}; i < array.length(); ++i) {
-          if (array.IsValid(i)) {
-            const auto val = array.Value(i);
+      [&]<class T>(const T& array)
+        requires concepts::one_of<type_from_arrow_t<T>, duration_type, time_type>
+      {
+        using Ty = type_from_arrow_t<T>;
+        for (const auto& val : values(Ty{}, array)) {
+          if (val) {
             if (not max_) {
-              max_ = duration{val};
+              max_ = val;
             }
-            max_ = max_->match(warn, [&](duration self) -> max_t {
-              return duration{std::max(self.count(), val)};
+            max_ = max_->match(warn, [&](type_to_data_t<Ty> self) -> max_t {
+              return std::max(self, val.value());
             });
             if (std::holds_alternative<caf::none_t>(max_.value())) {
               return;
@@ -122,8 +124,8 @@ public:
         }
       },
       [&](const auto&) {
-        diagnostic::warning("expected types `int`, `uint`, "
-                            "`double` or `duration`, got `{}`",
+        diagnostic::warning("expected types `number`, `time` or `duration`, "
+                            "got `{}`",
                             arg.type.kind())
           .primary(expr_)
           .emit(ctx);


### PR DESCRIPTION
Adds support for `time` type in aggregations `min()` and `max()`.