### PR TITLE
Allow aggregation functions to be called on lists

### DIFF
--- a/changelog/next/features/4821--aggregating-lists.md
+++ b/changelog/next/features/4821--aggregating-lists.md
@@ -1,0 +1,3 @@
+Aggregation functions now work on lists. For example, `[1, 2, 3].sum()` will
+return `6`, and `["foo", "bar", "baz"].map(x, x == "bar").any()` will return
+`true`.

--- a/libtenzir/builtins/aggregation-functions/all.cpp
+++ b/libtenzir/builtins/aggregation-functions/all.cpp
@@ -143,6 +143,11 @@ public:
       .emit(ctx);
   }
 
+  auto reset() -> void override {
+    all_ = true;
+    state_ = state::none;
+  }
+
 private:
   ast::expression expr_;
   bool all_{true};

--- a/libtenzir/builtins/aggregation-functions/any.cpp
+++ b/libtenzir/builtins/aggregation-functions/any.cpp
@@ -143,6 +143,11 @@ public:
       .emit(ctx);
   }
 
+  auto reset() -> void override {
+    any_ = {};
+    state_ = state::none;
+  }
+
 private:
   ast::expression expr_;
   bool any_{false};

--- a/libtenzir/builtins/aggregation-functions/collect.cpp
+++ b/libtenzir/builtins/aggregation-functions/collect.cpp
@@ -130,6 +130,10 @@ public:
     }
   }
 
+  auto reset() -> void override {
+    result_ = {};
+  }
+
 private:
   ast::expression expr_;
   list result_;

--- a/libtenzir/builtins/aggregation-functions/count_distinct.cpp
+++ b/libtenzir/builtins/aggregation-functions/count_distinct.cpp
@@ -166,6 +166,10 @@ public:
     }
   }
 
+  auto reset() -> void override {
+    distinct_ = {};
+  }
+
 private:
   ast::expression expr_;
   tsl::robin_set<data> distinct_;

--- a/libtenzir/builtins/aggregation-functions/distinct.cpp
+++ b/libtenzir/builtins/aggregation-functions/distinct.cpp
@@ -173,6 +173,10 @@ public:
     }
   }
 
+  auto reset() -> void override {
+    distinct_ = {};
+  }
+
 private:
   ast::expression expr_;
   tsl::robin_set<data> distinct_;

--- a/libtenzir/builtins/aggregation-functions/first_last.cpp
+++ b/libtenzir/builtins/aggregation-functions/first_last.cpp
@@ -91,6 +91,10 @@ public:
     }
   }
 
+  auto reset() -> void override {
+    result_ = {};
+  }
+
 private:
   ast::expression expr_ = {};
   data result_ = {};

--- a/libtenzir/builtins/aggregation-functions/mean.cpp
+++ b/libtenzir/builtins/aggregation-functions/mean.cpp
@@ -195,6 +195,12 @@ public:
       .emit(ctx);
   }
 
+  auto reset() -> void override {
+    mean_ = {};
+    count_ = {};
+    state_ = state::none;
+  }
+
 private:
   ast::expression expr_;
   enum class state { none, failed, dur, numeric } state_{};

--- a/libtenzir/builtins/aggregation-functions/min_max.cpp
+++ b/libtenzir/builtins/aggregation-functions/min_max.cpp
@@ -210,17 +210,17 @@ public:
       return;
     }
     match(result, [&]<class T>(const T& x) {
-        if constexpr (std::is_same_v<T, caf::none_t>) {
-          result_.reset();
-        } else if constexpr (result_t::can_have<T>) {
-          result_.emplace(x);
-        } else {
-          diagnostic::warning("invalid value for field `result`: `{}`", result)
-            .note("failed to restore `{}` aggregation instance",
-                  Mode == mode::min ? "min" : "max")
-            .emit(ctx);
-        }
-      });
+      if constexpr (std::is_same_v<T, caf::none_t>) {
+        result_.reset();
+      } else if constexpr (result_t::can_have<T>) {
+        result_.emplace(x);
+      } else {
+        diagnostic::warning("invalid value for field `result`: `{}`", result)
+          .note("failed to restore `{}` aggregation instance",
+                Mode == mode::min ? "min" : "max")
+          .emit(ctx);
+      }
+    });
     const auto* fb_type = (*fb)->type();
     if (not fb_type) {
       diagnostic::warning("missing field `type`")
@@ -232,6 +232,11 @@ public:
     const auto* fb_type_nested_root = (*fb)->type_nested_root();
     TENZIR_ASSERT(fb_type_nested_root);
     type_ = type{fb->slice(*fb_type_nested_root, *fb_type)};
+  }
+
+  auto reset() -> void override {
+    type_ = {};
+    result_ = {};
   }
 
 private:

