### PR TITLE
Use separate volumes in docker-compose

### DIFF
--- a/changelog/next/bug-fixes/4749--separate-docker-volumes.md
+++ b/changelog/next/bug-fixes/4749--separate-docker-volumes.md
@@ -1,0 +1,1 @@
+The `docker compose` setup now uses separate local volumes for each `tenzir` directory. This fixes a bug where restarting the container resets installed packages or pipelines.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,9 +15,8 @@ services:
     entrypoint:
       - tenzir-node
     volumes:
-      - tenzir-node:/var/lib/tenzir/
-      - tenzir-node:/var/log/tenzir/
-      - tenzir-node:/var/cache/tenzir/
+      - tenzir-lib:/var/lib/tenzir/
+      - tenzir-log:/var/log/tenzir/
     healthcheck:
       test: tenzir --connection-timeout=30s --connection-retry-delay=1s 'api /ping'
       interval: 30s
@@ -51,9 +50,9 @@ services:
       - tenzir-node
     environment:
       - TENZIR_ENDPOINT=tenzir-node:5158
-    volumes:
-      - tenzir-node:/var/cache/tenzir/
 
 volumes:
-  tenzir-node:
+  tenzir-lib:
+    driver: local
+  tenzir-log:
     driver: local


### PR DESCRIPTION
relates to https://github.com/tenzir/issues/issues/2322

### Reason for change

docker-compose volumes overlap which causes unintended side effects

### Change

Use separate volumes in docker-compose