### PR TITLE
Implement response latency metric for component actors

### DIFF
--- a/libtenzir/builtins/components/metrics_collector.cpp
+++ b/libtenzir/builtins/components/metrics_collector.cpp
@@ -125,10 +125,8 @@ auto metrics_collector(
     return metrics_collector_actor::behavior_type::make_empty_behavior();
   }
   return {
-    [](atom::status, status_verbosity, duration) -> caf::result<record> {
-      // The `tenzir-ctl status` command is on its way out, so there is no need
-      // to implement this.
-      return record{};
+    [](atom::ping) -> caf::result<void> {
+      return {};
     },
   };
 }

--- a/libtenzir/builtins/operators/cache.cpp
+++ b/libtenzir/builtins/operators/cache.cpp
@@ -267,7 +267,7 @@ auto make_cache_manager(
                                 std::move(diagnostics),
                                 {capacity, capacity_loc}, ttl, max_ttl);
     },
-    [](atom::status, status_verbosity, duration) -> caf::result<record> {
+    [](atom::ping) -> caf::result<void> {
       return {};
     },
   };

--- a/libtenzir/builtins/operators/serve.cpp
+++ b/libtenzir/builtins/operators/serve.cpp
@@ -216,6 +216,8 @@ using serve_manager_actor = typed_actor_fwd<
   auto(atom::get, std::string serve_id, std::string continuation_token,
        uint64_t min_events, duration timeout, uint64_t max_events)
     ->caf::result<std::tuple<std::string, std::vector<table_slice>>>>
+  // Conform to the protocol of the STATUS CLIENT actor.
+  ::extend_with<status_client_actor>
   // Conform to the protocol of the COMPONENT PLUGIN actor interface.
   ::extend_with<component_plugin_actor>::unwrap;
 
@@ -588,6 +590,9 @@ auto serve_manager(
     [self](atom::status, status_verbosity verbosity,
            duration) -> caf::result<record> {
       return self->state.status(verbosity);
+    },
+    [](atom::ping) -> caf::result<void> {
+      return {};
     },
   };
 }

--- a/libtenzir/include/tenzir/actors.hpp
+++ b/libtenzir/include/tenzir/actors.hpp
@@ -62,6 +62,13 @@ using receiver_actor = typename typed_actor_fwd<
   // Add a new source.
   auto(T, Ts...)->caf::result<void>>::unwrap;
 
+/// The PINGABLE actor interface.
+using pingable_actor = typed_actor_fwd<
+  // Reply to a ping.
+  // Implementations should respond immediately. The consumption of this message
+  // should not trigger any side effects.
+  auto(atom::ping)->caf::result<void>>::unwrap;
+
 /// The STATUS CLIENT actor interface.
 using status_client_actor = typed_actor_fwd<
   // Reply to a status request from the NODE.
@@ -301,8 +308,8 @@ using rest_handler_actor = typed_actor_fwd<
 
 /// The interface of a COMPONENT PLUGIN actor.
 using component_plugin_actor = typed_actor_fwd<
-  // Conform to the protocol of the STATUS CLIENT actor.
-  >::extend_with<status_client_actor>::unwrap;
+  // Conform to the protocol of the PINGABLE actor.
+  >::extend_with<pingable_actor>::unwrap;
 
 /// The receiving part of interface of an EXEC NODE actor.
 using exec_node_sink_actor = typed_actor_fwd<

--- a/plugins/web/include/web/fwd.hpp
+++ b/plugins/web/include/web/fwd.hpp
@@ -39,7 +39,7 @@ using authenticator_actor = typed_actor_fwd<
   auto(atom::generate)->caf::result<token_t>,
   // Validate a token.
   auto(atom::validate, token_t)->caf::result<bool>>
-  // Conform to the protocol of a STATUS CLIENT actor.
+  // Conform to the protocol of a COMPONENT PLUGIN actor.
   ::extend_with<component_plugin_actor>::unwrap;
 
 } // namespace tenzir::plugins::web

--- a/plugins/web/src/authenticator.cpp
+++ b/plugins/web/src/authenticator.cpp
@@ -197,8 +197,8 @@ authenticator(authenticator_actor::stateful_pointer<authenticator_state> self,
     [self](atom::validate, const token_t& token) -> bool {
       return self->state.authenticate(token);
     },
-    [](atom::status, status_verbosity, duration) -> tenzir::record {
-      return record{};
+    [](atom::ping) -> caf::result<void> {
+      return {};
     },
   };
 }


### PR DESCRIPTION
This change adds a new metric to measure response latencies of all component level actors.

- [ ] Implement the actual metric.
- [ ] Update the docs.
