### PR TITLE
Fix the TQL2 for the google_cloud_pubsub operators

### DIFF
--- a/web/docs/tql2/operators/load_google_cloud_pubsub.md
+++ b/web/docs/tql2/operators/load_google_cloud_pubsub.md
@@ -3,7 +3,7 @@
 Subscribes to a Google Cloud Pub/Sub subscription and obtains bytes.
 
 ```tql
-load_google_cloud_pubsub project_id:str, subscription_id:str, [timeout:duration]
+load_google_cloud_pubsub project_id=str, subscription_id=str, [timeout=duration]
 ```
 
 :::note Authentication
@@ -15,11 +15,11 @@ The connector tries to retrieve the appropriate credentials using Google's
 
 The `google_cloud_pubsub` loader acquires raw bytes from a Google Cloud Pub/Sub subscription.
 
-### `project_id: str`
+### `project_id = str`
 
 The project to connect to. Note that this is the project id, not the display name.
 
-### `subscription_id: str`
+### `subscription_id = str`
 
 The subscription to subscribe to.
 
@@ -34,6 +34,6 @@ The default value is `0s`.
 Subscribe to `my-subscription` in the project `amazing-project-123456` and parse the messages as JSON:
 
 ```tql
-load_google_cloud_pubsub "amazing-project-123456", "my-subscription"
+load_google_cloud_pubsub project_id="amazing-project-123456", subscription_id="my-subscription"
 read_json
 ```

--- a/web/docs/tql2/operators/save_google_cloud_pubsub.md
+++ b/web/docs/tql2/operators/save_google_cloud_pubsub.md
@@ -3,7 +3,7 @@
 Publishes to a Google Cloud Pub/Sub topic.
 
 ```tql
-save_google_cloud_pubsub project_id:str, topic_id:str
+save_google_cloud_pubsub project_id=str, topic_id=str
 ```
 
 :::note Authentication
@@ -15,11 +15,11 @@ The connector tries to retrieve the appropriate credentials using Google's
 
 The `google_cloud_pubsub` saver publishes bytes to a Google Cloud Pub/Sub topic.
 
-### `project_id: str`
+### `project_id = str`
 
 The project to connect to. Note that this is the project_id, not the display name.
 
-### `topic_id: str`
+### `topic_id = str`
 
 The topic to publish to.
 
@@ -31,5 +31,5 @@ Publish `suricata.alert` events as JSON to `alerts-topic`.
 export
 where @name = "suricata.alert"
 write_json
-save_google_cloud_pubsub "amazing-project-123456", "alerts-topic"
+save_google_cloud_pubsub project_id="amazing-project-123456", topic_id="alerts-topic"
 ```

--- a/web/versioned_docs/version-v4.22/tql2/operators/load_google_cloud_pubsub.md
+++ b/web/versioned_docs/version-v4.22/tql2/operators/load_google_cloud_pubsub.md
@@ -3,7 +3,7 @@
 Subscribes to a Google Cloud Pub/Sub subscription and obtains bytes.
 
 ```tql
-load_google_cloud_pubsub project_id:str, subscription_id:str, [timeout:duration]
+load_google_cloud_pubsub project_id=str, subscription_id=str, [timeout=duration]
 ```
 
 :::note Authentication
@@ -15,11 +15,11 @@ The connector tries to retrieve the appropriate credentials using Google's
 
 The `google_cloud_pubsub` loader acquires raw bytes from a Google Cloud Pub/Sub subscription.
 
-### `project_id: str`
+### `project_id = str`
 
 The project to connect to. Note that this is the project id, not the display name.
 
-### `subscription_id: str`
+### `subscription_id = str`
 
 The subscription to subscribe to.
 
@@ -34,6 +34,6 @@ The default value is `0s`.
 Subscribe to `my-subscription` in the project `amazing-project-123456` and parse the messages as JSON:
 
 ```tql
-load_google_cloud_pubsub "amazing-project-123456", "my-subscription"
+load_google_cloud_pubsub project_id="amazing-project-123456", subscription_id="my-subscription"
 read_json
 ```

--- a/web/versioned_docs/version-v4.22/tql2/operators/save_google_cloud_pubsub.md
+++ b/web/versioned_docs/version-v4.22/tql2/operators/save_google_cloud_pubsub.md
@@ -3,7 +3,7 @@
 Publishes to a Google Cloud Pub/Sub topic.
 
 ```tql
-save_google_cloud_pubsub project_id:str, topic_id:str
+save_google_cloud_pubsub project_id=str, topic_id=str
 ```
 
 :::note Authentication
@@ -15,11 +15,11 @@ The connector tries to retrieve the appropriate credentials using Google's
 
 The `google_cloud_pubsub` saver publishes bytes to a Google Cloud Pub/Sub topic.
 
-### `project_id: str`
+### `project_id = str`
 
 The project to connect to. Note that this is the project_id, not the display name.
 
-### `topic_id: str`
+### `topic_id = str`
 
 The topic to publish to.
 
@@ -31,5 +31,5 @@ Publish `suricata.alert` events as JSON to `alerts-topic`.
 export
 where @name = "suricata.alert"
 write_json
-save_google_cloud_pubsub "amazing-project-123456", "alerts-topic"
+save_google_cloud_pubsub project_id="amazing-project-123456", topic_id="alerts-topic"
 ```


### PR DESCRIPTION
The TQL2 docs for `load_google_cloud_pubsub` and `save_google_cloud_pubsub` were written for positional arguments, but the operators in TQL2 have required, named arguments.

This also fixes the past versioned docs, since those were also wrong.