### PR TITLE
Add an option to prevent persisting internal events

### DIFF
--- a/changelog/next/features/4773--no-store-internal-events.md
+++ b/changelog/next/features/4773--no-store-internal-events.md
@@ -1,3 +1,3 @@
-You can now disable the persistence of internally generated events like
-diagnostics and metrics by setting the option `no-store-internal-events` to
-`true`.
+You can now disable the persistence of internally generated diagnostics and
+metrics by setting the options `dont-persist-diagnostics` and
+`dont-persist-metrics` to `true`.

--- a/changelog/next/features/4773--no-store-internal-events.md
+++ b/changelog/next/features/4773--no-store-internal-events.md
@@ -1,0 +1,3 @@
+You can now disable the persistence of internally generated events like
+diagnostics and metrics by setting the option `no-store-internal-events` to
+`true`.

--- a/libtenzir/include/tenzir/defaults.hpp
+++ b/libtenzir/include/tenzir/defaults.hpp
@@ -223,9 +223,6 @@ inline constexpr size_t max_partition_size = 4'194'304; // 4 Mi
 inline constexpr caf::timespan active_partition_timeout
   = std::chrono::seconds{30};
 
-/// Whether not to store internally generated events.
-inline constexpr bool no_store_internal_events = false;
-
 /// Timeout after which a new automatic rebuild is triggered.
 inline constexpr caf::timespan rebuild_interval = std::chrono::minutes{120};
 

--- a/libtenzir/include/tenzir/defaults.hpp
+++ b/libtenzir/include/tenzir/defaults.hpp
@@ -223,6 +223,9 @@ inline constexpr size_t max_partition_size = 4'194'304; // 4 Mi
 inline constexpr caf::timespan active_partition_timeout
   = std::chrono::seconds{30};
 
+/// Whether not to store internally generated events.
+inline constexpr bool no_store_internal_events = false;
+
 /// Timeout after which a new automatic rebuild is triggered.
 inline constexpr caf::timespan rebuild_interval = std::chrono::minutes{120};
 

--- a/libtenzir/include/tenzir/index.hpp
+++ b/libtenzir/include/tenzir/index.hpp
@@ -249,8 +249,9 @@ struct index_state {
   /// Timeout after which an active partition is forcibly flushed.
   duration active_partition_timeout = {};
 
-  /// Wether to drop all data flagged as internal.
-  bool no_store_internal_events = {};
+  /// Wether to drop data flagged as internal.
+  bool dont_persist_diagnostics = {};
+  bool dont_persist_metrics = {};
 
   /// The maximum size of the partition LRU cache (or the maximum number of
   /// read-only partition loaded to memory).
@@ -342,8 +343,10 @@ struct index_state {
 /// @param taste_partitions How many lookup partitions to schedule immediately.
 /// @param max_concurrent_partition_lookups The maximum amount of concurrent
 ///        lookups.
-/// @param no_store_internal_events Whether to ignore internally generated events
-///        like metrics or diagnostics instead of persisting them.
+/// @param dont_persist_diagnostics Whether to ignore internally generated
+///        diagnostics instead of persisting them.
+/// @param dont_persist_metrics Whether to ignore internally generated
+///        metrics instead of persisting them.
 /// @param catalog_dir The directory used by the catalog.
 /// @param index_config The meta-index configuration of the false-positives
 /// rates for the types and fields.
@@ -355,7 +358,8 @@ index(index_actor::stateful_pointer<index_state> self,
       const std::filesystem::path& dir, std::string store_backend,
       size_t partition_capacity, duration active_partition_timeout,
       size_t max_inmem_partitions, size_t taste_partitions,
-      size_t max_concurrent_partition_lookups, bool no_store_internal_events,
-      const std::filesystem::path& catalog_dir, index_config);
+      size_t max_concurrent_partition_lookups, bool dont_persist_diagnostics,
+      bool dont_persist_metrics, const std::filesystem::path& catalog_dir,
+      index_config);
 
 } // namespace tenzir

