### PR TITLE
Fix bugs in `where` when predicate evaluates to `null`

### DIFF
--- a/changelog/next/bug-fixes/4785--where.md
+++ b/changelog/next/bug-fixes/4785--where.md
@@ -1,0 +1,3 @@
+We fixed a bug in TQL2's `where` operator that made it sometimes return
+incorrect results for events for which the predicate evaluated to `null`. Now,
+the operator consistently warns when this happens and drops the events.

--- a/libtenzir/builtins/operators/where.cpp
+++ b/libtenzir/builtins/operators/where.cpp
@@ -164,11 +164,7 @@ public:
         co_yield {};
         continue;
       }
-      if (array->null_count() != 0) {
-        diagnostic::warning("expected `bool`, got `null`")
-          .primary(expr_)
-          .emit(ctrl.diagnostics());
-      } else if (array->false_count() == 0) {
+      if (array->true_count() == array->length()) {
         co_yield std::move(slice);
         continue;
       }

--- a/libtenzir/builtins/operators/where.cpp
+++ b/libtenzir/builtins/operators/where.cpp
@@ -164,7 +164,11 @@ public:
         co_yield {};
         continue;
       }
-      if (array->false_count() == 0) {
+      if (array->null_count() != 0) {
+        diagnostic::warning("expected `bool`, got `null`")
+          .primary(expr_)
+          .emit(ctrl.diagnostics());
+      } else if (array->false_count() == 0) {
         co_yield std::move(slice);
         continue;
       }
@@ -179,7 +183,7 @@ public:
       // We add an artificial `false` at index `length` to flush.
       auto results = std::vector<table_slice>{};
       for (auto i = int64_t{1}; i < length + 1; ++i) {
-        auto next = i != length && array->Value(i);
+        const auto next = i != length && array->IsValid(i) && array->Value(i);
         if (current_value == next) {
           continue;
         }


### PR DESCRIPTION
This fixes two bugs in the `where` operator when the evaluated predicate contained `null` values:
1. When the result only contained `true` and `null`, we incorrectly returned the entire input.
2. When the result contained `null` and at least one `false`, we ran into UB by incorrectly accessing the value of an `arrow::BooleanArray` for an invalid row.

Now, we correctly warn about `null` values in the result and drop all events for which the predicate evaluated to `null`.