### PR TITLE
Mask secrets in `/serve`

### DIFF
--- a/web/docs/tql2/functions/secret.md
+++ b/web/docs/tql2/functions/secret.md
@@ -19,6 +19,10 @@ tenzir:
     geheim: 1528F9F3-FAFA-45B4-BC3C-B755D0E0D9C2
 ```
 
+The [`serve`](../operators/serve.md) operator unconditionally replaces all
+secrets with `***` in all schemas and data of all events. This is to prevent
+secrets from showing up in the Tenzir Platform.
+
 ## Examples
 
 ### Read a secret from the configuration


### PR DESCRIPTION
This adjusts the `serve` operator to replace all secrets as defined in the `tenzir.secrets` configuration section for the `secret` function with `***`. This effectively causes secrets not to show up in the Tenzir Platform anymore.

Note, though, that this is not yet a complete solution, as the download button starts a pipeline that does not go through the `serve` operator, but rather uploads events to the platform's S3-compatible storage so that the user's web browser can download the file directly afterwards. To fix this, we would need to adjust how that data is uploaded.

I'm not certain whether we want to merge this as-is, or whether we want to consider alternative approaches in the future.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made in the pull request description in a way that
   is consumable by everyone, not just developers who know the context of the
   change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://docs.tenzir.com/next/contribute/changelog
3. Provide instructions for the reviewer.
4. Remove this comment so it doesn't show up in the merge commit.
-->
