### PR TITLE
Fix TQL2 `summarize` with no groups and no input

### DIFF
--- a/changelog/next/bug-fixes/4709--summarize-no-groups.md
+++ b/changelog/next/bug-fixes/4709--summarize-no-groups.md
@@ -1,0 +1,3 @@
+TQL2's `summarize` now returns a single event when used with no groups and no
+input events just like in TQL1, making `from [] | summarize count=count()`
+return `{count: 0}` instead of nothing.

--- a/tenzir/integration/data/reference/pipelines_local/test_summarize_an_empty_input/step_00.ref
+++ b/tenzir/integration/data/reference/pipelines_local/test_summarize_an_empty_input/step_00.ref
@@ -1,0 +1,1 @@
+{"count()": 0, "sum(foo)": null}

--- a/tenzir/integration/tests/pipelines_local.bats
+++ b/tenzir/integration/tests/pipelines_local.bats
@@ -829,3 +829,8 @@ EOF
   check tenzir --strict --tql2 'from [{x: 1}, {x: 2}, {x: 3}] | assert x != 0'
   check ! tenzir --strict --tql2 'from [{x: 1}, {x: 2}, {x: 3}] | assert x != 2'
 }
+
+@test "summarize an empty input" {
+  check tenzir --tql2 'from [] | summarize count(), sum(foo)'
+  check tenzir --tql2 'from [] | summarize count(), sum(foo), bar'
+}


### PR DESCRIPTION
This makes TQL2's `summarize` work properly when there are no groups and no input by creating a new bucket and then immediately finishing it to return the aggregation function's default values as a single event. This makes `from [] | summarize count=count()` return the expected `{count: 0}` instead of nothing.

- Fixes https://github.com/tenzir/issues/issues/2289