--- a/libtenzir/builtins/aggregation-functions/mode_value_counts.cpp
+++ b/libtenzir/builtins/aggregation-functions/mode_value_counts.cpp
@@ -134,6 +134,10 @@ public:
     }
   }
 
+  auto reset() -> void override {
+    counts_ = {};
+  }
+
 private:
   const ast::expression expr_ = {};
   tsl::robin_map<data, int64_t> counts_ = {};

--- a/libtenzir/builtins/aggregation-functions/stddev_variance.cpp
+++ b/libtenzir/builtins/aggregation-functions/stddev_variance.cpp
@@ -234,6 +234,13 @@ public:
       .emit(ctx);
   }
 
+  auto reset() -> void override {
+    mean_ = {};
+    mean_squared_ = {};
+    count_ = {};
+    state_ = state::none;
+  }
+
 private:
   double mean_ = {};
   double mean_squared_ = {};

--- a/libtenzir/builtins/aggregation-functions/sum.cpp
+++ b/libtenzir/builtins/aggregation-functions/sum.cpp
@@ -210,16 +210,16 @@ public:
       return;
     }
     match(result, [&]<class T>(const T& x) {
-        if constexpr (std::is_same_v<T, caf::none_t>) {
-          sum_.reset();
-        } else if constexpr (sum_t::can_have<T>) {
-          sum_.emplace(x);
-        } else {
-          diagnostic::warning("invalid value for field `result`: `{}`", result)
-            .note("failed to restore `sum` aggregation instance")
-            .emit(ctx);
-        }
-      });
+      if constexpr (std::is_same_v<T, caf::none_t>) {
+        sum_.reset();
+      } else if constexpr (sum_t::can_have<T>) {
+        sum_.emplace(x);
+      } else {
+        diagnostic::warning("invalid value for field `result`: `{}`", result)
+          .note("failed to restore `sum` aggregation instance")
+          .emit(ctx);
+      }
+    });
     const auto* fb_type = (*fb)->type();
     if (not fb_type) {
       diagnostic::warning("missing field `type`")
@@ -230,6 +230,11 @@ public:
     const auto* fb_type_nested_root = (*fb)->type_nested_root();
     TENZIR_ASSERT(fb_type_nested_root);
     type_ = type{fb->slice(*fb_type_nested_root, *fb_type)};
+  }
+
+  auto reset() -> void override {
+    type_ = {};
+    sum_ = {};
   }
 
 private:

--- a/libtenzir/builtins/functions/numeric.cpp
+++ b/libtenzir/builtins/functions/numeric.cpp
@@ -29,8 +29,8 @@ public:
     return "tql2.sqrt";
   }
 
