### PR TITLE
Small docs fixes

### DIFF
--- a/web/docs/tql2/operators.md
+++ b/web/docs/tql2/operators.md
@@ -59,17 +59,17 @@ Operator | Description | Example
 
 Operator | Description | Example
 :--------|:------------|:-------
-[`diagnostics`](./operators/diagnostics.md) | Retrieves diagnostic events of managed pipelines | `diagnostics`
+[`diagnostics`](./operators/diagnostics.md) | Returns diagnostic events of managed pipelines | `diagnostics`
 [`export`](./operators/export.md) | Retrieves events from the node | `export`
-[`from_velociraptor`](./operators/from_velociraptor.md) | Returns results from a Velociraptor server | `from_velociraptor subscribe="Windows"`
+[`from_velocira…`](./operators/from_velociraptor.md) | Returns results from a Velociraptor server | `from_velociraptor subscribe="Windows"`
 [`load_amqp`](./operators/load_amqp.md) | Loads bytes from an AMQP server | `load_amqp`
 [`load_file`](./operators/load_file.md) | Loads bytes from a file | `load_file "/tmp/data.json"`
 [`load_ftp`](./operators/load_ftp.md) | Loads bytes via FTP | `load_ftp "ftp.example.org"`
-[`load_google…`](./operators/load_google_cloud_pubsub.md) | Listen to a Google Cloud Pub/Sub subscription | `load_google_cloud_pubsub "…", "…"`
+[`load_google_c…`](./operators/load_google_cloud_pubsub.md) | Listen to a Google Cloud Pub/Sub subscription | `load_google_cloud_pubsub project_id=…`
 [`load_http`](./operators/load_http.md) | Receives bytes from a HTTP request | `load_http "example.org", params={n: 5}`
 [`load_kafka`](./operators/load_kafka.md) | Receives bytes from an Apache Kafka topic | `load_kafka topic="example"`
 [`load_nic`](./operators/load_nic.md) | Receives bytes from a Network Interface Card | `load_nic "eth0"`
-[`load_s3`](./operators/load_s3.md) | Receives bytes from an Amazon S3 object | `load_s3 "s3://examplebucket/obj.csv`
+[`load_s3`](./operators/load_s3.md) | Receives bytes from an Amazon S3 object | `load_s3 "s3://my-bucket/obj.csv"`
 [`load_sqs`](./operators/load_sqs.md) | Receives bytes from an Amazon SQS queue | `load_sqs "sqs://tenzir"`
 [`load_tcp`](./operators/load_tcp.md) | Loads bytes from a TCP or TLS connection | `load_tcp "0.0.0.0:8090" { read_json }`
 [`load_udp`](./operators/load_udp.md) | Loads bytes from a UDP socket | `load_udp "0.0.0.0:8090"`
@@ -93,17 +93,17 @@ Operator | Description | Example
 [`save_email`](./operators/save_email.md) | Saves incoming bytes through an SMTP server | `save_email "user@example.org"`
 [`save_file`](./operators/save_file.md) | Saves incoming bytes into a file | `save_file "/tmp/out.json"`
 [`save_ftp`](./operators/save_ftp.md) | Saves incoming bytes via FTP | `save_ftp "ftp.example.org"`
-[`save_google_cloud…`](./operators/save_google_cloud_pubsub.md) | Publishes to a Google Cloud Pub/Sub topic | `save_google_cloud_pubsub "…", "…"`
+[`save_google_cloud…`](./operators/save_google_cloud_pubsub.md) | Publishes to a Google Cloud Pub/Sub topic | `save_google_cloud_pubsub project…`
 [`save_http`](./operators/save_http.md) | Sends incoming bytes over a HTTP connection | `save_http "example.org/api"`
 [`save_kafka`](./operators/save_kafka.md) | Saves incoming bytes to an Apache Kafka topic | `save_kafka topic="example"`
