### PR TITLE
Add a feature flag for modules in TQL2

### DIFF
--- a/libtenzir/src/version.cpp
+++ b/libtenzir/src/version.cpp
@@ -73,7 +73,11 @@ auto tenzir_features() -> std::vector<std::string> {
   // that downstream API consumers can adjust their behavior depending on the
   // capabilities of the node. We remove entries once they're stabilized in the
   // Tenzir Platform.
-  return {};
+  return {
+    // The node supports modules in TQL2. Alongside this a few operators were
+    // renamed, e.g., `package_add` was renamed to `package::add`.
+    "modules",
+  };
 }
 
 } // namespace tenzir


### PR DESCRIPTION
This allows the platform to handle the renaming of the package-related operators more smoothly.