-  auto make_function(invocation inv,
-                     session ctx) const -> failure_or<function_ptr> override {
+  auto make_function(invocation inv, session ctx) const
+    -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
     TRY(argument_parser2::function("sqrt")
           .positional("x", expr, "number")
@@ -99,8 +99,8 @@ public:
     return "tql2.random";
   }
 
-  auto make_function(invocation inv,
-                     session ctx) const -> failure_or<function_ptr> override {
+  auto make_function(invocation inv, session ctx) const
+    -> failure_or<function_ptr> override {
     argument_parser2::function("random").parse(inv, ctx).ignore();
     return function_use::make([](evaluator eval, session ctx) -> series {
       TENZIR_UNUSED(ctx);
@@ -151,6 +151,10 @@ public:
       return;
     }
     count_ = (*fb)->result();
+  }
+
+  auto reset() -> void override {
+    count_ = {};
   }
 
 private:
@@ -259,6 +263,12 @@ public:
     diagnostic::warning(
       "restoring `quantile` aggregation instances is not implemented")
       .emit(ctx);
+  }
+
+  auto reset() -> void override {
+    quantile_ = {};
+    state_ = state::none;
+    digest_.Reset();
   }
 
 private:

--- a/libtenzir/builtins/operators/top_rare.cpp
+++ b/libtenzir/builtins/operators/top_rare.cpp
@@ -108,7 +108,10 @@ class top_rare_plugin final : public virtual operator_parser_plugin,
     auto summarized = summarize->make(
       {
         inv.self,
-        {summarize_args, std::move(selector).unwrap()},
+        {
+          std::move(selector).unwrap(),
+          summarize_args,
+        },
       },
       ctx);
     const auto sort_args = [&]() {

--- a/libtenzir/include/tenzir/tql2/plugin.hpp
+++ b/libtenzir/include/tenzir/tql2/plugin.hpp
@@ -63,9 +63,10 @@ public:
     void* self_;
   };
 
-  virtual auto run(evaluator eval, session ctx) const -> series = 0;
+  virtual auto run(evaluator eval, session ctx) -> series = 0;
 
-  static auto make(std::function<auto(evaluator eval, session ctx)->series> f)
+  static auto
+  make(detail::unique_function<auto(evaluator eval, session ctx)->series> f)
     -> function_ptr;
 };
 class function_plugin : public virtual plugin {
@@ -98,6 +99,8 @@ public:
   virtual void update(const table_slice& input, session ctx) = 0;
 
   virtual auto get() const -> data = 0;
+
+  virtual auto reset() -> void = 0;
 
   /// Save and restore the state of the aggregation instance. Note that the
   /// restore function should eventually be moved into `aggregation_plugin`, but

--- a/libtenzir/src/tql2/plugin.cpp
+++ b/libtenzir/src/tql2/plugin.cpp
@@ -8,6 +8,8 @@
 
 #include "tenzir/tql2/plugin.hpp"
 
+#include "tenzir/detail/assert.hpp"
+#include "tenzir/tql2/ast.hpp"
 #include "tenzir/tql2/eval_impl.hpp"
 
 namespace tenzir {
@@ -23,28 +25,78 @@ auto function_use::evaluator::operator()(const ast::expression& expr) const
 
 auto aggregation_plugin::make_function(invocation inv, session ctx) const
   -> failure_or<function_ptr> {
-  // TODO: Consider making this pure-virtual or provide a default implementation.
-  diagnostic::error("this function can only be used as an aggregation function")
-    .primary(inv.call.fn)
-    .emit(ctx);
-  return failure::promise();
+  if (inv.call.args.empty()) {
+    diagnostic::error("aggregation functions need at least one list argument "
+                      "to be called as regular functions")
+      .hint("use with `summarize` to aggregate over multiple events instead")
+      .primary(inv.call)
+      .emit(ctx);
+    return failure::promise();
+  }
+  auto subject_arg = inv.call.args.front();
+  auto adjusted_call = inv.call;
+  auto inner_selector
+    = ast::root_field{ast::identifier{"x", subject_arg.get_location()}};
+  adjusted_call.args.front() = inner_selector;
+  TRY(auto fn, this->make_aggregation(invocation{adjusted_call}, ctx));
+  return function_use::make([fn = std::move(fn), subject_arg
+                                                 = std::move(subject_arg)](
+                              evaluator eval, session ctx) mutable -> series {
+    const auto subject = eval(subject_arg);
+    if (is<null_type>(subject.type)) {
+      return series::null(null_type{}, eval.length());
+    }
+    const auto lists = subject.as<list_type>();
+    if (not lists) {
+      diagnostic::warning("expected `list`, but got `{}`", subject.type.kind())
+        .primary(subject_arg)
+        .emit(ctx);
+      return series::null(null_type{}, eval.length());
+    }
+    const auto dummy_type = type{
+      "dummy",
+      record_type{
+        {"x", lists->type.value_type()},
+      },
+    };
+    auto slice = table_slice{
+      arrow::RecordBatch::Make(dummy_type.to_arrow_schema(),
+                               lists->array->values()->length(),
+                               arrow::ArrayVector{lists->array->values()}),
+      dummy_type,
+    };
+    auto builder = series_builder{};
+    for (auto i = int64_t{}; i < lists->array->length(); ++i) {
+      if (lists->array->IsNull(i)) {
+        builder.null();
+        continue;
+      }
+      const auto start = lists->array->value_offset(i);
+      const auto end = start + lists->array->value_length(i);
+      fn->update(subslice(slice, start, end), ctx);
+      builder.data(fn->get());
+      fn->reset();
+    }
+    return builder.finish_assert_one_array();
+  });
 }
 
 auto function_use::make(
-  std::function<auto(evaluator eval, session ctx)->series> f)
+  detail::unique_function<auto(evaluator eval, session ctx)->series> f)
   -> std::unique_ptr<function_use> {
   class result final : public function_use {
   public:
-    explicit result(std::function<auto(evaluator eval, session ctx)->series> f)
+    explicit result(
+      detail::unique_function<auto(evaluator eval, session ctx)->series> f)
       : f_{std::move(f)} {
     }
 
-    auto run(evaluator eval, session ctx) const -> series override {
+    auto run(evaluator eval, session ctx) -> series override {
       return f_(eval, ctx);
     }
 
   private:
-    std::function<auto(evaluator eval, session ctx)->series> f_;
+    detail::unique_function<auto(evaluator eval, session ctx)->series> f_;
   };
   return std::make_unique<result>(std::move(f));
 }


### PR DESCRIPTION
This enables `[1, 2, 3].sum()` and all the other combinations you can think of. This was already documented, but not implemented.

The current implementation is done by mapping the list array's value array onto a table slice with a single field called `x`, and swapping the first argument of the aggregation function call with a root field called `x`. That's a bit hacky, but the alternative would've required changing the interface of aggregation functions not to evaluate their arguments on table slices directly anymore. Note that this effectively adds the restriction that the first argument of an aggregation function must be the aggregation function's subject, which holds true for all aggregation functions we currently have.