### PR TITLE
Add copy button to named language code blocks

### DIFF
--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -23,6 +23,10 @@ async function createConfig() {
       transformerCopyButton({
         jsx: true, // required for React, disables the onclick handler, which we add using clientModules
         feedbackDuration: 3_000,
+        copyIcon:
+          "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxOCIgaGVpZ2h0PSIxOCIgdmlld0JveD0iMCAwIDM2IDM2Ij48cmVjdCB3aWR0aD0iMzYiIGhlaWdodD0iMzYiIGZpbGw9Im5vbmUiLz48cGF0aCBmaWxsPSIjYmZjN2Q1IiBkPSJNMjkuNSA3aC0xOUExLjUgMS41IDAgMCAwIDkgOC41djI0YTEuNSAxLjUgMCAwIDAgMS41IDEuNWgxOWExLjUgMS41IDAgMCAwIDEuNS0xLjV2LTI0QTEuNSAxLjUgMCAwIDAgMjkuNSA3TTI5IDMySDExVjloMThaIiBjbGFzcz0iY2xyLWktb3V0bGluZSBjbHItaS1vdXRsaW5lLXBhdGgtMSIvPjxwYXRoIGZpbGw9IiNiZmM3ZDUiIGQ9Ik0yNiAzLjVBMS41IDEuNSAwIDAgMCAyNC41IDJoLTE5QTEuNSAxLjUgMCAwIDAgNCAzLjV2MjRBMS41IDEuNSAwIDAgMCA1LjUgMjlINlY0aDIwWiIgY2xhc3M9ImNsci1pLW91dGxpbmUgY2xyLWktb3V0bGluZS1wYXRoLTIiLz48cGF0aCBmaWxsPSJub25lIiBkPSJNMCAwaDM2djM2SDB6Ii8+PC9zdmc+",
+        successIcon:
+          "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxOCIgaGVpZ2h0PSIxOCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cmVjdCB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIGZpbGw9Im5vbmUiLz48cGF0aCBmaWxsPSIjMDBkNjAwIiBkPSJNMjEgN0w5IDE5bC01LjUtNS41bDEuNDEtMS40MUw5IDE2LjE3TDE5LjU5IDUuNTl6Ii8+PC9zdmc+",
       }),
     ],
   };

--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -8,6 +8,8 @@ const tqlGrammar = require("@tenzir/vscode-tql/syntaxes/tql.tmLanguage.json");
 async function createConfig() {
   const rehypePrettyCode = (await import('rehype-pretty-code')).default;
   const shikiHighlighter = (await import('shiki')).createHighlighter;
+  const transformerCopyButton = (await import("@rehype-pretty/transformers"))
+    .transformerCopyButton;
 
   const rehypePrettyCodeOptions = {
     keepBackground: false,
@@ -17,6 +19,12 @@ async function createConfig() {
         ...options,
         langs: [() => tqlGrammar],
       }),
+    transformers: [
+      transformerCopyButton({
+        jsx: true, // required for React, disables the onclick handler, which we add using clientModules
+        feedbackDuration: 3_000,
+      }),
+    ],
   };
 
   /// BEGIN CUSTOM CODE ///
@@ -99,6 +107,7 @@ async function createConfig() {
     },
     themes: ['@docusaurus/theme-mermaid'],
 
