### PR TITLE
Ensure cache directory is writable for multiple users

### DIFF
--- a/changelog/next/bug-fixes/4694--cache-writeable.md
+++ b/changelog/next/bug-fixes/4694--cache-writeable.md
@@ -1,0 +1,3 @@
+Using the `tenzir` process from multiple users on the same host sometimes failed
+because the cache directory was not writable for all users. This no longer
+happens.

--- a/libtenzir/src/configuration.cpp
+++ b/libtenzir/src/configuration.cpp
@@ -520,7 +520,7 @@ auto configuration::parse(int argc, char** argv) -> caf::error {
         return caf::make_error(ec::filesystem_error,
                                "failed to determine temp_directory_path");
       }
-      auto path = tmp / "tenzir" / "cache" / fmt::format("{:}", getuid());
+      auto path = tmp / fmt::format("tenzir-cache-{:}", getuid());
       std::filesystem::create_directories(path, ec);
       if (ec) {
         return caf::make_error(

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -32,11 +32,11 @@ tenzir:
   #   - $XDG_CACHE_HOME
   #   - $XDG_HOME_DIR/.cache/tenzir (linux) or $XDG_HOME_DIR/Libraries/caches/tenzir (mac)
   #   - $HOME/.cache/tenzir (linux) or $HOME/Libraries/caches/tenzir (mac)
-  #   - $TEMPORARY_DIRECTORY/tenzir/cache/<uid>
+  #   - $TEMPORARY_DIRECTORY/tenzir-cache-<uid>
   # To determine $TEMPORARY_DIRECTORY, the values of TMPDIR, TMP, TEMP, TEMPDIR are
   # checked in that order, and as a last resort "/tmp" is used.
-  # In a client process, this setting is ignored and `$TEMPORARY_DIRECTORY/tenzir/client-cache/<uid>`
-  # is used as cache directory.
+  # In a client process, this setting is ignored and
+  # `$TEMPORARY_DIRECTORY/tenzir-client-cache-<uid>` is used as cache directory.
   #cache-directory:
 
   # The file system path used for log files.

--- a/tenzir/tenzir.cpp
+++ b/tenzir/tenzir.cpp
@@ -103,7 +103,7 @@ auto main(int argc, char** argv) -> int {
       TENZIR_ERROR("failed to determine location of temporary directory");
       return EXIT_FAILURE;
     }
-    auto path = tmp / "tenzir" / "client-cache" / fmt::format("{:}", getuid());
+    auto path = tmp / fmt::format("tenzir-client-cache-{:}", getuid());
     put(cfg.content, "tenzir.cache-directory", path.string());
     if (previous_value) {
       TENZIR_VERBOSE("using {} as cache directory instead of configured value "


### PR DESCRIPTION
The `tenzir` binary creates intermediate directories for the cache directory as necessary. If these do not yet exist, they will be owned by the first user running the process. That can cause other users running the process later to fail, as they may not have permission to access the intermediate directories if the system is locked down enough. This change fixes this problem by simply removing the intermediate directories.