### PR TITLE
Prepend the field added by `enumerate`

### DIFF
--- a/changelog/next/bug-fixes/4756--enumerate-prepend.md
+++ b/changelog/next/bug-fixes/4756--enumerate-prepend.md
@@ -1,0 +1,2 @@
+The `enumerate` operator now correctly prepends the added index field instead of
+appending it.

--- a/libtenzir/builtins/operators/enumerate.cpp
+++ b/libtenzir/builtins/operators/enumerate.cpp
@@ -140,7 +140,7 @@ public:
         check(b->Append(idx++));
       }
       co_yield assign(selector_, series{int64_type{}, finish(*b)}, slice,
-                      ctrl.diagnostics(), true);
+                      ctrl.diagnostics(), assign_position::front);
     }
   }
 

--- a/libtenzir/builtins/operators/enumerate.cpp
+++ b/libtenzir/builtins/operators/enumerate.cpp
@@ -44,8 +44,8 @@ public:
   }
 
   auto
-  operator()(generator<table_slice> input,
-             operator_control_plane& ctrl) const -> generator<table_slice> {
+  operator()(generator<table_slice> input, operator_control_plane& ctrl) const
+    -> generator<table_slice> {
     auto current_type = type{};
     std::unordered_map<type, uint64_t> offsets;
     std::unordered_set<type> skipped_schemas;
@@ -104,8 +104,8 @@ public:
     return "enumerate";
   }
 
-  auto
-  optimize(expression const&, event_order) const -> optimize_result override {
+  auto optimize(expression const&, event_order) const
+    -> optimize_result override {
     return optimize_result{std::nullopt, event_order::ordered, copy()};
   }
 
@@ -126,8 +126,8 @@ public:
   }
 
   auto
-  operator()(generator<table_slice> input,
-             operator_control_plane& ctrl) const -> generator<table_slice> {
+  operator()(generator<table_slice> input, operator_control_plane& ctrl) const
+    -> generator<table_slice> {
     auto idx = int64_t{};
     for (auto&& slice : input) {
       if (slice.rows() == 0) {
@@ -139,9 +139,8 @@ public:
       for (auto i = int64_t{}; i < detail::narrow<int64_t>(slice.rows()); ++i) {
         check(b->Append(idx++));
       }
-      // TODO: We should insert it at the beginning.
       co_yield assign(selector_, series{int64_type{}, finish(*b)}, slice,
-                      ctrl.diagnostics());
+                      ctrl.diagnostics(), true);
     }
   }
 
@@ -149,8 +148,8 @@ public:
     return "tql2.enumerate";
   }
 
-  auto
-  optimize(expression const&, event_order) const -> optimize_result override {
+  auto optimize(expression const&, event_order) const
+    -> optimize_result override {
     return optimize_result{std::nullopt, event_order::ordered, copy()};
   }
 
@@ -195,8 +194,8 @@ public:
 
 class plugin2 final : public virtual operator_plugin2<enumerate_operator2> {
 public:
-  auto
-  make(invocation inv, session ctx) const -> failure_or<operator_ptr> override {
+  auto make(invocation inv, session ctx) const
+    -> failure_or<operator_ptr> override {
     auto selector = ast::simple_selector::try_from(
       ast::root_field{ast::identifier{"#", inv.self.get_location()}});
     TENZIR_ASSERT(selector.has_value());

--- a/libtenzir/include/tenzir/tql2/set.hpp
+++ b/libtenzir/include/tenzir/tql2/set.hpp
@@ -14,12 +14,18 @@
 
 namespace tenzir {
 
+enum class assign_position {
+  front,
+  back,
+};
+
 auto assign(const ast::selector& left, series right, const table_slice& input,
-            diagnostic_handler& dh, bool prepend = false) -> table_slice;
+            diagnostic_handler& dh,
+            assign_position position = assign_position::back) -> table_slice;
 
 auto assign(const ast::simple_selector& left, series right,
             const table_slice& input, diagnostic_handler& dh,
-            bool prepend = false) -> table_slice;
+            assign_position position = assign_position::back) -> table_slice;
 
 auto assign(const ast::meta& left, series right, const table_slice& input,
             diagnostic_handler& diag) -> table_slice;
@@ -27,7 +33,7 @@ auto assign(const ast::meta& left, series right, const table_slice& input,
 class set_operator final : public crtp_operator<set_operator> {
 public:
   set_operator() = default;
-  ~set_operator() = default;
+  ~set_operator() override = default;
   set_operator(const set_operator&) = delete;
   set_operator(set_operator&&) = delete;
   auto operator=(const set_operator&) -> set_operator& = delete;

--- a/libtenzir/include/tenzir/tql2/set.hpp
+++ b/libtenzir/include/tenzir/tql2/set.hpp
@@ -15,10 +15,11 @@
 namespace tenzir {
 
 auto assign(const ast::selector& left, series right, const table_slice& input,
-            diagnostic_handler& dh) -> table_slice;
+            diagnostic_handler& dh, bool prepend = false) -> table_slice;
 
 auto assign(const ast::simple_selector& left, series right,
-            const table_slice& input, diagnostic_handler& dh) -> table_slice;
+            const table_slice& input, diagnostic_handler& dh,
+            bool prepend = false) -> table_slice;
 
 auto assign(const ast::meta& left, series right, const table_slice& input,
             diagnostic_handler& diag) -> table_slice;
@@ -43,8 +44,8 @@ public:
   auto operator()(generator<table_slice> input,
                   operator_control_plane& ctrl) const -> generator<table_slice>;
 
-  auto optimize(expression const& filter,
-                event_order order) const -> optimize_result override {
+  auto optimize(expression const& filter, event_order order) const
+    -> optimize_result override {
     TENZIR_UNUSED(filter, order);
     return do_not_optimize(*this);
   }


### PR DESCRIPTION
This causes `enumerate` to prepend the added field insread of appending it, which (1) restores the behavior from TQL1 and (2) is just generally nicer to use.

- Fixes https://github.com/tenzir/issues/issues/2269