### PR TITLE
Allow aggregation functions to be saved and restored

### DIFF
--- a/libtenzir/builtins/aggregation-functions/any.cpp
+++ b/libtenzir/builtins/aggregation-functions/any.cpp
@@ -7,6 +7,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include <tenzir/aggregation_function.hpp>
+#include <tenzir/fbs/aggregation.hpp>
+#include <tenzir/flatbuffer.hpp>
 #include <tenzir/plugin.hpp>
 #include <tenzir/tql2/eval.hpp>
 #include <tenzir/tql2/plugin.hpp>
@@ -85,7 +87,7 @@ public:
     caf::visit(f, *arg.array);
   }
 
-  auto finish() -> data override {
+  auto get() const -> data override {
     switch (state_) {
       case state::none:
         return any_;
@@ -95,6 +97,50 @@ public:
         return data{};
     }
     TENZIR_UNREACHABLE();
+  }
+
+  auto save() const -> chunk_ptr override {
+    auto fbb = flatbuffers::FlatBufferBuilder{};
+    const auto fb_state = [&] {
+      switch (state_) {
+        case state::none:
+          return fbs::aggregation::AnyAllState::None;
+        case state::failed:
+          return fbs::aggregation::AnyAllState::Failed;
+        case state::nulled:
+          return fbs::aggregation::AnyAllState::Nulled;
+      }
+      TENZIR_UNREACHABLE();
+    }();
+    const auto fb_any_all = fbs::aggregation::CreateAnyAll(fbb, any_, fb_state);
+    fbb.Finish(fb_any_all);
+    return chunk::make(fbb.Release());
+  }
+
+  auto restore(chunk_ptr chunk, session ctx) -> void override {
+    const auto fb
+      = flatbuffer<fbs::aggregation::AnyAll>::make(std::move(chunk));
+    if (not fb) {
+      diagnostic::warning("invalid FlatBuffer")
+        .note("failed to restore `any` aggregation instance")
+        .emit(ctx);
+      return;
+    }
+    any_ = (*fb)->result();
+    switch ((*fb)->state()) {
+      case fbs::aggregation::AnyAllState::None:
+        state_ = state::none;
+        return;
+      case fbs::aggregation::AnyAllState::Failed:
+        state_ = state::failed;
+        return;
+      case fbs::aggregation::AnyAllState::Nulled:
+        state_ = state::nulled;
+        return;
+    }
+    diagnostic::warning("unknown `state` value")
+      .note("failed to restore `any` aggregation instance")
+      .emit(ctx);
   }
 
 private:

--- a/libtenzir/builtins/aggregation-functions/distinct.cpp
+++ b/libtenzir/builtins/aggregation-functions/distinct.cpp
@@ -8,6 +8,8 @@
 
 #include <tenzir/aggregation_function.hpp>
 #include <tenzir/detail/passthrough.hpp>
+#include <tenzir/fbs/aggregation.hpp>
+#include <tenzir/flatbuffer.hpp>
 #include <tenzir/hash/hash.hpp>
 #include <tenzir/plugin.hpp>
 #include <tenzir/tql2/eval.hpp>
@@ -117,8 +119,58 @@ public:
     }
   }
 
-  auto finish() -> data override {
+  auto get() const -> data override {
     return list{distinct_.begin(), distinct_.end()};
+  }
+
+  auto save() const -> chunk_ptr override {
+    auto fbb = flatbuffers::FlatBufferBuilder{};
+    auto offsets = std::vector<flatbuffers::Offset<fbs::Data>>{};
+    offsets.reserve(distinct_.size());
+    for (const auto& element : distinct_) {
+      offsets.push_back(pack(fbb, element));
+    }
+    const auto fb_result = fbb.CreateVector(offsets);
+    const auto fb_min_max
+      = fbs::aggregation::CreateCollectDistinct(fbb, fb_result);
+    fbb.Finish(fb_min_max);
+    return chunk::make(fbb.Release());
+  }
+
+  auto restore(chunk_ptr chunk, session ctx) -> void override {
+    const auto fb
+      = flatbuffer<fbs::aggregation::CollectDistinct>::make(std::move(chunk));
+    if (not fb) {
+      diagnostic::warning("invalid FlatBuffer")
+        .note("failed to restore `distinct` aggregation instance")
+        .emit(ctx);
+      return;
+    }
+    const auto* fb_result = (*fb)->result();
+    if (not fb_result) {
+      diagnostic::warning("missing field `result`")
+        .note("failed to restore `distinct` aggregation instance")
+        .emit(ctx);
+      return;
+    }
+    distinct_.clear();
+    distinct_.reserve(fb_result->size());
+    for (const auto* fb_element : *fb_result) {
+      if (not fb_element) {
+        diagnostic::warning("missing element in field `result`")
+          .note("failed to restore `distinct` aggregation instance")
+          .emit(ctx);
+        return;
+      }
+      auto element = data{};
+      if (auto err = unpack(*fb_element, element)) {
+        diagnostic::warning("{}", err)
+          .note("failed to restore `distinct` aggregation instance")
+          .emit(ctx);
+        return;
+      }
+      distinct_.insert(std::move(element));
+    }
   }
 
 private:

--- a/libtenzir/builtins/aggregation-functions/first_last.cpp
+++ b/libtenzir/builtins/aggregation-functions/first_last.cpp
@@ -7,6 +7,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include <tenzir/arrow_table_slice.hpp>
+#include <tenzir/fbs/aggregation.hpp>
+#include <tenzir/flatbuffer.hpp>
 #include <tenzir/tql2/eval.hpp>
 #include <tenzir/tql2/plugin.hpp>
 
@@ -50,8 +52,43 @@ public:
     }
   }
 
