### PR TITLE
Make `to_hive` a "local" operator

### DIFF
--- a/changelog/next/bug-fixes/4771--to-hive-local.md
+++ b/changelog/next/bug-fixes/4771--to-hive-local.md
@@ -1,0 +1,2 @@
+The `to_hive` operator now correctly writes files relative to the working
+directory of a `tenzir` client process instead of relative to the node.

--- a/libtenzir/builtins/operators/to_hive.cpp
+++ b/libtenzir/builtins/operators/to_hive.cpp
@@ -341,6 +341,10 @@ public:
     return "to_hive";
   }
 
+  auto location() const -> operator_location override {
+    return operator_location::local;
+  }
+
   auto optimize(expression const& filter, event_order order) const
     -> optimize_result override {
     TENZIR_UNUSED(filter, order);


### PR DESCRIPTION
The proposed documentation change from #4770 is a bug, not a feature—the operator had its location unset, which caused it to fall back to the previous operator's location.