### PR TITLE
Add `load_balance` operator 

### DIFF
--- a/changelog/next/features/4720--load-balance.md
+++ b/changelog/next/features/4720--load-balance.md
@@ -1,0 +1,2 @@
+The new `load_balance` operator can be used to distribute events over a set of
+subpipelines.

--- a/changelog/next/features/4720--load-balance.md
+++ b/changelog/next/features/4720--load-balance.md
@@ -1,2 +1,1 @@
-The new `load_balance` operator can be used to distribute events over a set of
-subpipelines.
+The new `load_balance` operator distributes events over a set of subpipelines.

--- a/libtenzir/builtins/operators/load_balance.cpp
+++ b/libtenzir/builtins/operators/load_balance.cpp
@@ -274,6 +274,7 @@ public:
   auto
   operator()(generator<table_slice> input, operator_control_plane& ctrl) const
     -> generator<std::monostate> {
+    // TODO: Handle empty list.
     // TODO: Re-batch before?
     auto load_balancer = scope_linked{ctrl.self().spawn<caf::linked>(
       make_load_balancer, pipes_, ctrl.shared_diagnostics(),

--- a/libtenzir/builtins/operators/load_balance.cpp
+++ b/libtenzir/builtins/operators/load_balance.cpp
@@ -60,12 +60,10 @@ struct load_balancer_state {
   auto write(table_slice events) -> caf::result<void> {
     TENZIR_ASSERT(events.rows() > 0);
     if (not reads.empty()) {
-      TENZIR_VERBOSE("writing {} events directly", events.rows());
       reads.front().deliver(std::move(events));
       reads.pop_front();
       return {};
     }
-    TENZIR_VERBOSE("writing {} events delayed", events.rows());
     writes.emplace_back(std::move(events), self->make_response_promise<void>());
     return writes.back().second;
   }
@@ -73,7 +71,6 @@ struct load_balancer_state {
   auto read() -> caf::result<table_slice> {
     if (not writes.empty()) {
       auto events = std::move(writes.front().first);
-      TENZIR_VERBOSE("reading {} events directly", events.rows());
       writes.front().second.deliver();
       writes.pop_front();
       return events;
@@ -81,7 +78,6 @@ struct load_balancer_state {
     if (finished) {
       return table_slice{};
     }
-    TENZIR_VERBOSE("reading events delayed");
     reads.emplace_back(self->make_response_promise<table_slice>());
     return reads.back();
   }
@@ -91,9 +87,8 @@ struct load_balancer_state {
       return;
     }
     finished = true;
-    TENZIR_VERBOSE("load_balancer finished and marks {} outstanding reads as "
-                   "done",
-                   reads.size());
+    TENZIR_DEBUG("load_balancer finished and marks {} outstanding reads done",
+                 reads.size());
     // If there are any outstanding reads, we know that there are no remaining
     // writes. Thus it's fine to mark all outstanding reads as done.
     for (auto& read : reads) {
@@ -117,7 +112,7 @@ public:
 
   auto operator()(operator_control_plane& ctrl) const
     -> generator<table_slice> {
-    TENZIR_VERBOSE("beginning execution of load_balance_source");
+    TENZIR_DEBUG("beginning execution of load_balance_source");
     TENZIR_ASSERT(load_balancer_);
     while (true) {
       auto result = table_slice{};
@@ -137,10 +132,9 @@ public:
       co_yield {};
       // We signal completion with an empty table slice.
       if (result.rows() == 0) {
-        TENZIR_VERBOSE("load_balance_source detected end");
+        TENZIR_DEBUG("load_balance_source detected end");
         break;
       }
-      TENZIR_VERBOSE("load_balance_source read {} events", result.rows());
       co_yield std::move(result);
     }
   }
@@ -184,9 +178,9 @@ auto make_load_balancer(
   std::vector<pipeline> pipes, shared_diagnostic_handler diagnostics,
   metrics_receiver_actor metrics, uint64_t operator_index, bool is_hidden,
   const node_actor& node) -> load_balancer_actor::behavior_type {
-  TENZIR_VERBOSE("spawning load balancer");
+  TENZIR_DEBUG("spawning load balancer");
   self->attach_functor([] {
-    TENZIR_VERBOSE("destroyed load balancer");
+    TENZIR_DEBUG("destroyed load balancer");
   });
   self->state.self = self;
   self->state.diagnostics = std::move(diagnostics);
@@ -196,16 +190,16 @@ auto make_load_balancer(
   for (auto& pipe : pipes) {
     pipe.prepend(std::make_unique<load_balance_source>(self));
     auto has_terminal = false;
-    TENZIR_VERBOSE("spawning inner executor");
+    TENZIR_DEBUG("spawning inner executor");
     auto executor = self->spawn<caf::monitored>(
       pipeline_executor, pipe, self, self, node, has_terminal, is_hidden);
     executor->attach_functor([] {
-      TENZIR_VERBOSE("inner executor terminated");
+      TENZIR_DEBUG("inner executor terminated");
     });
     self->request(executor, caf::infinite, atom::start_v)
       .then(
         []() {
-          TENZIR_VERBOSE("started inner pipeline successfully");
+          TENZIR_DEBUG("started inner pipeline successfully");
         },
         [self](const caf::error& err) {
           // This error should be enough to cause the outer pipeline to get
@@ -217,7 +211,7 @@ auto make_load_balancer(
   self->set_exit_handler([self](caf::exit_msg& msg) {
     if (msg.reason != caf::exit_reason::user_shutdown) {
       // This should never happen.
-      TENZIR_VERBOSE("load balancer got unexpected exit msg: {}", msg.reason);
+      TENZIR_DEBUG("load balancer got unexpected exit msg: {}", msg.reason);
       self->quit(msg.reason);
       return;
     }
@@ -243,14 +237,12 @@ auto make_load_balancer(
     },
     [self](uint64_t op_index, uint64_t metric_index,
            type& schema) -> caf::result<void> {
-      auto id = get_or_compute(
-        self->state.metrics_id_map, std::pair{op_index, metric_index}, [&] {
-          TENZIR_VERBOSE("load_balancer allocates metrics id for {}/{}",
-                         op_index, metric_index);
-          auto id = self->state.next_metrics_id;
-          self->state.next_metrics_id += 1;
-          return id;
-        });
+      auto id = get_or_compute(self->state.metrics_id_map,
+                               std::pair{op_index, metric_index}, [&] {
+                                 auto id = self->state.next_metrics_id;
+                                 self->state.next_metrics_id += 1;
+                                 return id;
+                               });
       return self->delegate(self->state.metrics, self->state.operator_index, id,
                             schema);
     },
@@ -321,7 +313,6 @@ public:
                  std::move(slice))
         .then(
           [&]() {
-            TENZIR_VERBOSE("successfully sent events to load_balancer");
             ctrl.set_waiting(false);
           },
           [&](const caf::error& err) {
@@ -332,7 +323,7 @@ public:
           });
       co_yield {};
     }
-    TENZIR_VERBOSE("waiting for termination of load_balancer");
+    TENZIR_DEBUG("waiting for termination of load_balancer");
     ctrl.set_waiting(true);
     load_balancer.get()->attach_functor(
       [self = caf::actor_cast<caf::actor>(&ctrl.self()), &ctrl] {
@@ -342,7 +333,7 @@ public:
       });
     caf::anon_send_exit(load_balancer.get(), caf::exit_reason::user_shutdown);
     co_yield {};
-    TENZIR_VERBOSE("load_balance terminated");
+    TENZIR_DEBUG("load_balance terminated");
   }
 
   auto optimize(expression const& filter, event_order order) const

--- a/libtenzir/builtins/operators/load_balance.cpp
+++ b/libtenzir/builtins/operators/load_balance.cpp
@@ -1,0 +1,296 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2024 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "tenzir/pipeline_executor.hpp"
+#include "tenzir/scope_linked.hpp"
+#include "tenzir/tql2/exec.hpp"
+
+#include <tenzir/tql2/plugin.hpp>
+
+#include <deque>
+
+namespace tenzir::plugins::load_balance {
+
+namespace {
+
+using load_balancer_actor = caf::typed_actor<
+  //
+  auto(atom::write, table_slice events)->caf::result<void>,
+  //
+  auto(atom::read)->caf::result<table_slice>>
+  //
+  ::extend_with<metrics_receiver_actor>
+  //
+  ::extend_with<receiver_actor<diagnostic>>;
+
+struct load_balancer_state {
+  [[maybe_unused]] static constexpr auto name = "load-balance-host";
+
+  load_balancer_actor::pointer self{};
+  shared_diagnostic_handler diagnostics;
+  std::vector<pipeline_executor_actor> executors;
+  std::deque<caf::typed_response_promise<table_slice>> reads;
+  std::deque<std::pair<table_slice, caf::typed_response_promise<void>>> writes;
+  bool finished = false;
+
+  void finish() {
+    TENZIR_WARN("marking load_balancer as finished");
+    finished = true;
+    // If there are any outstanding reads, we know that there are no remaining
+    // writes. Thus it's fine to mark all outstanding reads as done.
+    for (auto& read : reads) {
+      read.deliver(table_slice{});
+    }
+    reads.clear();
+  }
+};
+
+// TODO: Plugin?
+class load_balance_source final : public crtp_operator<load_balance_source> {
+public:
+  load_balance_source() = default;
+
+  explicit load_balance_source(load_balancer_actor load_balancer)
+    : load_balancer_{std::move(load_balancer)} {
+  }
+
+  auto name() const -> std::string override {
+    return "internal-load-balance-source";
+  }
+
+  auto operator()(operator_control_plane& ctrl) const
+    -> generator<table_slice> {
+    TENZIR_WARN("beginning execution of load_balance_source");
+    TENZIR_ASSERT(load_balancer_);
+    while (true) {
+      auto result = table_slice{};
+      ctrl.set_waiting(true);
+      ctrl.self()
+        .request(load_balancer_, caf::infinite, atom::read_v)
+        .then(
+          [&](table_slice slice) {
+            result = std::move(slice);
+            ctrl.set_waiting(false);
+          },
+          [](const caf::error&) {
+
+          });
+      co_yield {};
+      // We signal completion with an empty table slice.
+      if (result.rows() == 0) {
+        TENZIR_WARN("load_balance_source detected end");
+        break;
+      }
+      TENZIR_WARN("load_balance_source read {} events", result.rows());
+      co_yield std::move(result);
+    }
+  }
+
+  auto optimize(const expression& filter, event_order order) const
+    -> optimize_result override {
+    TENZIR_UNUSED(filter, order);
+    return do_not_optimize(*this);
+  }
+
+  friend auto inspect(auto& f, load_balance_source& x) -> bool {
+    return f.apply(x.load_balancer_);
+  }
+
+private:
+  load_balancer_actor load_balancer_;
+};
+
+auto make_load_balancer(
+  load_balancer_actor::stateful_pointer<load_balancer_state> self,
+  std::vector<pipeline> pipes, const shared_diagnostic_handler& diagnostics,
+  const metrics_receiver_actor& metrics_receiver, uint64_t operator_id,
+  bool is_hidden, const node_actor& node)
+  -> load_balancer_actor::behavior_type {
+  TENZIR_WARN("spawning load balancer");
+  self->attach_functor([] {
+    TENZIR_WARN("destroyed load balancer");
+  });
+  self->state.self = self;
+  self->state.diagnostics = diagnostics;
+  self->state.executors.reserve(pipes.size());
+  for (auto& pipe : pipes) {
+    pipe.prepend(std::make_unique<load_balance_source>(self));
+    auto has_terminal = false;
+    // TODO: Link? Monitor?
+    TENZIR_WARN("spawning inner executor");
+    auto executor = self->spawn(pipeline_executor, pipe, self, self, node,
+                                has_terminal, is_hidden);
+    executor->attach_functor([] {
+      TENZIR_WARN("inner executor terminated");
+    });
+    self->request(executor, caf::infinite, atom::start_v)
+      .then(
+        []() {
+          // TODO
+          TENZIR_WARN("started pipeline executor successfully");
+        },
+        [](const caf::error& err) {
+          // TODO
+          TENZIR_WARN("failed to start pipeline executor: {}", err);
+        });
+    self->state.executors.push_back(std::move(executor));
+  }
+  self->set_exit_handler([self](caf::exit_msg& msg) {
+    TENZIR_WARN("load balancer got exit msg: {}", msg.reason);
+    // TODO: Let sources know that we are done.
+    // TODO: Wait for executors to terminate?
+    self->state.finish();
+  });
+  return {
+    [self](atom::write, table_slice events) -> caf::result<void> {
+      // TODO: If `events` is too big, we could consider splitting it up.
+      TENZIR_ASSERT(events.rows() > 0);
+      if (not self->state.reads.empty()) {
+        TENZIR_WARN("writing {} events directly", events.rows());
+        self->state.reads.front().deliver(std::move(events));
+        self->state.reads.pop_front();
+        return {};
+      }
+      TENZIR_WARN("writing {} events delayed", events.rows());
+      self->state.writes.emplace_back(std::move(events),
+                                      self->make_response_promise<void>());
+      return self->state.writes.back().second;
+    },
+    [self](atom::read) -> caf::result<table_slice> {
+      if (not self->state.writes.empty()) {
+        auto events = std::move(self->state.writes.front().first);
+        TENZIR_WARN("reading {} events directly", events.rows());
+        self->state.writes.front().second.deliver();
+        self->state.writes.pop_front();
+        return events;
+      }
+      if (self->state.finished) {
+        return table_slice{};
+      }
+      TENZIR_WARN("reading events delayed");
+      self->state.reads.emplace_back(
+        self->make_response_promise<table_slice>());
+      return self->state.reads.back();
+    },
+    [self](uint64_t op_index, uint64_t metric_index,
+           type& schema) -> caf::result<void> {
+      // TODO
+      return {};
+    },
+    [self](uint64_t op_index, uint64_t metric_index,
+           record& metric) -> caf::result<void> {
+      // TODO
+      return {};
+    },
+    [](const operator_metric& op_metric) -> caf::result<void> {
+      // TODO
+      return {};
+    },
+    [self](diagnostic& diagnostic) -> caf::result<void> {
+      // TODO: Can we assume this?
+      TENZIR_ASSERT(diagnostic.severity != severity::error);
+      self->state.diagnostics.emit(std::move(diagnostic));
+      return {};
+    },
+  };
+}
+
+class load_balance final : public crtp_operator<load_balance> {
+public:
+  load_balance() = default;
+
+  explicit load_balance(std::vector<pipeline> pipes)
+    : pipes_{std::move(pipes)} {
+  }
+
+  auto name() const -> std::string override {
+    return "load_balance";
+  }
+
+  auto
+  operator()(generator<table_slice> input, operator_control_plane& ctrl) const
+    -> generator<std::monostate> {
+    // TODO: Re-batch before?
+    auto load_balancer = scope_linked{ctrl.self().spawn<caf::linked>(
+      make_load_balancer, pipes_, ctrl.shared_diagnostics(),
+      ctrl.metrics_receiver(), ctrl.operator_index(), ctrl.is_hidden(),
+      ctrl.node())};
+    for (auto&& slice : input) {
+      if (slice.rows() == 0) {
+        co_yield {};
+        continue;
+      }
+      // TODO: Is this form of back pressure what we want?
+      ctrl.set_waiting(true);
+      ctrl.self()
+        .request(load_balancer.get(), caf::infinite, atom::write_v,
+                 std::move(slice))
+        .then(
+          [&]() {
+            TENZIR_WARN("successfully sent events");
+            ctrl.set_waiting(false);
+          },
+          [&](const caf::error& err) {
+            diagnostic::error("failed to write data to load balancer")
+              .note("reason: {}", err)
+              .emit(ctrl.diagnostics());
+          });
+      co_yield {};
+    }
+    TENZIR_WARN("terminating load_balance");
+  }
+
+  auto optimize(expression const& filter, event_order order) const
+    -> optimize_result override {
+    TENZIR_UNUSED(filter, order);
+    return do_not_optimize(*this);
+  }
+
+  friend auto inspect(auto& f, load_balance& x) -> bool {
+    return f.apply(x.pipes_);
+  }
+
+private:
+  std::vector<pipeline> pipes_;
+};
+
+class plugin final : public virtual operator_plugin2<load_balance> {
+public:
+  auto make(invocation inv, session ctx) const
+    -> failure_or<operator_ptr> override {
+    auto pipes = std::vector<pipeline>{};
+    for (auto& arg : inv.args) {
+      auto pipe = std::get_if<ast::pipeline_expr>(&*arg.kind);
+      TENZIR_ASSERT(pipe);
+      TRY(auto compiled, compile(std::move(pipe->inner), ctx));
+      auto output = compiled.infer_type<table_slice>();
+      if (not output) {
+        diagnostic::error("pipeline must take events as input")
+          .primary(pipe->begin)
+          .emit(ctx);
+        return failure::promise();
+      }
+      if (not output->is<void>()) {
+        diagnostic::error("pipeline must end with a sink")
+          .primary(pipe->end)
+          .emit(ctx);
+        return failure::promise();
+      }
+      pipes.push_back(std::move(compiled));
+    }
+    return std::make_unique<load_balance>(std::move(pipes));
+  }
+};
+
+} // namespace
+
+} // namespace tenzir::plugins::load_balance
+
+TENZIR_REGISTER_PLUGIN(tenzir::plugins::load_balance::plugin)
+TENZIR_REGISTER_PLUGIN(tenzir::operator_inspection_plugin<
+                       tenzir::plugins::load_balance::load_balance_source>)

--- a/libtenzir/builtins/operators/load_balance.cpp
+++ b/libtenzir/builtins/operators/load_balance.cpp
@@ -60,12 +60,12 @@ struct load_balancer_state {
   auto write(table_slice events) -> caf::result<void> {
     TENZIR_ASSERT(events.rows() > 0);
     if (not reads.empty()) {
-      TENZIR_VERBOSE("writing {} events directly", events.rows());
+      TENZIR_WARN("writing {} events directly", events.rows());
       reads.front().deliver(std::move(events));
       reads.pop_front();
       return {};
     }
-    TENZIR_VERBOSE("writing {} events delayed", events.rows());
+    TENZIR_WARN("writing {} events delayed", events.rows());
     writes.emplace_back(std::move(events), self->make_response_promise<void>());
     return writes.back().second;
   }
@@ -73,7 +73,7 @@ struct load_balancer_state {
   auto read() -> caf::result<table_slice> {
     if (not writes.empty()) {
       auto events = std::move(writes.front().first);
-      TENZIR_VERBOSE("reading {} events directly", events.rows());
+      TENZIR_WARN("reading {} events directly", events.rows());
       writes.front().second.deliver();
       writes.pop_front();
       return events;
@@ -81,7 +81,7 @@ struct load_balancer_state {
     if (finished) {
       return table_slice{};
     }
-    TENZIR_VERBOSE("reading events delayed");
+    TENZIR_WARN("reading events delayed");
     reads.emplace_back(self->make_response_promise<table_slice>());
     return reads.back();
   }
@@ -91,9 +91,9 @@ struct load_balancer_state {
       return;
     }
     finished = true;
-    TENZIR_VERBOSE("load_balancer finished and marks {} outstanding reads as "
-                   "done",
-                   reads.size());
+    TENZIR_WARN("load_balancer finished and marks {} outstanding reads as "
+                "done",
+                reads.size());
     // If there are any outstanding reads, we know that there are no remaining
     // writes. Thus it's fine to mark all outstanding reads as done.
     for (auto& read : reads) {
@@ -117,7 +117,7 @@ public:
 
   auto operator()(operator_control_plane& ctrl) const
     -> generator<table_slice> {
-    TENZIR_VERBOSE("beginning execution of load_balance_source");
+    TENZIR_WARN("beginning execution of load_balance_source");
     TENZIR_ASSERT(load_balancer_);
     while (true) {
       auto result = table_slice{};
@@ -137,10 +137,10 @@ public:
       co_yield {};
       // We signal completion with an empty table slice.
       if (result.rows() == 0) {
-        TENZIR_VERBOSE("load_balance_source detected end");
+        TENZIR_WARN("load_balance_source detected end");
         break;
       }
-      TENZIR_VERBOSE("load_balance_source read {} events", result.rows());
+      TENZIR_WARN("load_balance_source read {} events", result.rows());
       co_yield std::move(result);
     }
   }
@@ -184,9 +184,9 @@ auto make_load_balancer(
   std::vector<pipeline> pipes, shared_diagnostic_handler diagnostics,
   metrics_receiver_actor metrics, uint64_t operator_index, bool is_hidden,
   const node_actor& node) -> load_balancer_actor::behavior_type {
-  TENZIR_VERBOSE("spawning load balancer");
+  TENZIR_WARN("spawning load balancer");
   self->attach_functor([] {
-    TENZIR_VERBOSE("destroyed load balancer");
+    TENZIR_WARN("destroyed load balancer");
   });
   self->state.self = self;
   self->state.diagnostics = std::move(diagnostics);
@@ -196,16 +196,16 @@ auto make_load_balancer(
   for (auto& pipe : pipes) {
     pipe.prepend(std::make_unique<load_balance_source>(self));
     auto has_terminal = false;
-    TENZIR_VERBOSE("spawning inner executor");
+    TENZIR_WARN("spawning inner executor");
     auto executor = self->spawn<caf::monitored>(
       pipeline_executor, pipe, self, self, node, has_terminal, is_hidden);
     executor->attach_functor([] {
-      TENZIR_VERBOSE("inner executor terminated");
+      TENZIR_WARN("inner executor terminated");
     });
     self->request(executor, caf::infinite, atom::start_v)
       .then(
         []() {
-          TENZIR_VERBOSE("started inner pipeline successfully");
+          TENZIR_WARN("started inner pipeline successfully");
         },
         [self](const caf::error& err) {
           // This error should be enough to cause the outer pipeline to get
@@ -229,8 +229,8 @@ auto make_load_balancer(
                                 &pipeline_executor_actor::address);
     TENZIR_ASSERT(it != self->state.executors.end());
     self->state.executors.erase(it);
-    // TODO: What if not finished?
-    if (self->state.executors.empty() and self->state.finished) {
+    if (self->state.executors.empty()) {
+      // We are done, even if `not self->state.finished`.
       self->quit();
     }
   });
@@ -245,8 +245,8 @@ auto make_load_balancer(
            type& schema) -> caf::result<void> {
       auto id = get_or_compute(
         self->state.metrics_id_map, std::pair{op_index, metric_index}, [&] {
-          TENZIR_VERBOSE("load_balancer allocates metrics id for {}/{}",
-                         op_index, metric_index);
+          TENZIR_WARN("load_balancer allocates metrics id for {}/{}", op_index,
+                      metric_index);
           auto id = self->state.next_metrics_id;
           self->state.next_metrics_id += 1;
           return id;
@@ -294,7 +294,8 @@ public:
     // three sources of exit messages:
     // 1) Spawning the actor with `caf::linked`, which is bidirectional. Exit
     //    messages are exchanges when the load balancer dies or after the
-    //    execution node has terminated.
+    //    execution node has terminated. This is also used to exit execution if
+    //    all subpipelines have terminated, for example when they use `head`.
     // 2) Wrapping the actor with `scope_linked`, which sends an exit message at
     //    the end of the scope. This can thus happen before the previous one and
     //    ensures that we still have access to all resources. It is also called
@@ -320,7 +321,7 @@ public:
                  std::move(slice))
         .then(
           [&]() {
-            TENZIR_VERBOSE("successfully sent events to load_balancer");
+            TENZIR_WARN("successfully sent events to load_balancer");
             ctrl.set_waiting(false);
           },
           [&](const caf::error& err) {
@@ -331,7 +332,7 @@ public:
           });
       co_yield {};
     }
-    TENZIR_VERBOSE("waiting for termination of load_balancer");
+    TENZIR_WARN("waiting for termination of load_balancer");
     ctrl.set_waiting(true);
     auto self = caf::actor_cast<caf::actor>(&ctrl.self());
     load_balancer.get()->attach_functor([self, &ctrl] {
@@ -341,7 +342,7 @@ public:
     });
     caf::anon_send_exit(load_balancer.get(), caf::exit_reason::user_shutdown);
     co_yield {};
-    TENZIR_VERBOSE("load_balance terminated");
+    TENZIR_WARN("load_balance terminated");
   }
 
   auto optimize(expression const& filter, event_order order) const

--- a/libtenzir/builtins/operators/load_balance.cpp
+++ b/libtenzir/builtins/operators/load_balance.cpp
@@ -348,7 +348,7 @@ public:
   auto optimize(expression const& filter, event_order order) const
     -> optimize_result override {
     TENZIR_UNUSED(filter, order);
-    return do_not_optimize(*this);
+    return optimize_result{std::nullopt, event_order::unordered, copy()};
   }
 
   friend auto inspect(auto& f, load_balance& x) -> bool {

--- a/libtenzir/builtins/operators/load_balance.cpp
+++ b/libtenzir/builtins/operators/load_balance.cpp
@@ -334,12 +334,12 @@ public:
     }
     TENZIR_VERBOSE("waiting for termination of load_balancer");
     ctrl.set_waiting(true);
-    auto self = caf::actor_cast<caf::actor>(&ctrl.self());
-    load_balancer.get()->attach_functor([self, &ctrl] {
-      caf::anon_send(self, caf::make_action([&ctrl] {
-                       ctrl.set_waiting(false);
-                     }));
-    });
+    load_balancer.get()->attach_functor(
+      [self = caf::actor_cast<caf::actor>(&ctrl.self()), &ctrl] {
+        caf::anon_send(self, caf::make_action([&ctrl] {
+                         ctrl.set_waiting(false);
+                       }));
+      });
     caf::anon_send_exit(load_balancer.get(), caf::exit_reason::user_shutdown);
     co_yield {};
     TENZIR_VERBOSE("load_balance terminated");

--- a/libtenzir/include/tenzir/detail/stable_map.hpp
+++ b/libtenzir/include/tenzir/detail/stable_map.hpp
@@ -35,7 +35,7 @@ struct stable_map_policy {
   template <class Ts, class Key_Like, class... Args>
   static auto try_emplace(Ts& xs, Key_Like&& k, Args&&... args) {
     const auto it = lookup(xs, k);
-    if (it == xs.end() || k == it->first) {
+    if (it == xs.end()) {
       return std::make_pair(
         xs.emplace(it, std::piecewise_construct,
                    std::forward_as_tuple(std::forward<Key_Like>(k)),

--- a/libtenzir/src/argument_parser2.cpp
+++ b/libtenzir/src/argument_parser2.cpp
@@ -234,6 +234,7 @@ auto argument_parser2::parse(const ast::entity& self,
         if (positional_idx == positional_.size()) {
           emit(diagnostic::error("did not expect more positional arguments")
                  .primary(*arg));
+          return;
         }
         positional_[positional_idx].set.match(
           [&](setter<located<pipeline>>& set) {

--- a/libtenzir/src/tql2/exec.cpp
+++ b/libtenzir/src/tql2/exec.cpp
@@ -89,7 +89,12 @@ public:
   }
 
   void load_balance(ast::invocation& x) {
-    // TODO: Remove special casing.
+    // We currently have some special casing here for the `load_balance`
+    // operator. The `let_resolver` must somehow interact with operators that
+    // modify the constant environment. There are probably better ways to do
+    // this, but putting everything here was easy to do. We should reconsider
+    // this strategy when introducing a second operator that can modify the
+    // constant environment.
     auto docs = "https://docs.tenzir.com/tql2/operators/load_balance";
     auto usage = "load_balance over:list { … }";
     auto emit = [&](diagnostic_builder d) {
@@ -139,6 +144,11 @@ public:
         return type_kind::of<data_to_type_t<T>>;
       });
       emit(diagnostic::error("expected a list, got `{}`", got).primary(*var));
+      *it->second = std::move(original);
+      return;
+    }
+    if (entries->empty()) {
+      emit(diagnostic::error("expected list to not be empty").primary(*var));
       *it->second = std::move(original);
       return;
     }

--- a/web/docs/tql2/operators.md
+++ b/web/docs/tql2/operators.md
@@ -51,7 +51,7 @@ Operator | Description | Example
 [`every`](./operators/every.md) | Restarts a pipeline periodically | `every 10s { summarize sum(amount) }`
 [`fork`](./operators/fork.md) | Forwards a copy of the events to another pipeline | `fork { to "copy.json" }`
 [`if`](language/statements.md#if) | Splits the flow based on a predicate | `if transaction > 0 { … } else { … }`
-[`load_balance`](./operators/load_balance.md) | Routes the data through alternating subpipelines | `load_balance $over { publish $over }`
+[`load_balance`](./operators/load_balance.md) | Routes the data to one of multiple subpipelines | `load_balance $over { publish $over }`
 
 <!--
 [`group`]() | Starts a new pipeline for each group | `group path { to $path }`

--- a/web/docs/tql2/operators.md
+++ b/web/docs/tql2/operators.md
@@ -38,7 +38,7 @@ Operator | Description | Example
 
 Operator | Description | Example
 :--------|:------------|:-------
-[`summarize`](./operators/summarize.md) | Aggregates events with implicit grouping | `summarize name, sum(transaction)`
+[`summarize`](./operators/summarize.md) | Aggregates events with implicit grouping | `summarize name, sum(amount)`
 [`sort`](./operators/sort.md) | Sorts the events by one or more expressions | `sort name, -abs(transaction)`
 [`reverse`](./operators/reverse.md) | Reverses the event order | `reverse`
 [`top`](./operators/top.md) | Shows the most common values | `top user`
@@ -48,9 +48,10 @@ Operator | Description | Example
 
 Operator | Description | Example
 :--------|:------------|:-------
-[`every`](./operators/every.md) | Restarts a pipeline periodically | `every 10s { summarize sum(transaction) }`
+[`every`](./operators/every.md) | Restarts a pipeline periodically | `every 10s { summarize sum(amount) }`
 [`fork`](./operators/fork.md) | Forwards a copy of the events to another pipeline | `fork { to "copy.json" }`
 [`if`](language/statements.md#if) | Splits the flow based on a predicate | `if transaction > 0 { … } else { … }`
+[`load_balance`](./operators/load_balance.md) | Routes the data through alternating subpipelines | `load_balance $over { publish $over }`
 
 <!--
 [`group`]() | Starts a new pipeline for each group | `group path { to $path }`

--- a/web/docs/tql2/operators/load_balance.md
+++ b/web/docs/tql2/operators/load_balance.md
@@ -35,11 +35,17 @@ load_balance $cfg {
 ### Route data to multiple Splunk endpoints
 
 ```tql
-let $cfg = [192.168.0.30, 192.168.0.31]
+let $cfg = [{
+  ip: 192.168.0.30,
+  token: "example-token-1234",
+}, {
+  ip: 192.168.0.31,
+  token: "example-token-5678",
+}]
 
 subscribe "input"
 load_balance $cfg {
-  let $endpoint = str($cfg) + ":8080"
-  to_splunk $endpoint, hec_token="example-token-1234"
+  let $endpoint = str($cfg.ip) + ":8080"
+  to_splunk $endpoint, hec_token=$cfg.token
 }
 ```

--- a/web/docs/tql2/operators/load_balance.md
+++ b/web/docs/tql2/operators/load_balance.md
@@ -10,7 +10,7 @@ load_balance over:list { … }
 
 The `load_balance` operator spawns a nested pipeline for each element in the
 given list. Incoming events are distributed to exactly one of the nested
-pipelines.
+pipelines. This operator may reorder the event stream.
 
 ### `over: list`
 

--- a/web/docs/tql2/operators/load_balance.md
+++ b/web/docs/tql2/operators/load_balance.md
@@ -1,6 +1,6 @@
 # load_balance
 
-Routes the data through alternating subpipelines.
+Routes the data to one of multiple subpipelines.
 
 ```tql
 load_balance over:list { … }
@@ -8,15 +8,29 @@ load_balance over:list { … }
 
 ## Description
 
-TODO
+The `load_balance` operator spawns a nested pipeline for each element in the
+given list. Incoming events are distributed to exactly one of the nested
+pipelines.
 
 ### `over: list`
 
-TODO
+This must be a `$`-variable, previously declared with `let`. For example, to
+load balance over a list of ports, use `let $cfg = [8080, 8081, 8082]` followed
+by `load_balance $cfg { … }`.
 
 ### `{ … }`
 
-TODO
+The nested pipeline to spawn. This pipeline can use the same variable as passed to `over`, which will be resolved to one of the list items. The following example spawns three nested pipelines, where `$port` is bound to `8080`, `8081` and `8082`, respectively.
+
+```tql
+let $cfg = [8080, 8081, 8082]
+load_balance $cfg {
+  let $port = $cfg
+  // … continue here
+}
+```
+
+The given subpipeline must end with a sink. This limitation might be removed in future versions.
 
 ## Examples
 
@@ -28,7 +42,7 @@ let $cfg = ["192.168.0.30:8080", "192.168.0.30:8081"]
 subscribe "input"
 load_balance $cfg {
   write_json
-  save $cfg
+  save_tcp $cfg
 }
 ```
 

--- a/web/docs/tql2/operators/load_balance.md
+++ b/web/docs/tql2/operators/load_balance.md
@@ -1,0 +1,45 @@
+# load_balance
+
+ Routes the data through alternating subpipelines.
+
+```tql
+load_balance over:list { … }
+```
+
+## Description
+
+TODO
+
+### `over: list`
+
+TODO
+
+### `{ … }`
+
+TODO
+
+## Examples
+
+### Route data to multiple TCP ports
+
+```tql
+let $cfg = ["192.168.0.30:8080", "192.168.0.30:8081"]
+
+subscribe "input"
+load_balance $cfg {
+  write_json
+  save $cfg
+}
+```
+
+### Route data to multiple Splunk endpoints
+
+```tql
+let $cfg = [192.168.0.30, 192.168.0.31]
+
+subscribe "input"
+load_balance $cfg {
+  let $endpoint = str($cfg) + ":8080"
+  to_splunk $endpoint, hec_token="example-token-1234"
+}
+```

--- a/web/docs/tql2/operators/load_balance.md
+++ b/web/docs/tql2/operators/load_balance.md
@@ -20,7 +20,10 @@ by `load_balance $cfg { … }`.
 
 ### `{ … }`
 
-The nested pipeline to spawn. This pipeline can use the same variable as passed to `over`, which will be resolved to one of the list items. The following example spawns three nested pipelines, where `$port` is bound to `8080`, `8081` and `8082`, respectively.
+The nested pipeline to spawn. This pipeline can use the same variable as passed
+to `over`, which will be resolved to one of the list items. The following
+example spawns three nested pipelines, where `$port` is bound to `8080`, `8081`
+and `8082`, respectively.
 
 ```tql
 let $cfg = [8080, 8081, 8082]
@@ -30,7 +33,8 @@ load_balance $cfg {
 }
 ```
 
-The given subpipeline must end with a sink. This limitation might be removed in future versions.
+The given subpipeline must end with a sink. This limitation might be removed in
+future versions.
 
 ## Examples
 

--- a/web/docs/tql2/operators/load_balance.md
+++ b/web/docs/tql2/operators/load_balance.md
@@ -1,6 +1,6 @@
 # load_balance
 
- Routes the data through alternating subpipelines.
+Routes the data through alternating subpipelines.
 
 ```tql
 load_balance over:list { … }


### PR DESCRIPTION
This PR adds a `load_balance` operator that can be used to distribute events over a set of nested pipelines:
```tql
let $cfg = [{
  ip: 192.168.0.30,
  token: "example-token-1234",
}, {
  ip: 192.168.0.31,
  token: "example-token-5678",
}]

subscribe "input"
load_balance $cfg {
  let $endpoint = str($cfg.ip) + ":8080"
  to_splunk $endpoint, hec_token=$cfg.token
}
```