### PR TITLE
Improve names for the `cache` operator's timeout options

### DIFF
--- a/changelog/next/changes/4758--cache-timeout-options.md
+++ b/changelog/next/changes/4758--cache-timeout-options.md
@@ -1,0 +1,2 @@
+The `cache` operator's `ttl` and `max_ttl` options are now called `read_timeout`
+and `write_timeout`, respectively.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "186e8e968b668df00d1b864d6ef5df25e0733de6",
+  "rev": "1f564fd7e61d4ef3f9cace4f314ab308b1350d73",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/web/docs/operators/cache.md
+++ b/web/docs/operators/cache.md
@@ -15,7 +15,7 @@ An in-memory cache shared between pipelines.
 
 ```
 cache <id> [--mode <read|write|readwrite>] [--capacity <capacity>]
-           [--ttl <duration>] [--max-ttl <duration>]
+           [--read-timeout <duration>] [--write-timeout <duration>]
 ```
 
 ## Description
@@ -59,7 +59,7 @@ capacity is reached and emit a warning.
 
 Defaults to 4 Mi.
 
-### `--ttl <duration>`
+### `--read-timeout <duration>`
 
 Defines the maximum inactivity time until the cache is evicted from memory. The
 timer starts when writing the cache completes (or runs into the capacity limit),
@@ -67,10 +67,10 @@ and resets whenever the cache is read from.
 
 Defaults to 1 minute.
 
-### `--max-ttl <duration>`
+### `--write-timeout <duration>`
 
-If set, defines an upper bound for the lifetime of the cache. Unlike the `--ttl`
-option, this does not refresh when the cache is accessed.
+If set, defines an upper bound for the lifetime of the cache. Unlike the
+`--read-timeout` option, this does not refresh when the cache is accessed.
 
 Disabled by default.
 

--- a/web/docs/tql2/operators/cache.md
+++ b/web/docs/tql2/operators/cache.md
@@ -10,7 +10,7 @@ automatically manage caches for you.
 An in-memory cache shared between pipelines.
 
 ```tql
-cache id:str, [mode=str, capacity=int, ttl=duration, max_ttl=duration]
+cache id:str, [mode=str, capacity=int, read_timeout=duration, write_timeout=duration]
 ```
 
 ## Description
@@ -48,7 +48,7 @@ capacity is reached and emit a warning.
 
 Defaults to `4Mi`.
 
-### `ttl = duration (optional)`
+### `read_timeout = duration (optional)`
 
 Defines the maximum inactivity time until the cache is evicted from memory. The
 timer starts when writing the cache completes (or runs into the capacity limit),
@@ -56,10 +56,10 @@ and resets whenever the cache is read from.
 
 Defaults to `1min`.
 
-### `max_ttl = duration (optional)`
+### `write_timeout = duration (optional)`
 
-If set, defines an upper bound for the lifetime of the cache. Unlike the `ttl`
-option, this does not refresh when the cache is accessed.
+If set, defines an upper bound for the lifetime of the cache. Unlike the
+`read_timeout` option, this does not refresh when the cache is accessed.
 
 ## Examples
 
@@ -81,7 +81,7 @@ delete the cache if it's unused for more than a minute.
 export
 where @name == "suricata.flow"
 summarize src_ip, total=sum(bytes_toserver), dest_ip
-cache "some-unique-identifier", ttl=1min
+cache "some-unique-identifier", read_timeout=1min
 summarize src_ip, total=sum(total), destinations=count(dest_ip)
 ```
 

--- a/web/openapi/openapi.yaml
+++ b/web/openapi/openapi.yaml
@@ -115,13 +115,13 @@ components:
               type: integer
               description: The maximum number of events to keep in the `cache` operator.
               example: 4000
-            cache_ttl:
+            cache_read_timeout:
               type: string
               description: "The time to live of the cache. Resets when reading from the cache.\n"
               example: 1.0m
-            cache_max_ttl:
+            cache_write_timeout:
               type: string
-              description: "The maximum time to live of the cache. Unlike the `cache_ttl`\nparameter, this does not reset when reading from the cache.\n"
+              description: "The maximum time to live of the cache. Unlike the `cache_read_timeout`\nparameter, this does not reset when reading from the cache.\n"
               example: 1.0h
             serve_id:
               type: string


### PR DESCRIPTION
This renames `ttl` to `read_timeout` and `max_ttl` to `write_timeout` for the `cache` operator. I stumbled over this while renaming the TTL options in a similar manner for the `lookup-table` context. The new names are more idiomatic and clearly express what the timeouts are doing.