### PR TITLE
Return instantly in `/serve` if pipeline fails early

### DIFF
--- a/changelog/next/bug-fixes/4688--serve-error-return-instantly.md
+++ b/changelog/next/bug-fixes/4688--serve-error-return-instantly.md
@@ -1,0 +1,4 @@
+The `/serve` endpoint now returns instantly when its pipeline fails before the
+endpoint is used for the first time. In the Tenzir Platform this causes the load
+more button in the Explorer to correctly stop showing for pipelines that fail
+shortly after starting.

--- a/libtenzir/builtins/operators/serve.cpp
+++ b/libtenzir/builtins/operators/serve.cpp
@@ -483,6 +483,9 @@ struct serve_manager_state {
                     "{} for serve id {}",
                     *self, request.continuation_token, request.serve_id));
     }
+    if (found->done) {
+      return std::make_tuple(std::string{}, std::vector<table_slice>{});
+    }
     auto rp = self->make_response_promise<
       std::tuple<std::string, std::vector<table_slice>>>();
     found->get_rps.push_back(rp);


### PR DESCRIPTION
Before this change, the `/serve` endpoint waited for its long-poll timeout to expire if the pipeline failed before the first request to `/serve` came in. Now it returns instantly. For the Tenzir Platform, this causes the loading button in the Explorer to disappear immediately for such cases.

Here's a simle reproduction that now returns instantly but took some time before:

```
// tql2
shell "echo null"
read_json
serve "foo"
```

```
// tql2
api "/serve", {
  serve_id: "foo"
}
```