### PR TITLE
Copy some metafunctions from `caf::detail::type_list`

### DIFF
--- a/libtenzir/builtins/contexts/lookup_table.cpp
+++ b/libtenzir/builtins/contexts/lookup_table.cpp
@@ -93,12 +93,12 @@ auto try_lossless_cast(From from) -> std::optional<To>
 // conversion is lossless. The original type information is retained, to be used
 // with context dumps and binary serialization.
 class key_data {
-  static constexpr size_t i64_index = static_cast<size_t>(
-    caf::detail::tl_index_of<data::types, int64_t>::value);
-  static constexpr size_t u64_index = static_cast<size_t>(
-    caf::detail::tl_index_of<data::types, uint64_t>::value);
+  static constexpr size_t i64_index
+    = static_cast<size_t>(detail::tl_index_of<data::types, int64_t>::value);
+  static constexpr size_t u64_index
+    = static_cast<size_t>(detail::tl_index_of<data::types, uint64_t>::value);
   static constexpr size_t double_index
-    = static_cast<size_t>(caf::detail::tl_index_of<data::types, double>::value);
+    = static_cast<size_t>(detail::tl_index_of<data::types, double>::value);
 
 public:
   key_data() = default;

--- a/libtenzir/include/tenzir/argument_parser2.hpp
+++ b/libtenzir/include/tenzir/argument_parser2.hpp
@@ -23,7 +23,7 @@
 namespace tenzir {
 
 using argument_parser_data_types
-  = detail::tl_map_t<caf::detail::tl_filter_not_type_t<data::types, pattern>,
+  = detail::tl_map_t<detail::tl_filter_not_type_t<data::types, pattern>,
                      as_located>;
 
 using argument_parser_full_types = detail::tl_concat_t<
@@ -141,7 +141,7 @@ private:
   using setter_variant = variant<setter<Ts>...>;
 
   using any_setter
-    = caf::detail::tl_apply_t<argument_parser_full_types, setter_variant>;
+    = detail::tl_apply_t<argument_parser_full_types, setter_variant>;
 
   struct positional_t {
     positional_t(std::string name, std::string type, any_setter set)

--- a/libtenzir/include/tenzir/bitmap.hpp
+++ b/libtenzir/include/tenzir/bitmap.hpp
@@ -10,6 +10,7 @@
 
 #include "tenzir/bitmap_base.hpp"
 #include "tenzir/detail/operators.hpp"
+#include "tenzir/detail/type_list.hpp"
 #include "tenzir/detail/type_traits.hpp"
 #include "tenzir/ewah_bitmap.hpp"
 #include "tenzir/null_bitmap.hpp"
@@ -17,7 +18,6 @@
 #include "tenzir/variant_traits.hpp"
 #include "tenzir/wah_bitmap.hpp"
 
-#include <caf/detail/type_list.hpp>
 #include <fmt/core.h>
 
 namespace tenzir {
@@ -30,9 +30,9 @@ class bitmap : public bitmap_base<bitmap>, detail::equality_comparable<bitmap> {
   friend bitmap_bit_range;
 
 public:
-  using types = caf::detail::type_list<ewah_bitmap, null_bitmap, wah_bitmap>;
+  using types = detail::type_list<ewah_bitmap, null_bitmap, wah_bitmap>;
 
-  using variant = caf::detail::tl_apply_t<types, tenzir::variant>;
+  using variant = detail::tl_apply_t<types, tenzir::variant>;
 
   /// The concrete bitmap type to be used for default construction.
   using default_bitmap = ewah_bitmap;
@@ -143,7 +143,7 @@ struct sum_type_access<tenzir::bitmap>
 namespace fmt {
 
 template <class Bitmap>
-  requires(caf::detail::tl_contains<tenzir::bitmap::types, Bitmap>::value
+  requires(tenzir::detail::tl_contains<tenzir::bitmap::types, Bitmap>::value
            || std::is_same_v<Bitmap, tenzir::bitmap>)
 struct formatter<Bitmap> {
   template <typename ParseContext>

--- a/libtenzir/include/tenzir/concept/printable/tenzir/json.hpp
+++ b/libtenzir/include/tenzir/concept/printable/tenzir/json.hpp
@@ -303,7 +303,7 @@ struct json_printer : printer_base<json_printer> {
   }
 
   template <class Iterator, class T>
-    requires caf::detail::tl_contains<view<data>::types, T>::value
+    requires detail::tl_contains<view<data>::types, T>::value
   auto print(Iterator& out, const T& d) const noexcept -> bool {
     return print_visitor{out, options_}(d);
   }
@@ -314,8 +314,8 @@ struct json_printer : printer_base<json_printer> {
   }
 
   template <class Iterator, class T>
-    requires(!caf::detail::tl_contains<view<data>::types, T>::value
-             && caf::detail::tl_contains<data::types, T>::value)
+    requires(!detail::tl_contains<view<data>::types, T>::value
+             && detail::tl_contains<data::types, T>::value)
   auto print(Iterator& out, const T& d) const noexcept -> bool {
     return print(out, make_view(d));
   }

--- a/libtenzir/include/tenzir/concept/support/detail/variant.hpp
+++ b/libtenzir/include/tenzir/concept/support/detail/variant.hpp
@@ -56,6 +56,6 @@ using variant_type_concat =
 
 template <class T, class U>
 using flattened_variant
-  = caf::detail::tl_apply_t<variant_type_concat<T, U>, tenzir::variant>;
+  = detail::tl_apply_t<variant_type_concat<T, U>, tenzir::variant>;
 
 } // namespace tenzir::detail

--- a/libtenzir/include/tenzir/data.hpp
+++ b/libtenzir/include/tenzir/data.hpp
@@ -16,6 +16,7 @@
 #include "tenzir/detail/debug_writer.hpp"
 #include "tenzir/detail/operators.hpp"
 #include "tenzir/detail/string.hpp"
+#include "tenzir/detail/type_list.hpp"
 #include "tenzir/detail/type_traits.hpp"
 #include "tenzir/die.hpp"
 #include "tenzir/ip.hpp"
@@ -27,7 +28,6 @@
 #include "tenzir/variant_traits.hpp"
 
 #include <caf/default_sum_type_access.hpp>
-#include <caf/detail/type_list.hpp>
 #include <caf/expected.hpp>
 #include <caf/fwd.hpp>
 #include <caf/none.hpp>
@@ -93,7 +93,7 @@ using to_data_type = decltype(detail::to_data_type<std::decay_t<T>>());
 class data : detail::totally_ordered<data>, detail::addable<data> {
 public:
   // clang-format off
-  using types = caf::detail::type_list<
+  using types = detail::type_list<
     caf::none_t,
     bool,
     int64_t,
@@ -114,7 +114,7 @@ public:
   // clang-format on
 
   /// The sum type of all possible builtin types.
-  using variant = caf::detail::tl_apply_t<types, tenzir::variant>;
+  using variant = detail::tl_apply_t<types, tenzir::variant>;
 
   /// Default-constructs empty data.
   data() = default;
@@ -383,7 +383,7 @@ auto try_get_or(const record& r, std::string_view path, const T& fallback)
 /// does not exist.
 /// @pre `!path.empty()`
 template <typename T>
-  requires caf::detail::tl_contains<data::types, T>::value
+  requires detail::tl_contains<data::types, T>::value
 auto get_if(const record* r, std::string_view path) -> const T* {
   auto result = descend(r, path);
   if (not result || not *result) {

--- a/libtenzir/include/tenzir/data_builder.hpp
+++ b/libtenzir/include/tenzir/data_builder.hpp
@@ -10,13 +10,12 @@
 #include "tenzir/fwd.hpp"
 
 #include "tenzir/aliases.hpp"
-#include "tenzir/detail/assert.hpp"
 #include "tenzir/detail/flat_map.hpp"
+#include "tenzir/detail/type_list.hpp"
 #include "tenzir/diagnostics.hpp"
 #include "tenzir/series_builder.hpp"
 #include "tsl/robin_map.h"
 
-#include <caf/detail/type_list.hpp>
 #include <caf/error.hpp>
 #include <caf/expected.hpp>
 
@@ -82,7 +81,7 @@ struct enriched_dummy {};
 // The indices in this MUST line up with the tenzir type indices, hence the
 // dummies
 // clang-format off
-using field_type_list = caf::detail::type_list<
+using field_type_list = detail::type_list<
   caf::none_t,
   bool,
   int64_t,
@@ -105,13 +104,13 @@ using field_type_list = caf::detail::type_list<
 
 template <typename T>
 concept non_structured_data_type
-  = caf::detail::tl_contains<field_type_list, T>::value
+  = detail::tl_contains<field_type_list, T>::value
     and not detail::is_any_v<T, node_record, node_list, pattern_dummy,
                              map_dummy, enriched_dummy>;
 
 template <typename T>
 concept non_structured_type_type
-  = caf::detail::tl_contains<concrete_types, T>::value
+  = detail::tl_contains<concrete_types, T>::value
     and not detail::is_any_v<record_type, list_type, legacy_pattern_type,
                              map_type>;
 
@@ -139,26 +138,26 @@ using schema_type_lookup_map
   = std::unordered_map<tenzir::record_type, field_type_lookup_map>;
 
 constexpr inline size_t type_index_empty
-  = caf::detail::tl_size<field_type_list>::value;
+  = detail::tl_size<field_type_list>::value;
 constexpr inline size_t type_index_generic_mismatch
-  = caf::detail::tl_size<field_type_list>::value + 1;
+  = detail::tl_size<field_type_list>::value + 1;
 constexpr inline size_t type_index_numeric_mismatch
-  = caf::detail::tl_size<field_type_list>::value + 2;
+  = detail::tl_size<field_type_list>::value + 2;
 constexpr inline size_t type_index_null
-  = caf::detail::tl_index_of<field_type_list, caf::none_t>::value;
+  = detail::tl_index_of<field_type_list, caf::none_t>::value;
 constexpr inline size_t type_index_string
-  = caf::detail::tl_index_of<field_type_list, std::string>::value;
+  = detail::tl_index_of<field_type_list, std::string>::value;
 constexpr inline size_t type_index_double
-  = caf::detail::tl_index_of<field_type_list, double>::value;
+  = detail::tl_index_of<field_type_list, double>::value;
 constexpr inline size_t type_index_list
-  = caf::detail::tl_index_of<field_type_list, node_list>::value;
+  = detail::tl_index_of<field_type_list, node_list>::value;
 constexpr inline size_t type_index_record
-  = caf::detail::tl_index_of<field_type_list, node_record>::value;
+  = detail::tl_index_of<field_type_list, node_record>::value;
 
 inline constexpr auto is_structural(size_t idx) -> bool {
   switch (idx) {
-    case caf::detail::tl_index_of<field_type_list, node_list>::value:
-    case caf::detail::tl_index_of<field_type_list, node_record>::value:
+    case detail::tl_index_of<field_type_list, node_list>::value:
+    case detail::tl_index_of<field_type_list, node_record>::value:
       return true;
     default:
       return false;
@@ -167,10 +166,10 @@ inline constexpr auto is_structural(size_t idx) -> bool {
 
 inline constexpr auto is_numeric(size_t idx) -> bool {
   switch (idx) {
-    case caf::detail::tl_index_of<field_type_list, int64_t>::value:
-    case caf::detail::tl_index_of<field_type_list, uint64_t>::value:
-    case caf::detail::tl_index_of<field_type_list, double>::value:
-    case caf::detail::tl_index_of<field_type_list, enumeration>::value:
+    case detail::tl_index_of<field_type_list, int64_t>::value:
+    case detail::tl_index_of<field_type_list, uint64_t>::value:
+    case detail::tl_index_of<field_type_list, double>::value:
+    case detail::tl_index_of<field_type_list, enumeration>::value:
       return true;
     default:
       return false;
@@ -178,7 +177,7 @@ inline constexpr auto is_numeric(size_t idx) -> bool {
 }
 
 inline auto is_null(size_t idx) -> bool {
-  return idx == caf::detail::tl_index_of<field_type_list, caf::none_t>::value;
+  return idx == detail::tl_index_of<field_type_list, caf::none_t>::value;
 }
 
 static inline auto
@@ -493,8 +492,7 @@ private:
   /// @brief marks the node and its contents as dead
   auto clear() -> void;
 
-  using object_variant_type
-    = caf::detail::tl_apply_t<field_type_list, std::variant>;
+  using object_variant_type = detail::tl_apply_t<field_type_list, std::variant>;
 
   object_variant_type data_;
 

--- a/libtenzir/include/tenzir/detail/legacy_deserialize.hpp
+++ b/libtenzir/include/tenzir/detail/legacy_deserialize.hpp
@@ -11,6 +11,7 @@
 #include "tenzir/as_bytes.hpp"
 #include "tenzir/detail/byteswap.hpp"
 #include "tenzir/detail/inspection_common.hpp"
+#include "tenzir/detail/type_list.hpp"
 #include "tenzir/error.hpp"
 #include "tenzir/logger.hpp"
 #include "tenzir/variant_traits.hpp"
@@ -249,7 +250,7 @@ public:
   template <class... Ts>
   result_type apply(uint8_t type_tag, caf::variant<Ts...>& x) {
     using namespace caf;
-    using caf::detail::tl_at;
+    using detail::tl_at;
     auto& f = *this;
     switch (type_tag) {
       default:
@@ -257,8 +258,8 @@ public:
 #define CAF_VARIANT_ASSIGN_CASE_IMPL(n)                                        \
   case n: {                                                                    \
     using tmp_t =                                                              \
-      typename caf::detail::tl_at<caf::detail::type_list<Ts...>,               \
-                                  ((n) < sizeof...(Ts) ? (n) : 0)>::type;      \
+      typename detail::tl_at<detail::type_list<Ts...>,                         \
+                             ((n) < sizeof...(Ts) ? (n) : 0)>::type;           \
     x = tmp_t{};                                                               \
     return f(as<tmp_t>(x));                                                    \
   }
@@ -315,8 +316,8 @@ public:
 #define TENZIR_VARIANT_ASSIGN_CASE_IMPL(n)                                     \
   case n: {                                                                    \
     using tmp_t =                                                              \
-      typename caf::detail::tl_at<caf::detail::type_list<Ts...>,               \
-                                  ((n) < sizeof...(Ts) ? (n) : 0)>::type;      \
+      typename detail::tl_at<detail::type_list<Ts...>,                         \
+                             ((n) < sizeof...(Ts) ? (n) : 0)>::type;           \
     x = tmp_t{};                                                               \
     return f(as<tmp_t>(x));                                                    \
   }

--- a/libtenzir/include/tenzir/detail/type_list.hpp
+++ b/libtenzir/include/tenzir/detail/type_list.hpp
@@ -274,4 +274,29 @@ struct tl_make<T<Ts...>> {
 template <class T>
 using tl_make_t = typename tl_make<T>::type;
 
+template <class...>
+struct common_types_helper;
+
+template <class L1>
+struct common_types_helper<L1, type_list<>> {
+  using type = type_list<>;
+};
+
+template <class L1, class L2>
+struct common_types_helper<L1, L2> {
+  using type = std::conditional_t<
+    tl_contains_v<L1, caf::detail::tl_head_t<L2>>,
+    tl_prepend_t<
+      typename common_types_helper<L1, caf::detail::tl_tail_t<L2>>::type,
+      caf::detail::tl_head_t<L2>>,
+    typename common_types_helper<L1, caf::detail::tl_tail_t<L2>>::type>;
+};
+
+// Creates a new type list that contains all the types that are present in both
+// L1 and L2
+template <class L1, class L2>
+  requires(is_type_list<L1>::value and is_type_list<L2>::value)
+using tl_common_types_t
+  = tl_distinct_t<typename common_types_helper<L1, L2>::type>;
+
 } // namespace tenzir::detail

--- a/libtenzir/include/tenzir/detail/type_list.hpp
+++ b/libtenzir/include/tenzir/detail/type_list.hpp
@@ -8,54 +8,53 @@
 
 #pragma once
 
+#include <caf/config.hpp>
 #include <caf/detail/is_one_of.hpp>
 #include <caf/detail/type_list.hpp>
 
-#include <tuple>
-
 namespace tenzir::detail {
 
-using caf::detail::tbind;
-
+#if CAF_VERSION >= 10000
+using caf::type_list;
+#else
+using caf::detail::type_list;
+#endif
 using caf::detail::empty_type_list;
 using caf::detail::is_type_list;
 using caf::detail::tl_apply;
-using caf::detail::tl_apply_all;
 using caf::detail::tl_at;
 using caf::detail::tl_back;
-using caf::detail::tl_concat;
 using caf::detail::tl_contains;
-using caf::detail::tl_count;
-using caf::detail::tl_count_not;
-using caf::detail::tl_distinct;
-using caf::detail::tl_empty;
 using caf::detail::tl_exists;
 using caf::detail::tl_filter;
 using caf::detail::tl_filter_not;
-using caf::detail::tl_find;
 using caf::detail::tl_forall;
 using caf::detail::tl_head;
 using caf::detail::tl_index_of;
 using caf::detail::tl_is_distinct;
 using caf::detail::tl_map;
-using caf::detail::tl_map_conditional;
-using caf::detail::tl_pop_back;
-using caf::detail::tl_prepend;
-using caf::detail::tl_push_back;
-using caf::detail::tl_push_front;
-using caf::detail::tl_reverse;
 using caf::detail::tl_size;
-using caf::detail::tl_slice;
-using caf::detail::tl_tail;
-using caf::detail::tl_trim;
-using caf::detail::tl_unzip;
-using caf::detail::tl_zip;
-using caf::detail::type_list;
-// using caf::detail::tl_is_strict_subset;
-using caf::detail::tl_equal;
+
+template <class List>
+struct tl_empty {
+  static constexpr bool value = std::is_same<empty_type_list, List>::value;
+};
 
 template <class List>
 using tl_head_t = typename tl_head<List>::type;
+
+template <class List>
+struct tl_tail;
+
+template <>
+struct tl_tail<type_list<>> {
+  using type = type_list<>;
+};
+
+template <typename T0, class... Ts>
+struct tl_tail<type_list<T0, Ts...>> {
+  using type = type_list<Ts...>;
+};
 
 template <class List>
 using tl_tail_t = typename tl_tail<List>::type;
@@ -63,14 +62,79 @@ using tl_tail_t = typename tl_tail<List>::type;
 template <class List>
 using tl_back_t = typename tl_back<List>::type;
 
+template <size_t LeftOffset, size_t Remaining, typename PadType, class List,
+          class... Ts>
+struct tl_slice_impl {
+  using type = typename tl_slice_impl<LeftOffset - 1, Remaining, PadType,
+                                      tl_tail_t<List>, Ts...>::type;
+};
+
+template <size_t Remaining, typename PadType, class List, class... Ts>
+struct tl_slice_impl<0, Remaining, PadType, List, Ts...> {
+  using type =
+    typename tl_slice_impl<0, Remaining - 1, PadType, tl_tail_t<List>, Ts...,
+                           tl_head_t<List>>::type;
+};
+
+template <size_t Remaining, typename PadType, class... Ts>
+struct tl_slice_impl<0, Remaining, PadType, empty_type_list, Ts...> {
+  using type = typename tl_slice_impl<0, Remaining - 1, PadType,
+                                      empty_type_list, Ts..., PadType>::type;
+};
+
+template <class PadType, class List, class... T>
+struct tl_slice_impl<0, 0, PadType, List, T...> {
+  using type = type_list<T...>;
+};
+
+template <class PadType, class... T>
+struct tl_slice_impl<0, 0, PadType, empty_type_list, T...> {
+  using type = type_list<T...>;
+};
+
+template <class List, size_t ListSize, size_t First, size_t Last,
+          typename PadType = caf::unit_t>
+struct tl_slice_ {
+  using type =
+    typename tl_slice_impl<First, (Last - First), PadType, List>::type;
+};
+
+template <class List, size_t ListSize, typename PadType>
+struct tl_slice_<List, ListSize, 0, ListSize, PadType> {
+  using type = List;
+};
+
+/// Creates a new list from range (First, Last].
+template <class List, size_t First, size_t Last>
+struct tl_slice {
+  using type = typename tl_slice_<List, tl_size<List>::value,
+                                  (First > Last ? Last : First), Last>::type;
+};
+
 template <class List, size_t First, size_t Last>
 using tl_slice_t = typename tl_slice<List, First, Last>::type;
 
-template <class ListA, class ListB, template <class, class> class Fun>
-using tl_zip_t = typename tl_zip<ListA, ListB, Fun>::type;
+template <class List, size_t First, size_t Last>
+using tl_slice_t = typename tl_slice<List, First, Last>::type;
 
+template <class From, class... Elements>
+struct tl_reverse_impl;
+
+template <class T0, class... T, class... E>
+struct tl_reverse_impl<type_list<T0, T...>, E...> {
+  using type = typename tl_reverse_impl<type_list<T...>, T0, E...>::type;
+};
+
+template <class... E>
+struct tl_reverse_impl<empty_type_list, E...> {
+  using type = type_list<E...>;
+};
+
+/// Creates a new list with elements in reversed order.
 template <class List>
-using tl_unzip_t = typename tl_unzip<List>::type;
+struct tl_reverse {
+  using type = typename tl_reverse_impl<List>::type;
+};
 
 template <class List>
 using tl_reverse_t = typename tl_reverse<List>::type;
@@ -79,33 +143,82 @@ template <class List, class T>
 constexpr auto tl_contains_v = tl_contains<List, T>::value;
 
 template <class ListA, class ListB>
-using tl_concat_t = typename tl_concat<ListA, ListB>::type;
+struct tl_concat_impl;
+
+/// Concatenates two lists.
+template <class... LhsTs, class... RhsTs>
+struct tl_concat_impl<type_list<LhsTs...>, type_list<RhsTs...>> {
+  using type = type_list<LhsTs..., RhsTs...>;
+};
+
+// static list concat(list, list)
+
+/// Concatenates lists.
+template <class... Lists>
+struct tl_concat;
+
+template <class List0>
+struct tl_concat<List0> {
+  using type = List0;
+};
+
+template <class List0, class List1, class... Lists>
+struct tl_concat<List0, List1, Lists...> {
+  using type = typename tl_concat<typename tl_concat_impl<List0, List1>::type,
+                                  Lists...>::type;
+};
+
+template <class... Lists>
+using tl_concat_t = typename tl_concat<Lists...>::type;
+
+template <class List, class What>
+struct tl_push_back;
+
+/// Appends `What` to given list.
+template <class... ListTs, class What>
+struct tl_push_back<type_list<ListTs...>, What> {
+  using type = type_list<ListTs..., What>;
+};
 
 template <class List, class What>
 using tl_push_back_t = typename tl_push_back<List, What>::type;
 
-template <class List, class What>
-using tl_push_front_t = typename tl_push_front<List, What>::type;
-
-template <class L, template <class> class... Funs>
-using tl_apply_all_t = typename tl_apply_all<L, Funs...>::type;
-
 template <class List, template <class> class... Funs>
 using tl_map_t = typename tl_map<List, Funs...>::type;
-
-template <class List, template <class> class Trait, bool TRes,
-          template <class> class... Funs>
-using tl_map_conditional_t =
-  typename tl_map_conditional<List, Trait, TRes, Funs...>::type;
-
-template <class List>
-using tl_popback_t = typename tl_pop_back<List>::type;
 
 template <class List, size_t N>
 using tl_at_t = typename tl_at<List, N>::type;
 
 template <class List, class What>
+struct tl_prepend;
+
+/// Creates a new list with `What` prepended to `List`.
+template <class What, class... T>
+struct tl_prepend<type_list<T...>, What> {
+  using type = type_list<What, T...>;
+};
+
+template <class List, class What>
 using tl_prepend_t = typename tl_prepend<List, What>::type;
+
+template <class List, bool... Selected>
+struct tl_filter_impl;
+
+template <>
+struct tl_filter_impl<empty_type_list> {
+  using type = empty_type_list;
+};
+
+template <class T0, class... T, bool... S>
+struct tl_filter_impl<type_list<T0, T...>, false, S...> {
+  using type = typename tl_filter_impl<type_list<T...>, S...>::type;
+};
+
+template <class T0, class... T, bool... S>
+struct tl_filter_impl<type_list<T0, T...>, true, S...> {
+  using type
+    = tl_prepend_t<typename tl_filter_impl<type_list<T...>, S...>::type, T0>;
+};
 
 template <class List, template <class> class Pred>
 using tl_filter_t = typename tl_filter<List, Pred>::type;
@@ -113,11 +226,36 @@ using tl_filter_t = typename tl_filter<List, Pred>::type;
 template <class List, template <class> class Pred>
 using tl_filter_not_t = typename tl_filter_not<List, Pred>::type;
 
+template <class List, class Type>
+struct tl_filter_type;
+
+template <class Type, class... T>
+struct tl_filter_type<type_list<T...>, Type> {
+  using type = typename tl_filter_impl<type_list<T...>,
+                                       !std::is_same<T, Type>::value...>::type;
+};
+
+template <class List, class T>
+using tl_filter_type_t = typename tl_filter_type<List, T>::type;
+
+/// Creates a new list from `List` without any duplicate elements.
+template <class List>
+struct tl_distinct;
+
+template <>
+struct tl_distinct<empty_type_list> {
+  using type = empty_type_list;
+};
+
+template <class T0, class... Ts>
+struct tl_distinct<type_list<T0, Ts...>> {
+  using type = tl_concat_t<
+    type_list<T0>,
+    typename tl_distinct<tl_filter_type_t<type_list<Ts...>, T0>>::type>;
+};
+
 template <class List>
 using tl_distinct_t = typename tl_distinct<List>::type;
-
-template <class List, class What>
-using tl_trim_t = typename tl_trim<List, What>::type;
 
 template <class List, template <class...> class VarArgTemplate>
 using tl_apply_t = typename tl_apply<List, VarArgTemplate>::type;
@@ -135,30 +273,5 @@ struct tl_make<T<Ts...>> {
 
 template <class T>
 using tl_make_t = typename tl_make<T>::type;
-
-template <class...>
-struct common_types_helper;
-
-template <class L1>
-struct common_types_helper<L1, type_list<>> {
-  using type = type_list<>;
-};
-
-template <class L1, class L2>
-struct common_types_helper<L1, L2> {
-  using type = std::conditional_t<
-    tl_contains_v<L1, caf::detail::tl_head_t<L2>>,
-    tl_prepend_t<
-      typename common_types_helper<L1, caf::detail::tl_tail_t<L2>>::type,
-      caf::detail::tl_head_t<L2>>,
-    typename common_types_helper<L1, caf::detail::tl_tail_t<L2>>::type>;
-};
-
-// Creates a new type list that contains all the types that are present in both
-// L1 and L2
-template <class L1, class L2>
-  requires(is_type_list<L1>::value and is_type_list<L2>::value)
-using tl_common_types_t
-  = tl_distinct_t<typename common_types_helper<L1, L2>::type>;
 
 } // namespace tenzir::detail

--- a/libtenzir/include/tenzir/detail/type_traits.hpp
+++ b/libtenzir/include/tenzir/detail/type_traits.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "tenzir/detail/type_list.hpp"
+
 #include <caf/detail/type_traits.hpp>
 #include <experimental/type_traits>
 
@@ -133,13 +135,13 @@ inline constexpr bool contains_type_v = contains_type_t<TList, T>::value;
 
 // -- type list --------------------------------------------------------------
 
-/// Map elements of a caf type_list by wrapping them into `std::shared_ptr`.
+/// Map elements of a type_list by wrapping them into `std::shared_ptr`.
 template <class Types>
 struct tl_map_shared_ptr;
 
 template <class... Ts>
-struct tl_map_shared_ptr<caf::detail::type_list<Ts...>> {
-  using type = caf::detail::type_list<std::shared_ptr<Ts>...>;
+struct tl_map_shared_ptr<detail::type_list<Ts...>> {
+  using type = detail::type_list<std::shared_ptr<Ts>...>;
 };
 
 } // namespace tenzir::detail

--- a/libtenzir/include/tenzir/expression.hpp
+++ b/libtenzir/include/tenzir/expression.hpp
@@ -9,10 +9,10 @@
 #pragma once
 
 #include "detail/inspection_common.hpp"
-#include "tenzir/atoms.hpp"
 #include "tenzir/concept/printable/print.hpp"
 #include "tenzir/data.hpp"
 #include "tenzir/detail/operators.hpp"
+#include "tenzir/detail/type_list.hpp"
 #include "tenzir/detail/type_traits.hpp"
 #include "tenzir/hash/hash.hpp"
 #include "tenzir/offset.hpp"
@@ -20,7 +20,6 @@
 #include "tenzir/type.hpp"
 
 #include <caf/default_sum_type_access.hpp>
-#include <caf/detail/type_list.hpp>
 #include <caf/none.hpp>
 
 #include <memory>
@@ -245,10 +244,10 @@ auto inspect(Inspector& f, negation& x) {
 /// A query expression.
 class expression : detail::totally_ordered<expression> {
 public:
-  using types = caf::detail::type_list<caf::none_t, conjunction, disjunction,
-                                       negation, predicate>;
+  using types = detail::type_list<caf::none_t, conjunction, disjunction,
+                                  negation, predicate>;
 
-  using node = caf::detail::tl_apply_t<types, tenzir::variant>;
+  using node = detail::tl_apply_t<types, tenzir::variant>;
 
   /// Default-constructs empty an expression.
   expression() = default;

--- a/libtenzir/include/tenzir/series_builder.hpp
+++ b/libtenzir/include/tenzir/series_builder.hpp
@@ -172,8 +172,7 @@ private:
 /// TODO: Consider eventually retiring the current `data_view`, perhaps
 /// replacing it with an implementation that does not use ref-counts internally.
 struct data_view2
-  : caf::detail::tl_apply_t<caf::detail::tl_map_t<data::types, view_trait>,
-                            variant> {
+  : detail::tl_apply_t<detail::tl_map_t<data::types, view_trait>, variant> {
   using variant::variant;
 
   explicit(false) data_view2(const data& x) : data_view2(make_view(x)) {

--- a/libtenzir/include/tenzir/table_slice_builder.hpp
+++ b/libtenzir/include/tenzir/table_slice_builder.hpp
@@ -60,7 +60,7 @@ public:
     if constexpr (sizeof...(xs) == 0) {
       if constexpr (std::is_same_v<T, data_view>) {
         return add(x);
-      } else if constexpr (caf::detail::tl_contains<data_view::types, T>::value) {
+      } else if constexpr (detail::tl_contains<data_view::types, T>::value) {
         return add(data_view{x});
       } else {
         return add(make_view(x));

--- a/libtenzir/include/tenzir/tql2/ast.hpp
+++ b/libtenzir/include/tenzir/tql2/ast.hpp
@@ -11,11 +11,11 @@
 #include "tenzir/data.hpp"
 #include "tenzir/detail/default_formatter.hpp"
 #include "tenzir/detail/enum.hpp"
+#include "tenzir/detail/type_list.hpp"
 #include "tenzir/location.hpp"
 #include "tenzir/tql2/entity_path.hpp"
 
 #include <caf/detail/is_one_of.hpp>
-#include <caf/detail/type_list.hpp>
 
 #include <type_traits>
 
@@ -94,8 +94,9 @@ struct null {};
 struct constant {
   // TODO: Consider moving the location into the variant inhabitants.
   // TODO: Consider representing integers differently.
-  using kind = caf::detail::tl_apply_t<
-    caf::detail::tl_filter_not_type_t<data::types, pattern>, variant>;
+  using kind
+    = detail::tl_apply_t<detail::tl_filter_not_type_t<data::types, pattern>,
+                         variant>;
 
   constant() = default;
 
@@ -147,19 +148,19 @@ struct root_field {
 };
 
 using expression_kinds
-  = caf::detail::type_list<record, list, meta, this_, root_field, pipeline_expr,
-                           constant, field_access, index_expr, binary_expr,
-                           unary_expr, function_call, underscore, unpack,
-                           assignment, dollar_var>;
+  = detail::type_list<record, list, meta, this_, root_field, pipeline_expr,
+                      constant, field_access, index_expr, binary_expr,
+                      unary_expr, function_call, underscore, unpack, assignment,
+                      dollar_var>;
 
-using expression_kind = caf::detail::tl_apply_t<expression_kinds, variant>;
+using expression_kind = detail::tl_apply_t<expression_kinds, variant>;
 
 struct expression {
   expression() = default;
 
   template <class T>
     requires(
-      caf::detail::tl_contains<expression_kinds, std::remove_cvref_t<T>>::value)
+      detail::tl_contains<expression_kinds, std::remove_cvref_t<T>>::value)
   explicit(false) expression(T&& x)
     : kind{std::make_unique<expression_kind>(std::forward<T>(x))} {
   }
@@ -895,8 +896,7 @@ namespace tenzir {
 template <>
 class variant_traits<ast::expression> {
 public:
-  static constexpr auto count
-    = caf::detail::tl_size<ast::expression_kinds>::value;
+  static constexpr auto count = detail::tl_size<ast::expression_kinds>::value;
 
   static auto index(const ast::expression& x) -> size_t {
     TENZIR_ASSERT(x.kind);

--- a/libtenzir/include/tenzir/tql2/eval_impl.hpp
+++ b/libtenzir/include/tenzir/tql2/eval_impl.hpp
@@ -54,7 +54,7 @@ public:
   auto eval(const ast::index_expr& x) -> series;
 
   template <class T>
-    requires(caf::detail::tl_contains<ast::expression_kinds, T>::value)
+    requires(detail::tl_contains<ast::expression_kinds, T>::value)
   auto eval(const T& x) -> series {
     return not_implemented(x);
   }

--- a/libtenzir/include/tenzir/variant.hpp
+++ b/libtenzir/include/tenzir/variant.hpp
@@ -10,6 +10,7 @@
 
 #include "tenzir/detail/debug_writer.hpp"
 #include "tenzir/detail/overload.hpp"
+#include "tenzir/detail/type_list.hpp"
 #include "tenzir/error.hpp"
 #include "tenzir/variant_traits.hpp"
 
@@ -56,7 +57,7 @@ class variant : public std::variant<Ts...> {
 public:
   using std::variant<Ts...>::variant;
 
-  using types = caf::detail::type_list<Ts...>;
+  using types = detail::type_list<Ts...>;
 
   template <class T>
   static constexpr auto can_have = (std::same_as<T, Ts> || ...);
@@ -66,7 +67,7 @@ public:
     // This can save about ~10% size since the type index is repeated once
     // per `data`, but the main purpose of this compression is to achieve
     // binary compatibility with the previously used `caf::variant`.
-    constexpr auto size = caf::detail::tl_size<types>::value;
+    constexpr auto size = tenzir::detail::tl_size<types>::value;
     auto result = bool{false};
     if constexpr (size < (1u << 8)) {
       auto u8 = static_cast<uint8_t>(idx);

--- a/libtenzir/src/configuration.cpp
+++ b/libtenzir/src/configuration.cpp
@@ -22,6 +22,7 @@
 #include "tenzir/detail/settings.hpp"
 #include "tenzir/detail/stable_set.hpp"
 #include "tenzir/detail/string.hpp"
+#include "tenzir/detail/type_list.hpp"
 #include "tenzir/diagnostics.hpp"
 #include "tenzir/factory.hpp"
 #include "tenzir/synopsis_factory.hpp"
@@ -363,11 +364,11 @@ configuration::configuration() {
   factory<value_index>::initialize();
   // Register Arrow extension types.
   auto register_extension_types
-    = []<concrete_type... Ts>(caf::detail::type_list<Ts...>) {
+    = []<concrete_type... Ts>(detail::type_list<Ts...>) {
         (static_cast<void>(Ts::arrow_type::register_extension()), ...);
       };
   register_extension_types(
-    caf::detail::tl_filter_t<concrete_types, has_extension_type>{});
+    detail::tl_filter_t<concrete_types, has_extension_type>{});
 }
 
 auto configuration::parse(int argc, char** argv) -> caf::error {

--- a/libtenzir/src/data_builder.cpp
+++ b/libtenzir/src/data_builder.cpp
@@ -347,7 +347,7 @@ namespace {
 template <typename Field, typename Tenzir_Type>
 struct index_regression_tester {
   constexpr static auto index_in_field
-    = caf::detail::tl_index_of<field_type_list, Field>::value;
+    = detail::tl_index_of<field_type_list, Field>::value;
   constexpr static auto tenzir_type_index = Tenzir_Type::type_index;
 
   static_assert(index_in_field == tenzir_type_index);
@@ -355,8 +355,8 @@ struct index_regression_tester {
   using type = void;
 };
 
-static_assert(caf::detail::tl_size<field_type_list>::value
-                == caf::detail::tl_size<data::types>::value + 1,
+static_assert(detail::tl_size<field_type_list>::value
+                == detail::tl_size<data::types>::value + 1,
               "The could should match up, apart from the lack of `enriched` in "
               "`tenzir::data`");
 
@@ -747,7 +747,7 @@ auto node_object::try_resolve_nonstructural_field_mismatch(
     },
     [&rb, seed, this]<non_structured_data_type T>(const T& v) {
       constexpr static auto type_idx
-        = caf::detail::tl_index_of<field_type_list, T>::value;
+        = detail::tl_index_of<field_type_list, T>::value;
       const auto seed_idx = seed->type_index();
       if (type_idx == seed_idx) {
         return;
@@ -756,7 +756,7 @@ auto node_object::try_resolve_nonstructural_field_mismatch(
         // numeric conversion if possible
         if (is_numeric(seed_idx)) {
           switch (seed_idx) {
-            case caf::detail::tl_index_of<field_type_list, int64_t>::value: {
+            case detail::tl_index_of<field_type_list, int64_t>::value: {
               if constexpr (std::same_as<uint64_t, T>) {
                 if (v > static_cast<uint64_t>(
                       std::numeric_limits<int64_t>::max())) {
@@ -779,7 +779,7 @@ auto node_object::try_resolve_nonstructural_field_mismatch(
               data(static_cast<int64_t>(v));
               return;
             }
-            case caf::detail::tl_index_of<field_type_list, uint64_t>::value: {
+            case detail::tl_index_of<field_type_list, uint64_t>::value: {
               if (v < 0) {
                 null();
                 rb.emit_or_throw(diagnostic::warning("value is out of range "
@@ -800,11 +800,11 @@ auto node_object::try_resolve_nonstructural_field_mismatch(
               data(static_cast<uint64_t>(v));
               return;
             }
-            case caf::detail::tl_index_of<field_type_list, double>::value: {
+            case detail::tl_index_of<field_type_list, double>::value: {
               data(static_cast<double>(v));
               return;
             }
-            case caf::detail::tl_index_of<field_type_list, enumeration>::value: {
+            case detail::tl_index_of<field_type_list, enumeration>::value: {
               if (v < 0
                   or v > static_cast<T>(
                        std::numeric_limits<enumeration>::max())) {
@@ -830,8 +830,7 @@ auto node_object::try_resolve_nonstructural_field_mismatch(
               TENZIR_UNREACHABLE();
           }
         } else if (seed_idx
-                   == caf::detail::tl_index_of<field_type_list,
-                                               duration>::value) {
+                   == detail::tl_index_of<field_type_list, duration>::value) {
           auto unit = seed->attribute("unit").value_or("s");
           auto res = cast_value(data_to_type_t<T>{}, v, duration_type{}, unit);
           if (res) {
@@ -839,7 +838,7 @@ auto node_object::try_resolve_nonstructural_field_mismatch(
             return;
           }
         } else if (seed_idx
-                   == caf::detail::tl_index_of<field_type_list, time>::value) {
+                   == detail::tl_index_of<field_type_list, time>::value) {
           auto unit = seed->attribute("unit");
           if (not unit) {
             rb.emit_or_throw(
@@ -945,14 +944,14 @@ auto node_object::append_to_signature(signature_type& sig,
         return true;
       } else {
         constexpr static auto type_idx
-          = caf::detail::tl_index_of<field_type_list, caf::none_t>::value;
+          = detail::tl_index_of<field_type_list, caf::none_t>::value;
         sig.push_back(static_cast<std::byte>(type_idx));
         return true;
       }
     },
     [&sig, seed, this]<non_structured_data_type T>(T&) {
       constexpr static auto type_idx
-        = caf::detail::tl_index_of<field_type_list, T>::value;
+        = detail::tl_index_of<field_type_list, T>::value;
       if (seed) {
         const auto seed_idx = seed->type_index();
         if (seed_idx != type_idx) {
@@ -1224,11 +1223,11 @@ auto node_list::append_to_signature(signature_type& sig, class data_builder& rb,
     auto large_positive = size_t{0};
     auto floating = size_t{0};
     constexpr static auto idx_int
-      = caf::detail::tl_index_of<field_type_list, int64_t>::value;
+      = detail::tl_index_of<field_type_list, int64_t>::value;
     constexpr static auto idx_uint
-      = caf::detail::tl_index_of<field_type_list, uint64_t>::value;
+      = detail::tl_index_of<field_type_list, uint64_t>::value;
     constexpr static auto idx_double
-      = caf::detail::tl_index_of<field_type_list, double>::value;
+      = detail::tl_index_of<field_type_list, double>::value;
     {
       const auto visitor = detail::overload{
         [](const auto&) {

--- a/libtenzir/src/legacy_type.cpp
+++ b/libtenzir/src/legacy_type.cpp
@@ -336,7 +336,7 @@ const char* kind_tbl[] = {
   "list", "map",    "record",  "alias",
 };
 
-using caf::detail::tl_size;
+using detail::tl_size;
 
 static_assert(std::size(kind_tbl) == tl_size<legacy_concrete_types>::value);
 

--- a/libtenzir/src/series_builder.cpp
+++ b/libtenzir/src/series_builder.cpp
@@ -100,11 +100,11 @@ template <class T>
 concept atom_type = is_atom_type<T>::value;
 
 using atom_view_types
-  = caf::detail::tl_map_t<caf::detail::tl_filter_t<concrete_types, is_atom_type>,
-                          type_to_data, view_trait>;
+  = detail::tl_map_t<detail::tl_filter_t<concrete_types, is_atom_type>,
+                     type_to_data, view_trait>;
 
 template <class T>
-concept atom_view_type = caf::detail::tl_contains<atom_view_types, T>::value;
+concept atom_view_type = detail::tl_contains<atom_view_types, T>::value;
 
 template <class T>
 struct atom_view_to_type : data_to_type<T> {};
@@ -126,7 +126,7 @@ using atom_view_to_type_t = atom_view_to_type<T>::type;
 
 namespace detail {
 
-struct atom_view : caf::detail::tl_apply_t<atom_view_types, variant> {
+struct atom_view : detail::tl_apply_t<atom_view_types, variant> {
   using variant::variant;
 };
 

--- a/libtenzir/src/table_slice_builder.cpp
+++ b/libtenzir/src/table_slice_builder.cpp
@@ -527,7 +527,7 @@ struct instantiate_append_array_slice {
   };
 
   static constexpr auto value
-    = caf::detail::tl_apply_t<concrete_types, inner>::value;
+    = detail::tl_apply_t<concrete_types, inner>::value;
 };
 
 template struct instantiate_append_array_slice<std::monostate{}>;

--- a/libtenzir/src/tql2/ast.cpp
+++ b/libtenzir/src/tql2/ast.cpp
@@ -91,7 +91,7 @@ auto expression::get_location() const -> location {
 }
 
 expression::expression(expression const& other) {
-  static_assert(caf::detail::tl_empty<caf::detail::tl_filter_not_t<
+  static_assert(detail::tl_empty<detail::tl_filter_not_t<
                   expression_kinds, std::is_copy_constructible>>::value);
   if (other.kind) {
     kind = std::make_unique<expression_kind>(*other.kind);

--- a/libtenzir/test/data_builder.cpp
+++ b/libtenzir/test/data_builder.cpp
@@ -167,10 +167,9 @@ TEST(overwrite record fields) {
     {
       const auto key_bytes = as_bytes("0"sv);
       expected.insert(expected.end(), key_bytes.begin(), key_bytes.end());
-      expected.insert(
-        expected.end(),
-        static_cast<std::byte>(
-          caf::detail::tl_index_of<field_type_list, uint64_t>::value));
+      expected.insert(expected.end(),
+                      static_cast<std::byte>(
+                        detail::tl_index_of<field_type_list, uint64_t>::value));
     }
     expected.insert(expected.end(), detail::data_builder::record_end_marker);
   }
@@ -213,18 +212,16 @@ TEST(signature record simple) {
     {
       const auto key_bytes = as_bytes("0"sv);
       expected.insert(expected.end(), key_bytes.begin(), key_bytes.end());
-      expected.insert(
-        expected.end(),
-        static_cast<std::byte>(
-          caf::detail::tl_index_of<field_type_list, uint64_t>::value));
+      expected.insert(expected.end(),
+                      static_cast<std::byte>(
+                        detail::tl_index_of<field_type_list, uint64_t>::value));
     }
     {
       const auto key_bytes = as_bytes("1"sv);
       expected.insert(expected.end(), key_bytes.begin(), key_bytes.end());
-      expected.insert(
-        expected.end(),
-        static_cast<std::byte>(
-          caf::detail::tl_index_of<field_type_list, int64_t>::value));
+      expected.insert(expected.end(),
+                      static_cast<std::byte>(
+                        detail::tl_index_of<field_type_list, int64_t>::value));
     }
     expected.insert(expected.end(), detail::data_builder::record_end_marker);
   }
@@ -245,10 +242,9 @@ TEST(signature list) {
     const auto key_bytes = as_bytes("l"sv);
     expected.insert(expected.end(), key_bytes.begin(), key_bytes.end());
     expected.insert(expected.end(), detail::data_builder::list_start_marker);
-    expected.insert(
-      expected.end(),
-      static_cast<std::byte>(
-        caf::detail::tl_index_of<field_type_list, uint64_t>::value));
+    expected.insert(expected.end(),
+                    static_cast<std::byte>(
+                      detail::tl_index_of<field_type_list, uint64_t>::value));
     expected.insert(expected.end(), detail::data_builder::list_end_marker);
     expected.insert(expected.end(), detail::data_builder::record_end_marker);
   }
@@ -310,10 +306,9 @@ TEST(signature list with null) {
     const auto key_bytes = as_bytes("l"sv);
     expected.insert(expected.end(), key_bytes.begin(), key_bytes.end());
     expected.insert(expected.end(), detail::data_builder::list_start_marker);
-    expected.insert(
-      expected.end(),
-      static_cast<std::byte>(
-        caf::detail::tl_index_of<field_type_list, uint64_t>::value));
+    expected.insert(expected.end(),
+                    static_cast<std::byte>(
+                      detail::tl_index_of<field_type_list, uint64_t>::value));
     expected.insert(expected.end(), detail::data_builder::list_end_marker);
     expected.insert(expected.end(), detail::data_builder::record_end_marker);
   }
@@ -362,10 +357,9 @@ TEST(signature list mismatch) {
   {
     expected.insert(expected.end(), detail::data_builder::list_start_marker);
     {
-      expected.insert(
-        expected.end(),
-        static_cast<std::byte>(
-          caf::detail::tl_index_of<field_type_list, double>::value));
+      expected.insert(expected.end(),
+                      static_cast<std::byte>(
+                        detail::tl_index_of<field_type_list, double>::value));
       expected.insert(expected.end(),
                       detail::data_builder::record_start_marker);
       expected.insert(expected.end(), detail::data_builder::record_end_marker);
@@ -401,18 +395,16 @@ TEST(signature record seeding matching) {
     {
       const auto key_bytes = as_bytes("0"sv);
       expected.insert(expected.end(), key_bytes.begin(), key_bytes.end());
-      expected.insert(
-        expected.end(),
-        static_cast<std::byte>(
-          caf::detail::tl_index_of<field_type_list, uint64_t>::value));
+      expected.insert(expected.end(),
+                      static_cast<std::byte>(
+                        detail::tl_index_of<field_type_list, uint64_t>::value));
     }
     {
       const auto key_bytes = as_bytes("1"sv);
       expected.insert(expected.end(), key_bytes.begin(), key_bytes.end());
-      expected.insert(
-        expected.end(),
-        static_cast<std::byte>(
-          caf::detail::tl_index_of<field_type_list, int64_t>::value));
+      expected.insert(expected.end(),
+                      static_cast<std::byte>(
+                        detail::tl_index_of<field_type_list, int64_t>::value));
     }
     expected.insert(expected.end(), detail::data_builder::record_end_marker);
   }
@@ -441,18 +433,16 @@ TEST(signature record seeding field not in data) {
     {
       const auto key_bytes = as_bytes("0"sv);
       expected.insert(expected.end(), key_bytes.begin(), key_bytes.end());
-      expected.insert(
-        expected.end(),
-        static_cast<std::byte>(
-          caf::detail::tl_index_of<field_type_list, uint64_t>::value));
+      expected.insert(expected.end(),
+                      static_cast<std::byte>(
+                        detail::tl_index_of<field_type_list, uint64_t>::value));
     }
     {
       const auto key_bytes = as_bytes("1"sv);
       expected.insert(expected.end(), key_bytes.begin(), key_bytes.end());
-      expected.insert(
-        expected.end(),
-        static_cast<std::byte>(
-          caf::detail::tl_index_of<field_type_list, int64_t>::value));
+      expected.insert(expected.end(),
+                      static_cast<std::byte>(
+                        detail::tl_index_of<field_type_list, int64_t>::value));
     }
     expected.insert(expected.end(), detail::data_builder::record_end_marker);
   }
@@ -528,10 +518,9 @@ TEST(signature record seeding nested record) {
     { // field x
       const auto key_bytes = as_bytes("x"sv);
       expected.insert(expected.end(), key_bytes.begin(), key_bytes.end());
-      expected.insert(
-        expected.end(),
-        static_cast<std::byte>(
-          caf::detail::tl_index_of<field_type_list, int64_t>::value));
+      expected.insert(expected.end(),
+                      static_cast<std::byte>(
+                        detail::tl_index_of<field_type_list, int64_t>::value));
     }
     { // field y
       const auto key_bytes = as_bytes("y"sv);
@@ -544,7 +533,7 @@ TEST(signature record seeding nested record) {
         expected.insert(
           expected.end(),
           static_cast<std::byte>(
-            caf::detail::tl_index_of<field_type_list, int64_t>::value));
+            detail::tl_index_of<field_type_list, int64_t>::value));
       }
       expected.insert(expected.end(), detail::data_builder::record_end_marker);
     }
@@ -596,10 +585,9 @@ TEST(signature record seeding nested list) {
       const auto key_bytes = as_bytes("l"sv);
       expected.insert(expected.end(), key_bytes.begin(), key_bytes.end());
       expected.insert(expected.end(), detail::data_builder::list_start_marker);
-      expected.insert(
-        expected.end(),
-        static_cast<std::byte>(
-          caf::detail::tl_index_of<field_type_list, int64_t>::value));
+      expected.insert(expected.end(),
+                      static_cast<std::byte>(
+                        detail::tl_index_of<field_type_list, int64_t>::value));
       expected.insert(expected.end(), detail::data_builder::list_end_marker);
     }
     expected.insert(expected.end(), detail::data_builder::record_end_marker);
@@ -641,18 +629,16 @@ TEST(signature record seeding field not in data schema_only) {
     {
       const auto key_bytes = as_bytes("0"sv);
       expected.insert(expected.end(), key_bytes.begin(), key_bytes.end());
-      expected.insert(
-        expected.end(),
-        static_cast<std::byte>(
-          caf::detail::tl_index_of<field_type_list, uint64_t>::value));
+      expected.insert(expected.end(),
+                      static_cast<std::byte>(
+                        detail::tl_index_of<field_type_list, uint64_t>::value));
     }
     {
       const auto key_bytes = as_bytes("1"sv);
       expected.insert(expected.end(), key_bytes.begin(), key_bytes.end());
-      expected.insert(
-        expected.end(),
-        static_cast<std::byte>(
-          caf::detail::tl_index_of<field_type_list, int64_t>::value));
+      expected.insert(expected.end(),
+                      static_cast<std::byte>(
+                        detail::tl_index_of<field_type_list, int64_t>::value));
     }
     expected.insert(expected.end(), detail::data_builder::record_end_marker);
   }
@@ -681,18 +667,16 @@ TEST(signature record seeding data - field not in seed) {
     {
       const auto key_bytes = as_bytes("0"sv);
       expected.insert(expected.end(), key_bytes.begin(), key_bytes.end());
-      expected.insert(
-        expected.end(),
-        static_cast<std::byte>(
-          caf::detail::tl_index_of<field_type_list, uint64_t>::value));
+      expected.insert(expected.end(),
+                      static_cast<std::byte>(
+                        detail::tl_index_of<field_type_list, uint64_t>::value));
     }
     {
       const auto key_bytes = as_bytes("1"sv);
       expected.insert(expected.end(), key_bytes.begin(), key_bytes.end());
-      expected.insert(
-        expected.end(),
-        static_cast<std::byte>(
-          caf::detail::tl_index_of<field_type_list, int64_t>::value));
+      expected.insert(expected.end(),
+                      static_cast<std::byte>(
+                        detail::tl_index_of<field_type_list, int64_t>::value));
     }
     expected.insert(expected.end(), detail::data_builder::record_end_marker);
   }
@@ -725,10 +709,9 @@ TEST(signature record seeding data - field not in seed schema_only) {
     {
       const auto key_bytes = as_bytes("0"sv);
       expected.insert(expected.end(), key_bytes.begin(), key_bytes.end());
-      expected.insert(
-        expected.end(),
-        static_cast<std::byte>(
-          caf::detail::tl_index_of<field_type_list, uint64_t>::value));
+      expected.insert(expected.end(),
+                      static_cast<std::byte>(
+                        detail::tl_index_of<field_type_list, uint64_t>::value));
     }
     expected.insert(expected.end(), detail::data_builder::record_end_marker);
   }
@@ -758,10 +741,9 @@ TEST(signature record seeding numeric mismatch) {
     {
       const auto key_bytes = as_bytes("0"sv);
       expected.insert(expected.end(), key_bytes.begin(), key_bytes.end());
-      expected.insert(
-        expected.end(),
-        static_cast<std::byte>(
-          caf::detail::tl_index_of<field_type_list, int64_t>::value));
+      expected.insert(expected.end(),
+                      static_cast<std::byte>(
+                        detail::tl_index_of<field_type_list, int64_t>::value));
     }
     expected.insert(expected.end(), detail::data_builder::record_end_marker);
   }


### PR DESCRIPTION
These have been removed in the CAF 1.0 release. Some of them weren't used, the rest is copied over.