-[`save_s3`](./operators/save_s3.md) | Saves incoming bytes to an Amazon S3 object | `save_s3 "s3://examplebucket/obj.csv`
+[`save_s3`](./operators/save_s3.md) | Saves incoming bytes to an Amazon S3 object | `save_s3 "s3://my-bucket/obj.csv"`
 [`save_sqs`](./operators/save_sqs.md) | Saves incoming bytes to an Amazon SQS queue | `save_sqs "sqs://tenzir"`
 [`save_udp`](./operators/save_udp.md) | Saves incoming bytes to a UDP socket | `save_udp "0.0.0.0:8090"`
 [`save_zmq`](./operators/save_zmq.md) | Saves incoming bytes to ZeroMQ messages | `save_zmq`
 [`serve`](./operators/serve.md) | Makes events available at `/serve` | `serve "abcde12345"`
-[`to_azure_log_analytics`](./operators/to_azure_log_analytics.md) | Sends events to Azure Log Analytics | `to_azure_log_analytics tenant_id=…`
+[`to_azure_log_ana…`](./operators/to_azure_log_analytics.md) | Sends events to Azure Log Analytics | `to_azure_log_analytics tenant_id=…`
 [`to_hive`](./operators/to_hive.md) | Writes events using hive partitioning | `to_hive "s3://…", partition_by=[x]`
-[`to_splunk`](./operators/to_splunk.md) | Sends incoming events to a Splunk HEC | `to_splunk "https://localhost:8088", …`
+[`to_splunk`](./operators/to_splunk.md) | Sends incoming events to a Splunk HEC | `to_splunk "localhost:8088", …`
 
 <!---
 [`save`](./operators/save.md) | Save incoming bytes according to a URL | `save "https://example.org/api"`

--- a/web/docs/tql2/operators/context/create_bloom_filter.md
+++ b/web/docs/tql2/operators/context/create_bloom_filter.md
@@ -3,7 +3,7 @@
 Creates a Bloom filter context.
 
 ```tql
-context::create_bloom_filter name:string capacity:uint fp_probability:float
+context::create_bloom_filter name:string, capacity=int, fp_probability=float
 ```
 
 ## Description
@@ -30,17 +30,17 @@ tenzir:
 
 Making changes to `arguments` of an already created context has no effect.
 
-### `name : string`
+### `name: string`
 
 The name of the new Bloom filter.
 
-### `capacity : uint`
+### `capacity = uint`
 
 The maximum number of items in the filter that maintain the false positive
-probility. Adding more elements does not yield an error, but lookups will
+probability. Adding more elements does not yield an error, but lookups will
 more likely return false positives.
 
-### `fp_probability : float`
+### `fp_probability = float`
 
 The false-positive probability of the Bloom filter.
 
@@ -49,7 +49,7 @@ The false-positive probability of the Bloom filter.
 ### Create a new Bloom filter context
 
 ```tql
-context::create_bloom_filter "ctx"
+context::create_bloom_filter "ctx", capacity=1B, fp_probability=0.001
 ```
 
 ## See Also

--- a/web/docs/tql2/operators/context/create_geoip.md
+++ b/web/docs/tql2/operators/context/create_geoip.md
@@ -3,7 +3,7 @@
 Creates a GeoIP context.
 
 ```tql
-context::create_geoip name:string [db_path:string]
+context::create_geoip name:string, [db_path=string]
 ```
 
 ## Description
@@ -28,11 +28,11 @@ tenzir:
 
 Making changes to `arguments` of an already created context has no effect.
 
-### `name : string`
+### `name: string`
 
 The name of the new GeoIP context.
 
