### PR TITLE
Enhance HTTP connector controls

### DIFF
--- a/changelog/next/features/4811--http-args.md
+++ b/changelog/next/features/4811--http-args.md
@@ -1,0 +1,5 @@
+Several new options are now available for the `load_http` operator: `data`,
+`json`, `form`, `skip_peer_verification`, `skip_hostname_verification`,
+`chunked`, and `multipart`. The `skip_peer_verification` and
+`skip_hostname_verification` options are now also available for the `save_http`
+operator.

--- a/libtenzir/builtins/connectors/curl.cpp
+++ b/libtenzir/builtins/connectors/curl.cpp
@@ -466,20 +466,41 @@ auto parse_http_args(std::string name,
                      const operator_factory_plugin::invocation& inv,
                      session ctx) -> failure_or<connector_args> {
   auto url = std::string{};
-  auto method = std::optional<std::string>{};
+  auto body_data = std::optional<located<record>>{};
   auto params = std::optional<located<record>>{};
   auto headers = std::optional<located<record>>{};
-  argument_parser2::operator_(std::move(name))
-    .positional("url", url)
-    .named("method", method)
-    .named("params", params)
-    .named("headers", headers)
-    .parse(inv, ctx)
-    .ignore();
+  auto form = std::optional<location>{};
+  auto method = std::optional<std::string>{};
   auto args = connector_args{};
+  args.transfer_opts.default_protocol = "https";
+  auto parser = argument_parser2::operator_(name);
+  parser.positional("url", url);
+  parser.named("params", params);
+  parser.named("headers", headers);
+  parser.named("method", method);
+  if (name == "load_http") {
+    parser.named("data", body_data);
+    parser.named("form", form);
+    parser.named("chunked", args.http_opts.chunked);
+    parser.named("multipart", args.http_opts.multipart);
+  }
+  parser.named("skip_peer_verification",
+               args.transfer_opts.skip_peer_verification);
+  parser.named("skip_hostname_verification",
+               args.transfer_opts.skip_hostname_verification);
+  parser.named("_verbose", args.transfer_opts.verbose);
+  TRY(parser.parse(inv, ctx));
   args.url = std::move(url);
-  if (method) {
-    args.http_opts.method = *method;
+  if (form) {
+    args.http_opts.form = true;
+  }
+  if (body_data) {
+    for (auto& [key, value] : body_data->inner) {
+      auto str = to_json(value);
+      TENZIR_ASSERT(str);
+      args.http_opts.items.emplace_back(tenzir::http::request_item::data_json,
+                                        std::move(key), std::move(*str));
+    }
   }
   if (params) {
     for (auto& [name, value] : params->inner) {
@@ -508,6 +529,9 @@ auto parse_http_args(std::string name,
       args.http_opts.items.emplace_back(tenzir::http::request_item::header,
                                         std::move(name), std::move(*str));
     }
+  }
+  if (method) {
+    args.http_opts.method = std::move(*method);
   }
   return args;
 }

--- a/tenzir/integration/data/reference/http2/test_load_http_post/step_00.ref
+++ b/tenzir/integration/data/reference/http2/test_load_http_post/step_00.ref
@@ -1,0 +1,10 @@
+"POST / HTTP/1.1" 200 -
+
+Host: localhost:50380
+Accept-Encoding: *
+User-Agent: Tenzir/*.*.*
+Content-Type: application/json
+Accept: application/json, */*
+Content-Length: 48
+
+{"foo": "42", "bar": {"baz": 1, "baz2": "baz2"}}

--- a/tenzir/integration/data/reference/http2/test_load_http_post_form/step_00.ref
+++ b/tenzir/integration/data/reference/http2/test_load_http_post_form/step_00.ref
@@ -1,0 +1,10 @@
+"POST / HTTP/1.1" 200 -
+
+Host: localhost:50381
+Accept-Encoding: *
+User-Agent: Tenzir/*.*.*
+Content-Type: application/x-www-form-urlencoded
+Accept: */*
+Content-Length: 18
+
+foo=42&bar.baz=baz

--- a/tenzir/integration/data/reference/http2/test_save_http_post/step_00.ref
+++ b/tenzir/integration/data/reference/http2/test_save_http_post/step_00.ref
@@ -1,0 +1,12 @@
+"POST / HTTP/1.1" 200 -
+
+Host: localhost:51382
+Accept-Encoding: *
+User-Agent: Tenzir/*.*.*
+Accept: */*
+Content-Type: application/json
+Content-Length: 19
+
+{
+  "foo": "bar"
+}

--- a/tenzir/integration/data/reference/http2/test_save_http_post_add_header/step_00.ref
+++ b/tenzir/integration/data/reference/http2/test_save_http_post_add_header/step_00.ref
@@ -1,0 +1,13 @@
+"POST / HTTP/1.1" 200 -
+
+Host: localhost:51385
+Accept-Encoding: *
+User-Agent: Tenzir/*.*.*
+X-Test: foo
+Accept: */*
+Content-Type: application/json
+Content-Length: 19
+
+{
+  "foo": "bar"
+}

--- a/tenzir/integration/data/reference/http2/test_save_http_post_delete_header/step_00.ref
+++ b/tenzir/integration/data/reference/http2/test_save_http_post_delete_header/step_00.ref
@@ -1,0 +1,11 @@
+"POST / HTTP/1.1" 200 -
+
+Host: localhost:51383
+Accept-Encoding: *
+User-Agent: Tenzir/*.*.*
+Accept: */*
+Content-Length: 19
+
+{
+  "foo": "bar"
+}

--- a/tenzir/integration/data/reference/http2/test_save_http_post_overwrite_header/step_00.ref
+++ b/tenzir/integration/data/reference/http2/test_save_http_post_overwrite_header/step_00.ref
@@ -1,0 +1,12 @@
+"POST / HTTP/1.1" 200 -
+
+Host: localhost:51384
+Accept-Encoding: *
+User-Agent: Test
+Accept: */*
+Content-Type: application/json
+Content-Length: 19
+
+{
+  "foo": "bar"
+}

--- a/tenzir/integration/data/reference/http2/test_save_http_put/step_00.ref
+++ b/tenzir/integration/data/reference/http2/test_save_http_put/step_00.ref
@@ -1,0 +1,12 @@
+"PUT / HTTP/1.1" 200 -
+
+Host: localhost:51380
+Accept-Encoding: *
+User-Agent: Tenzir/*.*.*
+Accept: */*
+Content-Type: application/json
+Content-Length: 19
+
+{
+  "foo": "bar"
+}

--- a/tenzir/integration/tests/http2.bats
+++ b/tenzir/integration/tests/http2.bats
@@ -1,0 +1,56 @@
+: "${BATS_TEST_TIMEOUT:=10}"
+
+setup() {
+  bats_load_library bats-support
+  bats_load_library bats-assert
+  bats_load_library bats-tenzir
+
+  export TENZIR_TQL2=true
+}
+
+load() {
+  if ! command -v python; then
+    skip "python executable must be in PATH"
+  fi
+  check --bg server python "${MISCDIR}/scripts/webserver.py" --port=$1
+  check tenzir "$2"
+  wait_all ${server[@]}
+}
+
+save() {
+  if ! command -v python; then
+    skip "python executable must be in PATH"
+  fi
+  check --bg server python "${MISCDIR}/scripts/webserver.py" --port=$1
+  tenzir "$2"
+  wait_all ${server[@]}
+}
+
+@test "load HTTP POST" {
+  load 50380 'load_http "http://localhost:50380", data={foo: "42", bar: {baz: 1, baz2: "baz2"}}'
+}
+
+@test "load HTTP POST form" {
+  load 50381 'load_http "http://localhost:50381", form=true, data={foo: "42", bar: {baz: "baz"}}'
+}
+
+@test "save HTTP PUT" {
+  save 51380 'version | select foo="bar" | write_json | save_http "http://localhost:51380", method="PUT"'
+}
+
+@test "save HTTP POST" {
+  # save 51381 'version | select foo="bar" | to http://localhost:51381'
+  save 51382 'version | select foo="bar" | write_json | save_http "http://localhost:51382", method="POST"'
+}
+
+@test "save HTTP POST delete header" {
+  save 51383 'version | select foo="bar" | write_json | save_http "http://localhost:51383", headers={"Content-Type": ""}'
+}
+
+@test "save HTTP POST overwrite header" {
+  save 51384 'version | select foo="bar" | write_json | save_http "http://localhost:51384", headers={"User-Agent": "Test"}'
+}
+
+@test "save HTTP POST add header" {
+  save 51385 'version | select foo="bar" | write_json | save_http "http://localhost:51385", headers={"X-Test": "foo"}'
+}

--- a/web/docs/tql2/operators/load_http.md
+++ b/web/docs/tql2/operators/load_http.md
@@ -3,12 +3,14 @@
 Loads a byte stream via HTTP.
 
 ```tql
-load_http url:string, [method=string, params=record, headers=record]
+load_http url:string, [data=record, params=record, headers=record,
+          method=string, form=bool, chunked=bool, multipart=bool,
+          skip_peer_verification=bool, skip_hostname_verification=bool, verbose=bool]
 ```
 
 ## Description
 
-The `save_http` operator performs a HTTP request and returns the response.
+The `load_http` operator performs a HTTP request and returns the response.
 
 ### `url: string`
 
@@ -27,6 +29,56 @@ The query parameters for the request.
 ### `headers = record (optional)`
 
 The headers for the request.
+
+### `data = record (optional)`
+
+The request body as a record of key-value pairs. The body is encoded as JSON
+unless `form=true` has been set.
+
+### `form = bool (optional)`
+
+Submits the HTTP request body as form-encoded data.
+
+This automatically sets the `Content-Type` header to
+`application/x-www-form-urlencoded`.
+
+Defaults to `false`.
+
+### `chunked = bool (optional)`
+
+Whether to enable [chunked transfer
+encoding](https://en.wikipedia.org/wiki/Chunked_transfer_encoding). This is
+equivalent to manually setting the header `Transfer-Encoding: chunked`.
+
+Defaults to `false`.
+
+### `multipart = bool (optional)`
+
+Whether to encode the HTTP request body as [multipart
+message](https://en.wikipedia.org/wiki/MIME#Multipart_messages).
+
+This automatically sets the `Content-Type` header to
+`application/form-multipart; X` where `X` contains the MIME part boundary.
+
+Defaults to `false`.
+
+### `skip_peer_verification = bool (optional)`
+
+Whether to skip TLS peer verification.
+
+Defaults to `false`.
+
+### `skip_hostname_verification = bool (optional)`
+
+Whether to skip TLS peer verification.
+
+Defaults to `false`.
+
+<!-- ### `verbose = bool (optional)` -->
+<!---->
+<!-- Whether to emit verbose output. -->
+<!---->
+<!-- Defaults to `false`. -->
 
 ## Examples
 

--- a/web/docs/tql2/operators/save_http.md
+++ b/web/docs/tql2/operators/save_http.md
@@ -3,7 +3,9 @@
 Sends a byte stream via HTTP.
 
 ```tql
-save_http url:string, [method=string, params=record, headers=record]
+save_http url:string, [params=record, headers=record, method=string,
+          skip_peer_verification=bool, skip_hostname_verification=bool,
+          verbose=bool]
 ```
 
 ## Description
@@ -28,6 +30,24 @@ The query parameters for the request.
 ### `headers = record (optional)`
 
 The headers for the request.
+
+### `skip_peer_verification = bool (optional)`
+
+Whether to skip TLS peer verification.
+
+Defaults to `false`.
+
+### `skip_hostname_verification = bool (optional)`
+
+Whether to skip TLS peer verification.
+
+Defaults to `false`.
+
+<!-- ### `verbose = bool (optional)` -->
+<!---->
+<!-- Whether to emit verbose output. -->
+<!---->
+<!-- Defaults to `false`. -->
 
 ## Examples
 

--- a/web/docs/usage/enrich-with-threat-intel/README.md
+++ b/web/docs/usage/enrich-with-threat-intel/README.md
@@ -28,7 +28,8 @@ data from the [ThreatFox](https://threatfox.abuse.ch/) API:
 
 ```tql
 load_http "https://threatfox-api.abuse.ch/api/v1/",
-  body={query: "get_iocs", days: 1}
+  data={query: "get_iocs", days: 1}
+read_json
 unroll data
 where data.ioc_type == "domain"
 context::update "threatfox", key="ioc", value=data


### PR DESCRIPTION
This PR adds re-exposes existing HTTP functionality for TQL2.

- [x] Implement functionality
- [x] Consider improving interface
- [x] Port integration tests
- [x] Update docs

### Discussion

#### Default Protocol

How are we inferring the default protocol? In the past, we had this:

```
args.transfer_opts.default_protocol = protocol();
```

For HTTP, this should be either `http` or `https`. We only need this when there is no URL scheme given.

I would be inclined to go with HTTPs by default for security reasons.