### PR TITLE
Add timeout to multiline syslog

### DIFF
--- a/changelog/next/bug-fixes/4829--multiline-syslog.md
+++ b/changelog/next/bug-fixes/4829--multiline-syslog.md
@@ -1,0 +1,2 @@
+We fixed an oversight in the syslog parsers, which caused it to not yield an
+event until the next line came in.

--- a/libtenzir/builtins/connectors/udp.cpp
+++ b/libtenzir/builtins/connectors/udp.cpp
@@ -306,9 +306,9 @@ class load_plugin final
     -> failure_or<operator_ptr> override {
     auto args = loader_args{};
     auto parser = argument_parser2::operator_(name());
-    parser.named("endpoint", args.url);
-    parser.positional("connect", args.connect);
-    parser.positional("insert_newlines", args.insert_newlines);
+    parser.positional("endpoint", args.url);
+    parser.named("connect", args.connect);
+    parser.named("insert_newlines", args.insert_newlines);
     TRY(parser.parse(inv, ctx));
     if (not args.url.starts_with("udp://")) {
       args.url.insert(0, "udp://");

--- a/libtenzir/builtins/formats/syslog.cpp
+++ b/libtenzir/builtins/formats/syslog.cpp
@@ -635,13 +635,17 @@ auto parse_loop(generator<std::optional<std::string_view>> lines,
     auto now = time::clock::now();
     if (now - last_line_received > opts.settings.timeout) {
       finish_all();
-      // We call finalize here because we do the timeout handling ourselves.
+      // We call finalize here because we did the timeout handling ourselves.
       // Otherwise we would double the timeout.
       for (auto&& slice : msb.finalize_as_table_slice()) {
         co_yield std::move(slice);
       }
     } else {
       finish_all_but_last();
+      // In here we rely on the timeout handling by the MSB.
+      for (auto&& slice : msb.yield_ready_as_table_slice()) {
+        co_yield std::move(slice);
+      }
     }
     if (not line) {
       co_yield {};


### PR DESCRIPTION
This adds a timeout to the multiline syslog in order to not hold back the last event until the next one shows up.

There also is a fix to `load_udp` , that wasnt live yet.

- Fixes https://github.com/tenzir/issues/issues/2379