--- a/libtenzir/include/tenzir/index.hpp
+++ b/libtenzir/include/tenzir/index.hpp
@@ -249,6 +249,9 @@ struct index_state {
   /// Timeout after which an active partition is forcibly flushed.
   duration active_partition_timeout = {};
 
+  /// Wether to drop all data flagged as internal.
+  bool no_store_internal_events = {};
+
   /// The maximum size of the partition LRU cache (or the maximum number of
   /// read-only partition loaded to memory).
   size_t max_inmem_partitions = {};
@@ -327,18 +330,20 @@ struct index_state {
 
 /// Indexes events in horizontal partitions.
 /// @param filesystem The filesystem actor. Not used by the index itself but
-/// forwarded to partitions.
+///        forwarded to partitions.
 /// @param catalog The catalog actor.
 /// @param dir The directory of the index.
 /// @param store_backend The store backend to use for new partitions.
 /// @param partition_capacity The maximum number of events per partition.
 /// @param active_partition_timeout Timeout after which an active partition is
-/// forcibly flushed.
+///        forcibly flushed.
 /// @param max_inmem_partitions The maximum number of passive partitions loaded
-/// into memory.
+///        into memory.
 /// @param taste_partitions How many lookup partitions to schedule immediately.
 /// @param max_concurrent_partition_lookups The maximum amount of concurrent
-/// lookups.
+///        lookups.
+/// @param no_store_internal_events Whether to ignore internally generated events
+///        like metrics or diagnostics instead of persisting them.
 /// @param catalog_dir The directory used by the catalog.
 /// @param index_config The meta-index configuration of the false-positives
 /// rates for the types and fields.
@@ -350,7 +355,7 @@ index(index_actor::stateful_pointer<index_state> self,
       const std::filesystem::path& dir, std::string store_backend,
       size_t partition_capacity, duration active_partition_timeout,
       size_t max_inmem_partitions, size_t taste_partitions,
-      size_t max_concurrent_partition_lookups,
+      size_t max_concurrent_partition_lookups, bool no_store_internal_events,
       const std::filesystem::path& catalog_dir, index_config);
 
 } // namespace tenzir

--- a/libtenzir/src/index.cpp
+++ b/libtenzir/src/index.cpp
@@ -668,10 +668,16 @@ void index_state::flush_to_disk() {
 
 void index_state::handle_slice(table_slice x) {
   const auto& schema = x.schema();
-  if (no_store_internal_events) {
+  if (dont_persist_diagnostics or dont_persist_metrics) {
     const auto is_internal = schema.attribute("internal").has_value();
     if (is_internal) {
-      return;
+      auto name = schema.name();
+      if (dont_persist_diagnostics and name == "tenzir.diagnostic") {
+        return;
+      }
+      if (dont_persist_metrics and name.starts_with("tenzir.metrics.")) {
+        return;
+      }
     }
   }
   auto active_partition = active_partitions.find(schema);
@@ -1035,8 +1041,9 @@ index(index_actor::stateful_pointer<index_state> self,
       const std::filesystem::path& dir, std::string store_backend,
       size_t partition_capacity, duration active_partition_timeout,
       size_t max_inmem_partitions, size_t taste_partitions,
-      size_t max_concurrent_partition_lookups, bool no_store_internal_events,
-      const std::filesystem::path& catalog_dir, index_config index_config) {
+      size_t max_concurrent_partition_lookups, bool dont_persist_diagnostics,
+      bool dont_persist_metrics, const std::filesystem::path& catalog_dir,
+      index_config index_config) {
   TENZIR_TRACE("index {} {} {} {} {} {} {} {} {} {}", TENZIR_ARG(self->id()),
                TENZIR_ARG(filesystem), TENZIR_ARG(dir),
                TENZIR_ARG(partition_capacity),
@@ -1059,7 +1066,8 @@ index(index_actor::stateful_pointer<index_state> self,
   self->state().accept_queries = true;
   self->state().max_concurrent_partition_lookups
     = max_concurrent_partition_lookups;
-  self->state.no_store_internal_events = no_store_internal_events;
+  self->state().dont_persist_diagnostics = dont_persist_diagnostics;
+  self->state().dont_persist_metrics = dont_persist_metrics;
   self->state().store_actor_plugin
     = plugins::find<store_actor_plugin>(store_backend);
   if (!self->state().store_actor_plugin) {

--- a/libtenzir/src/node.cpp
+++ b/libtenzir/src/node.cpp
@@ -196,8 +196,8 @@ auto spawn_index(node_actor::stateful_pointer<node_state> self,
              defaults::active_partition_timeout),
       defaults::max_in_mem_partitions, defaults::taste_partitions,
       defaults::num_query_supervisors,
-      get_or(settings, "tenzir.no-store-internal-events",
-             defaults::no_store_internal_events),
+      get_or(settings, "tenzir.dont-persist-diagnostics", false),
+      get_or(settings, "tenzir.dont-persist-metrics", false),
       self->state().dir / "index", std::move(index_config));
   }();
   TENZIR_ASSERT(index);

--- a/libtenzir/src/node.cpp
+++ b/libtenzir/src/node.cpp
@@ -195,8 +195,10 @@ auto spawn_index(node_actor::stateful_pointer<node_state> self,
       get_or(settings, "tenzir.active-partition-timeout",
              defaults::active_partition_timeout),
       defaults::max_in_mem_partitions, defaults::taste_partitions,
-      defaults::num_query_supervisors, self->state().dir / "index",
-      std::move(index_config));
+      defaults::num_query_supervisors,
+      get_or(settings, "tenzir.no-store-internal-events",
+             defaults::no_store_internal_events),
+      self->state().dir / "index", std::move(index_config));
   }();
   TENZIR_ASSERT(index);
   if (auto err

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -138,6 +138,10 @@ tenzir:
   # its size.
   active-partition-timeout: 30 seconds
 
+  # Prevent saving internally created events from being persisted in the
+  # internal storeage engine.
+  no-store-internal-events: false
+
   # Automatically rebuild undersized and outdated partitions in the background.
   # The given number controls how much resources to spend on it. Set to 0 to
   # disable.

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -142,6 +142,9 @@ tenzir:
   # internal storeage engine.
   no-store-internal-events: false
 
+  dont-persist-diagnostics: false
+  dont-persist-metrics: false
+
   # Automatically rebuild undersized and outdated partitions in the background.
   # The given number controls how much resources to spend on it. Set to 0 to
   # disable.


### PR DESCRIPTION
Setting `tenzir.no-store-internal-events` to `true` makes it possible to run in a setting where disk IO is undesired or not possible.
