### PR TITLE
Implement `append`, `prepend`, and `concatenate`

### DIFF
--- a/changelog/next/features/4792--append-prepend-concatenate.md
+++ b/changelog/next/features/4792--append-prepend-concatenate.md
@@ -1,0 +1,4 @@
+The new `append`, `prepend`, and `concatenate` functions add an element to the
+end of a list, to the front of a list, and merge two lists, respectively.
+`xs.append(y)` is equivalent to `[...xs, y]`, `xs.prepend(y)` is equivalent to
+`[y, ...xs]`, and `concatenate(xs, ys)` is equivalent to `[...xs, ..ys]`.

--- a/libtenzir/builtins/functions/list.cpp
+++ b/libtenzir/builtins/functions/list.cpp
@@ -1,0 +1,126 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2024 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <tenzir/arrow_utils.hpp>
+#include <tenzir/tql2/ast.hpp>
+#include <tenzir/tql2/eval.hpp>
+#include <tenzir/tql2/plugin.hpp>
+
+#include <arrow/compute/api.h>
+
+namespace tenzir::plugins::list {
+
+namespace {
+
+class prepend : public virtual function_plugin {
+public:
+  auto name() const -> std::string override {
+    return "prepend";
+  }
+
+  auto make_function(invocation inv, session ctx) const
+    -> failure_or<function_ptr> override {
+    auto list = ast::expression{};
+    auto element = ast::expression{};
+    TRY(argument_parser2::function(name())
+          .add(list, "<list>")
+          .add(element, "<element>")
+          .parse(inv, ctx));
+    return function_use::make(
+      [list = std::move(list),
+       element = std::move(element)](evaluator eval, session) -> series {
+        return eval(ast::list{
+          location::unknown,
+          {
+            element,
+            ast::spread{
+              location::unknown,
+              list,
+            },
+          },
+          location::unknown,
+        });
+      });
+  }
+};
+
+class append : public virtual function_plugin {
+public:
+  auto name() const -> std::string override {
+    return "append";
+  }
+
+  auto make_function(invocation inv, session ctx) const
+    -> failure_or<function_ptr> override {
+    auto list = ast::expression{};
+    auto element = ast::expression{};
+    TRY(argument_parser2::function(name())
+          .add(list, "<list>")
+          .add(element, "<element>")
+          .parse(inv, ctx));
+    return function_use::make(
+      [list = std::move(list),
+       element = std::move(element)](evaluator eval, session) -> series {
+        return eval(ast::list{
+          location::unknown,
+          {
+            ast::spread{
+              location::unknown,
+              list,
+            },
+            element,
+          },
+          location::unknown,
+        });
+      });
+  }
+};
+
+class concatenate : public virtual function_plugin {
+public:
+  auto name() const -> std::string override {
+    return "concatenate";
+  }
+
+  auto make_function(invocation inv, session ctx) const
+    -> failure_or<function_ptr> override {
+    auto list1 = ast::expression{};
+    auto list2 = ast::expression{};
+    TRY(argument_parser2::function(name())
+          .add(list1, "<list>")
+          .add(list2, "<list>")
+          .parse(inv, ctx));
+    return function_use::make(
+      [list1 = std::move(list1), list2 = std::move(list2)](evaluator eval,
+                                                           session) -> series {
+        return eval(ast::list{
+          location::unknown,
+          {
+            ast::spread{
+              location::unknown,
+              list1,
+            },
+            ast::spread{
+              location::unknown,
+              list2,
+            },
+          },
+          location::unknown,
+        });
+      });
+  }
+};
+
+} // namespace
+
+} // namespace tenzir::plugins::list
+
+using namespace tenzir::plugins::list;
+TENZIR_REGISTER_PLUGIN(prepend)
+TENZIR_REGISTER_PLUGIN(append)
+TENZIR_REGISTER_PLUGIN(concatenate)

--- a/web/docs/tql2/functions.md
+++ b/web/docs/tql2/functions.md
@@ -71,6 +71,9 @@ Function | Description | Example
 
 Function | Description | Example
 :--------|:------------|:-------
+[`append`](functions/append.md) | Inserts an element at the back of a list | `xs.append(y)`
+[`prepend`](functions/prepend.md) | Inserts an element at the front of a list | `xs.prepend(y)`
+[`concatenate`](functions/concatenate.md) | Merges two lists | `concatenate(xs, ys)`
 [`map`](functions/map.md) | Maps each list element to an expression | `xs.map(x, x + 3)`
 [`where`](functions/where.md) | Removes list elements based on a predicate | `xs.where(x, x > 5)`
 

--- a/web/docs/tql2/functions/append.md
+++ b/web/docs/tql2/functions/append.md
@@ -3,13 +3,13 @@
 Inserts an element at the back of a list.
 
 ```tql
-append(list:list, element:any) -> list
+append(xs:list, x:any) -> list
 ```
 
 ## Description
 
