### PR TITLE
Allow reinstantiating the `buffer` operator

### DIFF
--- a/changelog/next/bug-fixes/4702--restart-buffer.md
+++ b/changelog/next/bug-fixes/4702--restart-buffer.md
@@ -1,0 +1,3 @@
+We fixed a bug in the `buffer` operator that caused it to break when
+restarting a pipeline or using multiple buffers in a "parallel" context,
+such as in `load_tcp`'s pipeline argument.

--- a/libtenzir/builtins/operators/tcp-listen.cpp
+++ b/libtenzir/builtins/operators/tcp-listen.cpp
@@ -16,6 +16,7 @@
 #include <tenzir/parser_interface.hpp>
 #include <tenzir/pipeline.hpp>
 #include <tenzir/plugin.hpp>
+#include <tenzir/uuid.hpp>
 
 #include <arrow/type.h>
 #include <boost/asio.hpp>
@@ -78,6 +79,10 @@ public:
   }
 
   auto self() noexcept -> exec_node_actor::base& override {
+    TENZIR_UNIMPLEMENTED();
+  }
+
+  auto run_id() const noexcept -> uuid override {
     TENZIR_UNIMPLEMENTED();
   }
 

--- a/libtenzir/include/tenzir/actors.hpp
+++ b/libtenzir/include/tenzir/actors.hpp
@@ -355,7 +355,7 @@ using node_actor = typed_actor_fwd<
   // Spawn a set of execution nodes for a given pipeline. Does not start the
   // execution nodes.
   auto(atom::spawn, operator_box, operator_type, receiver_actor<diagnostic>,
-       metrics_receiver_actor, int index, bool is_hidden)
+       metrics_receiver_actor, int index, bool is_hidden, uuid run_id)
     ->caf::result<exec_node_actor>>::unwrap;
 
 /// The interface of a PIPELINE EXECUTOR actor.

--- a/libtenzir/include/tenzir/execution_node.hpp
+++ b/libtenzir/include/tenzir/execution_node.hpp
@@ -4,6 +4,7 @@
 
 #include "tenzir/actors.hpp"
 #include "tenzir/pipeline.hpp"
+#include "tenzir/uuid.hpp"
 
 #include <caf/typed_event_based_actor.hpp>
 
@@ -46,6 +47,7 @@ namespace tenzir {
 /// @param metrices_receiver The handler asked to receive and forward metrics.
 /// @param has_terminal True if the operator shall have access to the terminal.
 /// @param is_hidden Whether the operator is run in the background.
+/// @param run_id A unique id for the current pipeline run.
 ///
 /// @returns The execution node actor and its output type, or an error.
 /// @pre op != nullptr
@@ -55,7 +57,7 @@ auto spawn_exec_node(caf::scheduled_actor* self, operator_ptr op,
                      operator_type input_type, node_actor node,
                      receiver_actor<diagnostic> diagnostics_handler,
                      metrics_receiver_actor metrics_receiver, int index,
-                     bool has_terminal, bool is_hidden)
+                     bool has_terminal, bool is_hidden, uuid run_id)
   -> caf::expected<std::pair<exec_node_actor, operator_type>>;
 
 } // namespace tenzir

