### PR TITLE
Migrate to tenzir::scope_guard

### DIFF
--- a/libtenzir/builtins/connectors/directory.cpp
+++ b/libtenzir/builtins/connectors/directory.cpp
@@ -8,6 +8,7 @@
 
 #include <tenzir/argument_parser.hpp>
 #include <tenzir/concept/parseable/tenzir/pipeline.hpp>
+#include <tenzir/detail/scope_guard.hpp>
 #include <tenzir/diagnostics.hpp>
 #include <tenzir/plugin.hpp>
 #include <tenzir/tql/parser.hpp>
@@ -86,7 +87,7 @@ public:
     auto file_saver = parsed->instantiate(ctrl, std::move(info));
     if (not file_saver)
       return std::move(file_saver.error());
-    auto guard = caf::detail::make_scope_guard([=] {
+    auto guard = detail::scope_guard([=]() noexcept {
       // We also print this when the operator fails at runtime, but
       // then again this also means that we did create the file, so
       // that's probably alright.

--- a/libtenzir/builtins/connectors/file.cpp
+++ b/libtenzir/builtins/connectors/file.cpp
@@ -16,6 +16,7 @@
 #include <tenzir/detail/fdoutbuf.hpp>
 #include <tenzir/detail/file_path_to_plugin_name.hpp>
 #include <tenzir/detail/posix.hpp>
+#include <tenzir/detail/scope_guard.hpp>
 #include <tenzir/detail/string.hpp>
 #include <tenzir/diagnostics.hpp>
 #include <tenzir/fwd.hpp>
@@ -24,7 +25,6 @@
 #include <tenzir/plugin.hpp>
 #include <tenzir/tql2/plugin.hpp>
 
-#include <caf/detail/scope_guard.hpp>
 #include <caf/error.hpp>
 
 #include <chrono>
@@ -408,7 +408,7 @@ public:
       stream = std::make_shared<file_writer>(handle);
     }
     TENZIR_ASSERT(stream);
-    auto guard = caf::detail::make_scope_guard([&ctrl, stream] {
+    auto guard = detail::scope_guard([&ctrl, stream]() noexcept {
       if (auto error = stream->close()) {
         diagnostic::error(error)
           .note("failed to close stream")

--- a/libtenzir/builtins/contexts/geoip.cpp
+++ b/libtenzir/builtins/contexts/geoip.cpp
@@ -10,6 +10,7 @@
 #include <tenzir/context.hpp>
 #include <tenzir/data.hpp>
 #include <tenzir/detail/posix.hpp>
+#include <tenzir/detail/scope_guard.hpp>
 #include <tenzir/error.hpp>
 #include <tenzir/fbs/geoip.hpp>
 #include <tenzir/fbs/utils.hpp>
@@ -363,7 +364,7 @@ public:
         continue;
       }
       status = MMDB_get_entry_data_list(&result.entry, &entry_data_list);
-      auto free_entry_data_list = caf::detail::make_scope_guard([&] {
+      auto free_entry_data_list = detail::scope_guard([&]() noexcept {
         if (entry_data_list) {
           MMDB_free_entry_data_list(entry_data_list);
         }
@@ -434,7 +435,7 @@ public:
         continue;
       }
       status = MMDB_get_entry_data_list(&result.entry, &entry_data_list);
-      auto free_entry_data_list = caf::detail::make_scope_guard([&] {
+      auto free_entry_data_list = detail::scope_guard([&]() noexcept {
         if (entry_data_list) {
           MMDB_free_entry_data_list(entry_data_list);
         }
@@ -511,7 +512,7 @@ public:
         if (current_dump->status != MMDB_SUCCESS) {
           break;
         }
-        auto free_entry_data_list = caf::detail::make_scope_guard([&] {
+        auto free_entry_data_list = detail::scope_guard([&]() noexcept {
           if (entry_data_list) {
             MMDB_free_entry_data_list(entry_data_list);
           }

--- a/libtenzir/builtins/operators/python.cpp
+++ b/libtenzir/builtins/operators/python.cpp
@@ -16,6 +16,7 @@
 #include <tenzir/detail/overload.hpp>
 #include <tenzir/detail/posix.hpp>
 #include <tenzir/detail/preserved_fds.hpp>
+#include <tenzir/detail/scope_guard.hpp>
 #include <tenzir/detail/strip_leading_indentation.hpp>
 #include <tenzir/error.hpp>
 #include <tenzir/generator.hpp>
@@ -35,7 +36,6 @@
 #include <boost/interprocess/sync/named_semaphore.hpp>
 #include <boost/process.hpp>
 #include <caf/actor_system_config.hpp>
-#include <caf/detail/scope_guard.hpp>
 #include <caf/settings.hpp>
 
 #include <filesystem>
@@ -234,7 +234,7 @@ public:
           env["UV_CACHE_DIR"]
             = (venv_base_dir->parent_path() / "cache" / "uv").string();
         }
-        return caf::detail::scope_guard([maybe_venv] {
+        return detail::scope_guard([maybe_venv]() noexcept {
           if (maybe_venv) {
             std::error_code ec;
             auto exists = std::filesystem::exists(*maybe_venv, ec);

--- a/libtenzir/builtins/operators/shell.cpp
+++ b/libtenzir/builtins/operators/shell.cpp
@@ -12,6 +12,7 @@
 #include <tenzir/concept/parseable/string/quoted_string.hpp>
 #include <tenzir/concept/parseable/tenzir/pipeline.hpp>
 #include <tenzir/detail/preserved_fds.hpp>
+#include <tenzir/detail/scope_guard.hpp>
 #include <tenzir/error.hpp>
 #include <tenzir/logger.hpp>
 #include <tenzir/pipeline.hpp>
@@ -22,7 +23,6 @@
 
 #include <boost/asio.hpp>
 #include <boost/process.hpp>
-#include <caf/detail/scope_guard.hpp>
 
 #include <mutex>
 #include <queue>
@@ -243,7 +243,7 @@ public:
     });
     {
       // Coroutines require RAII-style exit handling.
-      auto unplanned_exit = caf::detail::make_scope_guard([&] {
+      auto unplanned_exit = detail::scope_guard([&]() noexcept {
         child->terminate();
         TENZIR_DEBUG("joining thread");
         thread.join();

--- a/libtenzir/include/tenzir/detail/logger.hpp
+++ b/libtenzir/include/tenzir/detail/logger.hpp
@@ -33,7 +33,7 @@ bool setup_spdlog(bool is_server, const tenzir::invocation& cmd_invocation,
 /// Shuts down the logging system
 /// Since tenzir logger runs async and has therefore a  background thread.
 /// for a graceful exit this function should be called.
-void shutdown_spdlog();
+void shutdown_spdlog() noexcept;
 
 /// Get a spdlog::logger handel
 std::shared_ptr<spdlog::logger>& logger();

--- a/libtenzir/include/tenzir/detail/logger.hpp
+++ b/libtenzir/include/tenzir/detail/logger.hpp
@@ -14,7 +14,6 @@
 
 #include <caf/deep_to_string.hpp>
 #include <caf/detail/pretty_type_name.hpp>
-#include <caf/detail/scope_guard.hpp>
 #include <caf/string_view.hpp>
 #include <spdlog/spdlog.h>
 

--- a/libtenzir/include/tenzir/detail/scope_guard.hpp
+++ b/libtenzir/include/tenzir/detail/scope_guard.hpp
@@ -1,0 +1,57 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2024 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <utility>
+
+namespace tenzir::detail {
+
+/// A lightweight scope guard implementation.
+template <class Fun>
+class [[nodiscard]] scope_guard {
+public:
+  static_assert(noexcept(std::declval<Fun>()()),
+                "scope_guard requires a noexcept cleanup function");
+
+  explicit scope_guard(Fun f) noexcept : fun_{std::move(f)}, enabled_{true} {
+  }
+
+  scope_guard() = delete;
+
+  scope_guard(const scope_guard&) = delete;
+  scope_guard(scope_guard&& other) noexcept
+    : fun_{std::move(other.fun_)}, enabled_{other.enabled_} {
+    other.enabled_ = false;
+  }
+
+  auto operator=(const scope_guard&) -> scope_guard& = delete;
+  auto operator=(scope_guard&& other) noexcept -> scope_guard& {
+    fun_ = std::move(other.fun_);
+    enabled_ = std::move(other.enabled_);
+    other.enabled_ = false;
+  }
+
+  ~scope_guard() noexcept {
+    if (enabled_) {
+      fun_();
+    }
+  }
+
+  /// Disables this guard, i.e., the guard does not
+  /// run its cleanup code as it goes out of scope.
+  void disable() noexcept {
+    enabled_ = false;
+  }
+
+private:
+  Fun fun_;
+  bool enabled_;
+};
+
+} // namespace tenzir::detail

--- a/libtenzir/include/tenzir/logger.hpp
+++ b/libtenzir/include/tenzir/logger.hpp
@@ -10,6 +10,7 @@
 
 #include "tenzir/config.hpp"
 #include "tenzir/detail/discard.hpp"
+#include "tenzir/detail/scope_guard.hpp"
 #include "tenzir/error.hpp"
 
 #include <string>
@@ -63,7 +64,7 @@
           const std::string& format, auto&&... args) {                         \
           TENZIR_DEBUG(TENZIR_FMT_RUNTIME("ENTER {} " + format), __func__,     \
                        std::forward<decltype(args)>(args)...);                 \
-          return ::caf::detail::make_scope_guard([func_name_] {                \
+          return ::tenzir::detail::scope_guard([func_name_]() noexcept {       \
             TENZIR_DEBUG("EXIT {}", func_name_);                               \
           });                                                                  \
         }(__VA_ARGS__);
@@ -152,7 +153,7 @@ namespace tenzir {
 /// Used to make log level strings from config, like 'debug', to a log level int.
 int loglevel_to_int(std::string c, int default_value = TENZIR_LOG_LEVEL_QUIET);
 
-[[nodiscard]] caf::expected<caf::detail::scope_guard<void (*)()>>
+[[nodiscard]] caf::expected<detail::scope_guard<void (*)() noexcept>>
 create_log_context(bool is_server, const tenzir::invocation& cmd_invocation,
                    const caf::settings& cfg_file);
 

--- a/libtenzir/include/tenzir/tql2/registry.hpp
+++ b/libtenzir/include/tenzir/tql2/registry.hpp
@@ -9,9 +9,8 @@
 #pragma once
 
 #include "tenzir/detail/heterogeneous_string_hash.hpp"
+#include "tenzir/detail/scope_guard.hpp"
 #include "tenzir/tql2/plugin.hpp"
-
-#include <caf/detail/scope_guard.hpp>
 
 namespace tenzir {
 
@@ -82,7 +81,7 @@ template <class F>
 auto with_thread_local_registry(const registry& reg, F&& f) -> decltype(auto) {
   auto prev = thread_local_registry();
   set_thread_local_registry(&reg);
-  auto guard = caf::detail::scope_guard{[&] {
+  auto guard = detail::scope_guard{[&]() noexcept {
     set_thread_local_registry(prev);
   }};
   return std::invoke(std::forward<F>(f));

--- a/libtenzir/src/detail/subnet_tree.cpp
+++ b/libtenzir/src/detail/subnet_tree.cpp
@@ -9,6 +9,7 @@
 #include "tenzir/detail/subnet_tree.hpp"
 
 #include "tenzir/detail/narrow.hpp"
+#include "tenzir/detail/scope_guard.hpp"
 
 #include <span>
 
@@ -887,7 +888,7 @@ auto type_erased_subnet_tree::search(subnet key) const
   auto num_elements = 0;
   patricia_node_t** xs = nullptr;
   patricia_search_all(impl_->tree.get(), prefix, &xs, &num_elements);
-  auto guard = caf::detail::make_scope_guard([prefix, xs] {
+  auto guard = detail::scope_guard([prefix, xs]() noexcept {
     Deref_Prefix(prefix);
     free(xs);
   });
@@ -902,7 +903,7 @@ auto type_erased_subnet_tree::search(subnet key)
   auto num_elements = 0;
   patricia_node_t** xs = nullptr;
   patricia_search_all(impl_->tree.get(), prefix, &xs, &num_elements);
-  auto guard = caf::detail::make_scope_guard([prefix, xs] {
+  auto guard = detail::scope_guard([prefix, xs]() noexcept {
     Deref_Prefix(prefix);
     free(xs);
   });

--- a/libtenzir/src/disk_monitor.cpp
+++ b/libtenzir/src/disk_monitor.cpp
@@ -15,12 +15,12 @@
 #include "tenzir/data.hpp"
 #include "tenzir/detail/process.hpp"
 #include "tenzir/detail/recursive_size.hpp"
+#include "tenzir/detail/scope_guard.hpp"
 #include "tenzir/error.hpp"
 #include "tenzir/logger.hpp"
 #include "tenzir/status.hpp"
 #include "tenzir/uuid.hpp"
 
-#include <caf/detail/scope_guard.hpp>
 #include <caf/typed_event_based_actor.hpp>
 
 #include <filesystem>
@@ -49,8 +49,8 @@ struct diskstate_blacklist_comparator {
 };
 
 template <typename Fun>
-std::shared_ptr<caf::detail::scope_guard<Fun>> make_shared_guard(Fun f) {
-  return std::make_shared<caf::detail::scope_guard<Fun>>(std::forward<Fun>(f));
+std::shared_ptr<detail::scope_guard<Fun>> make_shared_guard(Fun f) {
+  return std::make_shared<detail::scope_guard<Fun>>(std::forward<Fun>(f));
 }
 
 } // namespace

--- a/libtenzir/src/execution_node.cpp
+++ b/libtenzir/src/execution_node.cpp
@@ -11,6 +11,7 @@
 #include "tenzir/actors.hpp"
 #include "tenzir/chunk.hpp"
 #include "tenzir/defaults.hpp"
+#include "tenzir/detail/scope_guard.hpp"
 #include "tenzir/detail/weak_handle.hpp"
 #include "tenzir/detail/weak_run_delayed.hpp"
 #include "tenzir/diagnostics.hpp"
@@ -75,8 +76,8 @@ namespace {
 template <class... Duration>
   requires(std::is_same_v<Duration, duration> && ...)
 auto make_timer_guard(Duration&... elapsed) {
-  return caf::detail::make_scope_guard(
-    [&, start_time = std::chrono::steady_clock::now()] {
+  return detail::scope_guard(
+    [&, start_time = std::chrono::steady_clock::now()]() noexcept {
       const auto delta = std::chrono::steady_clock::now() - start_time;
       ((void)(elapsed += delta, true), ...);
     });

--- a/libtenzir/src/logger.cpp
+++ b/libtenzir/src/logger.cpp
@@ -13,6 +13,7 @@
 #include "tenzir/configuration.hpp"
 #include "tenzir/defaults.hpp"
 #include "tenzir/detail/assert.hpp"
+#include "tenzir/detail/scope_guard.hpp"
 #include "tenzir/detail/settings.hpp"
 #include "tenzir/si_literals.hpp"
 #include "tenzir/systemd.hpp"
@@ -37,13 +38,12 @@
 
 namespace tenzir {
 
-caf::expected<caf::detail::scope_guard<void (*)()>>
+caf::expected<detail::scope_guard<void (*)() noexcept>>
 create_log_context(bool is_server, const tenzir::invocation& cmd_invocation,
                    const caf::settings& cfg_file) {
   if (!tenzir::detail::setup_spdlog(is_server, cmd_invocation, cfg_file))
     return caf::make_error(tenzir::ec::unspecified);
-  return {caf::detail::make_scope_guard(
-    std::addressof(tenzir::detail::shutdown_spdlog))};
+  return {detail::scope_guard(tenzir::detail::shutdown_spdlog)};
 }
 
 /// Convert a log level to an int.
@@ -288,7 +288,7 @@ bool setup_spdlog(bool is_server, const tenzir::invocation& cmd_invocation,
   return false;
 }
 
-void shutdown_spdlog() {
+void shutdown_spdlog() noexcept {
   TENZIR_DEBUG("shut down logging");
   spdlog::shutdown();
 }

--- a/libtenzir/src/systemd.cpp
+++ b/libtenzir/src/systemd.cpp
@@ -3,10 +3,10 @@
 #include "tenzir/concept/parseable/numeric.hpp"
 #include "tenzir/detail/env.hpp"
 #include "tenzir/detail/posix.hpp"
+#include "tenzir/detail/scope_guard.hpp"
 #include "tenzir/error.hpp"
 #include "tenzir/logger.hpp"
 
-#include <caf/detail/scope_guard.hpp>
 #include <sys/socket.h>
 #include <sys/stat.h>
 
@@ -50,7 +50,7 @@ bool connected_to_journal() {
 // reference implementation at `libsystemd/sd-daemon/sd-daemon.c` to decide
 // which conditions should result in errors.
 caf::error notify_ready() {
-  caf::detail::scope_guard guard([] {
+  detail::scope_guard guard([]() noexcept {
     // Always unset $NOTIFY_SOCKET.
     if (auto err = detail::unsetenv("NOTIFY_SOCKET"))
       TENZIR_WARN("failed to unset NOTIFY_SOCKET: {}", err);

--- a/libtenzir/src/tql/parser.cpp
+++ b/libtenzir/src/tql/parser.cpp
@@ -15,14 +15,13 @@
 #include "tenzir/concept/parseable/tenzir/expression.hpp"
 #include "tenzir/concept/parseable/tenzir/pipeline.hpp"
 #include "tenzir/concept/parseable/tenzir/si.hpp"
+#include "tenzir/detail/scope_guard.hpp"
 #include "tenzir/diagnostics.hpp"
 #include "tenzir/expression.hpp"
 #include "tenzir/parser_interface.hpp"
 #include "tenzir/plugin.hpp"
 #include "tenzir/tql/expression.hpp"
 #include "tenzir/type.hpp"
-
-#include <caf/detail/scope_guard.hpp>
 
 #include <iterator>
 
@@ -180,7 +179,7 @@ private:
 
   template <typename F>
   auto rollback(F&& f) {
-    auto guard = caf::detail::scope_guard{[this, previous = current_] {
+    auto guard = detail::scope_guard{[this, previous = current_]() noexcept {
       current_ = previous;
     }};
     return std::forward<F>(f)();

--- a/libtenzir/src/transfer.cpp
+++ b/libtenzir/src/transfer.cpp
@@ -10,6 +10,7 @@
 
 #include "tenzir/concept/printable/to_string.hpp"
 #include "tenzir/config.hpp"
+#include "tenzir/detail/scope_guard.hpp"
 #include "tenzir/diagnostics.hpp"
 
 namespace tenzir {
@@ -200,7 +201,7 @@ auto transfer::download_chunks() -> generator<caf::expected<chunk_ptr>> {
   auto multi = curl::multi{};
   auto multi_code = multi.add(easy_);
   TENZIR_ASSERT(multi_code == curl::multi::code::ok);
-  auto guard = caf::detail::make_scope_guard([&] {
+  auto guard = detail::scope_guard([&]() noexcept {
     multi_code = multi.remove(easy_);
     TENZIR_ASSERT(multi_code == curl::multi::code::ok);
   });

--- a/libtenzir/src/wah_bitmap.cpp
+++ b/libtenzir/src/wah_bitmap.cpp
@@ -8,9 +8,8 @@
 
 #include "tenzir/wah_bitmap.hpp"
 
+#include "tenzir/detail/scope_guard.hpp"
 #include "tenzir/fbs/bitmap.hpp"
-
-#include <caf/detail/scope_guard.hpp>
 
 #include <iostream>
 
@@ -134,7 +133,7 @@ void wah_bitmap::flip() {
 void wah_bitmap::merge_active_word() {
   TENZIR_ASSERT(!blocks_.empty());
   TENZIR_ASSERT(num_last_ == word_type::literal_word_size);
-  auto guard = caf::detail::make_scope_guard([&] {
+  auto guard = detail::scope_guard([&]() noexcept {
     blocks_.push_back(word_type::none);
     num_last_ = 0;
   });

--- a/libtenzir_test/src/main.cpp
+++ b/libtenzir_test/src/main.cpp
@@ -8,6 +8,7 @@
 
 #include "tenzir/configuration.hpp"
 #include "tenzir/detail/env.hpp"
+#include "tenzir/detail/scope_guard.hpp"
 #include "tenzir/logger.hpp"
 #include "tenzir/plugin.hpp"
 #include "tenzir/test/test.hpp"
@@ -88,7 +89,7 @@ int main(int argc, char** argv) {
   }
 
   // Make sure to deinitialize all plugins at the end.
-  auto plugin_guard = caf::detail::make_scope_guard([]() noexcept {
+  auto plugin_guard = tenzir::detail::scope_guard([]() noexcept {
     tenzir::plugins::get_mutable().clear();
   });
   caf::settings log_settings;

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "6427520ab17a4d441c38f2442c3e8f30d938d7ad",
+  "rev": "11acd2ffc7f54d5f624845defad5cc8627eeb99b",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/plugins/azure-blob-storage/include/saver.hpp
+++ b/plugins/azure-blob-storage/include/saver.hpp
@@ -6,6 +6,7 @@
 // SPDX-FileCopyrightText: (c) 2024 The Tenzir Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+#include <tenzir/detail/scope_guard.hpp>
 #include <tenzir/location.hpp>
 #include <tenzir/plugin.hpp>
 
@@ -57,7 +58,7 @@ public:
         .to_error();
     }
     auto stream_guard
-      = caf::detail::make_scope_guard([this, &ctrl, output_stream]() {
+      = detail::scope_guard([this, &ctrl, output_stream]() noexcept {
           auto status = output_stream.ValueUnsafe()->Close();
           if (not output_stream.ok()) {
             diagnostic::error("failed to close stream: {}", status.ToString())

--- a/plugins/gcs/src/plugin.cpp
+++ b/plugins/gcs/src/plugin.cpp
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include <tenzir/argument_parser.hpp>
+#include <tenzir/detail/scope_guard.hpp>
 #include <tenzir/location.hpp>
 #include <tenzir/plugin.hpp>
 
@@ -176,7 +177,7 @@ public:
         .emit(ctrl.diagnostics());
     }
     auto stream_guard
-      = caf::detail::make_scope_guard([this, &ctrl, output_stream]() {
+      = detail::scope_guard([this, &ctrl, output_stream]() noexcept {
           auto status = output_stream.ValueUnsafe()->Close();
           if (not output_stream.ok()) {
             diagnostic::error("failed to close output stream for URI `{}`: {}",

--- a/plugins/kafka/include/kafka/operator.hpp
+++ b/plugins/kafka/include/kafka/operator.hpp
@@ -21,6 +21,7 @@
 #include <tenzir/concept/parseable/tenzir/pipeline.hpp>
 #include <tenzir/data.hpp>
 #include <tenzir/detail/narrow.hpp>
+#include <tenzir/detail/scope_guard.hpp>
 #include <tenzir/die.hpp>
 #include <tenzir/error.hpp>
 #include <tenzir/logger.hpp>
@@ -255,7 +256,7 @@ public:
       TENZIR_ERROR(client.error());
       return client.error();
     };
-    auto guard = caf::detail::make_scope_guard([client = *client]() mutable {
+    auto guard = detail::scope_guard([client = *client]() mutable noexcept {
       TENZIR_VERBOSE("waiting 10 seconds to flush pending messages");
       if (auto err = client.flush(10s)) {
         TENZIR_WARN(err);

--- a/plugins/s3/include/operator.hpp
+++ b/plugins/s3/include/operator.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <tenzir/argument_parser.hpp>
+#include <tenzir/detail/scope_guard.hpp>
 #include <tenzir/location.hpp>
 #include <tenzir/plugin.hpp>
 
@@ -200,7 +201,7 @@ public:
                                          output_stream.status().ToString()));
     }
     auto stream_guard
-      = caf::detail::make_scope_guard([this, &ctrl, output_stream]() {
+      = detail::scope_guard([this, &ctrl, output_stream]() noexcept {
           auto status = output_stream.ValueUnsafe()->Close();
           if (not output_stream.ok()) {
             diagnostic::error("{}", status.ToString())

--- a/tenzir/tenzir.cpp
+++ b/tenzir/tenzir.cpp
@@ -10,6 +10,7 @@
 #include "tenzir/concept/convertible/to.hpp"
 #include "tenzir/default_configuration.hpp"
 #include "tenzir/detail/posix.hpp"
+#include "tenzir/detail/scope_guard.hpp"
 #include "tenzir/detail/settings.hpp"
 #include "tenzir/detail/signal_handlers.hpp"
 #include "tenzir/logger.hpp"
@@ -62,7 +63,7 @@ auto main(int argc, char** argv) -> int {
   // created before the call to `make_application`, as the return value of that
   // can reference dynamically loaded command plugins, which must not be
   // unloaded before the destructor of the return value.
-  auto plugin_guard = caf::detail::make_scope_guard([&]() noexcept {
+  auto plugin_guard = detail::scope_guard([&]() noexcept {
     plugins::get_mutable().clear();
   });
   // Application setup.


### PR DESCRIPTION
The new implementation in CAF 1.0 does not implement the rule of 5 and is therefore not moveable. We do need that for our logger scope tho.