### PR TITLE
Add universal function call syntax

### DIFF
--- a/changelog/next/features/4730--universal-function-call-syntax.md
+++ b/changelog/next/features/4730--universal-function-call-syntax.md
@@ -1,0 +1,3 @@
+TQL now supports "universal function call syntax", which means that every method
+is callable as a function and every function with at least one positional
+argument is callable as a method.

--- a/changelog/next/features/4730--universal-function-call-syntax.md
+++ b/changelog/next/features/4730--universal-function-call-syntax.md
@@ -1,3 +1,3 @@
-TQL now supports "universal function call syntax", which means that every method
+TQL now supports "universal function call syntax," which means that every method
 is callable as a function and every function with at least one positional
 argument is callable as a method.

--- a/libtenzir/builtins/formats/cef.cpp
+++ b/libtenzir/builtins/formats/cef.cpp
@@ -268,7 +268,7 @@ public:
   }
 };
 
-class parse_cef final : public virtual method_plugin {
+class parse_cef final : public virtual function_plugin {
 public:
   auto name() const -> std::string override {
     return "parse_cef";
@@ -277,7 +277,8 @@ public:
   auto make_function(invocation inv,
                      session ctx) const -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
-    TRY(argument_parser2::method(name()).add(expr, "<string>").parse(inv, ctx));
+    TRY(
+      argument_parser2::function(name()).add(expr, "<string>").parse(inv, ctx));
     return function_use::make(
       [call = inv.call, expr = std::move(expr)](auto eval, session ctx) {
         auto arg = eval(expr);

--- a/libtenzir/builtins/formats/grok.cpp
+++ b/libtenzir/builtins/formats/grok.cpp
@@ -683,7 +683,7 @@ public:
   }
 };
 
-class parse_grok_plugin final : public virtual method_plugin {
+class parse_grok_plugin final : public virtual function_plugin {
 public:
   auto name() const -> std::string override {
     return "tql2.parse_grok";
@@ -695,7 +695,7 @@ public:
     auto pattern = located<std::string>{};
     auto indexed_captures = false;
     auto include_unnamed = false;
-    TRY(argument_parser2::method("grok")
+    TRY(argument_parser2::function("grok")
           .add(input, "<input>")
           .add(pattern, "<pattern>")
           .add("indexed_captures", indexed_captures)

--- a/libtenzir/builtins/formats/json.cpp
+++ b/libtenzir/builtins/formats/json.cpp
@@ -1229,7 +1229,7 @@ using read_suricata_plugin
 using read_zeek_plugin
   = configured_read_plugin<"zeek_json", "_path", "zeek", ".">;
 
-class parse_json_plugin final : public virtual method_plugin {
+class parse_json_plugin final : public virtual function_plugin {
 public:
   auto name() const -> std::string override {
     return "tql2.parse_json";
@@ -1240,7 +1240,7 @@ public:
     auto expr = ast::expression{};
     // TODO: Consider adding a `many` option to expect multiple json values.
     // TODO: Consider adding a `precise` option (this needs evaluator support).
-    TRY(argument_parser2::method("parse_json")
+    TRY(argument_parser2::function("parse_json")
           .add(expr, "<string>")
           .parse(inv, ctx));
     return function_use::make(

--- a/libtenzir/builtins/formats/leef.cpp
+++ b/libtenzir/builtins/formats/leef.cpp
@@ -346,7 +346,7 @@ public:
   }
 };
 
-class parse_leef final : public virtual method_plugin {
+class parse_leef final : public virtual function_plugin {
 public:
   auto name() const -> std::string override {
     return "parse_leef";
@@ -355,7 +355,8 @@ public:
   auto make_function(invocation inv,
                      session ctx) const -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
-    TRY(argument_parser2::method(name()).add(expr, "<string>").parse(inv, ctx));
+    TRY(
+      argument_parser2::function(name()).add(expr, "<string>").parse(inv, ctx));
     return function_use::make(
       [call = inv.call, expr = std::move(expr)](auto eval, session ctx) {
         auto arg = eval(expr);

--- a/libtenzir/builtins/functions/ip.cpp
+++ b/libtenzir/builtins/functions/ip.cpp
@@ -70,7 +70,7 @@ public:
   }
 };
 
-class is_v4_or_v6 final : public method_plugin {
+class is_v4_or_v6 final : public function_plugin {
 public:
   is_v4_or_v6(bool v4) : v4_{v4} {
   }

--- a/libtenzir/builtins/functions/misc.cpp
+++ b/libtenzir/builtins/functions/misc.cpp
@@ -184,7 +184,7 @@ private:
   detail::heterogeneous_string_hashmap<std::string> env_ = {};
 };
 
-class length final : public method_plugin {
+class length final : public function_plugin {
 public:
   auto name() const -> std::string override {
     return "length";
@@ -193,7 +193,7 @@ public:
   auto make_function(invocation inv, session ctx) const
     -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
-    TRY(argument_parser2::method(name()).add(expr, "<expr>").parse(inv, ctx));
+    TRY(argument_parser2::function(name()).add(expr, "<expr>").parse(inv, ctx));
     return function_use::make(
       [expr = std::move(expr)](evaluator eval, session ctx) -> series {
         TENZIR_UNUSED(ctx);
@@ -231,7 +231,7 @@ public:
   }
 };
 
-class has final : public method_plugin {
+class has final : public function_plugin {
 public:
   auto name() const -> std::string override {
     return "has";
@@ -241,7 +241,7 @@ public:
     -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
     auto needle = located<std::string>{};
-    TRY(argument_parser2::method(name())
+    TRY(argument_parser2::function(name())
           .add(expr, "<expr>")
           .add(needle, "<string>")
           .parse(inv, ctx));
@@ -280,7 +280,7 @@ public:
   }
 };
 
-class select_drop_matching final : public method_plugin {
+class select_drop_matching final : public function_plugin {
 public:
   explicit select_drop_matching(bool select) : select_{select} {
   }
@@ -293,7 +293,7 @@ public:
     -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
     auto str = located<std::string>{};
-    TRY(argument_parser2::method(name())
+    TRY(argument_parser2::function(name())
           .add(expr, "<expr>")
           .add(str, "<pattern>")
           .parse(inv, ctx));

--- a/libtenzir/builtins/functions/string.cpp
+++ b/libtenzir/builtins/functions/string.cpp
@@ -16,7 +16,7 @@ namespace tenzir::plugins::string {
 
 namespace {
 
-class starts_or_ends_with : public virtual method_plugin {
+class starts_or_ends_with : public virtual function_plugin {
 public:
   explicit starts_or_ends_with(bool starts_with) : starts_with_{starts_with} {
   }
@@ -29,7 +29,7 @@ public:
                      session ctx) const -> failure_or<function_ptr> override {
     auto subject_expr = ast::expression{};
     auto arg_expr = ast::expression{};
-    TRY(argument_parser2::method(name())
+    TRY(argument_parser2::function(name())
           .add(subject_expr, "<string>")
           .add(arg_expr, "<string>")
           .parse(inv, ctx));
@@ -73,7 +73,7 @@ private:
   bool starts_with_;
 };
 
-class trim : public virtual method_plugin {
+class trim : public virtual function_plugin {
 public:
   explicit trim(std::string name, std::string fn_name)
     : name_{std::move(name)}, fn_name_{std::move(fn_name)} {
@@ -87,7 +87,7 @@ public:
                      session ctx) const -> failure_or<function_ptr> override {
     auto subject_expr = ast::expression{};
     auto characters = std::optional<std::string>{};
-    TRY(argument_parser2::method(name())
+    TRY(argument_parser2::function(name())
           .add(subject_expr, "<string>")
           .add(characters, "<characters>")
           .parse(inv, ctx));
@@ -131,7 +131,7 @@ private:
   std::string fn_name_;
 };
 
-class nullary_method : public virtual method_plugin {
+class nullary_method : public virtual function_plugin {
 public:
   nullary_method(std::string name, std::string fn_name, type result_ty)
     : name_{std::move(name)},
@@ -160,7 +160,7 @@ public:
   auto make_function(invocation inv,
                      session ctx) const -> failure_or<function_ptr> override {
     auto subject_expr = ast::expression{};
-    TRY(argument_parser2::method(name())
+    TRY(argument_parser2::function(name())
           .add(subject_expr, "<string>")
           .parse(inv, ctx));
     return function_use::make([this, subject_expr = std::move(subject_expr)](
@@ -204,7 +204,7 @@ private:
   std::shared_ptr<arrow::DataType> result_arrow_ty_;
 };
 
-class replace : public virtual method_plugin {
+class replace : public virtual function_plugin {
 public:
   replace() = default;
   explicit replace(bool regex) : regex_{regex} {
@@ -220,7 +220,7 @@ public:
     auto pattern = located<std::string>{};
     auto replacement = std::string{};
     auto max_replacements = std::optional<located<int64_t>>{};
-    TRY(argument_parser2::method(name())
+    TRY(argument_parser2::function(name())
           .add(subject_expr, "<string>")
           .add(pattern, "<pattern>")
           .add(replacement, "<replacement>")
@@ -280,7 +280,7 @@ private:
   bool regex_ = {};
 };
 
-class slice : public virtual method_plugin {
+class slice : public virtual function_plugin {
 public:
   auto name() const -> std::string override {
     return "tql2.slice";
@@ -292,7 +292,7 @@ public:
     auto begin = std::optional<located<int64_t>>{};
     auto end = std::optional<located<int64_t>>{};
     auto stride = std::optional<located<int64_t>>{};
-    TRY(argument_parser2::method(name())
+    TRY(argument_parser2::function(name())
           .add(subject_expr, "<string>")
           .add("begin", begin)
           .add("end", end)
@@ -354,7 +354,7 @@ public:
   auto make_function(invocation inv,
                      session ctx) const -> failure_or<function_ptr> override {
     auto subject_expr = ast::expression{};
-    TRY(argument_parser2::method("string")
+    TRY(argument_parser2::function("string")
           .add(subject_expr, "<expr>")
           .parse(inv, ctx));
     return function_use::make([subject_expr = std::move(subject_expr)](

--- a/libtenzir/builtins/functions/time.cpp
+++ b/libtenzir/builtins/functions/time.cpp
@@ -74,7 +74,7 @@ public:
   }
 };
 
-class since_epoch final : public method_plugin {
+class since_epoch final : public function_plugin {
 public:
   auto name() const -> std::string override {
     return "since_epoch";
@@ -195,7 +195,7 @@ public:
   }
 };
 
-class year_month_day final : public method_plugin {
+class year_month_day final : public function_plugin {
 public:
   explicit year_month_day(ymd_subtype field) : ymd_subtype_(field) {
   }
@@ -260,7 +260,7 @@ private:
   ymd_subtype ymd_subtype_;
 };
 
-class as_secs final : public method_plugin {
+class as_secs final : public function_plugin {
 public:
   auto name() const -> std::string override {
     return "as_secs";

--- a/libtenzir/builtins/operators/sort.cpp
+++ b/libtenzir/builtins/operators/sort.cpp
@@ -528,7 +528,7 @@ private:
 };
 
 class plugin2 final : public virtual operator_plugin2<sort_operator2>,
-                      public virtual method_plugin {
+                      public virtual function_plugin {
 public:
   auto make(operator_factory_plugin::invocation inv, session ctx) const
     -> failure_or<operator_ptr> override {
@@ -558,10 +558,10 @@ public:
     return std::make_unique<sort_operator2>(std::move(sort_exprs));
   }
 
-  auto make_function(method_plugin::invocation inv, session ctx) const
+  auto make_function(function_plugin::invocation inv, session ctx) const
     -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
-    TRY(argument_parser2::method(name()).add(expr, "<expr>").parse(inv, ctx));
+    TRY(argument_parser2::function(name()).add(expr, "<expr>").parse(inv, ctx));
     return function_use::make(
       [call = inv.call, expr = std::move(expr)](auto eval, session ctx) {
         auto arg = eval(expr);

--- a/libtenzir/builtins/operators/top_rare.cpp
+++ b/libtenzir/builtins/operators/top_rare.cpp
@@ -99,7 +99,7 @@ class top_rare_plugin final : public virtual operator_parser_plugin,
     TENZIR_ASSERT(summarize);
     TENZIR_ASSERT(sort);
     auto ident = ast::identifier{"count", loc};
-    auto call = ast::function_call{std::nullopt, ast::entity{{ident}}, {}, loc};
+    auto call = ast::function_call{ast::entity{{ident}}, {}, loc, false};
     auto out
       = ast::simple_selector::try_from(ast::root_field{std::move(ident)});
     TENZIR_ASSERT(out);

--- a/libtenzir/include/tenzir/argument_parser2.hpp
+++ b/libtenzir/include/tenzir/argument_parser2.hpp
@@ -56,11 +56,7 @@ public:
   }
 
   static auto function(std::string name) -> argument_parser2 {
-    return argument_parser2{kind::function, std::move(name)};
-  }
-
-  static auto method(std::string name) -> argument_parser2 {
-    return argument_parser2{kind::method, std::move(name)};
+    return argument_parser2{kind::fn, std::move(name)};
   }
 
   // ------------------------------------------------------------------------
@@ -105,7 +101,7 @@ public:
   auto docs() const -> std::string;
 
 private:
-  enum class kind { op, function, method };
+  enum class kind { op, fn };
 
   argument_parser2(kind kind, std::string name)
     : kind_{kind}, name_{std::move(name)} {

--- a/libtenzir/include/tenzir/tql2/ast.hpp
+++ b/libtenzir/include/tenzir/tql2/ast.hpp
@@ -375,29 +375,27 @@ struct entity {
 struct function_call {
   function_call() = default;
 
-  function_call(std::optional<expression> subject, entity fn,
-                std::vector<expression> args, location rpar)
-    : subject{std::move(subject)},
-      fn{std::move(fn)},
-      args(std::move(args)),
-      rpar{rpar} {
+  function_call(entity fn, std::vector<expression> args, location rpar,
+                bool method)
+    : fn{std::move(fn)}, args(std::move(args)), rpar{rpar}, method{method} {
   }
 
-  std::optional<expression> subject;
   entity fn;
   std::vector<expression> args;
   location rpar;
+  bool method{};
 
   friend auto inspect(auto& f, function_call& x) -> bool {
-    return f.object(x).fields(f.field("subject", x.subject),
-                              f.field("fn", x.fn), f.field("args", x.args),
-                              f.field("rpar", x.rpar));
+    return f.object(x).fields(f.field("fn", x.fn), f.field("args", x.args),
+                              f.field("rpar", x.rpar),
+                              f.field("method", x.method));
   }
 
   auto get_location() const -> location {
     auto left = location{};
-    if (subject) {
-      left = subject->get_location();
+    if (method) {
+      TENZIR_ASSERT(not args.empty());
+      left = args[0].get_location();
     } else {
       left = fn.get_location();
     }
@@ -753,7 +751,6 @@ protected:
   }
 
   void enter(function_call& x) {
-    go(x.subject);
     go(x.fn);
     go(x.args);
   }

--- a/libtenzir/include/tenzir/tql2/plugin.hpp
+++ b/libtenzir/include/tenzir/tql2/plugin.hpp
@@ -90,8 +90,6 @@ public:
   virtual auto function_name() const -> std::string;
 };
 
-class method_plugin : public virtual function_plugin {};
-
 class aggregation_instance {
 public:
   virtual ~aggregation_instance() = default;

--- a/libtenzir/include/tenzir/tql2/registry.hpp
+++ b/libtenzir/include/tenzir/tql2/registry.hpp
@@ -40,7 +40,6 @@ public:
   // TODO: Everything below assumes that there are no modules.
   auto operator_names() const -> std::vector<std::string_view>;
   auto function_names() const -> std::vector<std::string_view>;
-  auto method_names() const -> std::vector<std::string_view>;
 
   void add(std::string name, entity_def def);
 

--- a/libtenzir/src/tql2/parser.cpp
+++ b/libtenzir/src/tql2/parser.cpp
@@ -232,7 +232,7 @@ public:
       // instead. This could be done differently by slightly rewriting the
       // parser. Because this is not (yet) reflected in the AST, the optional
       // parenthesis are not reflected.
-      if (call->subject) {
+      if (call->method) {
         // TODO: We could consider rewriting method calls to mutate their
         // subject, e.g., `foo.bar.baz(qux) => foo.bar = foo.bar.baz(qux)`.
         diagnostic::error("expected operator invocation, found method call")
@@ -750,13 +750,18 @@ public:
     expect(tk::lpar);
     auto scope = ignore_newlines(true);
     auto args = std::vector<ast::expression>{};
+    auto method = false;
+    if (subject) {
+      method = true;
+      args.push_back(std::move(*subject));
+    }
     while (true) {
       if (auto rpar = accept(tk::rpar)) {
         return ast::function_call{
-          std::move(subject),
           std::move(fn),
           std::move(args),
           rpar.location,
+          method,
         };
       }
       if (auto comma = accept(tk::comma)) {

--- a/libtenzir/src/tql2/registry.cpp
+++ b/libtenzir/src/tql2/registry.cpp
@@ -114,18 +114,7 @@ auto registry::operator_names() const -> std::vector<std::string_view> {
 auto registry::function_names() const -> std::vector<std::string_view> {
   auto result = std::vector<std::string_view>{};
   for (auto& [name, def] : defs_) {
-    if (def.fn and not dynamic_cast<const method_plugin*>(def.fn)) {
-      result.push_back(name);
-    }
-  }
-  std::ranges::sort(result);
-  return result;
-}
-
-auto registry::method_names() const -> std::vector<std::string_view> {
-  auto result = std::vector<std::string_view>{};
-  for (auto& [name, def] : defs_) {
-    if (def.fn and dynamic_cast<const method_plugin*>(def.fn)) {
+    if (def.fn) {
       result.push_back(name);
     }
   }

--- a/libtenzir/src/tql2/resolve.cpp
+++ b/libtenzir/src/tql2/resolve.cpp
@@ -70,15 +70,7 @@ public:
       result_ = failure::promise();
       return;
     }
-    entity->match(
-      [&](std::reference_wrapper<const function_plugin> function) {
-        TENZIR_ASSERT(ns == entity_ns::fn);
-        x.ref = std::move(path);
-      },
-      [&](std::reference_wrapper<const operator_factory_plugin>) {
-        TENZIR_ASSERT(ns == entity_ns::op);
-        x.ref = std::move(path);
-      });
+    x.ref = std::move(path);
   }
 
   void visit(ast::invocation& x) {

--- a/libtenzir/src/tql2/resolve.cpp
+++ b/libtenzir/src/tql2/resolve.cpp
@@ -46,8 +46,6 @@ public:
           return "operator";
         case context_t::fn_name:
           return "function";
-        case context_t::method_name:
-          return "method";
         case context_t::none:
           TENZIR_UNREACHABLE();
       }
@@ -55,18 +53,16 @@ public:
     });
     if (not entity) {
       auto available = std::invoke([&] {
-        switch (context_) {
-          case context_t::op_name:
+        switch (ns) {
+          case entity_ns::op:
             return reg_.operator_names();
-          case context_t::fn_name:
+          case entity_ns::fn:
             return reg_.function_names();
-          case context_t::method_name:
-            return reg_.method_names();
-          case context_t::none:
-            TENZIR_UNREACHABLE();
         }
         TENZIR_UNREACHABLE();
       });
+      // TODO: Consider reporting whether an entity with this name of another
+      // type would be found.
       diagnostic::error("{} `{}` not found", expected, name)
         .primary(x)
         .hint("must be one of: {}", fmt::join(available, ", "))
@@ -74,34 +70,13 @@ public:
       result_ = failure::promise();
       return;
     }
-    // TODO: Check if this entity has right type?
     entity->match(
       [&](std::reference_wrapper<const function_plugin> function) {
-        if (dynamic_cast<const method_plugin*>(&function.get())) {
-          if (context_ != context_t::method_name) {
-            diagnostic::error("expected {}, got method", expected)
-              .primary(x)
-              .emit(diag_);
-            result_ = failure::promise();
-            return;
-          }
-        } else if (context_ != context_t::fn_name) {
-          diagnostic::error("expected {}, got function", expected)
-            .primary(x)
-            .emit(diag_);
-          result_ = failure::promise();
-          return;
-        }
+        TENZIR_ASSERT(ns == entity_ns::fn);
         x.ref = std::move(path);
       },
       [&](std::reference_wrapper<const operator_factory_plugin>) {
-        if (context_ != context_t::op_name) {
-          diagnostic::error("expected {}, got operator", expected)
-            .primary(x)
-            .emit(diag_);
-          result_ = failure::promise();
-          return;
-        }
+        TENZIR_ASSERT(ns == entity_ns::op);
         x.ref = std::move(path);
       });
   }
@@ -116,11 +91,7 @@ public:
   }
 
   void visit(ast::function_call& x) {
-    if (x.subject) {
-      visit(*x.subject);
-    }
-    auto prev = std::exchange(context_, x.subject ? context_t::method_name
-                                                  : context_t::fn_name);
+    auto prev = std::exchange(context_, context_t::fn_name);
     visit(x.fn);
     context_ = prev;
     for (auto& y : x.args) {
@@ -138,7 +109,7 @@ public:
   }
 
 private:
-  enum class context_t { none, op_name, fn_name, method_name };
+  enum class context_t { none, op_name, fn_name };
   const registry& reg_;
   diagnostic_handler& diag_;
   context_t context_ = context_t::none;

--- a/tenzir/integration/data/reference/expression/test_universal_function_call_syntax/step_00.ref
+++ b/tenzir/integration/data/reference/expression/test_universal_function_call_syntax/step_00.ref
@@ -1,0 +1,1 @@
+{"x": true, "y": true}

--- a/tenzir/integration/data/reference/expression/test_universal_function_call_syntax/step_01.ref
+++ b/tenzir/integration/data/reference/expression/test_universal_function_call_syntax/step_01.ref
@@ -1,8 +1,1 @@
-error: expected additional positional argument `<string>`
- --> /dev/stdin:1:17
-  |
-1 | from { x: "abc".starts_with() }
-  |                 ^^^^^^^^^^^ 
-  |
-  = usage: starts_with(<string>, <string>)
-  = docs: https://docs.tenzir.com/functions/starts_with
+{"sum(x)": 3}

--- a/tenzir/integration/data/reference/expression/test_universal_function_call_syntax/step_01.ref
+++ b/tenzir/integration/data/reference/expression/test_universal_function_call_syntax/step_01.ref
@@ -1,0 +1,8 @@
+error: expected additional positional argument `<string>`
+ --> /dev/stdin:1:17
+  |
+1 | from { x: "abc".starts_with() }
+  |                 ^^^^^^^^^^^ 
+  |
+  = usage: starts_with(<string>, <string>)
+  = docs: https://docs.tenzir.com/functions/starts_with

--- a/tenzir/integration/data/reference/expression/test_universal_function_call_syntax/step_02.ref
+++ b/tenzir/integration/data/reference/expression/test_universal_function_call_syntax/step_02.ref
@@ -1,0 +1,8 @@
+error: expected additional positional argument `<string>`
+ --> /dev/stdin:1:11
+  |
+1 | from { x: starts_with("abc") }
+  |           ^^^^^^^^^^^ 
+  |
+  = usage: starts_with(<string>, <string>)
+  = docs: https://docs.tenzir.com/functions/starts_with

--- a/tenzir/integration/data/reference/expression/test_universal_function_call_syntax/step_03.ref
+++ b/tenzir/integration/data/reference/expression/test_universal_function_call_syntax/step_03.ref
@@ -1,8 +1,8 @@
 error: expected additional positional argument `<string>`
- --> /dev/stdin:1:17
+ --> /dev/stdin:1:11
   |
-1 | from { x: "abc".starts_with() }
-  |                 ^^^^^^^^^^^ 
+1 | from { x: starts_with("abc") }
+  |           ^^^^^^^^^^^ 
   |
   = usage: starts_with(<string>, <string>)
   = docs: https://docs.tenzir.com/functions/starts_with

--- a/tenzir/integration/data/reference/parser/test_functions/step_00.ref
+++ b/tenzir/integration/data/reference/parser/test_functions/step_00.ref
@@ -18,7 +18,8 @@
       args: [
         
       ],
-      rpar: 6..7
+      rpar: 6..7,
+      method: false
     }
   },
   assignment {
@@ -40,7 +41,8 @@
       args: [
         root_field `c` @ 14..15
       ],
-      rpar: 15..16
+      rpar: 15..16,
+      method: false
     }
   },
   assignment {
@@ -72,7 +74,8 @@
           right: root_field `d` @ 25..26
         }
       ],
-      rpar: 26..27
+      rpar: 26..27,
+      method: false
     }
   },
   assignment {
@@ -105,7 +108,8 @@
           right: root_field `e` @ 39..40
         }
       ],
-      rpar: 40..41
+      rpar: 40..41,
+      method: false
     }
   },
   assignment {
@@ -150,7 +154,8 @@
         },
         root_field `i` @ 61..62
       ],
-      rpar: 63..64
+      rpar: 63..64,
+      method: false
     }
   },
   invocation {
@@ -162,7 +167,6 @@
     },
     args: [
       function_call {
-        subject: root_field `a` @ 69..70,
         fn: {
           path: [
             `b` @ 71..72
@@ -170,9 +174,10 @@
           ref: unresolved
         },
         args: [
-          
+          root_field `a` @ 69..70
         ],
-        rpar: 73..74
+        rpar: 73..74,
+        method: true
       }
     ]
   },
@@ -185,7 +190,6 @@
     },
     args: [
       function_call {
-        subject: root_field `a` @ 79..80,
         fn: {
           path: [
             `b` @ 81..82
@@ -193,9 +197,11 @@
           ref: unresolved
         },
         args: [
+          root_field `a` @ 79..80,
           root_field `c` @ 83..84
         ],
-        rpar: 84..85
+        rpar: 84..85,
+        method: true
       }
     ]
   },
@@ -208,7 +214,6 @@
     },
     args: [
       function_call {
-        subject: root_field `a` @ 90..91,
         fn: {
           path: [
             `b` @ 92..93
@@ -216,6 +221,7 @@
           ref: unresolved
         },
         args: [
+          root_field `a` @ 90..91,
           assignment {
             left: simple_selector {
               expr: root_field `c` @ 94..95,
@@ -228,7 +234,8 @@
             right: root_field `d` @ 96..97
           }
         ],
-        rpar: 97..98
+        rpar: 97..98,
+        method: true
       }
     ]
   },
@@ -241,7 +248,6 @@
     },
     args: [
       function_call {
-        subject: root_field `a` @ 103..104,
         fn: {
           path: [
             `b` @ 105..106
@@ -249,6 +255,7 @@
           ref: unresolved
         },
         args: [
+          root_field `a` @ 103..104,
           root_field `c` @ 107..108,
           assignment {
             left: simple_selector {
@@ -262,7 +269,8 @@
             right: root_field `e` @ 112..113
           }
         ],
-        rpar: 113..114
+        rpar: 113..114,
+        method: true
       }
     ]
   },
@@ -275,7 +283,6 @@
     },
     args: [
       function_call {
-        subject: root_field `a` @ 119..120,
         fn: {
           path: [
             `b` @ 121..122
@@ -283,6 +290,7 @@
           ref: unresolved
         },
         args: [
+          root_field `a` @ 119..120,
           assignment {
             left: simple_selector {
               expr: root_field `c` @ 123..124,
@@ -308,7 +316,8 @@
           },
           root_field `i` @ 136..137
         ],
-        rpar: 138..139
+        rpar: 138..139,
+        method: true
       }
     ]
   }

--- a/tenzir/integration/data/reference/parser/test_ocsf_example/step_00.ref
+++ b/tenzir/integration/data/reference/parser/test_ocsf_example/step_00.ref
@@ -75,7 +75,8 @@
                       name: `ParentImage` @ 135..146
                     }
                   ],
-                  rpar: 146..147
+                  rpar: 146..147,
+                  method: false
                 }
               },
               field {
@@ -100,7 +101,8 @@
                       name: `ParentImage` @ 193..204
                     }
                   ],
-                  rpar: 204..205
+                  rpar: 204..205,
+                  method: false
                 }
               },
               field {
@@ -141,7 +143,8 @@
                 name: `ParentProcessId` @ 277..292
               }
             ],
-            rpar: 292..293
+            rpar: 292..293,
+            method: false
           }
         }
       ],
@@ -318,7 +321,8 @@
       args: [
         root_field `category_name` @ 637..650
       ],
-      rpar: 650..651
+      rpar: 650..651,
+      method: false
     }
   },
   assignment {
@@ -355,7 +359,8 @@
       args: [
         root_field `class_name` @ 711..721
       ],
-      rpar: 721..722
+      rpar: 721..722,
+      method: false
     }
   },
   assignment {
@@ -637,7 +642,8 @@
                       name: `Image` @ 1376..1381
                     }
                   ],
-                  rpar: 1381..1382
+                  rpar: 1381..1382,
+                  method: false
                 }
               },
               field {
@@ -662,7 +668,8 @@
                       name: `Image` @ 1428..1433
                     }
                   ],
-                  rpar: 1433..1434
+                  rpar: 1433..1434,
+                  method: false
                 }
               },
               field {
@@ -703,7 +710,8 @@
                 name: `ProcessId` @ 1506..1515
               }
             ],
-            rpar: 1515..1516
+            rpar: 1515..1516,
+            method: false
           }
         }
       ],
@@ -822,22 +830,6 @@
       args: [
         binary_expr {
           left: function_call {
-            subject: function_call {
-              fn: {
-                path: [
-                  `time` @ 1689..1693
-                ],
-                ref: unresolved
-              },
-              args: [
-                field_access {
-                  left: root_field `metadata` @ 1694..1702,
-                  dot: 1702..1703,
-                  name: `original_time` @ 1703..1716
-                }
-              ],
-              rpar: 1716..1717
-            },
             fn: {
               path: [
                 `timestamp` @ 1718..1727
@@ -845,9 +837,26 @@
               ref: unresolved
             },
             args: [
-              
+              function_call {
+                fn: {
+                  path: [
+                    `time` @ 1689..1693
+                  ],
+                  ref: unresolved
+                },
+                args: [
+                  field_access {
+                    left: root_field `metadata` @ 1694..1702,
+                    dot: 1702..1703,
+                    name: `original_time` @ 1703..1716
+                  }
+                ],
+                rpar: 1716..1717,
+                method: false
+              }
             ],
-            rpar: 1728..1729
+            rpar: 1728..1729,
+            method: true
           },
           op: "mul" @ 1730..1731,
           right: constant {
@@ -856,7 +865,8 @@
           }
         }
       ],
-      rpar: 1736..1737
+      rpar: 1736..1737,
+      method: false
     }
   },
   assignment {

--- a/tenzir/integration/tests/expression.bats
+++ b/tenzir/integration/tests/expression.bats
@@ -128,3 +128,18 @@ EOF
   exists = x in y
 EOF
 }
+
+@test "universal function call syntax" {
+  check tenzir -f '/dev/stdin' <<EOF
+from {
+  x: "abc".starts_with("ab"),
+  y: starts_with("abc", "ab"),
+}
+EOF
+  check ! tenzir -f '/dev/stdin' <<EOF
+from { x: "abc".starts_with() }
+EOF
+  check ! tenzir -f '/dev/stdin' <<EOF
+from { x: starts_with("abc") }
+EOF
+}

--- a/tenzir/integration/tests/expression.bats
+++ b/tenzir/integration/tests/expression.bats
@@ -124,7 +124,7 @@ EOF
 
 @test "in list" {
   check tenzir --tql2 -f /dev/stdin <<EOF
-  from "${INPUTSDIR}/json/lists.json" 
+  from "${INPUTSDIR}/json/lists.json"
   exists = x in y
 EOF
 }
@@ -135,6 +135,10 @@ from {
   x: "abc".starts_with("ab"),
   y: starts_with("abc", "ab"),
 }
+EOF
+  check tenzir -f '/dev/stdin' <<EOF
+from [{x: 1}, {x: 2}]
+summarize x.sum()
 EOF
   check ! tenzir -f '/dev/stdin' <<EOF
 from { x: "abc".starts_with() }

--- a/web/docs/tql2/functions.md
+++ b/web/docs/tql2/functions.md
@@ -35,7 +35,7 @@ f(arg1:<type>, arg2=<type>, [arg3=type]) -> <type>
 
 TQL features the [uniform function call syntax
 (UFCS)](https://en.wikipedia.org/wiki/Uniform_Function_Call_Syntax), which
-allows you to interchangeably call a function with more than one argument either
+allows you to interchangeably call a function with at least one argument either
 as *free function* or *method*. For example, `length(str)` and `str.length()`
 resolve to the identical function call. The latter syntax is particularly
 suitable for function chaining, e.g., `x.f().g().h()` reads left-to-right as


### PR DESCRIPTION
This makes `"abc".starts_with("ab")` equivalent to `starts_with("abc", "ab")` for every function. Thus, the distinction between functions and methods no longer exists.