### PR TITLE
Add `<aggregation>.over(<str>)`

### DIFF
--- a/changelog/next/bug-fixes/4703--over.md
+++ b/changelog/next/bug-fixes/4703--over.md
@@ -1,0 +1,6 @@
+The newly added aggregation function `over` computes another aggregation
+function per unique non-null value of an expression, returning a record with the
+values lifted into field names of the returned record and their corresponding
+aggregated values. In essence, the aggregation functions modifies an existing
+aggregation function to do another grouping, and also allows for pivoting
+columns into rows.

--- a/libtenzir/builtins/aggregation-functions/over.cpp
+++ b/libtenzir/builtins/aggregation-functions/over.cpp
@@ -1,0 +1,151 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2024 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <tenzir/tql2/ast.hpp>
+#include <tenzir/tql2/eval.hpp>
+#include <tenzir/tql2/parser.hpp>
+#include <tenzir/tql2/plugin.hpp>
+#include <tenzir/tql2/resolve.hpp>
+
+namespace tenzir::plugins::over {
+
+namespace {
+
+class over_instance : public aggregation_instance {
+public:
+  over_instance(ast::expression expr, ast::function_call call)
+    : expr_{std::move(expr)}, call_{std::move(call)} {
+  }
+
+  auto update(const table_slice& input, session ctx) -> void override {
+    const auto key_series = eval(expr_, input, ctx);
+    if (caf::holds_alternative<null_type>(key_series.type)) {
+      return;
+    }
+    const auto keys = key_series.as<string_type>();
+    if (not keys) {
+      diagnostic::warning("expected `string`, but got `{}`",
+                          key_series.type.kind())
+        .primary(expr_)
+        .emit(ctx);
+      return;
+    }
+    auto previous_key = std::optional<std::string>{};
+    const auto update = [&](int64_t begin, int64_t end) {
+      if (begin == end or not previous_key) {
+        return;
+      }
+      auto sub = subslice(input, begin, end);
+      auto it = instances_.find(*previous_key);
+      if (it == instances_.end()) {
+        const auto* fn
+          = dynamic_cast<const aggregation_plugin*>(&ctx.reg().get(call_));
+        TENZIR_ASSERT(fn);
+        auto instance
+          = fn->make_aggregation(aggregation_plugin::invocation{call_}, ctx);
+        TENZIR_ASSERT(instance);
+        it = instances_.emplace_hint(it, std::string{*previous_key},
+                                     std::move(*instance));
+      }
+      it->second->update(subslice(input, begin, end), ctx);
+    };
+    auto first = int64_t{0};
+    auto last = int64_t{0};
+    while (last < keys->length()) {
+      const auto is_null = keys->array->IsNull(last);
+      // If the key is null, we must flush.
+      if (is_null) {
+        update(first, last);
+        ++last;
+        first = last;
+        previous_key.reset();
+        continue;
+      }
+      // If the key stayed the same, we can keep going.
+      const auto view = keys->array->GetView(last);
+      if (view == previous_key) {
+        ++last;
+        continue;
+      }
+      // If the key changed and we have a previous key, we must flush.
+      if (previous_key) {
+        update(first, last);
+      }
+      // Update the key for the next round.
+      first = last;
+      ++last;
+      previous_key = std::string{view};
+    }
+    update(first, last);
+  }
+
+  auto finish() -> data override {
+    auto result = record{};
+    result.reserve(instances_.size());
+    for (const auto& [key, instance] : instances_) {
+      result.emplace(key, instance->finish());
+    }
+    std::ranges::sort(result, std::less<>{}, [](const auto& x) {
+      return x.first;
+    });
+    return result;
+  }
+
+private:
+  ast::expression expr_ = {};
+  ast::function_call call_ = {};
+  tsl::robin_map<std::string, std::unique_ptr<aggregation_instance>> instances_
+    = {};
+};
+
+class plugin : public virtual aggregation_plugin {
+  auto name() const -> std::string override {
+    return "over";
+  };
+
+  auto make_aggregation(invocation inv, session ctx) const
+    -> failure_or<std::unique_ptr<aggregation_instance>> override {
+    // value.sum().over(key)
+    auto call = ast::expression{};
+    auto expr = ast::expression{};
+    TRY(argument_parser2::function(name())
+          .add(call, "<aggregation>")
+          .add(expr, "<expr>")
+          .parse(inv, ctx));
+    return call.match(
+      [&](ast::function_call& call)
+        -> failure_or<std::unique_ptr<aggregation_instance>> {
+        const auto* fn
+          = dynamic_cast<const aggregation_plugin*>(&ctx.reg().get(call));
+        if (not fn) {
+          diagnostic::error("function does not support aggregations")
+            .primary(call.fn)
+            .emit(ctx);
+          return failure::promise();
+        }
+        if (not fn->make_aggregation(aggregation_plugin::invocation{call},
+                                     ctx)) {
+          return failure::promise();
+        }
+        return std::make_unique<over_instance>(std::move(expr),
+                                               std::move(call));
+      },
+      [&](const auto&) -> failure_or<std::unique_ptr<aggregation_instance>> {
+        diagnostic::error("expected aggregation function call")
+          .primary(call)
+          .emit(ctx);
+        return failure::promise();
+      });
+  }
+};
+
+} // namespace
+
+} // namespace tenzir::plugins::over
+
+TENZIR_REGISTER_PLUGIN(tenzir::plugins::over::plugin)

