### PR TITLE
Enable google-cloud-pubsub connector in the Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,22 +67,22 @@ ARG TENZIR_BUILD_OPTIONS
 FROM development-setup AS development
 
 RUN cmake -B build -G Ninja \
--D CMAKE_PREFIX_PATH="/opt/aws-sdk-cpp;/opt/google-cloud-cpp;" \
--D CMAKE_INSTALL_PREFIX:STRING="$PREFIX" \
--D CMAKE_BUILD_TYPE:STRING="Release" \
--D TENZIR_ENABLE_AVX_INSTRUCTIONS:BOOL="OFF" \
--D TENZIR_ENABLE_AVX2_INSTRUCTIONS:BOOL="OFF" \
--D TENZIR_ENABLE_UNIT_TESTS:BOOL="OFF" \
--D TENZIR_ENABLE_DEVELOPER_MODE:BOOL="OFF" \
--D TENZIR_ENABLE_BUNDLED_CAF:BOOL="ON" \
--D TENZIR_ENABLE_BUNDLED_SIMDJSON:BOOL="ON" \
--D TENZIR_ENABLE_MANPAGES:BOOL="OFF" \
--D TENZIR_ENABLE_PYTHON_BINDINGS_DEPENDENCIES:BOOL="ON" \
-${TENZIR_BUILD_OPTIONS} && \
-cmake --build build --parallel && \
-cmake --build build --target integration && \
-cmake --install build --strip && \
-rm -rf build
+      -D CMAKE_PREFIX_PATH="/opt/aws-sdk-cpp;/opt/google-cloud-cpp;" \
+      -D CMAKE_INSTALL_PREFIX:STRING="$PREFIX" \
+      -D CMAKE_BUILD_TYPE:STRING="Release" \
+      -D TENZIR_ENABLE_AVX_INSTRUCTIONS:BOOL="OFF" \
+      -D TENZIR_ENABLE_AVX2_INSTRUCTIONS:BOOL="OFF" \
+      -D TENZIR_ENABLE_UNIT_TESTS:BOOL="OFF" \
+      -D TENZIR_ENABLE_DEVELOPER_MODE:BOOL="OFF" \
+      -D TENZIR_ENABLE_BUNDLED_CAF:BOOL="ON" \
+      -D TENZIR_ENABLE_BUNDLED_SIMDJSON:BOOL="ON" \
+      -D TENZIR_ENABLE_MANPAGES:BOOL="OFF" \
+      -D TENZIR_ENABLE_PYTHON_BINDINGS_DEPENDENCIES:BOOL="ON" \
+      ${TENZIR_BUILD_OPTIONS} && \
+    cmake --build build --parallel && \
+    cmake --build build --target integration && \
+    cmake --install build --strip && \
+    rm -rf build
 
 RUN mkdir -p \
       $PREFIX/etc/tenzir \
@@ -115,7 +115,6 @@ COPY --from=development --chown=tenzir:tenzir /var/cache/tenzir/ /var/cache/tenz
 COPY --from=development --chown=tenzir:tenzir /var/lib/tenzir/ /var/lib/tenzir/
 COPY --from=development --chown=tenzir:tenzir /var/log/tenzir/ /var/log/tenzir/
 COPY --from=development /opt/aws-sdk-cpp/lib/ /opt/aws-sdk-cpp/lib/
-COPY --from=development /opt/google-cloud-cpp/lib/ /opt/google-cloud-cpp/lib/
 COPY --from=dependencies /arrow_*.deb /root/
 COPY --from=fluent-bit-package /root/fluent-bit_*.deb /root/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ ARG TENZIR_BUILD_OPTIONS
 FROM development-setup AS development
 
 RUN cmake -B build -G Ninja \
