### PR TITLE
Make the argument of `distinct` and `count_distinct` positional again

### DIFF
--- a/libtenzir/builtins/aggregation-functions/count_distinct.cpp
+++ b/libtenzir/builtins/aggregation-functions/count_distinct.cpp
@@ -197,7 +197,7 @@ class plugin : public virtual aggregation_function_plugin,
     auto expr = ast::expression{};
     // TODO: Maybe merge this functionality into `count` or `distinct`
     TRY(argument_parser2::function(name())
-          .named("x", expr, "any")
+          .positional("x", expr, "any")
           .parse(inv, ctx));
     return std::make_unique<count_distinct_instance>(std::move(expr));
   }

--- a/libtenzir/builtins/aggregation-functions/distinct.cpp
+++ b/libtenzir/builtins/aggregation-functions/distinct.cpp
@@ -203,7 +203,7 @@ class plugin : public virtual aggregation_function_plugin,
     -> failure_or<std::unique_ptr<aggregation_instance>> override {
     auto expr = ast::expression{};
     TRY(argument_parser2::function(name())
-          .named("x", expr, "any")
+          .positional("x", expr, "any")
           .parse(inv, ctx));
     return std::make_unique<distinct_instance>(std::move(expr));
   }


### PR DESCRIPTION
This was accidentally changed to a named argument in https://github.com/tenzir/tenzir/pull/4740. 

No changelog necessary because there wasn't a release in between.