--- a/web/docs/tql2/operators/summarize.md
+++ b/web/docs/tql2/operators/summarize.md
@@ -63,6 +63,9 @@ differently, take exactly one argument:
 - `count`: When used as `count()`, simply counts the events in the group. When
   used as `count(x)`, counts all grouped values that are not null.
 - `count_distinct`: Counts all distinct grouped values that are not null.
+- `over`: Given `fun(…).over(str)`, computes the aggregation function `fun(…)`
+  per unique non-null value of `str`, returning the record `{str: fun(…), …}`
+  with the values of `str` lifted into field names of the returned record.
 
 ## Examples
 
@@ -128,4 +131,19 @@ pairs:
 ```tql
 ts = round(ts, 1h)
 summarize ts, src_ip, dest_ip, sum(bytes_in), sum(bytes_out)
+```
+
+Count events in each category, creating separate counts depending on the name.
+
+```tql
+from [
+  {category: 1, name: "foo", x: 1},
+  {category: 1, name: "bar", x: 2},
+  {category: 1, name: "bar", x: 3},
+  {category: 2, name: "foo", x: 4},
+]
+summarize category, x=sum(x).over(name)
+―――――――――――――――――――――――――――――――――――――――
+{category: 1, x: {foo: 1, bar: 5}}
+{category: 2, x: {foo: 4, bar: null}}
 ```


### PR DESCRIPTION
This is our first higher-order aggregation function: It performs an aggregation once per unique value of a string, returning a record using the strings as keys and the respective aggregations as values.

> [!WARNING]
> We did not yet implement universal function call syntax, so in this PR the aggregation function must be used as `over(<aggregation>, <str>)` instead. This is coming soon, and because this is really easier to read as a method, I documented the function assuming UFCS already.

Why is this useful? The primary reason is creating charts, and having data of unknown cardinality defined by the value of a string. For example, consider wanting to create a chart that shows the throughout for all topics that all `publish` operators write to:

```tql
// tql2
metrics "publish"
select timestamp, topic, events
―――――――――――――――――――――――――――――――――――――――――
{
  timestamp: 2024-10-26T20:26:09.124214,
  topic: "foo",
  events: 40585
}
{
  timestamp: 2024-10-26T20:26:09.125613,
  topic: "bar",
  events: 3595
}
{
  timestamp: 2024-10-26T20:26:09.125616,
  topic: "baz",
  events: 2122
}
…
```

In production deployments, I have myself written code like this:

```tql
metrics "publish"
if topic == "foo" {
  select timestamp, foo=events, bar=0, baz=0
} else if topic == "bar" {
  select timestamp, foo=0, bar=events, baz=0
} else {
  assert topic == "baz"
  select timestamp, foo=0, bar=0, baz=events
}
timestamp = round(timestamp, 1h)
summarize timestamp, foo=sum(foo), bar=sum(bar), baz=sum(baz)
―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
{
  timestamp: 2024-10-26T20:00:00.000000,
  foo: 40585,
  bar: 3595,
  bar: 2122
}
…
```

This has a major problem: It only works if the possible values for `topic` are known ahead of time; if there's a new topic, then I need to adjust the pipeline. Also, it is just very tedious to write in the first place.

With the new `over` aggregation function, I can instead write this:

```tql
metrics "publish"
timestamp = round(timestamp, 1h)
summarize timestamp, events=sum(events).over(topic)
this = {
  timestamp: timestamp,
  ...events,
}
――――――――――――――――――――――――――――――――――――――――――――――――――――
{
  timestamp: 2024-10-26T20:00:00.000000,
  foo: 40585,
  bar: 3595,
  bar: 2122,
}
…
```

> [!NOTE]
> On a technical note: This effectively behaves like a very limited "pivot wider," except that is is restricted to aggregation functions. This has the distinct advantage that unlike a true pivoting operation, it does not require holding all events in memory, as aggregation functions already reduce the incoming events down to something that can be easily held in memory.