### PR TITLE
Fix configuration options for the kafka plugin

### DIFF
--- a/changelog/next/bug-fixes/4761--fix-kafka-config-options.md
+++ b/changelog/next/bug-fixes/4761--fix-kafka-config-options.md
@@ -1,0 +1,2 @@
+We fixed a bug in the kafka plugin so that it no longer wrongly splits config
+options from the `yaml` files at the dot character.

--- a/libtenzir/src/plugin.cpp
+++ b/libtenzir/src/plugin.cpp
@@ -357,7 +357,7 @@ caf::error initialize(caf::actor_system_config& cfg) {
   if (global_config.contains("plugins")) {
     if (auto* plugins_entry
         = caf::get_if<record>(&global_config.at("plugins"))) {
-      plugins_record = std::move(*plugins_entry);
+      plugins_record = *plugins_entry;
     }
   }
   TENZIR_DEBUG("collected {} global options for plugin initialization",

--- a/plugins/kafka/builtins/plugin.cpp
+++ b/plugins/kafka/builtins/plugin.cpp
@@ -29,9 +29,33 @@ constexpr auto stringify = detail::overload{
 class load_plugin final
   : public virtual operator_plugin2<loader_adapter<kafka_loader>> {
 public:
-  auto initialize(const record& config,
-                  const record& /* global_config */) -> caf::error override {
-    config_ = config;
+  auto initialize(const record& unused_plugin_config,
+                  const record& global_config) -> caf::error override {
+    if (not unused_plugin_config.empty()) {
+      return caf::make_error(ec::diagnostic,
+                             fmt::format("`{}.yaml` is unused; Use `s3.yaml` "
+                                         "instead",
+                                         this->name()));
+    }
+    [&] {
+      auto ptr = global_config.find("plugins");
+      if (ptr == global_config.end()) {
+        return;
+      }
+      const auto* plugin_config = caf::get_if<record>(&ptr->second);
+      if (not plugin_config) {
+        return;
+      }
+      auto kafka_config_ptr = plugin_config->find("kafka");
+      if (kafka_config_ptr == plugin_config->end()) {
+        return;
+      }
+      auto kafka_config = caf::get_if<record>(&kafka_config_ptr->second);
+      if (not kafka_config or kafka_config->empty()) {
+        return;
+      }
+      config_ = flatten(*kafka_config);
+    }();
     if (!config_.contains("bootstrap.servers")) {
       config_["bootstrap.servers"] = "localhost";
     }
@@ -105,9 +129,33 @@ private:
 
 class save_plugin final
   : public virtual operator_plugin2<saver_adapter<kafka_saver>> {
-  auto initialize(const record& config,
-                  const record& /* global_config */) -> caf::error override {
-    config_ = config;
+  auto initialize(const record& unused_plugin_config,
+                  const record& global_config) -> caf::error override {
+    if (not unused_plugin_config.empty()) {
+      return caf::make_error(ec::diagnostic,
+                             fmt::format("`{}.yaml` is unused; Use `s3.yaml` "
+                                         "instead",
+                                         this->name()));
+    }
+    [&] {
+      auto ptr = global_config.find("plugins");
+      if (ptr == global_config.end()) {
+        return;
+      }
+      const auto* plugin_config = caf::get_if<record>(&ptr->second);
+      if (not plugin_config) {
+        return;
+      }
+      auto kafka_config_ptr = plugin_config->find("kafka");
+      if (kafka_config_ptr == plugin_config->end()) {
+        return;
+      }
+      const auto kafka_config = caf::get_if<record>(&kafka_config_ptr->second);
+      if (not kafka_config or kafka_config->empty()) {
+        return;
+      }
+      config_ = flatten(*kafka_config);
+    }();
     if (!config_.contains("bootstrap.servers")) {
       config_["bootstrap.servers"] = "localhost";
     }

--- a/plugins/kafka/builtins/plugin.cpp
+++ b/plugins/kafka/builtins/plugin.cpp
@@ -32,10 +32,9 @@ public:
   auto initialize(const record& unused_plugin_config,
                   const record& global_config) -> caf::error override {
     if (not unused_plugin_config.empty()) {
-      return caf::make_error(ec::diagnostic,
-                             fmt::format("`{}.yaml` is unused; Use `s3.yaml` "
-                                         "instead",
-                                         this->name()));
+      return diagnostic::error("`{}.yaml` is unused; Use `kafka.yaml` instead",
+                               this->name())
+        .to_error();
     }
     [&] {
       auto ptr = global_config.find("plugins");
@@ -132,10 +131,9 @@ class save_plugin final
   auto initialize(const record& unused_plugin_config,
                   const record& global_config) -> caf::error override {
     if (not unused_plugin_config.empty()) {
-      return caf::make_error(ec::diagnostic,
-                             fmt::format("`{}.yaml` is unused; Use `s3.yaml` "
-                                         "instead",
-                                         this->name()));
+      return diagnostic::error("`{}.yaml` is unused; Use `kafka.yaml` instead",
+                               this->name())
+        .to_error();
     }
     [&] {
       auto ptr = global_config.find("plugins");

--- a/plugins/kafka/src/plugin.cpp
+++ b/plugins/kafka/src/plugin.cpp
@@ -33,7 +33,7 @@ class plugin final : public virtual loader_plugin<kafka_loader>,
 public:
   auto initialize(const record& config,
                   const record& /* global_config */) -> caf::error override {
-    config_ = config;
+    config_ = flatten(config);
     if (!config_.contains("bootstrap.servers")) {
       config_["bootstrap.servers"] = "localhost";
     }


### PR DESCRIPTION
Internal option name mangling broke the config options for the `kafka` plugin. This patch reverses the implicit unflattening so `kafka` gets the options in the form it expects them.