### PR TITLE
Stop URL-encoding pub/sub topics

### DIFF
--- a/changelog/next/changes/4738--pub-sub-topics.md
+++ b/changelog/next/changes/4738--pub-sub-topics.md
@@ -1,0 +1,5 @@
+The topics provided to the `publish` and `subscribe` operators now exactly match
+the `topic` field in the corresponding metrics.
+
+Using `publish` and `subscribe` without an explicitly provided topic now uses
+the topic `main` as opposed to an implementation-defined special name.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "97bdf46c8d84e177d3916b065aeade29a031cbd2",
+  "rev": "56477f5502628223a43beacaf92c51332a65093e",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/web/docs/operators/publish.md
+++ b/web/docs/operators/publish.md
@@ -27,7 +27,7 @@ original order.
 
 An optional topic for publishing events under.
 
-Defaults to the empty string.
+Defaults to `main`.
 
 ## Examples
 

--- a/web/docs/operators/subscribe.md
+++ b/web/docs/operators/subscribe.md
@@ -31,6 +31,8 @@ data rather than slow down their publishers.
 
 An optional topic identifying the channel events are published under.
 
+Defaults to `main`.
+
 ## Examples
 
 Subscribe to the events under the topic `zeek-conn`:

--- a/web/docs/tql2/operators/publish.md
+++ b/web/docs/tql2/operators/publish.md
@@ -20,7 +20,7 @@ original order.
 ### `topic: str (optional)`
 
 An optional topic for publishing events under. If unspecified, the operator
-publishes events to a global unnamed feed.
+publishes events to the topic `main`.
 
 ## Examples
 

--- a/web/docs/tql2/operators/subscribe.md
+++ b/web/docs/tql2/operators/subscribe.md
@@ -22,7 +22,7 @@ data rather than slow down their publishers.
 ### `topic: str (optional)`
 
 An optional channel name to subscribe to. If unspecified, the operator
-subscribes to the global unnamed feed.
+subscribes to the topic `main`.
 
 ## Examples
 


### PR DESCRIPTION
We had this grand idea in the past when adding the `publish` and `subscribe` operators to make topics hierarchical. Because of that, we URL-encoded them, envisioning use of the forward slash as a separator. In practice, what we've ended up doing is really treating the topics as totally separate channels, and using schema names to form a hierarchy if we want one.

Unforutnately, the URL-encoding became user-visible with the introduction of the `publish` and `subscribe` metrics, which contained the URL-encoded topic in metrics. This was confusing not just for users, but also for ourselves in production setups we manage.

This change removes the URL-encoding entirely. It also changes the default topic to be `main`.