### PR TITLE
Fix potential lifetime issue in `compress` and `decompress`

### DIFF
--- a/libtenzir/builtins/operators/compress_decompress.cpp
+++ b/libtenzir/builtins/operators/compress_decompress.cpp
@@ -55,10 +55,11 @@ public:
         return buffer->size();
       },
     };
-    return detail::narrow_cast<int64_t>(std::visit(f, buffer_));
+    return detail::narrow<int64_t>(std::visit(f, buffer_));
   }
 
   auto consume(chunk_ptr chunk) -> void {
+    TENZIR_ASSERT(chunk);
     auto f = detail::overload{
       [&](std::monostate) {
         buffer_ = std::move(chunk);
@@ -70,12 +71,13 @@ public:
       },
       [&](const chunk_ptr& buffer) {
         TENZIR_ASSERT(buffer);
-        auto& new_buffer = buffer_.emplace<std::vector<uint8_t>>();
+        auto new_buffer = std::vector<uint8_t>();
         new_buffer.reserve(buffer->size() + chunk->size());
         std::copy_n(reinterpret_cast<const uint8_t*>(buffer->data()),
                     buffer->size(), std::back_inserter(new_buffer));
         std::copy_n(reinterpret_cast<const uint8_t*>(chunk->data()),
                     chunk->size(), std::back_inserter(new_buffer));
+        buffer_ = std::move(new_buffer);
       },
     };
     std::visit(f, buffer_);
@@ -87,8 +89,8 @@ public:
         TENZIR_ASSERT(size == 0);
       },
       [&](std::vector<uint8_t>& buffer) {
-        TENZIR_ASSERT(size <= detail::narrow_cast<int64_t>(buffer.size()));
-        if (size == detail::narrow_cast<int64_t>(buffer.size())) {
+        TENZIR_ASSERT(size <= detail::narrow<int64_t>(buffer.size()));
+        if (size == detail::narrow<int64_t>(buffer.size())) {
           buffer_ = {};
           return;
         }
@@ -97,8 +99,8 @@ public:
       },
       [&](chunk_ptr& buffer) {
         TENZIR_ASSERT(buffer);
-        TENZIR_ASSERT(size <= detail::narrow_cast<int64_t>(buffer->size()));
-        if (size == detail::narrow_cast<int64_t>(buffer->size())) {
+        TENZIR_ASSERT(size <= detail::narrow<int64_t>(buffer->size()));
+        if (size == detail::narrow<int64_t>(buffer->size())) {
           buffer_ = {};
           return;
         }
@@ -179,7 +181,7 @@ public:
       while (in_buffer.size() > 0) {
         auto result = compressor.ValueUnsafe()->Compress(
           in_buffer.size(), in_buffer.data(),
-          detail::narrow_cast<int64_t>(out_buffer.size()), out_buffer.data());
+          detail::narrow<int64_t>(out_buffer.size()), out_buffer.data());
         if (not result.ok()) {
           diagnostic::error("failed to compress: {}",
                             result.status().ToString())
@@ -206,7 +208,7 @@ public:
         }
         if (result->bytes_written > 0) {
           TENZIR_ASSERT(result->bytes_written
-                        <= detail::narrow_cast<int64_t>(out_buffer.size()));
+                        <= detail::narrow<int64_t>(out_buffer.size()));
           co_yield chunk::copy(
             as_bytes(out_buffer).subspan(0, result->bytes_written));
         } else {
@@ -218,7 +220,7 @@ public:
     // we gracefully reset the compressor.
     while (true) {
       auto result = compressor.ValueUnsafe()->End(
-        detail::narrow_cast<int64_t>(out_buffer.size()), out_buffer.data());
+        detail::narrow<int64_t>(out_buffer.size()), out_buffer.data());
       if (result->should_retry) {
         TENZIR_ASSERT(result->bytes_written == 0);
         if (out_buffer.size() == out_buffer.max_size()) [[unlikely]] {
@@ -295,7 +297,7 @@ public:
       while (in_buffer.size() > 0) {
         auto result = decompressor.ValueUnsafe()->Decompress(
           in_buffer.size(), in_buffer.data(),
-          detail::narrow_cast<int64_t>(out_buffer.size()), out_buffer.data());
+          detail::narrow<int64_t>(out_buffer.size()), out_buffer.data());
         if (not result.ok()) {
           diagnostic::error("failed to decompress: {}",
                             result.status().ToString())
@@ -321,7 +323,7 @@ public:
         }
         if (result->bytes_written > 0) {
           TENZIR_ASSERT(result->bytes_written
-                        <= detail::narrow_cast<int64_t>(out_buffer.size()));
+                        <= detail::narrow<int64_t>(out_buffer.size()));
           co_yield chunk::copy(
             as_bytes(out_buffer).subspan(0, result->bytes_written));
         } else {


### PR DESCRIPTION
The original code did `.emplace` on the variant, which invalidates the buffer. Also, I replaced a bunch of calls to `narrow_cast` with `narrow`, although that doesn't really matter here.