### PR TITLE
Add a `value_counts` aggregation function

### DIFF
--- a/changelog/next/bug-fixes/4701--mode.md
+++ b/changelog/next/bug-fixes/4701--mode.md
@@ -1,0 +1,2 @@
+We fixed a bug that caused the `mode` aggregation function to sometimes ignore
+some input values.

--- a/changelog/next/features/4701--value-counts.md
+++ b/changelog/next/features/4701--value-counts.md
@@ -1,0 +1,2 @@
+The new `value_counts` aggregation function returns a list of values and their
+frequency.

--- a/libtenzir/builtins/aggregation-functions/mode_value_counts.cpp
+++ b/libtenzir/builtins/aggregation-functions/mode_value_counts.cpp
@@ -10,13 +10,19 @@
 #include <tenzir/tql2/eval.hpp>
 #include <tenzir/tql2/plugin.hpp>
 
-namespace tenzir::plugins::mode {
+namespace tenzir::plugins::mode_value_counts {
 
 namespace {
 
-class mode_instance final : public aggregation_instance {
+enum class kind {
+  mode,
+  value_counts,
+};
+
+template <kind Kind>
+class instance final : public aggregation_instance {
 public:
-  explicit mode_instance(ast::expression expr) : expr_{std::move(expr)} {
+  explicit instance(ast::expression expr) : expr_{std::move(expr)} {
   }
 
   auto update(const table_slice& input, session ctx) -> void override {
@@ -33,20 +39,34 @@ public:
           continue;
         }
         ++it.value();
-        return;
       }
     }
   }
 
   auto finish() -> data override {
-    const auto comp = [](const auto& lhs, const auto& rhs) {
-      return lhs.second < rhs.second;
-    };
-    const auto it = std::ranges::max_element(counts_, comp);
-    if (it == counts_.end()) {
-      return {};
+    if constexpr (Kind == kind::mode) {
+      const auto comp = [](const auto& lhs, const auto& rhs) {
+        return lhs.second < rhs.second;
+      };
+      const auto it = std::ranges::max_element(counts_, comp);
+      if (it == counts_.end()) {
+        return {};
+      }
+      return it->first;
+    } else {
+      auto result = list{};
+      result.reserve(counts_.size());
+      for (const auto& [value, count] : counts_) {
+        result.emplace_back(record{
+          {"value", value},
+          {"count", count},
+        });
+      }
+      std::ranges::sort(result, std::less<>{}, [](const auto& x) {
+        return as_vector(caf::get<record>(x))[0].second;
+      });
+      return result;
     }
-    return it->first;
   }
 
 private:
@@ -54,21 +74,26 @@ private:
   tsl::robin_map<data, int64_t> counts_ = {};
 };
 
+template <kind Kind>
 class plugin : public virtual aggregation_plugin {
   auto name() const -> std::string override {
-    return "mode";
+    return Kind == kind::mode ? "mode" : "value_counts";
   };
 
   auto make_aggregation(invocation inv, session ctx) const
     -> failure_or<std::unique_ptr<aggregation_instance>> override {
     auto expr = ast::expression{};
     TRY(argument_parser2::function(name()).add(expr, "<expr>").parse(inv, ctx));
-    return std::make_unique<mode_instance>(std::move(expr));
+    return std::make_unique<instance<Kind>>(std::move(expr));
   }
 };
 
+using mode_plugin = plugin<kind::mode>;
+using value_counts_plugin = plugin<kind::value_counts>;
+
 } // namespace
 
-} // namespace tenzir::plugins::mode
+} // namespace tenzir::plugins::mode_value_counts
 
-TENZIR_REGISTER_PLUGIN(tenzir::plugins::mode::plugin)
+TENZIR_REGISTER_PLUGIN(tenzir::plugins::mode_value_counts::mode_plugin)
+TENZIR_REGISTER_PLUGIN(tenzir::plugins::mode_value_counts::value_counts_plugin)

--- a/libtenzir/builtins/operators/version.cpp
+++ b/libtenzir/builtins/operators/version.cpp
@@ -35,7 +35,39 @@ public:
   version_operator() = default;
 
   auto operator()(operator_control_plane&) const -> generator<table_slice> {
-    auto builder = series_builder{};
+    auto builder = series_builder{type{
+      "tenzir.version",
+      record_type{
+        {"version", string_type{}},
+        {"tag", string_type{}},
+        {"major", uint64_type{}},
+        {"minor", uint64_type{}},
+        {"patch", uint64_type{}},
+        {"features", list_type{string_type{}}},
+        {
+          "build",
+          record_type{
+            {"type", string_type{}},
+            {"tree_hash", string_type{}},
+            {"assertions", bool_type{}},
+            {
+              "sanitizers",
+              record_type{
+                {"address", bool_type{}},
+                {"undefined_behavior", bool_type{}},
+              },
+            },
+          },
+        },
+        {
+          "dependencies",
+          list_type{record_type{
+            {"name", string_type{}},
+            {"version", string_type{}},
+          }},
+        },
+      },
+    }};
     auto event = builder.record();
     event.field("version", tenzir::version::version);
     event.field("tag", tenzir::version::build_metadata);

--- a/web/docs/tql2/operators/summarize.md
+++ b/web/docs/tql2/operators/summarize.md
@@ -52,6 +52,8 @@ differently, take exactly one argument:
 - `median`: Computes the approximate median of all grouped values with a
   t-digest algorithm.
 - `mode`: Takes the most common of all grouped values that is not null.
+- `value_counts`: Returns a list of all grouped values alongside their
+  frequency.
 - `quantile`: Computes the quantile specified by the named argument `q`, for
   example: `quantile(x, q=0.2)`.
 - `stddev`: Computes the standard deviation of all grouped values.


### PR DESCRIPTION
This adds a `value_counts` aggregation function that returns an a list of values alongside their frequency.

Additionally, this fixes a bug in `mode` that caused it to only consider the first non-null value per batch.