--D CMAKE_PREFIX_PATH="/opt/aws-sdk-cpp" \
+-D CMAKE_PREFIX_PATH="/opt/aws-sdk-cpp;/opt/google-cloud-cpp;" \
 -D CMAKE_INSTALL_PREFIX:STRING="$PREFIX" \
 -D CMAKE_BUILD_TYPE:STRING="Release" \
 -D TENZIR_ENABLE_AVX_INSTRUCTIONS:BOOL="OFF" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,15 +29,12 @@ RUN ./scripts/debian/install-dev-dependencies.sh && \
     rm -rf /var/lib/apt/lists/*
 COPY scripts/debian/install-aws-sdk.sh ./scripts/debian/
 RUN ./scripts/debian/install-aws-sdk.sh
-COPY scripts/debian/install-google-cloud.sh ./scripts/debian/
-RUN ./scripts/debian/install-google-cloud.sh
 
 # Tenzir
 COPY changelog ./changelog
 COPY cmake ./cmake
 COPY libtenzir ./libtenzir
 COPY libtenzir_test ./libtenzir_test
-COPY plugins ./plugins
 COPY python ./python
 COPY schema ./schema
 COPY scripts ./scripts
@@ -47,7 +44,7 @@ COPY CMakeLists.txt LICENSE README.md tenzir.spdx.json VERSIONING.md \
 
 # -- development ---------------------------------------------------------------
 
-FROM dependencies AS development-setup
+FROM dependencies AS development
 
 ENV PREFIX="/opt/tenzir" \
     PATH="/opt/tenzir/bin:${PATH}" \
@@ -64,10 +61,8 @@ ENV TENZIR_CACHE_DIRECTORY="/var/cache/tenzir" \
 # Additional arguments to be passed to CMake.
 ARG TENZIR_BUILD_OPTIONS
 
-FROM development-setup AS development
-
 RUN cmake -B build -G Ninja \
-      -D CMAKE_PREFIX_PATH="/opt/aws-sdk-cpp;/opt/google-cloud-cpp;" \
+      -D CMAKE_PREFIX_PATH="/opt/aws-sdk-cpp" \
       -D CMAKE_INSTALL_PREFIX:STRING="$PREFIX" \
       -D CMAKE_BUILD_TYPE:STRING="Release" \
       -D TENZIR_ENABLE_AVX_INSTRUCTIONS:BOOL="OFF" \
@@ -178,7 +173,147 @@ ENTRYPOINT ["tenzir-node"]
 FROM development AS plugins-source
 
 WORKDIR /tmp/tenzir
+COPY plugins ./plugins
 COPY contrib/tenzir-plugins ./contrib/tenzir-plugins
+
+RUN apt-get -y --no-install-recommends install \
+      bats \
+      bats-assert \
+      bats-support
+
+# -- bundled-plugins -------------------------------------------------------------------
+
+FROM plugins-source AS google-cloud-pubsub-plugin
+
+COPY scripts/debian/install-google-cloud.sh ./scripts/debian/
+RUN ./scripts/debian/install-google-cloud.sh
+RUN cmake -S plugins/google-cloud-pubsub -B build-google-cloud-pubsub -G Ninja \
+        -D CMAKE_INSTALL_PREFIX:STRING="$PREFIX" \
+        -D CMAKE_PREFIX_PATH="/opt/google-cloud-cpp;" && \
+      cmake --build build-google-cloud-pubsub --parallel && \
+      cmake --build build-google-cloud-pubsub --target integration && \
+      DESTDIR=/plugin/google-cloud-pubsub cmake --install build-google-cloud-pubsub --strip --component Runtime && \
+      rm -rf build-build-google-cloud-pubsub
+
+FROM plugins-source AS amqp-plugin
+
+RUN cmake -S plugins/amqp -B build-amqp -G Ninja \
+        -D CMAKE_INSTALL_PREFIX:STRING="$PREFIX" && \
+      cmake --build build-amqp --parallel && \
+      cmake --build build-amqp --target integration && \
+      DESTDIR=/plugin/amqp cmake --install build-amqp --strip --component Runtime && \
+      rm -rf build-build-amqp
+
+FROM plugins-source AS azure-blob-storage-plugin
+
+RUN cmake -S plugins/azure-blob-storage -B build-azure-blob-storage -G Ninja \
+        -D CMAKE_INSTALL_PREFIX:STRING="$PREFIX" && \
+      cmake --build build-azure-blob-storage --parallel && \
+      cmake --build build-azure-blob-storage --target integration && \
+      DESTDIR=/plugin/azure-blob-storage cmake --install build-azure-blob-storage --strip --component Runtime && \
+      rm -rf build-build-azure-blob-storage
+
+FROM plugins-source AS fluent-bit-plugin
+
+RUN cmake -S plugins/fluent-bit -B build-fluent-bit -G Ninja \
+        -D CMAKE_INSTALL_PREFIX:STRING="$PREFIX" && \
+      cmake --build build-fluent-bit --parallel && \
+      cmake --build build-fluent-bit --target integration && \
+      DESTDIR=/plugin/fluent-bit cmake --install build-fluent-bit --strip --component Runtime && \
+      rm -rf build-build-fluent-bit
+
+FROM plugins-source AS gcs-plugin
+
+RUN cmake -S plugins/gcs -B build-gcs -G Ninja \
+        -D CMAKE_INSTALL_PREFIX:STRING="$PREFIX" && \
+      cmake --build build-gcs --parallel && \
+      cmake --build build-gcs --target integration && \
+      DESTDIR=/plugin/gcs cmake --install build-gcs --strip --component Runtime && \
+      rm -rf build-build-gcs
+
+FROM plugins-source AS kafka-plugin
+
+RUN cmake -S plugins/kafka -B build-kafka -G Ninja \
+        -D CMAKE_INSTALL_PREFIX:STRING="$PREFIX" && \
+      cmake --build build-kafka --parallel && \
+      cmake --build build-kafka --target integration && \
+      DESTDIR=/plugin/kafka cmake --install build-kafka --strip --component Runtime && \
+      rm -rf build-build-kafka
+
+FROM plugins-source AS nic-plugin
+
+RUN cmake -S plugins/nic -B build-nic -G Ninja \
+        -D CMAKE_INSTALL_PREFIX:STRING="$PREFIX" && \
+      cmake --build build-nic --parallel && \
+      cmake --build build-nic --target integration && \
+      DESTDIR=/plugin/nic cmake --install build-nic --strip --component Runtime && \
+      rm -rf build-build-nic
+
+FROM plugins-source AS s3-plugin
+
+RUN cmake -S plugins/s3 -B build-s3 -G Ninja \
+        -D CMAKE_INSTALL_PREFIX:STRING="$PREFIX" && \
+      cmake --build build-s3 --parallel && \
+      cmake --build build-s3 --target integration && \
+      DESTDIR=/plugin/s3 cmake --install build-s3 --strip --component Runtime && \
+      rm -rf build-build-s3
+
+FROM plugins-source AS sigma-plugin
+
+RUN cmake -S plugins/sigma -B build-sigma -G Ninja \
+        -D CMAKE_INSTALL_PREFIX:STRING="$PREFIX" && \
+      cmake --build build-sigma --parallel && \
+      cmake --build build-sigma --target integration && \
+      DESTDIR=/plugin/sigma cmake --install build-sigma --strip --component Runtime && \
+      rm -rf build-build-sigma
+
+FROM plugins-source AS sqs-plugin
+
+RUN cmake -S plugins/sqs -B build-sqs -G Ninja \
+        -D CMAKE_PREFIX_PATH="/opt/aws-sdk-cpp" \
+        -D CMAKE_INSTALL_PREFIX:STRING="$PREFIX" && \
+      cmake --build build-sqs --parallel && \
+      cmake --build build-sqs --target integration && \
+      DESTDIR=/plugin/sqs cmake --install build-sqs --strip --component Runtime && \
+      rm -rf build-build-sqs
+
+FROM plugins-source AS velociraptor-plugin
+
+RUN cmake -S plugins/velociraptor -B build-velociraptor -G Ninja \
+        -D CMAKE_INSTALL_PREFIX:STRING="$PREFIX" && \
+      cmake --build build-velociraptor --parallel && \
+      cmake --build build-velociraptor --target integration && \
+      DESTDIR=/plugin/velociraptor cmake --install build-velociraptor --strip --component Runtime && \
+      rm -rf build-build-velociraptor
+
+FROM plugins-source AS web-plugin
+
+RUN cmake -S plugins/web -B build-web -G Ninja \
+        -D CMAKE_INSTALL_PREFIX:STRING="$PREFIX" && \
+      cmake --build build-web --parallel && \
+      cmake --build build-web --target integration && \
+      DESTDIR=/plugin/web cmake --install build-web --strip --component Runtime && \
+      rm -rf build-build-web
+
+FROM plugins-source AS yara-plugin
+
+RUN cmake -S plugins/yara -B build-yara -G Ninja \
+        -D CMAKE_INSTALL_PREFIX:STRING="$PREFIX" && \
+      cmake --build build-yara --parallel && \
+      cmake --build build-yara --target integration && \
+      DESTDIR=/plugin/yara cmake --install build-yara --strip --component Runtime && \
+      rm -rf build-build-yara
+
+FROM plugins-source AS zmq-plugin
+
+RUN cmake -S plugins/zmq -B build-zmq -G Ninja \
+        -D CMAKE_INSTALL_PREFIX:STRING="$PREFIX" && \
+      cmake --build build-zmq --parallel && \
+      cmake --build build-zmq --target integration && \
+      DESTDIR=/plugin/zmq cmake --install build-zmq --strip --component Runtime && \
+      rm -rf build-build-zmq
+
+# -- third-party-plugins -------------------------------------------------------------------
 
 FROM plugins-source AS azure-log-analytics-plugin
 
@@ -247,6 +382,21 @@ RUN cmake -S contrib/tenzir-plugins/vast -B build-vast -G Ninja \
 # -- tenzir-ce -------------------------------------------------------------------
 
 FROM tenzir-de AS tenzir-ce
+
+COPY --from=google-cloud-pubsub-plugin --chown=tenzir:tenzir /plugin/google-cloud-pubsub /
+COPY --from=amqp-plugin --chown=tenzir:tenzir /plugin/amqp /
+COPY --from=azure-blob-storage-plugin --chown=tenzir:tenzir /plugin/azure-blob-storage /
+COPY --from=fluent-bit-plugin --chown=tenzir:tenzir /plugin/fluent-bit /
+COPY --from=gcs-plugin --chown=tenzir:tenzir /plugin/gcs /
+COPY --from=kafka-plugin --chown=tenzir:tenzir /plugin/kafka /
+COPY --from=nic-plugin --chown=tenzir:tenzir /plugin/nic /
+COPY --from=s3-plugin --chown=tenzir:tenzir /plugin/s3 /
+COPY --from=sigma-plugin --chown=tenzir:tenzir /plugin/sigma /
+COPY --from=sqs-plugin --chown=tenzir:tenzir /plugin/sqs /
+COPY --from=velociraptor-plugin --chown=tenzir:tenzir /plugin/velociraptor /
+COPY --from=web-plugin --chown=tenzir:tenzir /plugin/web /
+COPY --from=yara-plugin --chown=tenzir:tenzir /plugin/yara /
+COPY --from=zmq-plugin --chown=tenzir:tenzir /plugin/zmq /
 
 COPY --from=azure-log-analytics-plugin --chown=tenzir:tenzir /plugin/azure-log-analytics /
 COPY --from=compaction-plugin --chown=tenzir:tenzir /plugin/compaction /

--- a/Dockerfile
+++ b/Dockerfile
@@ -183,18 +183,6 @@ RUN apt-get -y --no-install-recommends install \
 
 # -- bundled-plugins -------------------------------------------------------------------
 
-FROM plugins-source AS google-cloud-pubsub-plugin
-
-COPY scripts/debian/install-google-cloud.sh ./scripts/debian/
-RUN ./scripts/debian/install-google-cloud.sh
-RUN cmake -S plugins/google-cloud-pubsub -B build-google-cloud-pubsub -G Ninja \
-        -D CMAKE_INSTALL_PREFIX:STRING="$PREFIX" \
-        -D CMAKE_PREFIX_PATH="/opt/google-cloud-cpp;" && \
-      cmake --build build-google-cloud-pubsub --parallel && \
-      cmake --build build-google-cloud-pubsub --target integration && \
-      DESTDIR=/plugin/google-cloud-pubsub cmake --install build-google-cloud-pubsub --strip --component Runtime && \
-      rm -rf build-build-google-cloud-pubsub
-
 FROM plugins-source AS amqp-plugin
 
 RUN cmake -S plugins/amqp -B build-amqp -G Ninja \
@@ -230,6 +218,18 @@ RUN cmake -S plugins/gcs -B build-gcs -G Ninja \
       cmake --build build-gcs --target integration && \
       DESTDIR=/plugin/gcs cmake --install build-gcs --strip --component Runtime && \
       rm -rf build-build-gcs
+
+FROM plugins-source AS google-cloud-pubsub-plugin
+
+COPY scripts/debian/install-google-cloud.sh ./scripts/debian/
+RUN ./scripts/debian/install-google-cloud.sh
+RUN cmake -S plugins/google-cloud-pubsub -B build-google-cloud-pubsub -G Ninja \
+        -D CMAKE_INSTALL_PREFIX:STRING="$PREFIX" \
+        -D CMAKE_PREFIX_PATH="/opt/google-cloud-cpp;" && \
+      cmake --build build-google-cloud-pubsub --parallel && \
+      cmake --build build-google-cloud-pubsub --target integration && \
+      DESTDIR=/plugin/google-cloud-pubsub cmake --install build-google-cloud-pubsub --strip --component Runtime && \
+      rm -rf build-build-google-cloud-pubsub
 
 FROM plugins-source AS kafka-plugin
 
@@ -383,11 +383,11 @@ RUN cmake -S contrib/tenzir-plugins/vast -B build-vast -G Ninja \
 
 FROM tenzir-de AS tenzir-ce
 
-COPY --from=google-cloud-pubsub-plugin --chown=tenzir:tenzir /plugin/google-cloud-pubsub /
 COPY --from=amqp-plugin --chown=tenzir:tenzir /plugin/amqp /
 COPY --from=azure-blob-storage-plugin --chown=tenzir:tenzir /plugin/azure-blob-storage /
 COPY --from=fluent-bit-plugin --chown=tenzir:tenzir /plugin/fluent-bit /
 COPY --from=gcs-plugin --chown=tenzir:tenzir /plugin/gcs /
+COPY --from=google-cloud-pubsub-plugin --chown=tenzir:tenzir /plugin/google-cloud-pubsub /
 COPY --from=kafka-plugin --chown=tenzir:tenzir /plugin/kafka /
 COPY --from=nic-plugin --chown=tenzir:tenzir /plugin/nic /
 COPY --from=s3-plugin --chown=tenzir:tenzir /plugin/s3 /

--- a/changelog/next/bug-fixes/4690--google-cloud-pubsub-docker
+++ b/changelog/next/bug-fixes/4690--google-cloud-pubsub-docker
@@ -1,0 +1,2 @@
+This `google-cloud-pubsub` connector and TQL2 operators `load_google_cloud_pubsub`
+`save_google_cloud_pubsub` operators are now available in the Docker image.

--- a/changelog/next/bug-fixes/4690--google-cloud-pubsub-docker
+++ b/changelog/next/bug-fixes/4690--google-cloud-pubsub-docker
@@ -1,2 +1,2 @@
-This `google-cloud-pubsub` connector and TQL2 operators `load_google_cloud_pubsub`
+The `google-cloud-pubsub` connector and TQL2 operators `load_google_cloud_pubsub`
 `save_google_cloud_pubsub` operators are now available in the Docker image.

--- a/plugins/fluent-bit/integration/tests/setup_suite.bash
+++ b/plugins/fluent-bit/integration/tests/setup_suite.bash
@@ -7,4 +7,5 @@ setup_suite() {
 
 libpath_relative_to_binary="$(realpath "$(dirname "$(command -v tenzir)")")/../share/tenzir/integration/lib"
 libpath_relative_to_pwd="${BATS_TEST_DIRNAME}/../../../../lib"
-export BATS_LIB_PATH=${BATS_LIB_PATH:+${BATS_LIB_PATH}:}${libpath_relative_to_binary}:${libpath_relative_to_pwd}
+libpath_relative_if_external=${BATS_TEST_DIRNAME}/../../../../tenzir/integration/lib #needed for the externalized build in docker
+export BATS_LIB_PATH=${BATS_LIB_PATH:+${BATS_LIB_PATH}:}${libpath_relative_to_binary}:${libpath_relative_to_pwd}:${libpath_relative_if_external}

--- a/plugins/parquet/integration/tests/setup_suite.bash
+++ b/plugins/parquet/integration/tests/setup_suite.bash
@@ -1,6 +1,7 @@
 libpath_relative_to_binary="$(realpath "$(dirname "$(command -v tenzir)")")/../share/tenzir/integration/lib"
 libpath_relative_to_pwd="${BATS_TEST_DIRNAME}/../../../../lib"
-export BATS_LIB_PATH=${BATS_LIB_PATH:+${BATS_LIB_PATH}:}${libpath_relative_to_binary}:${libpath_relative_to_pwd}
+libpath_relative_if_external=${BATS_TEST_DIRNAME}/../../../../tenzir/integration/lib #needed for the externalized build in docker
+export BATS_LIB_PATH=${BATS_LIB_PATH:+${BATS_LIB_PATH}:}${libpath_relative_to_binary}:${libpath_relative_to_pwd}:${libpath_relative_if_external}
 
 setup_suite() {
   bats_require_minimum_version 1.8.0

--- a/plugins/sqs/integration/tests/setup_suite.bash
+++ b/plugins/sqs/integration/tests/setup_suite.bash
@@ -7,4 +7,5 @@ setup_suite() {
 
 libpath_relative_to_binary="$(realpath "$(dirname "$(command -v tenzir)")")/../share/tenzir/integration/lib"
 libpath_relative_to_pwd="${BATS_TEST_DIRNAME}/../../../../lib"
-export BATS_LIB_PATH=${BATS_LIB_PATH:+${BATS_LIB_PATH}:}${libpath_relative_to_binary}:${libpath_relative_to_pwd}
+libpath_relative_if_external=${BATS_TEST_DIRNAME}/../../../../tenzir/integration/lib #needed for the externalized build in docker
+export BATS_LIB_PATH=${BATS_LIB_PATH:+${BATS_LIB_PATH}:}${libpath_relative_to_binary}:${libpath_relative_to_pwd}:${libpath_relative_if_external}

--- a/plugins/web/integration/tests/setup_suite.bash
+++ b/plugins/web/integration/tests/setup_suite.bash
@@ -7,4 +7,5 @@ setup_suite() {
 
 libpath_relative_to_binary="$(realpath "$(dirname "$(command -v tenzir)")")/../share/tenzir/integration/lib"
 libpath_relative_to_pwd="${BATS_TEST_DIRNAME}/../../../../lib"
-export BATS_LIB_PATH=${BATS_LIB_PATH:+${BATS_LIB_PATH}:}${libpath_relative_to_binary}:${libpath_relative_to_pwd}
+libpath_relative_if_external=${BATS_TEST_DIRNAME}/../../../../tenzir/integration/lib #needed for the externalized build in docker
+export BATS_LIB_PATH=${BATS_LIB_PATH:+${BATS_LIB_PATH}:}${libpath_relative_to_binary}:${libpath_relative_to_pwd}:${libpath_relative_if_external}

--- a/plugins/yara/integration/tests/setup_suite.bash
+++ b/plugins/yara/integration/tests/setup_suite.bash
@@ -7,4 +7,5 @@ setup_suite() {
 
 libpath_relative_to_binary="$(realpath "$(dirname "$(command -v tenzir)")")/../share/tenzir/integration/lib"
 libpath_relative_to_pwd="${BATS_TEST_DIRNAME}/../../../../lib"
-export BATS_LIB_PATH=${BATS_LIB_PATH:+${BATS_LIB_PATH}:}${libpath_relative_to_binary}:${libpath_relative_to_pwd}
+libpath_relative_if_external=${BATS_TEST_DIRNAME}/../../../../tenzir/integration/lib #needed for the externalized build in docker
+export BATS_LIB_PATH=${BATS_LIB_PATH:+${BATS_LIB_PATH}:}${libpath_relative_to_binary}:${libpath_relative_to_pwd}:${libpath_relative_if_external}

--- a/scripts/debian/install-google-cloud.sh
+++ b/scripts/debian/install-google-cloud.sh
@@ -19,7 +19,7 @@ pushd crc32c
 cmake -B build -S . \
 -G "Unix Makefiles" \
   -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_INSTALL_PREFIX="&{INSTALL_PREFIX}" \
+  -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
   -DCRC32C_BUILD_TESTS=0 \
   -DCRC32C_BUILD_BENCHMARKS=0 \
   -DCRC32C_BUILD_BENCHMARKS=0 \
@@ -34,7 +34,8 @@ curl -L 'https://github.com/googleapis/google-cloud-cpp/archive/refs/tags/v2.30.
 cmake -B build -S . \
   -G "Unix Makefiles" \
   -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_INSTALL_PREFIX="&{INSTALL_PREFIX}" \
+  -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
+  -DCRC32C_DIR="${INSTALL_PREFIX}" \
   -DBUILD_TESTING=OFF \
   -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
   -DGOOGLE_CLOUD_CPP_WITH_MOCKS=OFF \

--- a/scripts/debian/install-google-cloud.sh
+++ b/scripts/debian/install-google-cloud.sh
@@ -1,0 +1,52 @@
+#! /usr/bin/env bash
+
+set -euo pipefail
+
+apt-get -qq update
+apt-get install --no-install-recommends -y \
+  git \
+  libgrpc++-dev \
+  libgtest-dev \
+  nlohmann-json3-dev
+
+INSTALL_PREFIX="/opt/google-cloud-cpp"
+
+mkdir -p source
+pushd source
+
+git clone --depth 1 --shallow-submodules --recurse-submodules  https://github.com/google/crc32c
+pushd crc32c
+cmake -B build -S . \
+-G "Unix Makefiles" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="&{INSTALL_PREFIX}" \
+  -DCRC32C_BUILD_TESTS=0 \
+  -DCRC32C_BUILD_BENCHMARKS=0 \
+  -DCRC32C_BUILD_BENCHMARKS=0 \
+  -DCMAKE_CXX_STANDARD=20
+cmake --build build --parallel "$(nproc --all)"
+cmake --install build --strip
+popd
+
+mkdir google-cloud-cpp
+pushd google-cloud-cpp
+curl -L 'https://github.com/googleapis/google-cloud-cpp/archive/refs/tags/v2.30.0.tar.gz' | tar -xz --strip-components=1
+cmake -B build -S . \
+  -G "Unix Makefiles" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="&{INSTALL_PREFIX}" \
+  -DBUILD_TESTING=OFF \
+  -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
+  -DGOOGLE_CLOUD_CPP_WITH_MOCKS=OFF \
+  -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+  -DCMAKE_CXX_STANDARD=20
+cmake --build build --parallel "$(nproc --all)"
+cmake --install build --strip
+popd
+
+popd
+rm -rf source
+ls -l /
+
+echo "/opt//opt/google-cloud-cpp/lib" > /etc/ld.so.conf.d/google-cloud-cpp.conf
+ldconfig


### PR DESCRIPTION
This PR builds the google_cloud_cpp dependency in the docker image, enabling the google-cloud-pubsub connector.