### PR TITLE
Fix `str` function quotes

### DIFF
--- a/changelog/next/bug-fixes/4809--str-function-quotes.md
+++ b/changelog/next/bug-fixes/4809--str-function-quotes.md
@@ -1,0 +1,2 @@
+The `str` function no longer adds extra quotes when given a string. For example,
+`str("") == "\"\""` was changed to `str("") == ""`.

--- a/libtenzir/builtins/functions/string.cpp
+++ b/libtenzir/builtins/functions/string.cpp
@@ -363,8 +363,8 @@ public:
       auto b = arrow::StringBuilder{};
       for (auto&& value : subject.values()) {
         auto f = detail::overload{
-          [](const std::string& x) {
-            return x;
+          [](std::string_view x) {
+            return std::string{x};
           },
           [](int64_t x) {
             return fmt::to_string(x);


### PR DESCRIPTION
Due to a bad function overload, the `str` function previously added extra quotes to strings: `str("") == "\"\""`. This bug fix makes it return the original input as-is instead.