-  auto finish() -> data override {
+  auto get() const -> data override {
     return result_;
+  }
+
+  auto save() const -> chunk_ptr override {
+    auto fbb = flatbuffers::FlatBufferBuilder{};
+    const auto fb_result = pack(fbb, result_);
+    const auto fb_min_max = fbs::aggregation::CreateFirstLast(fbb, fb_result);
+    fbb.Finish(fb_min_max);
+    return chunk::make(fbb.Release());
+  }
+
+  auto restore(chunk_ptr chunk, session ctx) -> void override {
+    const auto fb
+      = flatbuffer<fbs::aggregation::FirstLast>::make(std::move(chunk));
+    if (not fb) {
+      diagnostic::warning("invalid FlatBuffer")
+        .note("failed to restore `{}` aggregation instance",
+              Mode == mode::first ? "first" : "last")
+        .emit(ctx);
+      return;
+    }
+    const auto* fb_result = (*fb)->result();
+    if (not fb_result) {
+      diagnostic::warning("missing field `result`")
+        .note("failed to restore `{}` aggregation instance",
+              Mode == mode::first ? "first" : "last")
+        .emit(ctx);
+      return;
+    }
+    if (auto err = unpack(*fb_result, result_)) {
+      diagnostic::warning("{}", err)
+        .note("failed to restore `{}` aggregation instance",
+              Mode == mode::first ? "first" : "last")
+        .emit(ctx);
+      return;
+    }
   }
 
 private:

--- a/libtenzir/builtins/aggregation-functions/min_max.cpp
+++ b/libtenzir/builtins/aggregation-functions/min_max.cpp
@@ -7,6 +7,9 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include <tenzir/aggregation_function.hpp>
+#include <tenzir/data.hpp>
+#include <tenzir/fbs/aggregation.hpp>
+#include <tenzir/flatbuffer.hpp>
 #include <tenzir/plugin.hpp>
 #include <tenzir/tql2/eval.hpp>
 #include <tenzir/tql2/plugin.hpp>
@@ -155,13 +158,82 @@ public:
     caf::visit(f, *arg.array);
   }
 
