### PR TITLE
Only wipe the cache directory contents but not the dir itself

### DIFF
--- a/changelog/next/bug-fixes/4742--cache-directory-wipe.md
+++ b/changelog/next/bug-fixes/4742--cache-directory-wipe.md
@@ -1,0 +1,2 @@
+The node doesn't try to recreate its cache directory on startup anymore,
+avoiding permissions issues on systems with strict access control.

--- a/libtenzir/src/spawn_node.cpp
+++ b/libtenzir/src/spawn_node.cpp
@@ -73,13 +73,17 @@ caf::expected<scope_linked<node_actor>> spawn_node(caf::scoped_actor& self) {
   auto signal_reflector
     = self->system().registry().get<signal_reflector_actor>("signal-reflector");
   self->send(signal_reflector, atom::subscribe_v);
-  // Wipe the old cache directory.
+  // Wipe the contents of the old cache directory.
   {
     auto cache_directory = get_if<std::string>(&opts, "tenzir.cache-directory");
     if (cache_directory && std::filesystem::exists(*cache_directory)) {
-      std::filesystem::remove_all(*cache_directory, err);
-      if (err) {
-        TENZIR_WARN("failed to remove cache at {}: {}", *cache_directory, err);
+      for (auto const& item :
+           std::filesystem::directory_iterator{*cache_directory}) {
+        std::filesystem::remove_all(item.path(), err);
+        if (err) {
+          TENZIR_WARN("failed to remove {} from cache: {}", *cache_directory,
+                      err);
+        }
       }
     }
   }


### PR DESCRIPTION
On systems with strict access control, it can happen that the `tenzir-node` binary has permissions to write into the provided cache directory, but not to recreate the cache directory inside its parent folder.

So instead of removing the directory, we only wipe all contents of the directory on startup.