-### `db_path : string (optional)`
+### `db_path = string (optional)`
 
 The path to the [MMDB](https://maxmind.github.io/MaxMind-DB/) database, relative
 to the node's working directory.

--- a/web/docs/tql2/operators/context/create_lookup_table.md
+++ b/web/docs/tql2/operators/context/create_lookup_table.md
@@ -21,7 +21,7 @@ tenzir:
       type: lookup-table
 ```
 
-### `name : string`
+### `name: string`
 
 The name of the new lookup table.
 

--- a/web/docs/tql2/operators/context/enrich.md
+++ b/web/docs/tql2/operators/context/enrich.md
@@ -3,7 +3,7 @@
 Resets data with a context.
 
 ```tql
-context::enrich name:string, key=expression,
+context::enrich name:string, key=any,
                [into=field, mode=string, format=string]
 ```
 
@@ -11,11 +11,11 @@ context::enrich name:string, key=expression,
 
 The `context::inspect` operator shows details about a specified context.
 
-### `name : string`
+### `name: string`
 
 The name of the context to inspect.
 
-### `key = expression`
+### `key = any`
 
 The field to use for the context lookup.
 

--- a/web/docs/tql2/operators/context/inspect.md
+++ b/web/docs/tql2/operators/context/inspect.md
@@ -10,7 +10,7 @@ context::inspect name:string
 
 The `context::inspect` operator shows details about a specified context.
 
-### `name : string`
+### `name: string`
 
 The name of the context to inspect.
 

--- a/web/docs/tql2/operators/context/load.md
+++ b/web/docs/tql2/operators/context/load.md
@@ -11,7 +11,7 @@ context::load name:string
 The `context::load` operator replaces the state of the specified context with
 its (binary) input.
 
-### `name : string`
+### `name: string`
 
 The name of the context whose state to update.
 

--- a/web/docs/tql2/operators/context/remove.md
+++ b/web/docs/tql2/operators/context/remove.md
@@ -10,7 +10,7 @@ context::remove name:string
 
 The `context::remove` operator deletes the specified context.
 
-### `name : string`
+### `name: string`
 
 The name of the context to delete.
 

--- a/web/docs/tql2/operators/context/reset.md
+++ b/web/docs/tql2/operators/context/reset.md
@@ -11,7 +11,7 @@ context::reset name:string
 The `context::reset` operator erases all data that has been added with
 `context::update`.
 
-### `name : string`
+### `name: string`
 
 The name of the context to reset.
 

--- a/web/docs/tql2/operators/context/save.md
+++ b/web/docs/tql2/operators/context/save.md
@@ -11,7 +11,7 @@ context::save name:string
 The `context::save` operator dumps the state of the specified context into its
 (binary) output.
 
-### `name : string`
+### `name: string`
 
 The name of the context whose state to save.
 

--- a/web/docs/tql2/operators/context/update.md
+++ b/web/docs/tql2/operators/context/update.md
@@ -3,8 +3,8 @@
 Updates a context with new data.
 
 ```tql
-context::update name:string, key=expression,
-               [value=expression, create_timeout=duration,
+context::update name:string, key=any,
+               [value=any, create_timeout=duration,
                 write_timeout=duration, read_timeout=duration]
 ```
 
@@ -21,30 +21,30 @@ with the given key.
 The three arguments `create_timeout`, `write_timeout`, and `read_timeout` only
 work with lookup tables and set the respective timeouts per table entry.
 
-### `name : string`
+### `name: string`
 
 The name of the context to update.
 
-### `key : expression`
+### `key = any`
 
 The field that represents the enrichment key in the data.
 
-### `value : expression (optional)`
+### `value = any (optional)`
 
 The field that represents the enrichment value to associate with `key`.
 
 Defaults to `this`.
 
-### `create_timeout : duration (optional)`
+### `create_timeout = duration (optional)`
 
 Expires a context entry after a given duration since entry creation.
 
-### `write_timeout : duration (optional)`
+### `write_timeout = duration (optional)`
 
 Expires a context entry after a given duration since the last update time. Every
 Every call to `context::update` resets the timeout for the respective key.
 
-### `read_timeout : duration (optional)`
+### `read_timeout = duration (optional)`
 
 Expires a context entry after a given duration since the last access time.
 Every call to `context::enrich` resets the timeout for the respective key.

--- a/web/docs/tql2/operators/measure.md
+++ b/web/docs/tql2/operators/measure.md
@@ -48,7 +48,7 @@ load_file "input.json"
 measure
 ```
 
-```
+```tql
 {timestamp: 2023-04-28T10:22:10.192322, bytes: 16384}
 {timestamp: 2023-04-28T10:22:10.223612, bytes: 16384}
 {timestamp: 2023-04-28T10:22:10.297169, bytes: 16384}

--- a/web/docs/tql2/operators/top.md
+++ b/web/docs/tql2/operators/top.md
@@ -42,7 +42,7 @@ from [
 top x
 ```
 
-```
+```tql
 {x: "A", count: 3}
 {x: "B", count: 2}
 {x: "C", count: 2}


### PR DESCRIPTION
Adds two missing quotes and shortens some content to make it not line-break (when viewed on a MacBook Pro).