-  auto finish() -> data override {
+  auto get() const -> data override {
     if (result_) {
       return result_->match([](auto result) {
         return data{result};
       });
     }
     return {};
+  }
+
+  auto save() const -> chunk_ptr override {
+    auto fbb = flatbuffers::FlatBufferBuilder{};
+    const auto result
+      = not result_ ? data{} : result_->match<data>([](const auto& x) {
+          return data{x};
+        });
+    const auto fb_result = pack(fbb, result);
+    const auto type_bytes = as_bytes(type_);
+    auto fb_type = fbb.CreateVector(
+      reinterpret_cast<const uint8_t*>(type_bytes.data()), type_bytes.size());
+    const auto fb_min_max
+      = fbs::aggregation::CreateMinMaxSum(fbb, fb_result, fb_type);
+    fbb.Finish(fb_min_max);
+    return chunk::make(fbb.Release());
+  }
+
+  auto restore(chunk_ptr chunk, session ctx) -> void override {
+    const auto fb
+      = flatbuffer<fbs::aggregation::MinMaxSum>::make(std::move(chunk));
+    if (not fb) {
+      diagnostic::warning("invalid FlatBuffer")
+        .note("failed to restore `{}` aggregation instance",
+              Mode == mode::min ? "min" : "max")
+        .emit(ctx);
+      return;
+    }
+    const auto* fb_result = (*fb)->result();
+    if (not fb_result) {
+      diagnostic::warning("missing field `result`")
+        .note("failed to restore `{}` aggregation instance",
+              Mode == mode::min ? "min" : "max")
+        .emit(ctx);
+      return;
+    }
+    auto result = data{};
+    if (auto err = unpack(*fb_result, result)) {
+      diagnostic::warning("{}", err)
+        .note("failed to restore `{}` aggregation instance",
+              Mode == mode::min ? "min" : "max")
+        .emit(ctx);
+      return;
+    }
+    caf::visit(
+      [&]<class T>(const T& x) {
+        if constexpr (std::is_same_v<T, caf::none_t>) {
+          result_.reset();
+        } else if constexpr (result_t::can_have<T>) {
+          result_.emplace(x);
+        } else {
+          diagnostic::warning("invalid value for field `result`: `{}`", result)
+            .note("failed to restore `{}` aggregation instance",
+                  Mode == mode::min ? "min" : "max")
+            .emit(ctx);
+        }
+      },
+      result);
+    const auto* fb_type = (*fb)->type();
+    if (not fb_type) {
+      diagnostic::warning("missing field `type`")
+        .note("failed to restore `{}` aggregation instance",
+              Mode == mode::min ? "min" : "max")
+        .emit(ctx);
+      return;
+    }
+    const auto* fb_type_nested_root = (*fb)->type_nested_root();
+    TENZIR_ASSERT(fb_type_nested_root);
+    type_ = type{fb->slice(*fb_type_nested_root, *fb_type)};
   }
 
 private:
@@ -188,7 +260,8 @@ public:
       []<complex_type Type>(const Type& type)
         -> caf::expected<std::unique_ptr<aggregation_function>> {
         return caf::make_error(ec::invalid_configuration,
-                               fmt::format("max aggregation function does not "
+                               fmt::format("max aggregation function does "
+                                           "not "
                                            "support complex type {}",
                                            type));
       },

--- a/libtenzir/builtins/operators/summarize.cpp
+++ b/libtenzir/builtins/operators/summarize.cpp
@@ -1035,7 +1035,7 @@ public:
       for (auto index : cfg_.indices) {
         if (index >= 0) {
           auto& dest = cfg_.aggregates[index].dest;
-          auto value = group->aggregations[index]->finish();
+          auto value = group->aggregations[index]->get();
           if (dest) {
             emplace(result, *dest, value);
           } else {

--- a/libtenzir/fbs/aggregation.fbs
+++ b/libtenzir/fbs/aggregation.fbs
@@ -1,0 +1,68 @@
+include "data.fbs";
+include "type.fbs";
+
+namespace tenzir.fbs.aggregation;
+
+table MinMaxSum {
+  result: Data (required);
+  type: [ubyte] (required, nested_flatbuffer: "tenzir.fbs.Type");
+}
+
+enum AnyAllState : short {
+  None,
+  Failed,
+  Nulled,
+}
+
+table AnyAll {
+  result: bool;
+  state: AnyAllState;
+}
+
+enum MeanState : short {
+  None,
+  Failed,
+  Duration,
+  Numeric,
+}
+
+table Mean {
+  result: double;
+  count: ulong;
+  state: MeanState;
+}
+
+enum StddevVarianceState : short {
+  None,
+  Failed,
+  Duration,
+  Numeric,
+}
+
+table StddevVariance {
+  result: double;
+  result_squared: double;
+  count: ulong;
+  state: StddevVarianceState;
+}
+
+table FirstLast {
+  result: Data (required);
+}
+
+table CollectDistinct {
+  result: [Data] (required);
+}
+
+table ValueCount {
+  value: Data (required);
+  count: long;
+}
+
+table ModeValueCounts {
+  result: [ValueCount] (required);
+}
+
+table Count {
+  result: long;
+}

--- a/libtenzir/include/tenzir/tql2/plugin.hpp
+++ b/libtenzir/include/tenzir/tql2/plugin.hpp
@@ -74,6 +74,7 @@ public:
   struct invocation {
     explicit invocation(const ast::function_call& call) : call{call} {
     }
+    ~invocation() = default;
     invocation(const invocation&) = delete;
     invocation(invocation&&) = delete;
     auto operator=(const invocation&) -> invocation& = delete;
@@ -94,7 +95,14 @@ public:
 
   virtual void update(const table_slice& input, session ctx) = 0;
 
-  virtual auto finish() -> data = 0;
+  virtual auto get() const -> data = 0;
+
+  /// Save and restore the state of the aggregation instance. Note that the
+  /// restore function should eventually be moved into `aggregation_plugin`, but
+  /// we cannot do that yet as quite a few aggregation instances store
+  /// `ast::expression`, which is not yet serializable.
+  virtual auto save() const -> chunk_ptr = 0;
+  virtual auto restore(chunk_ptr chunk, session ctx) -> void = 0;
 };
 
 class aggregation_plugin : public virtual function_plugin {


### PR DESCRIPTION
This is in preparation for lookup-table contexts with explicitly specified fields via aggregation functions, which need to be able to roundtrip correctly.

I've split this out into a separate PR to make this easier to review; tests for this will arrive with the follow-up story that makes the changes to the contexts, as only then this newly added code will be reachable by users.

Note that `median` and `quantile` cannot be serialized and deserialized as of this PR, as they internally use Apache Arrow's TDigest implementation, which is unfortunately hidden via the pimpl idiom. We will need to change that in a follow-up PR to use another TDigest implementation that we can actually serialize.