### PR TITLE
 Improve `to_splunk` TLS functionality

### DIFF
--- a/changelog/next/bug-fixes/4825--fix-misnamed-option.md
+++ b/changelog/next/bug-fixes/4825--fix-misnamed-option.md
@@ -1,0 +1,2 @@
+The `max_content_length` option for the `to_splunk` operator was named incorrectly in
+an earlier version to `send_timeout`. This has now been fixed.

--- a/changelog/next/changes/4825--splunk-tls.md
+++ b/changelog/next/changes/4825--splunk-tls.md
@@ -1,0 +1,2 @@
+The `tls_no_verify` option of the `to_splunk` operator is now called
+`skip_peer_verification`.

--- a/changelog/next/features/4825--splunk-tls.md
+++ b/changelog/next/features/4825--splunk-tls.md
@@ -1,0 +1,2 @@
+The `to_splunk` operator now supports the `cacert`, `certfile`, and `keyfile`
+options to provide certificates for the TLS connection.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "d03819c4f591ea45ffad730d91f52114341a375f",
+  "rev": "9c0405afc5b0426df179bd49ecacfe14c01843e2",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/web/docs/tql2/operators/to_splunk.md
+++ b/web/docs/tql2/operators/to_splunk.md
@@ -5,11 +5,11 @@ Sends events to a Splunk [HTTP Event Collector (HEC)][hec].
 [hec]: https://docs.splunk.com/Documentation/Splunk/9.3.1/Data/UsetheHTTPEventCollector
 
 ```tql
-to_splunk
- url:string, hec_token=string,
-      [host=string, source=string, sourcetype=expr, index=expr,
-       tls_no_verify=bool, print_nulls=bool,
-       max_content_length=int, send_timeout=duration, compress=bool]
+to_splunk url:string, hec_token=string,
+          [host=string, source=string, sourcetype=expr, index=expr,
+          cacert=string, certfile=string, keyfile=string,
+          skip_peer_verification=bool, print_nulls=bool,
+          max_content_length=int, buffer_timeout=duration, compress=bool]
 ```
 
 ## Description
@@ -64,7 +64,19 @@ If you do not provide this option, Splunk will use the default index.
 
 **NB**: HEC silently drops events with an invalid `index`.
 
-### `tls_no_verify = bool (optional)`
+### `cacert = string (optional)`
+
+Path to the CA certificate used to verify the server's certificate.
+
+### `certfile = string (optional)`
+
+Path to the client certificate.
+
+### `keyfile = string (optional)`
+
+Path to the key for the client certificate.
+
+### `skip_peer_verification = bool (optional)`
 
 Toggles TLS certificate verification.
 


### PR DESCRIPTION
Adds options for `to_splunk` to specify CA Certificates, Client Certificate and Keyfile for the certificate.
Additionally tries to default to `https` in some cases where the URL doesn't have a scheme.
Unfortunately, this doesn't work for common cases such as `localhost:8088` or `127.0.0.1:8088`.

- Closes https://github.com/tenzir/issues/issues/2372