+    clientModules: [require.resolve("./registerCopyButton.js")],
     plugins: [
       'docusaurus-plugin-sass',
       [

--- a/web/package.json
+++ b/web/package.json
@@ -22,6 +22,7 @@
     "@docusaurus/theme-mermaid": "^2.4.1",
     "@giscus/react": "^2.3.0",
     "@mdx-js/react": "^1.6.22",
+    "@rehype-pretty/transformers": "npm:@jsr/rehype-pretty__transformers",
     "@tenzir/vscode-tql": "^0.0.3",
     "clsx": "^1.2.1",
     "docusaurus-plugin-sass": "^0.2.3",

--- a/web/registerCopyButton.js
+++ b/web/registerCopyButton.js
@@ -6,3 +6,14 @@ export function onRouteDidUpdate() {
     registerCopyButton();
   }
 }
+
+// NOTE: This is an ugly workaround for making the copy button work on page load.
+// See more at: https://stackoverflow.com/a/74736980
+if (ExecutionEnvironment.canUseDOM) {
+  // We also need to regiserCopyButton when the page first loads otherwise,
+  // after reloading the page, these triggers will not be set until the user
+  // navigates somewhere.
+  window.addEventListener("load", () => {
+    setTimeout(registerCopyButton, 1);
+  });
+}

--- a/web/registerCopyButton.js
+++ b/web/registerCopyButton.js
@@ -1,0 +1,8 @@
+import ExecutionEnvironment from "@docusaurus/ExecutionEnvironment";
+import { registerCopyButton } from "@rehype-pretty/transformers";
+
+export function onRouteDidUpdate() {
+  if (ExecutionEnvironment.canUseDOM) {
+    registerCopyButton();
+  }
+}

--- a/web/src/css/custom.scss
+++ b/web/src/css/custom.scss
@@ -200,6 +200,11 @@ figure[data-rehype-pretty-code-figure] > pre > code {
   padding: 0 !important;
 }
 
+figure[data-rehype-pretty-code-figure] > pre > code > code {
+  margin: 0 4px !important;
+  padding: 8px !important;
+}
+
 figure[data-rehype-pretty-code-figure] > pre > code > pre {
   margin: 0 !important;
   padding: 0 !important;

--- a/web/src/css/custom.scss
+++ b/web/src/css/custom.scss
@@ -194,3 +194,17 @@ figure[data-rehype-pretty-code-figure]+figure[data-rehype-pretty-code-figure]:no
   border-top-left-radius: 0;
   border-top-right-radius: 0;
 }
+
+figure[data-rehype-pretty-code-figure] > pre > code {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+figure[data-rehype-pretty-code-figure] > pre > code > pre {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+figure[data-rehype-pretty-code-figure] code {
+  font-size: 1rem;
+}

--- a/web/src/css/custom.scss
+++ b/web/src/css/custom.scss
@@ -183,14 +183,19 @@ figure[data-rehype-pretty-code-figure]
   display: none;
 }
 
-figure[data-rehype-pretty-code-figure]:has(+figure[data-rehype-pretty-code-figure]):not(:has(+figure[data-rehype-pretty-code-figure]>figcaption))>pre {
+figure[data-rehype-pretty-code-figure]:has(
+    + figure[data-rehype-pretty-code-figure]
+  ):not(:has(+ figure[data-rehype-pretty-code-figure] > figcaption))
+  > pre {
   margin-bottom: 0;
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
   border-bottom: 2px solid #6a7195;
 }
 
-figure[data-rehype-pretty-code-figure]+figure[data-rehype-pretty-code-figure]:not(:has(>figcaption))>pre {
+figure[data-rehype-pretty-code-figure]
+  + figure[data-rehype-pretty-code-figure]:not(:has(> figcaption))
+  > pre {
   border-top-left-radius: 0;
   border-top-right-radius: 0;
 }
@@ -203,6 +208,8 @@ figure[data-rehype-pretty-code-figure] > pre > code {
 figure[data-rehype-pretty-code-figure] > pre > code > code {
   margin: 0 4px !important;
   padding: 8px !important;
+  min-height: 48px;
+  align-items: center;
 }
 
 figure[data-rehype-pretty-code-figure] > pre > code > pre {
@@ -212,4 +219,29 @@ figure[data-rehype-pretty-code-figure] > pre > code > pre {
 
 figure[data-rehype-pretty-code-figure] code {
   font-size: 1rem;
+}
+
+pre button.rehype-pretty-copy {
+  width: 32px !important;
+  height: 32px !important;
+  display: flex !important;
+  position: absolute;
+  border-radius: 0px;
+  border: 1px solid #bfc7d5;
+  outline: inherit;
+  justify-content: center !important;
+  align-items: center !important;
+  background-color: transparent;
+}
+
+pre button.rehype-pretty-copy {
+  & .ready {
+    padding-left: 8px !important;
+    background-position: center;
+  }
+
+  & .success {
+    padding-left: 8px !important;
+    background-position: center;
+  }
 }

--- a/web/src/css/custom.scss
+++ b/web/src/css/custom.scss
@@ -232,6 +232,9 @@ pre button.rehype-pretty-copy {
   justify-content: center !important;
   align-items: center !important;
   background-color: transparent;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
 }
 
 pre button.rehype-pretty-copy {

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -2125,6 +2125,13 @@
     pluralize "^8.0.0"
     yaml-ast-parser "0.0.43"
 
+"@rehype-pretty/transformers@npm:@jsr/rehype-pretty__transformers":
+  version "0.13.4"
+  resolved "https://npm.jsr.io/~/11/@jsr/rehype-pretty__transformers/0.13.4.tgz#5D2528889AC40EE0DA77EE3B8A2271BFF49953C9"
+  integrity sha512-iGWAx/2I+5YcoZN2yB7YceBUA24ktRPAhyCBqEvkELuAmw7XCYknEqRAIm+0MdBgDv3wPlk3y6gz4IUXBf7I6w==
+  dependencies:
+    shiki "^1.22.2"
+
 "@shikijs/core@1.18.0":
   version "1.18.0"
   resolved "https://registry.yarnpkg.com/@shikijs/core/-/core-1.18.0.tgz#30dde8e53026dada606c4cf7f32d80a3f33d437c"
@@ -2137,6 +2144,18 @@
     "@types/hast" "^3.0.4"
     hast-util-to-html "^9.0.3"
 
+"@shikijs/core@1.23.1":
+  version "1.23.1"
+  resolved "https://registry.yarnpkg.com/@shikijs/core/-/core-1.23.1.tgz#911473e672e4f2d15ca36b28b28179c0959aa7af"
+  integrity sha512-NuOVgwcHgVC6jBVH5V7iblziw6iQbWWHrj5IlZI3Fqu2yx9awH7OIQkXIcsHsUmY19ckwSgUMgrqExEyP5A0TA==
+  dependencies:
+    "@shikijs/engine-javascript" "1.23.1"
+    "@shikijs/engine-oniguruma" "1.23.1"
+    "@shikijs/types" "1.23.1"
+    "@shikijs/vscode-textmate" "^9.3.0"
+    "@types/hast" "^3.0.4"
+    hast-util-to-html "^9.0.3"
+
 "@shikijs/engine-javascript@1.18.0":
   version "1.18.0"
   resolved "https://registry.yarnpkg.com/@shikijs/engine-javascript/-/engine-javascript-1.18.0.tgz#9888011c5d869a687b42e3e56c7243f15a73524b"
@@ -2146,6 +2165,15 @@
     "@shikijs/vscode-textmate" "^9.2.2"
     oniguruma-to-js "0.4.3"
 
+"@shikijs/engine-javascript@1.23.1":
+  version "1.23.1"
+  resolved "https://registry.yarnpkg.com/@shikijs/engine-javascript/-/engine-javascript-1.23.1.tgz#0f634bea22cb14f471835b7b5f1da66bc34bd359"
+  integrity sha512-i/LdEwT5k3FVu07SiApRFwRcSJs5QM9+tod5vYCPig1Ywi8GR30zcujbxGQFJHwYD7A5BUqagi8o5KS+LEVgBg==
+  dependencies:
+    "@shikijs/types" "1.23.1"
+    "@shikijs/vscode-textmate" "^9.3.0"
+    oniguruma-to-es "0.4.1"
+
 "@shikijs/engine-oniguruma@1.18.0":
   version "1.18.0"
   resolved "https://registry.yarnpkg.com/@shikijs/engine-oniguruma/-/engine-oniguruma-1.18.0.tgz#7e57fd19b62b18cf2de382da684d042ee934f65d"
@@ -2153,6 +2181,14 @@
   dependencies:
     "@shikijs/types" "1.18.0"
     "@shikijs/vscode-textmate" "^9.2.2"
+
+"@shikijs/engine-oniguruma@1.23.1":
+  version "1.23.1"
+  resolved "https://registry.yarnpkg.com/@shikijs/engine-oniguruma/-/engine-oniguruma-1.23.1.tgz#c6c34c9152cf90c1ee75fcdbd124253c8ad0635f"
+  integrity sha512-KQ+lgeJJ5m2ISbUZudLR1qHeH3MnSs2mjFg7bnencgs5jDVPeJ2NVDJ3N5ZHbcTsOIh0qIueyAJnwg7lg7kwXQ==
+  dependencies:
+    "@shikijs/types" "1.23.1"
+    "@shikijs/vscode-textmate" "^9.3.0"
 
 "@shikijs/types@1.18.0":
   version "1.18.0"
@@ -2162,10 +2198,23 @@
     "@shikijs/vscode-textmate" "^9.2.2"
     "@types/hast" "^3.0.4"
 
+"@shikijs/types@1.23.1":
+  version "1.23.1"
+  resolved "https://registry.yarnpkg.com/@shikijs/types/-/types-1.23.1.tgz#2386d49258be03e7b40fea1f28fda952739ad93d"
+  integrity sha512-98A5hGyEhzzAgQh2dAeHKrWW4HfCMeoFER2z16p5eJ+vmPeF6lZ/elEne6/UCU551F/WqkopqRsr1l2Yu6+A0g==
+  dependencies:
+    "@shikijs/vscode-textmate" "^9.3.0"
+    "@types/hast" "^3.0.4"
+
 "@shikijs/vscode-textmate@^9.2.2":
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/@shikijs/vscode-textmate/-/vscode-textmate-9.2.2.tgz#24571f50625c7cd075f9efe0def8b9d2c0930ada"
   integrity sha512-TMp15K+GGYrWlZM8+Lnj9EaHEFmOen0WJBrfa17hF7taDOYthuPPV0GWzfd/9iMij0akS/8Yw2ikquH7uVi/fg==
+
+"@shikijs/vscode-textmate@^9.3.0":
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/@shikijs/vscode-textmate/-/vscode-textmate-9.3.0.tgz#b2f1776e488c1d6c2b6cd129bab62f71bbc9c7ab"
+  integrity sha512-jn7/7ky30idSkd/O5yDBfAnVt+JJpepofP/POZ1iMOxK59cOfqIgg/Dj0eFsjOTMw+4ycJN0uhZH/Eb0bs/EUA==
 
 "@sideway/address@^4.1.3":
   version "4.1.4"
@@ -4551,6 +4600,11 @@ elkjs@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/elkjs/-/elkjs-0.8.2.tgz#c37763c5a3e24e042e318455e0147c912a7c248e"
   integrity sha512-L6uRgvZTH+4OF5NE/MBbzQx/WYpru1xCBE9respNj6qznEewGUIfhzmm7horWWxbNO2M0WckQypGctR8lH79xQ==
+
+emoji-regex-xs@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz#e8af22e5d9dbd7f7f22d280af3d19d2aab5b0724"
+  integrity sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -7094,6 +7148,15 @@ onetime@^5.1.2:
   dependencies:
     mimic-fn "^2.1.0"
 
+oniguruma-to-es@0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/oniguruma-to-es/-/oniguruma-to-es-0.4.1.tgz#112fbcd5fafe4f635983425a6db88f3e2de37107"
+  integrity sha512-rNcEohFz095QKGRovP/yqPIKc+nP+Sjs4YTHMv33nMePGKrq/r2eu9Yh4646M5XluGJsUnmwoXuiXE69KDs+fQ==
+  dependencies:
+    emoji-regex-xs "^1.0.0"
+    regex "^5.0.0"
+    regex-recursion "^4.2.1"
+
 oniguruma-to-js@0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/oniguruma-to-js/-/oniguruma-to-js-0.4.3.tgz#8d899714c21f5c7d59a3c0008ca50e848086d740"
@@ -8131,10 +8194,29 @@ regenerator-transform@^0.15.1:
   dependencies:
     "@babel/runtime" "^7.8.4"
 
+regex-recursion@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/regex-recursion/-/regex-recursion-4.2.1.tgz#024ee28593b8158e568307b99bf1b7a3d5ea31e9"
+  integrity sha512-QHNZyZAeKdndD1G3bKAbBEKOSSK4KOHQrAJ01N1LJeb0SoH4DJIeFhp0uUpETgONifS4+P3sOgoA1dhzgrQvhA==
+  dependencies:
+    regex-utilities "^2.3.0"
+
+regex-utilities@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/regex-utilities/-/regex-utilities-2.3.0.tgz#87163512a15dce2908cf079c8960d5158ff43280"
+  integrity sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==
+
 regex@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/regex/-/regex-4.3.2.tgz#a68a68c9b337a77bf4ce4ed0b4b1a49d97cb3b7b"
   integrity sha512-kK/AA3A9K6q2js89+VMymcboLOlF5lZRCYJv3gzszXFHBr6kO6qLGzbm+UIugBEV8SMMKCTR59txoY6ctRHYVw==
+
+regex@^5.0.0:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/regex/-/regex-5.0.2.tgz#291d960467e6499a79ceec022d20a4e0df67c54f"
+  integrity sha512-/pczGbKIQgfTMRV0XjABvc5RzLqQmwqxLHdQao2RTXPk+pmTXB2P0IaUHYdYyk412YLwUIkaeMd5T+RzVgTqnQ==
+  dependencies:
+    regex-utilities "^2.3.0"
 
 regexpu-core@^5.3.1:
   version "5.3.2"
@@ -8689,6 +8771,18 @@ shiki@^1.18.0:
     "@shikijs/engine-oniguruma" "1.18.0"
     "@shikijs/types" "1.18.0"
     "@shikijs/vscode-textmate" "^9.2.2"
+    "@types/hast" "^3.0.4"
+
+shiki@^1.22.2:
+  version "1.23.1"
+  resolved "https://registry.yarnpkg.com/shiki/-/shiki-1.23.1.tgz#02f149e8f2592509e701f3a806fd4f3dd64d17e9"
+  integrity sha512-8kxV9TH4pXgdKGxNOkrSMydn1Xf6It8lsle0fiqxf7a1149K1WGtdOu3Zb91T5r1JpvRPxqxU3C2XdZZXQnrig==
+  dependencies:
+    "@shikijs/core" "1.23.1"
+    "@shikijs/engine-javascript" "1.23.1"
+    "@shikijs/engine-oniguruma" "1.23.1"
+    "@shikijs/types" "1.23.1"
+    "@shikijs/vscode-textmate" "^9.3.0"
     "@types/hast" "^3.0.4"
 
 should-equal@^2.0.0:


### PR DESCRIPTION
Once again, there were quite a few hoops to pass through.

With the `jsx: true` option in the transformer, it disables the onclick handler on the transformer, which we manually add later on each page that contains the correct class name. See the implementation of the `registerCopyButton` function to understand what's going on here.

I expected docusaurus component swizzling to work, but adding the registerCopyButton as a hook (as the `@rehype-pretty/transformers` library suggests) to /theme/Root.tsx or /theme/Layout/index.tsx didn't do the job.


Note: The style of the copy-button is different for named codeblocks, and I couldn't find any easy way to match the styles completely (even though https://github.com/rehype-pretty/rehype-pretty-code/blob/eee1b216347fe4c1181ddf80bfa6a6a8e427ffdd/packages/transformers/src/copy-button.ts#L15 exists, the style for the borders is not controllable). You could simply use the language name `txt` for plaintext codeblocks moving forward.