### PR TITLE
Restore the s3 and from_velociraptor plugins

### DIFF
--- a/nix/tenzir/default.nix
+++ b/nix/tenzir/default.nix
@@ -60,15 +60,16 @@
       [
         "plugins/amqp"
         "plugins/azure-blob-storage"
+        "plugins/fluent-bit"
+        "plugins/from_velociraptor"
         "plugins/gcs"
         "plugins/google-cloud-pubsub"
-        "plugins/fluent-bit"
         "plugins/kafka"
         "plugins/nic"
         "plugins/parquet"
+        "plugins/s3"
         "plugins/sigma"
         "plugins/sqs"
-        "plugins/velociraptor"
         "plugins/web"
         "plugins/zmq"
       ]


### PR DESCRIPTION
They were dropped from being included in the static binary during some refactorings.
