### PR TITLE
Make `str(enum)` return the name of the enum entry

### DIFF
--- a/changelog/next/bug-fixes/4717--str-of-enumeration.md
+++ b/changelog/next/bug-fixes/4717--str-of-enumeration.md
@@ -1,0 +1,2 @@
+The `str` function no longer returns the numeric index of an enumeration value.
+Instead, the result is now the actual name associated with that value.

--- a/libtenzir/builtins/functions/string.cpp
+++ b/libtenzir/builtins/functions/string.cpp
@@ -363,14 +363,19 @@ public:
       auto b = arrow::StringBuilder{};
       for (auto&& value : subject.values()) {
         auto f = detail::overload{
-          [](int64_t x) {
-            return fmt::to_string(x);
-          },
           [](const std::string& x) {
             return x;
           },
-          [&](auto&) {
-            // TODO: How to stringify everything else?
+          [](int64_t x) {
+            return fmt::to_string(x);
+          },
+          [&](enumeration x) {
+            return std::string{
+              caf::get<enumeration_type>(subject.type).field(x)};
+          },
+          [&](const auto&) {
+            // TODO: This should probably use the TQL printer, once it exists.
+            // Then we can also remove the special cases above.
             return fmt::to_string(value);
           },
         };


### PR DESCRIPTION
This makes `str(some_enum_value)` return the textual name of the entry instead of a string that contains just its numeric index. We might in general make enum usable where strings are usable in the future, but this is an obvious bug for which the fix should not be controversial.