### PR TITLE
Replace add_context with diagnostic::error

### DIFF
--- a/libtenzir/builtins/components/metrics_collector.cpp
+++ b/libtenzir/builtins/components/metrics_collector.cpp
@@ -121,7 +121,9 @@ auto metrics_collector(
   self->state.self = self;
   self->state.importer = std::move(importer);
   if (const auto ok = self->state.setup(); not ok) {
-    self->quit(add_context(ok.error(), "failed to create {}", *self));
+    self->quit(diagnostic::error(ok.error())
+                 .note("failed to create {}", *self)
+                 .to_error());
     return metrics_collector_actor::behavior_type::make_empty_behavior();
   }
   return {

--- a/libtenzir/builtins/contexts/bloom_filter.cpp
+++ b/libtenzir/builtins/contexts/bloom_filter.cpp
@@ -241,7 +241,9 @@ public:
   auto save() const -> caf::expected<context_save_result> override {
     std::vector<std::byte> buffer;
     if (auto err = convert(bloom_filter_, buffer)) {
-      return add_context(err, "failed to serialize Bloom filter context");
+      return diagnostic::error(err)
+        .note("failed to serialize Bloom filter context")
+        .to_error();
     }
     return context_save_result{.data = chunk::make(std::move(buffer)),
                                .version = 1};
@@ -261,7 +263,9 @@ struct v1_loader : public context_loader {
     TENZIR_ASSERT(serialized != nullptr);
     auto bloom_filter = dcso_bloom_filter{};
     if (auto err = convert(as_bytes(*serialized), bloom_filter)) {
-      return add_context(err, "failed to deserialize Bloom filter context");
+      return diagnostic::error(err)
+        .note("failed to deserialize Bloom filter context")
+        .to_error();
     }
     return std::make_unique<bloom_filter_context>(std::move(bloom_filter));
   }

--- a/libtenzir/builtins/operators/api.cpp
+++ b/libtenzir/builtins/operators/api.cpp
@@ -40,8 +40,12 @@ public:
         [&](rest_response& value) {
           response = std::move(value);
         },
-        [&](const caf::error& error) {
-          diagnostic::error("internal server error: {}", error)
+        [&](caf::error error) {
+          if (error == ec::no_error) {
+            error = ec::unspecified;
+          }
+          diagnostic::error(std::move(error))
+            .note("internal server error")
             .note("endpoint: {}", endpoint_)
             .note("request body: {}", request_body_)
             .docs("https://docs.tenzir.com/operators/api")
@@ -50,9 +54,13 @@ public:
     co_yield {};
     TENZIR_ASSERT(response.has_value());
     if (response->is_error()) {
-      diagnostic::error("request failed with code {}", response->code())
+      auto detail = response->error_detail();
+      if (detail == ec::no_error) {
+        detail = ec::unspecified;
+      }
+      diagnostic::error(std::move(detail))
+        .note("request failed with code {}", response->code())
         .note("body: {}", response->body())
-        .hint("{}", response->error_detail())
         .docs("https://docs.tenzir.com/operators/api")
         .emit(ctrl.diagnostics());
       co_return;

--- a/libtenzir/builtins/operators/deduplicate.cpp
+++ b/libtenzir/builtins/operators/deduplicate.cpp
@@ -568,10 +568,11 @@ public:
     if (auto diags = std::move(diag_handler).collect(); not diags.empty()) {
       return {
         std::string_view{f, l},
-        add_context(diags.front().to_error(),
-                    "failed to parse the flags in the deduplicate "
-                    "operator: '{}'",
-                    pipeline),
+        diagnostic::error(diags.front().to_error())
+          .note("failed to parse the flags in the deduplicate "
+                "operator: '{}'",
+                pipeline)
+          .to_error(),
       };
     }
     // `0` as distance means infinity

--- a/libtenzir/builtins/operators/shell.cpp
+++ b/libtenzir/builtins/operators/shell.cpp
@@ -168,8 +168,8 @@ public:
     auto mode = ctrl.has_terminal() ? stdin_mode::inherit : stdin_mode::none;
     auto child = child::make(command_, mode);
     if (!child) {
-      diagnostic::error(
-        add_context(child.error(), "failed to spawn child process"))
+      diagnostic::error(child.error())
+        .note("failed to spawn child process")
         .emit(ctrl.diagnostics());
       co_return;
     }
@@ -180,8 +180,8 @@ public:
     while (true) {
       auto bytes_read = child->read(as_writeable_bytes(buffer));
       if (not bytes_read) {
-        diagnostic::error(
-          add_context(bytes_read.error(), "failed to read from child process"))
+        diagnostic::error(bytes_read.error())
+          .note("failed to read from child process")
           .emit(ctrl.diagnostics());
         co_return;
       }
@@ -194,7 +194,8 @@ public:
       co_yield chk;
     }
     if (auto error = child->wait()) {
-      diagnostic::error(add_context(error, "child process execution failed"))
+      diagnostic::error(error)
+        .note("child process execution failed")
         .emit(ctrl.diagnostics());
       co_return;
     }
@@ -205,8 +206,8 @@ public:
     // TODO: Handle exceptions from `boost::process`.
     auto child = child::make(command_, stdin_mode::pipe);
     if (!child) {
-      diagnostic::error(
-        add_context(child.error(), "failed to spawn child process"))
+      diagnostic::error(child.error())
+        .note("failed to spawn child process")
         .emit(ctrl.diagnostics());
       co_return;
     }
@@ -256,8 +257,8 @@ public:
           // TODO: If the reading end of the pipe to the child's stdin is
           // already closed, this will generate a SIGPIPE.
           if (auto err = child->write(as_bytes(*chunk))) {
-            diagnostic::error(
-              add_context(err, "failed to write to child process"))
+            diagnostic::error(err)
+              .note("failed to write to child process")
               .emit(ctrl.diagnostics());
             co_return;
           }
@@ -285,7 +286,8 @@ public:
       child->close_stdin();
       thread.join();
       if (auto error = child->wait()) {
-        diagnostic::error(add_context(error, "child process execution failed"))
+        diagnostic::error(error)
+          .note("child process execution failed")
           .emit(ctrl.diagnostics());
         co_return;
       }

--- a/libtenzir/include/tenzir/error.hpp
+++ b/libtenzir/include/tenzir/error.hpp
@@ -111,15 +111,6 @@ auto inspect(Inspector& f, ec& x) {
   return detail::inspect_enum(f, x);
 }
 
-auto add_context_impl(const caf::error& error, std::string str) -> caf::error;
-
-template <class... Ts>
-auto add_context(const caf::error& error, fmt::format_string<Ts...> fmt,
-                 Ts&&... args) -> caf::error {
-  return add_context_impl(error, fmt::format(std::move(fmt),
-                                             std::forward<Ts>(args)...));
-}
-
 inline void check(const caf::error& err, std::source_location location
                                          = std::source_location::current()) {
   if (err) [[unlikely]] {

--- a/libtenzir/src/error.cpp
+++ b/libtenzir/src/error.cpp
@@ -155,37 +155,4 @@ auto render(const caf::error& err, bool pretty_diagnostics) -> std::string {
   return oss.str();
 }
 
-auto add_context_impl(const caf::error& error, std::string str) -> caf::error {
-  if (!error) {
-    return error;
-  }
-  if (error.category() == caf::type_id_v<tenzir::ec>
-      && static_cast<tenzir::ec>(error.code()) == ec::diagnostic) {
-    auto ctx = error.context();
-    auto* inner = static_cast<diagnostic*>(nullptr);
-    caf::message_handler{
-      [&](diagnostic& diag) {
-        inner = &diag;
-      },
-      [](const caf::message&) {},
-    }(ctx);
-    if (inner) {
-      return caf::make_error(
-        ec::diagnostic, std::move(*inner).modify().note(std::move(str)).done());
-    }
-  }
-  if (!error.context()) {
-    return caf::error{
-      error.code(),
-      error.category(),
-      caf::make_message(std::move(str)),
-    };
-  }
-  return caf::error{
-    error.code(),
-    error.category(),
-    caf::message::concat(error.context(), caf::make_message(std::move(str))),
-  };
-}
-
 } // namespace tenzir

--- a/libtenzir/src/execution_node.cpp
+++ b/libtenzir/src/execution_node.cpp
@@ -407,9 +407,9 @@ struct exec_node_state {
       if (not output_generator) {
         TENZIR_DEBUG("{} {} failed to instantiate operator: {}", *self,
                      op->name(), output_generator.error());
-        return add_context(output_generator.error(),
-                           "{} {} failed to instantiate operator", *self,
-                           op->name());
+        return diagnostic::error(output_generator.error())
+          .note("{} {} failed to instantiate operator", *self, op->name())
+          .to_error();
       }
       if (not std::holds_alternative<generator<Output>>(*output_generator)) {
         return caf::make_error(

--- a/libtenzir/src/index.cpp
+++ b/libtenzir/src/index.cpp
@@ -573,10 +573,10 @@ caf::error index_state::load_from_disk() {
           // data is somewhere else entirely, but no known implementation ever
           // deviated from the default path scheme, so we assume filesystem
           // corruption here.
-          return add_context(ec::no_such_file,
-                             "discarding partition {} due to a missing store "
-                             "file",
-                             partition_uuid);
+          return diagnostic::error(ec::no_such_file)
+            .note("discarding partition {} due to a missing store file",
+                  partition_uuid)
+            .to_error();
         }
         auto store_path = f->second;
         auto store_size = std::filesystem::file_size(store_path, err);

--- a/libtenzir/src/pipeline_executor.cpp
+++ b/libtenzir/src/pipeline_executor.cpp
@@ -242,7 +242,8 @@ auto pipeline_executor_state::pause() -> caf::result<void> {
         rp.deliver();
       },
       [rp](const caf::error& err) mutable {
-        rp.deliver(add_context(err, "failed to pause exec-node"));
+        rp.deliver(
+          diagnostic::error(err).note("failed to pause exec-node").to_error());
       });
   return rp;
 }
@@ -258,7 +259,8 @@ auto pipeline_executor_state::resume() -> caf::result<void> {
         rp.deliver();
       },
       [rp](const caf::error& err) mutable {
-        rp.deliver(add_context(err, "failed to resume exec-node"));
+        rp.deliver(
+          diagnostic::error(err).note("failed to resume exec-node").to_error());
       });
   return rp;
 }

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "b27447a7829f76f0f8c7bf41b14a1ab5469ccbdd",
+  "rev": "561d5efe67455baa577d4acf3beb18a8b0bc69d1",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "561d5efe67455baa577d4acf3beb18a8b0bc69d1",
+  "rev": "65d38b4612b9d266a9421e84c4f1ada19715e812",
   "submodules": true,
   "shallow": true,
   "allRefs": true


### PR DESCRIPTION
Our old CAF fork carries a patch to make `add_context` possible. We can now achieve the same result by using the diagnostics API, so we don't have to maintain a fork any more.
