### PR TITLE
Make the `summarize` operator unordered

### DIFF
--- a/libtenzir/builtins/operators/summarize.cpp
+++ b/libtenzir/builtins/operators/summarize.cpp
@@ -804,7 +804,6 @@ public:
 
   auto optimize(expression const& filter, event_order order) const
     -> optimize_result override {
-    // Note: The `unordered` relies on commutativity of the aggregation functions.
     (void)filter, (void)order;
     return optimize_result{std::nullopt, event_order::unordered, copy()};
   }
@@ -1132,7 +1131,6 @@ public:
 
   auto optimize(expression const& filter, event_order order) const
     -> optimize_result override {
-    // Note: The `unordered` relies on commutativity of the aggregation functions.
     (void)filter, (void)order;
     return optimize_result{std::nullopt, event_order::unordered, copy()};
   }

--- a/libtenzir/builtins/operators/summarize.cpp
+++ b/libtenzir/builtins/operators/summarize.cpp
@@ -1132,8 +1132,9 @@ public:
 
   auto optimize(expression const& filter, event_order order) const
     -> optimize_result override {
-    TENZIR_UNUSED(filter, order);
-    return do_not_optimize(*this);
+    // Note: The `unordered` relies on commutativity of the aggregation functions.
+    (void)filter, (void)order;
+    return optimize_result{std::nullopt, event_order::unordered, copy()};
   }
 
   friend auto inspect(auto& f, summarize_operator2& x) -> bool {

--- a/web/docs/tql2/operators/summarize.md
+++ b/web/docs/tql2/operators/summarize.md
@@ -10,7 +10,8 @@ summarize (group|aggregation)...
 
 The `summarize` operator groups events according to certain fields and applies
 [aggregation functions](../functions.md#aggregation) to each group. The operator
-consumes the entire input before producing any output.
+consumes the entire input before producing any output, and may reorder the event
+stream.
 
 The order of the output fields follows the sequence of the provided arguments.
 Unspecified fields are dropped.


### PR DESCRIPTION
This makes the following pipeline 20x faster:

```
// tql2
load_http "https://storage.googleapis.com/tenzir-datasets/M57/suricata.json.zst"
decompress "zstd"
read_suricata
where @name == "suricata.flow"
summarize distinct(flow.state)
```