--- a/libtenzir/include/tenzir/operator_control_plane.hpp
+++ b/libtenzir/include/tenzir/operator_control_plane.hpp
@@ -29,6 +29,9 @@ struct operator_control_plane {
   /// Returns the hosting actor.
   virtual auto self() noexcept -> exec_node_actor::base& = 0;
 
+  /// Returns a unique id for the current run.
+  virtual auto run_id() const noexcept -> uuid = 0;
+
   /// Returns the node actor, if the operator location is remote.
   virtual auto node() noexcept -> node_actor = 0;
 

--- a/libtenzir/include/tenzir/pipeline_executor.hpp
+++ b/libtenzir/include/tenzir/pipeline_executor.hpp
@@ -5,6 +5,7 @@
 #include "tenzir/actors.hpp"
 #include "tenzir/diagnostics.hpp"
 #include "tenzir/pipeline.hpp"
+#include "tenzir/uuid.hpp"
 
 #include <caf/typed_event_based_actor.hpp>
 
@@ -16,7 +17,10 @@ struct pipeline_executor_state {
   /// A pointer to the parent actor.
   pipeline_executor_actor::pointer self = {};
 
-  // A handle to the node actor.
+  /// A unique id for the current run.
+  uuid run_id = uuid::random();
+
+  /// A handle to the node actor.
   node_actor node = {};
 
   /// The currently running pipeline.
@@ -24,12 +28,11 @@ struct pipeline_executor_state {
   std::vector<exec_node_actor> exec_nodes = {};
   caf::typed_response_promise<void> start_rp = {};
 
-  // The diagnostic handler that receives diagnostics from all the execution
-  // nodes.
+  /// The diagnostic handler that receives diagnostics from all the execution
+  /// nodes.
   receiver_actor<diagnostic> diagnostics = {};
 
-  // The metric handler that receives metrics from all the execution
-  // nodes.
+  /// The metric handler that receives metrics from all the execution nodes.
   metrics_receiver_actor metrics = {};
 
   /// Flag for disallowing location overrides.

--- a/libtenzir/src/node.cpp
+++ b/libtenzir/src/node.cpp
@@ -66,11 +66,14 @@ auto find_endpoint_plugin(const http_request_description& desc)
   -> const rest_endpoint_plugin* {
   for (auto const& plugin : plugins::get()) {
     auto const* rest_plugin = plugin.as<rest_endpoint_plugin>();
-    if (!rest_plugin)
+    if (!rest_plugin) {
       continue;
-    for (const auto& endpoint : rest_plugin->rest_endpoints())
-      if (endpoint.canonical_path() == desc.canonical_path)
+    }
+    for (const auto& endpoint : rest_plugin->rest_endpoints()) {
+      if (endpoint.canonical_path() == desc.canonical_path) {
         return rest_plugin;
+      }
+    }
   }
   return nullptr;
 }
@@ -118,17 +121,20 @@ auto node_state::get_endpoint_handler(const http_request_description& desc)
   -> const handler_and_endpoint& {
   static const auto empty_response = handler_and_endpoint{};
   auto it = rest_handlers.find(desc.canonical_path);
-  if (it != rest_handlers.end())
+  if (it != rest_handlers.end()) {
     return it->second;
+  }
   // Spawn handler on first usage
   auto const* plugin = find_endpoint_plugin(desc);
-  if (!plugin)
+  if (!plugin) {
     return empty_response;
+  }
   // TODO: Monitor the spawned handler and restart if it goes down.
   auto handler = plugin->handler(self->system(), self);
-  for (auto const& endpoint : plugin->rest_endpoints())
+  for (auto const& endpoint : plugin->rest_endpoints()) {
     rest_handlers[endpoint.canonical_path()]
       = std::make_pair(handler, endpoint);
+  }
   auto result = rest_handlers.find(desc.canonical_path);
   // If no canonical path matches, `find_endpoint_plugin()` should
   // have already returned `nullptr`.
@@ -428,17 +434,19 @@ auto node(node_actor::stateful_pointer<node_state> self, std::string /*name*/,
     caf::actor filesystem_handle;
     for (const char* name : ordered_core_components) {
       if (auto comp = registry.remove(name)) {
-        if (comp->type == "filesystem")
+        if (comp->type == "filesystem") {
           filesystem_handle = comp->actor;
-        else
+        } else {
           core_shutdown_handles.push_back(comp->actor);
+        }
       }
     }
     std::vector<caf::actor> aux_components;
     for (const auto& [_, comp] : registry.components()) {
       // Ignore remote actors.
-      if (comp.actor->node() != self->node())
+      if (comp.actor->node() != self->node()) {
         continue;
+      }
       aux_components.push_back(comp.actor);
     }
     // Drop everything.
@@ -512,13 +520,15 @@ auto node(node_actor::stateful_pointer<node_state> self, std::string /*name*/,
           caf::make_error(ec::logic_error, "failed to spawn endpoint handler"));
       }
       auto unparsed_params = http_parameter_map::from_json(desc.json_body);
-      if (!unparsed_params)
+      if (!unparsed_params) {
         return rest_response::make_error(400, "invalid json",
                                          unparsed_params.error());
+      }
       auto params = parse_endpoint_parameters(endpoint, *unparsed_params);
-      if (!params)
+      if (!params) {
         return rest_response::make_error(400, "invalid parameters",
                                          params.error());
+      }
       auto rp = self->make_response_promise<rest_response>();
       auto deliver = [rp, self, desc, params, endpoint,
                       request_id = std::move(request_id),
@@ -603,7 +613,7 @@ auto node(node_actor::stateful_pointer<node_state> self, std::string /*name*/,
     [self](atom::spawn, operator_box& box, operator_type input_type,
            const receiver_actor<diagnostic>& diagnostic_handler,
            const metrics_receiver_actor& metrics_receiver, int index,
-           bool is_hidden) -> caf::result<exec_node_actor> {
+           bool is_hidden, uuid run_id) -> caf::result<exec_node_actor> {
       auto op = std::move(box).unwrap();
       if (op->location() == operator_location::local) {
         return caf::make_error(ec::logic_error,
@@ -615,7 +625,7 @@ auto node(node_actor::stateful_pointer<node_state> self, std::string /*name*/,
       auto spawn_result
         = spawn_exec_node(self, std::move(op), input_type,
                           static_cast<node_actor>(self), diagnostic_handler,
-                          metrics_receiver, index, false, is_hidden);
+                          metrics_receiver, index, false, is_hidden, run_id);
       if (not spawn_result) {
         return caf::make_error(ec::logic_error,
                                fmt::format("{} failed to spawn execution node "

--- a/libtenzir/src/pipeline.cpp
+++ b/libtenzir/src/pipeline.cpp
@@ -13,6 +13,7 @@
 #include "tenzir/modules.hpp"
 #include "tenzir/plugin.hpp"
 #include "tenzir/tql/parser.hpp"
+#include "tenzir/uuid.hpp"
 
 #include <caf/detail/stringification_inspector.hpp>
 #include <caf/fwd.hpp>
@@ -22,6 +23,10 @@ namespace tenzir {
 class local_control_plane final : public operator_control_plane {
 public:
   auto self() noexcept -> exec_node_actor::base& override {
+    TENZIR_UNIMPLEMENTED();
+  }
+
+  auto run_id() const noexcept -> uuid override {
     TENZIR_UNIMPLEMENTED();
   }
 

--- a/libtenzir/src/pipeline_executor.cpp
+++ b/libtenzir/src/pipeline_executor.cpp
@@ -110,7 +110,7 @@ void pipeline_executor_state::spawn_execution_nodes(pipeline pipe) {
       self
         ->request(node, caf::infinite, atom::spawn_v,
                   operator_box{std::move(op)}, input_type, diagnostics, metrics,
-                  op_index, is_hidden)
+                  op_index, is_hidden, run_id)
         .then(
           [this, description, index](exec_node_actor& exec_node) {
             TENZIR_VERBOSE("{} spawned {} remotely", *self, description);
@@ -128,7 +128,7 @@ void pipeline_executor_state::spawn_execution_nodes(pipeline pipe) {
       TENZIR_DEBUG("{} spawns {} locally", *self, description);
       auto spawn_result
         = spawn_exec_node(self, std::move(op), input_type, node, diagnostics,
-                          metrics, op_index, has_terminal, is_hidden);
+                          metrics, op_index, has_terminal, is_hidden, run_id);
       if (not spawn_result) {
         abort_start(diagnostic::error(spawn_result.error())
                       .note("failed to spawn {} locally", description)


### PR DESCRIPTION
This fixes a rather annoying bug: it was not possible to instantiate the `buffer` operator a second time without parsing it again. This is due to how the operator, which physically consistents of two operators, exchanges information by (ab)using the actor registry as a communication channel. This broke when (1) restarting a pipeline with the oeprator through the Tenzir Platform, or (2) using the operator in a nested pipeline that gets instantiated multiple times, for example in `load_tcp` with at least two connections.
