### PR TITLE
Ignore whole line when NDJSON parser fails

### DIFF
--- a/changelog/next/bug-fixes/4801--ndjson-parser-failure.md
+++ b/changelog/next/bug-fixes/4801--ndjson-parser-failure.md
@@ -1,0 +1,3 @@
+The `read_ndjson` operator no longer uses an error-prone mechanism to continue
+parsing an NDJSON line that contains an error. Instead, the entire line is
+skipped.

--- a/libtenzir/builtins/formats/json.cpp
+++ b/libtenzir/builtins/formats/json.cpp
@@ -451,7 +451,7 @@ public:
           .note("skipped invalid JSON `{}`", truncate(source))
           .emit(*dh);
         ++diags_emitted;
-        continue;
+        break;
       }
       auto val = doc.get_value();
       if (auto err = val.error()) {
@@ -460,14 +460,14 @@ public:
           .note("skipped invalid JSON `{}`", truncate(source))
           .emit(*dh);
         ++diags_emitted;
-        continue;
+        break;
       }
       auto parser = doc_parser{json_line, *dh, lines_processed_};
       auto success = parser.parse_object(val.value_unsafe(), builder.record());
       if (not success) {
         builder.remove_last();
         ++diags_emitted;
-        continue;
+        break;
       }
     }
     if (objects_parsed == 0 and diags_emitted == 0) {


### PR DESCRIPTION
The NDJSON tries to continue with parsing the line after an error occurs. The current approach does not really work reliably though, see https://github.com/tenzir/issues/issues/2355. Thus this PR disables that logic, at least for now.