### PR TITLE
Replace `caf::optional` with `std::optional`

### DIFF
--- a/libtenzir/builtins/operators/put_extend_replace_set.cpp
+++ b/libtenzir/builtins/operators/put_extend_replace_set.cpp
@@ -49,7 +49,7 @@ constexpr auto operator_name(enum mode mode) -> std::string_view {
 
 /// The parsed configuration.
 struct configuration {
-  std::vector<std::tuple<std::string, caf::optional<operand>>>
+  std::vector<std::tuple<std::string, std::optional<operand>>>
     extractor_to_operand = {};
 
   friend auto inspect(auto& f, configuration& x) -> bool {

--- a/libtenzir/builtins/operators/sort.cpp
+++ b/libtenzir/builtins/operators/sort.cpp
@@ -318,12 +318,12 @@ public:
           }) >> required_ws_or_comment)
         >> ((extractor
              >> (-(required_ws_or_comment >> (str{"asc"} | str{"desc"})))
-                  .then([&](caf::optional<std::string> sort_order) {
+                  .then([&](std::optional<std::string> sort_order) {
                     return sort_order.value_or("asc") == "desc";
                   })
              >> (-(required_ws_or_comment
                    >> (str{"nulls-first"} | str{"nulls-last"})))
-                  .then([&](caf::optional<std::string> null_placement) {
+                  .then([&](std::optional<std::string> null_placement) {
                     return null_placement.value_or("nulls-last")
                            == "nulls-first";
                   })

--- a/libtenzir/builtins/operators/summarize.cpp
+++ b/libtenzir/builtins/operators/summarize.cpp
@@ -840,7 +840,7 @@ public:
                    >> -(required_ws_or_comment >> "update-timeout"
                         >> required_ws_or_comment >> duration)
                    >> optional_ws_or_comment >> end_of_pipeline_operator;
-    std::tuple<std::vector<std::tuple<caf::optional<std::string>, std::string,
+    std::tuple<std::vector<std::tuple<std::optional<std::string>, std::string,
                                       std::string>>,
                std::vector<std::string>, std::optional<tenzir::duration>,
                std::optional<tenzir::duration>, std::optional<tenzir::duration>>

--- a/libtenzir/include/tenzir/concept/convertible/data.hpp
+++ b/libtenzir/include/tenzir/concept/convertible/data.hpp
@@ -305,18 +305,6 @@ caf::error convert(const From& src, std::optional<To>& dst, const Type& t) {
   }
 }
 
-template <class From, class To, class Type>
-caf::error convert(const From& src, caf::optional<To>& dst, const Type& t) {
-  if (!dst) {
-    dst = To{};
-  }
-  if constexpr (IS_TYPED_CONVERTIBLE(src, *dst, t)) {
-    return convert(src, *dst, t);
-  } else {
-    return convert(src, *dst, type{t});
-  }
-}
-
 // Overload for lists.
 template <concepts::appendable To>
 caf::error convert(const list& src, To& dst, const list_type& t) {

--- a/libtenzir/include/tenzir/concept/parseable/core/optional.hpp
+++ b/libtenzir/include/tenzir/concept/parseable/core/optional.hpp
@@ -20,12 +20,9 @@ class optional_parser : public parser_base<optional_parser<Parser>> {
 public:
   using inner_attribute = detail::attr_fold_t<typename Parser::attribute>;
 
-  using attribute =
-    std::conditional_t<
-      std::is_same_v<inner_attribute, unused_type>,
-      unused_type,
-      caf::optional<inner_attribute>
-    >;
+  using attribute
+    = std::conditional_t<std::is_same_v<inner_attribute, unused_type>,
+                         unused_type, std::optional<inner_attribute>>;
 
   constexpr explicit optional_parser(Parser p) : parser_{std::move(p)} {
     // nop

--- a/libtenzir/include/tenzir/concept/parseable/tenzir/pipeline.hpp
+++ b/libtenzir/include/tenzir/concept/parseable/tenzir/pipeline.hpp
@@ -69,8 +69,8 @@ const inline auto operator_arg = qstr | qqstr | unquoted_operator_arg;
 namespace detail {
 
 constexpr inline auto or_default
-  = [](caf::optional<std::vector<std::string>> x) -> std::vector<std::string> {
-  // Note: `caf::optional::value_or` always performs a copy.
+  = [](std::optional<std::vector<std::string>> x) -> std::vector<std::string> {
+  // Note: `std::optional::value_or` always performs a copy.
   if (!x) {
     return {};
   }

--- a/libtenzir/include/tenzir/concept/parseable/tenzir/schema.hpp
+++ b/libtenzir/include/tenzir/concept/parseable/tenzir/schema.hpp
@@ -79,7 +79,7 @@ struct symbol_resolver {
       return y.error();
     x.value_type = *y;
     if (is<legacy_record_type>(x.value_type) && !has_skip_attribute(x)) {
-      x.update_attributes({{"skip", caf::none}});
+      x.update_attributes({{"skip", std::nullopt}});
     }
     return x;
   }

--- a/libtenzir/include/tenzir/detail/legacy_deserialize.hpp
+++ b/libtenzir/include/tenzir/detail/legacy_deserialize.hpp
@@ -295,24 +295,6 @@ public:
   }
 
   template <class T>
-  result_type apply(caf::optional<T>& x) {
-    bool is_set = false;
-    if (!apply(is_set)) {
-      x = {};
-      return false;
-    }
-    if (!is_set) {
-      x = {};
-      return true;
-    }
-    T v;
-    if (!apply(v))
-      return false;
-    x = v;
-    return true;
-  }
-
-  template <class T>
   result_type apply(std::optional<T>& x) {
     bool is_set = false;
     if (!apply(is_set)) {

--- a/libtenzir/include/tenzir/detail/logger_formatters.hpp
+++ b/libtenzir/include/tenzir/detail/logger_formatters.hpp
@@ -197,23 +197,6 @@ struct formatter<caf::intrusive_cow_ptr<T>> {
 };
 
 template <class T>
-struct formatter<caf::optional<T>> {
-  template <class ParseContext>
-  constexpr auto parse(ParseContext& ctx) {
-    return ctx.begin();
-  }
-
-  template <class FormatContext>
-  auto format(const caf::optional<T>& value, FormatContext& ctx) const {
-    if (!value)
-      return fmt::format_to(ctx.out(), "none");
-    return fmt::format_to(ctx.out(), "{}", *value);
-  }
-};
-
-#if FMT_VERSION / 10000 < 10
-
-template <class T>
 struct formatter<std::optional<T>> {
   template <class ParseContext>
   constexpr auto parse(ParseContext& ctx) {
@@ -223,12 +206,10 @@ struct formatter<std::optional<T>> {
   template <class FormatContext>
   auto format(const std::optional<T>& value, FormatContext& ctx) const {
     if (!value)
-      return fmt::format_to(ctx.out(), "nullopt");
+      return fmt::format_to(ctx.out(), "none");
     return fmt::format_to(ctx.out(), "{}", *value);
   }
 };
-
-#endif
 
 template <class T>
 struct formatter<caf::expected<T>> {

--- a/libtenzir/include/tenzir/detail/logger_formatters.hpp
+++ b/libtenzir/include/tenzir/detail/logger_formatters.hpp
@@ -23,6 +23,7 @@
 #include "tenzir/detail/logger.hpp"
 #include "tenzir/detail/type_traits.hpp"
 #include "tenzir/error.hpp"
+#include "tenzir/optional.hpp"
 
 #include <boost/core/detail/string_view.hpp>
 #include <caf/deep_to_string.hpp>
@@ -193,21 +194,6 @@ struct formatter<caf::intrusive_cow_ptr<T>> {
     if (!value)
       return fmt::format_to(ctx.out(), "*{}", "nullptr");
     return fmt::format_to(ctx.out(), "*{}", ptr(value.get()));
-  }
-};
-
-template <class T>
-struct formatter<std::optional<T>> {
-  template <class ParseContext>
-  constexpr auto parse(ParseContext& ctx) {
-    return ctx.begin();
-  }
-
-  template <class FormatContext>
-  auto format(const std::optional<T>& value, FormatContext& ctx) const {
-    if (!value)
-      return fmt::format_to(ctx.out(), "none");
-    return fmt::format_to(ctx.out(), "{}", *value);
   }
 };
 

--- a/libtenzir/include/tenzir/detail/type_traits.hpp
+++ b/libtenzir/include/tenzir/detail/type_traits.hpp
@@ -113,11 +113,6 @@ struct remove_optional {
 };
 
 template <class T>
-struct remove_optional<caf::optional<T>> {
-  using type = T;
-};
-
-template <class T>
 struct remove_optional<std::optional<T>> {
   using type = T;
 };

--- a/libtenzir/include/tenzir/legacy_type.hpp
+++ b/libtenzir/include/tenzir/legacy_type.hpp
@@ -46,7 +46,7 @@ namespace tenzir {
 /// A qualifier in the form of a key and optional value.
 struct legacy_attribute : detail::totally_ordered<legacy_attribute> {
   legacy_attribute(std::string key = {});
-  legacy_attribute(std::string key, caf::optional<std::string> value);
+  legacy_attribute(std::string key, std::optional<std::string> value);
 
   friend bool operator==(const legacy_attribute& x, const legacy_attribute& y);
 
@@ -58,7 +58,7 @@ struct legacy_attribute : detail::totally_ordered<legacy_attribute> {
   }
 
   std::string key;
-  caf::optional<std::string> value;
+  std::optional<std::string> value;
 };
 
 // -- type hierarchy ----------------------------------------------------------

--- a/libtenzir/include/tenzir/optional.hpp
+++ b/libtenzir/include/tenzir/optional.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <fmt/format.h>
+
 #include <optional>
 
 namespace tenzir {
@@ -20,3 +22,21 @@ std::optional<T> to_optional(const T* ptr) {
 }
 
 } // namespace tenzir
+
+namespace fmt {
+template <class T>
+struct formatter<std::optional<T>> {
+  template <class ParseContext>
+  constexpr auto parse(ParseContext& ctx) {
+    return ctx.begin();
+  }
+
+  template <class FormatContext>
+  auto format(const std::optional<T>& value, FormatContext& ctx) const {
+    if (!value) {
+      return fmt::format_to(ctx.out(), "none");
+    }
+    return fmt::format_to(ctx.out(), "{}", *value);
+  }
+};
+} // namespace fmt

--- a/libtenzir/include/tenzir/optional.hpp
+++ b/libtenzir/include/tenzir/optional.hpp
@@ -23,6 +23,8 @@ std::optional<T> to_optional(const T* ptr) {
 
 } // namespace tenzir
 
+#if FMT_VERSION / 10000 < 10
+
 namespace fmt {
 template <class T>
 struct formatter<std::optional<T>> {
@@ -34,9 +36,11 @@ struct formatter<std::optional<T>> {
   template <class FormatContext>
   auto format(const std::optional<T>& value, FormatContext& ctx) const {
     if (!value) {
-      return fmt::format_to(ctx.out(), "none");
+      return fmt::format_to(ctx.out(), "nullopt");
     }
     return fmt::format_to(ctx.out(), "{}", *value);
   }
 };
 } // namespace fmt
+
+#endif

--- a/libtenzir/include/tenzir/view.hpp
+++ b/libtenzir/include/tenzir/view.hpp
@@ -485,7 +485,7 @@ data_view make_data_view(const T& x) {
 
 /// @relates view_trait
 template <class T>
-data_view make_data_view(const caf::optional<T>& x) {
+data_view make_data_view(const std::optional<T>& x) {
   if (!x) {
     return make_view(caf::none);
   }

--- a/libtenzir/src/concept/parseable/tenzir/expression.cpp
+++ b/libtenzir/src/concept/parseable/tenzir/expression.cpp
@@ -91,7 +91,7 @@ struct expander {
           }
         }
       }
-      return caf::none;
+      return std::nullopt;
     };
     auto make_disjunction = [](auto x, auto y) {
       disjunction result;

--- a/libtenzir/src/concept/parseable/tenzir/expression.cpp
+++ b/libtenzir/src/concept/parseable/tenzir/expression.cpp
@@ -78,7 +78,7 @@ struct expander {
     // Builds an additional predicate for subnet type extractor predicates. The
     // additional :ip in S predicate gets appended as disjunction afterwards.
     auto build_addr_pred
-      = [](auto& lhs, auto op, auto& rhs) -> caf::optional<expression> {
+      = [](auto& lhs, auto op, auto& rhs) -> std::optional<expression> {
       if (auto t = try_as<type_extractor>(&lhs)) {
         if (auto d = try_as<data>(&rhs)) {
           if (op == relational_operator::equal) {

--- a/libtenzir/src/concept/parseable/tenzir/legacy_type.cpp
+++ b/libtenzir/src/concept/parseable/tenzir/legacy_type.cpp
@@ -31,7 +31,7 @@ bool legacy_type_parser::parse(Iterator& f, const Iterator& l,
   // clang-format off
   // Attributes: type meta data
   static auto to_attr =
-    [](std::tuple<std::string, caf::optional<std::string>> xs) {
+    [](std::tuple<std::string, std::optional<std::string>> xs) {
       auto& [key, value] = xs;
       return tenzir::legacy_attribute{std::move(key), std::move(value)};
     };

--- a/libtenzir/src/legacy_type.cpp
+++ b/libtenzir/src/legacy_type.cpp
@@ -31,7 +31,7 @@ legacy_attribute::legacy_attribute(std::string key) : key{std::move(key)} {
 }
 
 legacy_attribute::legacy_attribute(std::string key,
-                                   caf::optional<std::string> value)
+                                   std::optional<std::string> value)
   : key{std::move(key)}, value{std::move(value)} {
 }
 

--- a/libtenzir/test/convertible.cpp
+++ b/libtenzir/test/convertible.cpp
@@ -337,7 +337,7 @@ struct StdOpt {
 };
 
 struct CafOpt {
-  caf::optional<int64_t> value;
+  std::optional<int64_t> value;
 
   template <class Inspector>
   friend auto inspect(Inspector& f, CafOpt& c) {
@@ -362,7 +362,7 @@ TEST(std::optional member variable) {
   CHECK_EQUAL(*x.value, 22);
 }
 
-TEST(caf::optional member variable) {
+TEST(std::optional member variable) {
   auto x = CafOpt{int64_t{42}};
   auto r = record{{"value", caf::none}};
   REQUIRE_EQUAL(convert(r, x), ec::no_error);
@@ -586,8 +586,8 @@ TEST(list of record to map monoid) {
 struct OptVec {
   constexpr inline static bool use_deep_to_string_formatter = true;
 
-  caf::optional<std::vector<std::string>> ovs = {};
-  caf::optional<uint64_t> ou = 0;
+  std::optional<std::vector<std::string>> ovs = {};
+  std::optional<uint64_t> ou = 0;
 
   template <class Inspector>
   friend auto inspect(Inspector& f, OptVec& x) {

--- a/libtenzir/test/convertible.cpp
+++ b/libtenzir/test/convertible.cpp
@@ -336,34 +336,8 @@ struct StdOpt {
   }
 };
 
-struct CafOpt {
-  std::optional<int64_t> value;
-
-  template <class Inspector>
-  friend auto inspect(Inspector& f, CafOpt& c) {
-    return f.apply(c.value);
-  }
-
-  inline static const record_type& schema() noexcept {
-    static const auto result = record_type{
-      {"value", int64_type{}},
-    };
-    return result;
-  }
-};
-
 TEST(std::optional member variable) {
   auto x = StdOpt{int64_t{42}};
-  auto r = record{{"value", caf::none}};
-  REQUIRE_EQUAL(convert(r, x), ec::no_error);
-  CHECK_EQUAL(x.value, int64_t{42});
-  r = record{{"value", int64_t{22}}};
-  REQUIRE_EQUAL(convert(r, x), ec::no_error);
-  CHECK_EQUAL(*x.value, 22);
-}
-
-TEST(std::optional member variable) {
-  auto x = CafOpt{int64_t{42}};
   auto r = record{{"value", caf::none}};
   REQUIRE_EQUAL(convert(r, x), ec::no_error);
   CHECK_EQUAL(x.value, int64_t{42});

--- a/libtenzir/test/detail/legacy_deserialize.cpp
+++ b/libtenzir/test/detail/legacy_deserialize.cpp
@@ -359,9 +359,9 @@ struct custom {
 TEST(caf_optional) {
   caf::byte_buffer serialization_output;
   caf::binary_serializer s{nullptr, serialization_output};
-  auto in = caf::optional<custom>{custom{"test str", 221}};
+  auto in = std::optional<custom>{custom{"test str", 221}};
   REQUIRE(s.apply(in));
-  auto out = caf::optional<custom>{};
+  auto out = std::optional<custom>{};
   REQUIRE(ldes(serialization_output, out));
   REQUIRE_EQUAL(in->x, out->x);
   REQUIRE_EQUAL(in->y, out->y);

--- a/libtenzir/test/printable.cpp
+++ b/libtenzir/test/printable.cpp
@@ -234,7 +234,7 @@ TEST(list) {
 }
 
 TEST(optional) {
-  caf::optional<int> x;
+  std::optional<int> x;
   auto p = -printers::integral<int>;
   std::string str;
   CHECK(p(str, x));


### PR DESCRIPTION
This replaces every usage of `caf::optional` with `std::optional`

- Fixes https://github.com/tenzir/issues/issues/2334