### PR TITLE
doc: clarify where to_hive produces the files locally

### DIFF
--- a/web/versioned_docs/version-v4.23/tql2/operators/to_hive.md
+++ b/web/versioned_docs/version-v4.23/tql2/operators/to_hive.md
@@ -47,7 +47,7 @@ because it opens a new file when only after it is exceeded. Defaults to `100M`.
 ```tql
 from [{a: 0, b: 0}, {a: 0, b: 1}, {a: 1, b: 2}]
 to_hive "/tmp/out/", partition_by=[a], format="json"
-// This pipeline produces two files:
+// This pipeline produces two files on the node host:
 // -> /tmp/out/a=0/1.json:
 //    {"b": 0}
 //    {"b": 1}


### PR DESCRIPTION
Mention that to_hive produces the files on the node host (not the client)