### PR TITLE
Fix crash in `context::enrich` for heterogeneous enrichments

### DIFF
--- a/changelog/next/features/4828--subnet-network.md
+++ b/changelog/next/features/4828--subnet-network.md
@@ -1,0 +1,2 @@
+The `network` function returns the network address of a CIDR subnet. For
+example, `192.168.0.0/16.network()` returns `192.168.0.0`.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "a0ad6eb698e15e3053f25a8759923c4f7a5bd969",
+  "rev": "5d741c5627eca027656c81dea1c359d80a0db75c",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/web/docs/tql2/functions.md
+++ b/web/docs/tql2/functions.md
@@ -200,6 +200,7 @@ Function | Description | Example
 [`type_id`](functions/type_id.md) | Retrieves the type of an expression | `type_id(1 + 3.2)`
 [`has`](functions/has.md) | Checks whether a record has a field | `record.has("field")`
 [`length`](functions/length.md) | Retrieves the length of a list | `[1,2,3].length()`
+[`network`](functions/network.md) | Retrieves the network address of a subnet | `10.0.0.0/8.network()`
 
 ### Conversion
 

--- a/web/docs/tql2/functions/network.md
+++ b/web/docs/tql2/functions/network.md
@@ -1,0 +1,24 @@
+# network
+
+Retrieves the network address of a subnet.
+
+```tql
+network(x:subnet) -> ip
+```
+
+## Description
+
+The `network` function returns the network address of a subnet.
+
+## Examples
+
+### Get the network address of a subnet
+
+```tql
+from {subnet: 192.168.0.0/16}
+select ip = subnet.network()
+```
+
+```tql
+{ip: 192.168.0.0}
+```


### PR DESCRIPTION
This fixes a crash for enrichments of mixed types.