-The `append` function returns the `list` with `element` inserted at the end.
-`xs.append(y)` is equivalent to `[...xs, y]`.
+The `append` function returns the list `xs` with `x` inserted at the end. The
+expression `xs.append(x)` is equivalent to `[...xs, x]`.
 
 ## Examples
 
@@ -26,5 +26,4 @@ xs = xs.append(3)
 
 ## See Also
 
-[`prepend`](prepend.md), [`concatenate`](concatenate.md)
-
+[`concatenate`](concatenate.md), [`prepend`](prepend.md)

--- a/web/docs/tql2/functions/append.md
+++ b/web/docs/tql2/functions/append.md
@@ -1,0 +1,30 @@
+# append
+
+Inserts an element at the back of a list.
+
+```tql
+append(list:list, element:any) -> list
+```
+
+## Description
+
+The `append` function returns the `list` with `element` inserted at the end.
+`xs.append(y)` is equivalent to `[...xs, y]`.
+
+## Examples
+
+### Append a number to a list
+
+```tql
+from {xs: [1, 2]}
+xs = xs.append(3)
+```
+
+```tql
+{xs: [1, 2, 3]}
+```
+
+## See Also
+
+[`prepend`](prepend.md), [`concatenate`](concatenate.md)
+

--- a/web/docs/tql2/functions/concatenate.md
+++ b/web/docs/tql2/functions/concatenate.md
@@ -1,0 +1,34 @@
+# concatenate
+
+Merges two lists.
+
+```tql
+concatenate(list1:list, list2:list) -> list
+```
+
+## Description
+
+The `concatenate` function returns a list containing all elements from `list1`
+and `list2` in order. `concatenate(xs, ys)` is equivalent to `[...xs, ...ys]`.
+
+## Examples
+
+### Concatenate two lists
+
+```tql
+from {xs: [1, 2], ys: [3, 4]}
+zs = concatenate(xs, ys)
+```
+
+```tql
+{
+  xs: [1, 2],
+  ys: [3, 4],
+  zs: [1, 2, 3, 4]
+}
+```
+
+## See Also
+
+[`append`](append.md), [`prepend`](prepend.md)
+

--- a/web/docs/tql2/functions/concatenate.md
+++ b/web/docs/tql2/functions/concatenate.md
@@ -3,13 +3,14 @@
 Merges two lists.
 
 ```tql
-concatenate(list1:list, list2:list) -> list
+concatenate(xs:list, ys:list) -> list
 ```
 
 ## Description
 
-The `concatenate` function returns a list containing all elements from `list1`
-and `list2` in order. `concatenate(xs, ys)` is equivalent to `[...xs, ...ys]`.
+The `concatenate` function returns a list containing all elements from the lists
+`xs` and `ys` in order. The expression `concatenate(xs, ys)` is equivalent to
+`[...xs, ...ys]`.
 
 ## Examples
 
@@ -31,4 +32,3 @@ zs = concatenate(xs, ys)
 ## See Also
 
 [`append`](append.md), [`prepend`](prepend.md)
-

--- a/web/docs/tql2/functions/prepend.md
+++ b/web/docs/tql2/functions/prepend.md
@@ -1,0 +1,30 @@
+# prepend
+
+Inserts an element at the start of a list.
+
+```tql
+prepend(list:list, element:any) -> list
+```
+
+## Description
+
+The `prepend` function returns the `list` with `element` inserted at the front.
+`xs.prepend(y)` is equivalent to `[y, ...xs]`.
+
+## Examples
+
+### Prepend a number to a list
+
+```tql
+from {xs: [1, 2]}
+xs = xs.prepend(3)
+```
+
+```tql
+{xs: [3, 1, 2]}
+```
+
+## See Also
+
+[`append`](append.md), [`concatenate`](concatenate.md)
+

--- a/web/docs/tql2/functions/prepend.md
+++ b/web/docs/tql2/functions/prepend.md
@@ -3,13 +3,13 @@
 Inserts an element at the start of a list.
 
 ```tql
-prepend(list:list, element:any) -> list
+prepend(xs:list, x:any) -> list
 ```
 
 ## Description
 
-The `prepend` function returns the `list` with `element` inserted at the front.
-`xs.prepend(y)` is equivalent to `[y, ...xs]`.
+The `prepend` function returns the list `xs` with `x` inserted at the front.
+The expression `xs.prepend(y)` is equivalent to `[x, ...xs]`.
 
 ## Examples
 
@@ -27,4 +27,3 @@ xs = xs.prepend(3)
 ## See Also
 
 [`append`](append.md), [`concatenate`](concatenate.md)
-


### PR DESCRIPTION
These are functionally equivalent to `[...lhs, rhs]`, `[rhs, ...lhs]`, and `[...lhs, ...rhs]`, respectively, and simply implemented as an AST transformation.

- Fixes https://github.com/tenzir/issues/issues/2184