### PR TITLE
Consistently refer to metadata with `@`

### DIFF
--- a/libtenzir/include/tenzir/tql2/ast.hpp
+++ b/libtenzir/include/tenzir/tql2/ast.hpp
@@ -251,7 +251,7 @@ private:
 ///
 /// Note that this is not an actual `expression`. Instead, expressions can be
 /// converted to `selector` on-demand. Currently, this is limited to meta
-/// selectors (e.g., `meta.tag`) and simple selectors (see `simple_selector`).
+/// selectors (e.g., `@tag`) and simple selectors (see `simple_selector`).
 struct selector : variant<meta, simple_selector> {
   using variant::variant;
 

--- a/web/docs/tql2/language/expressions.md
+++ b/web/docs/tql2/language/expressions.md
@@ -62,13 +62,13 @@ instance, `from {x: 1, y: 2} | z = this` has the output
 `{x: 1, y: 2, z: {x: 1, y: 2}}`. This keyword can also be used to overwrite the
 whole event, as demonstrated by `this = {a: x, y: b}`.
 
-### `meta`
+### Metadata
 
 Events carry not only data, but also metadata. To refer to the metadata, use the
-`meta` keyword. For example, `meta.name` carries the name of the event.
-Currently, the set of metadata fields is limited to just  `meta.name`,
-`meta.import_time` and `meta.internal`, but will potentially be expanded later
-to allow arbitrary user-defined metadata fields.
+`@` keyword. For example, `@name` carries the name of the event. Currently, the
+set of metadata fields is limited to just  `@name`, `@import_time` and
+`@internal`, but will potentially be expanded later to allow arbitrary
+user-defined metadata fields.
 
 ### Unary Expression
 

--- a/web/docs/tql2/language/expressions.md
+++ b/web/docs/tql2/language/expressions.md
@@ -65,7 +65,7 @@ whole event, as demonstrated by `this = {a: x, y: b}`.
 ### Metadata
 
 Events carry not only data, but also metadata. To refer to the metadata, use the
-`@` keyword. For example, `@name` carries the name of the event. Currently, the
+`@` prefix. For example, `@name` carries the name of the event. Currently, the
 set of metadata fields is limited to just  `@name`, `@import_time` and
 `@internal`, but will potentially be expanded later to allow arbitrary
 user-defined metadata fields.

--- a/web/docs/tql2/operators/assert.md
+++ b/web/docs/tql2/operators/assert.md
@@ -28,6 +28,6 @@ assert x > 2
 Check that the topic only contains OCSF network activity events:
 ```tql
 subscribe "network"
-assert meta.name == "ocsf.network_activity"
+assert @name == "ocsf.network_activity"
 // continue processing
 ```

--- a/web/docs/tql2/operators/azure_log_analytics.md
+++ b/web/docs/tql2/operators/azure_log_analytics.md
@@ -51,7 +51,7 @@ Upload `custom.mydata` events to a table `Custom-MyData`:
 
 ```tql
 export
-where meta.name == "custom.mydata"
+where @name == "custom.mydata"
 azure_log_analytics tenant_id="00a00a00-0a00-0a00-00aa-000aa0a0a000",
   client_id="000a00a0-0aa0-00a0-0000-00a000a000a0",
   client_secret="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",

--- a/web/docs/tql2/operators/save_google_cloud_pubsub.md
+++ b/web/docs/tql2/operators/save_google_cloud_pubsub.md
@@ -29,7 +29,7 @@ Publish `suricata.alert` events as JSON to `alerts-topic`.
 
 ```tql
 export
-where meta.name = "suricata.alert"
+where @name = "suricata.alert"
 write_json
 save_google_cloud_pubsub "amazing-project-123456", "alerts-topic"
 ```


### PR DESCRIPTION
We made a call yesterday in the team between `@` and `meta.` as a prefix for metadata, and agreed to use `@`. So this adapts the remaining places in the docs accordingly.