### PR TITLE
Prepare small fixes for release

### DIFF
--- a/changelog/next/changes/4834--kafka-topic.md
+++ b/changelog/next/changes/4834--kafka-topic.md
@@ -1,0 +1,3 @@
+The `topic` argument for the `load_kafka` and `save_kafka` operators is now a
+positional, required argument. Additionally, the `topic` no longer defaults
+to `"tenzir"`.

--- a/changelog/next/changes/4834--str-string.md
+++ b/changelog/next/changes/4834--str-string.md
@@ -1,0 +1,3 @@
+The new `string` function now replaces the `str` function. The older `str`
+name will be available as an alias for some time for compatibility but will
+be removed in a future release.

--- a/plugins/kafka/include/kafka/operator.hpp
+++ b/plugins/kafka/include/kafka/operator.hpp
@@ -36,9 +36,6 @@ namespace tenzir::plugins::kafka {
 
 namespace {
 
-// Default topic if the user doesn't provide one.
-inline constexpr auto default_topic = "tenzir";
-
 // Valid values:
 // - beginning | end | stored
 // - <value>  (absolute offset)
@@ -68,7 +65,7 @@ inline auto offset_parser() {
 }
 
 struct loader_args {
-  std::optional<located<std::string>> topic;
+  std::string topic;
   std::optional<located<uint64_t>> count;
   std::optional<location> exit;
   std::optional<located<std::string>> offset;
@@ -151,9 +148,8 @@ public:
           .done());
       return {};
     };
-    auto topic = args_.topic ? args_.topic->inner : default_topic;
-    TENZIR_INFO("kafka subscribes to topic {}", topic);
-    if (auto err = client->subscribe({topic})) {
+    TENZIR_INFO("kafka subscribes to topic {}", args_.topic);
+    if (auto err = client->subscribe({args_.topic})) {
       ctrl.diagnostics().emit(
         diagnostic::error("failed to subscribe to topic: {}", err).done());
       return {};
@@ -207,7 +203,7 @@ private:
 };
 
 struct saver_args {
-  std::optional<located<std::string>> topic;
+  std::string topic;
   std::optional<located<std::string>> key;
   std::optional<located<std::string>> timestamp;
   located<std::vector<std::pair<std::string, std::string>>> options;
@@ -266,8 +262,7 @@ public:
         TENZIR_ERROR("{} messages were not delivered", num_messages);
       }
     });
-    auto topic = args_.topic ? args_.topic->inner : default_topic;
-    auto topics = std::vector<std::string>{std::move(topic)};
+    auto topics = std::vector<std::string>{std::move(args_.topic)};
     std::string key;
     if (args_.key) {
       key = args_.key->inner;

--- a/plugins/kafka/src/plugin.cpp
+++ b/plugins/kafka/src/plugin.cpp
@@ -48,14 +48,16 @@ public:
     auto parser = argument_parser{
       name(), fmt::format("https://docs.tenzir.com/connectors/{}", name())};
     auto args = loader_args{};
+    auto topic = std::optional<std::string>{"tenzir"};
     auto options = std::optional<located<std::string>>{};
-    parser.add("-t,--topic", args.topic, "<topic>");
+    parser.add("-t,--topic", topic, "<topic>");
     parser.add("-c,--count", args.count, "<n>");
     parser.add("-e,--exit", args.exit);
     parser.add("-o,--offset", args.offset, "<offset>");
     // We use -X because that's standard in Kafka applications, cf. kcat.
     parser.add("-X,--set", options, "<key=value>,...");
     parser.parse(p);
+    args.topic = topic.value();
     if (args.offset) {
       if (!offset_parser()(args.offset->inner)) {
         diagnostic::error("invalid `--offset` value")
@@ -83,12 +85,14 @@ public:
       name(), fmt::format("https://docs.tenzir.com/connectors/{}", name())};
     auto args = saver_args{};
     auto options = std::optional<located<std::string>>{};
-    parser.add("-t,--topic", args.topic, "<topic>");
+    auto topic = std::optional<std::string>{"tenzir"};
+    parser.add("-t,--topic", topic, "<topic>");
     parser.add("-k,--key", args.key, "<key>");
     parser.add("-T,--timestamp", args.timestamp, "<time>");
     // We use -X because that's standard in Kafka applications, cf. kcat.
     parser.add("-X,--set", options, "<key=value>,...");
     parser.parse(p);
+    args.topic = topic.value();
     if (args.timestamp) {
       if (!parsers::time(args.timestamp->inner)) {
         diagnostic::error("could not parse `--timestamp` as time")

--- a/tenzir/integration/data/reference/expression/test_universal_function_call_syntax/step_02.ref
+++ b/tenzir/integration/data/reference/expression/test_universal_function_call_syntax/step_02.ref
@@ -5,4 +5,4 @@ error: expected additional positional argument `prefix`
   |                 ^^^^^^^^^^^ 
   |
   = usage: starts_with(x:string, prefix:string)
-  = docs: https://docs.tenzir.com/functions/starts_with
+  = docs: https://docs.tenzir.com/tql2/functions/starts_with

--- a/tenzir/integration/data/reference/expression/test_universal_function_call_syntax/step_03.ref
+++ b/tenzir/integration/data/reference/expression/test_universal_function_call_syntax/step_03.ref
@@ -5,4 +5,4 @@ error: expected additional positional argument `prefix`
   |           ^^^^^^^^^^^ 
   |
   = usage: starts_with(x:string, prefix:string)
-  = docs: https://docs.tenzir.com/functions/starts_with
+  = docs: https://docs.tenzir.com/tql2/functions/starts_with

--- a/tenzir/integration/data/reference/functions/test_community-2d5fid/step_01.ref
+++ b/tenzir/integration/data/reference/functions/test_community-2d5fid/step_01.ref
@@ -5,4 +5,4 @@ error: required argument `proto` was not provided
   |                ^^^^^^^^^^^^ 
   |
   = usage: community_id(src_ip=ip, dst_ip=ip, proto=string, [src_port=int, dst_port=int, seed=int])
-  = docs: https://docs.tenzir.com/functions/community_id
+  = docs: https://docs.tenzir.com/tql2/functions/community_id

--- a/tenzir/integration/data/reference/functions/test_community-2d5fid/step_02.ref
+++ b/tenzir/integration/data/reference/functions/test_community-2d5fid/step_02.ref
@@ -5,4 +5,4 @@ error: required argument `dst_ip` was not provided
   |                ^^^^^^^^^^^^ 
   |
   = usage: community_id(src_ip=ip, dst_ip=ip, proto=string, [src_port=int, dst_port=int, seed=int])
-  = docs: https://docs.tenzir.com/functions/community_id
+  = docs: https://docs.tenzir.com/tql2/functions/community_id

--- a/tenzir/integration/data/reference/functions/test_community-2d5fid/step_03.ref
+++ b/tenzir/integration/data/reference/functions/test_community-2d5fid/step_03.ref
@@ -5,4 +5,4 @@ error: required argument `src_ip` was not provided
   |                ^^^^^^^^^^^^ 
   |
   = usage: community_id(src_ip=ip, dst_ip=ip, proto=string, [src_port=int, dst_port=int, seed=int])
-  = docs: https://docs.tenzir.com/functions/community_id
+  = docs: https://docs.tenzir.com/tql2/functions/community_id

--- a/web/docs/tql2/functions.md
+++ b/web/docs/tql2/functions.md
@@ -212,7 +212,7 @@ Function | Description | Example
 [`uint`](functions/uint.md) | Casts an expression to an unsigned integer | `uint(4.2)`
 [`float`](functions/float.md) | Casts an expression to a float | `float(42)`
 [`time`](functions/time.md) | Casts an expression to a time value | `time("2020-03-15")`
-[`str`](functions/str.md) | Casts an expression to string | `str(1.2.3.4)`
+[`string`](functions/string.md) | Casts an expression to string | `string(1.2.3.4)`
 [`ip`](functions/ip.md) | Casts an expression to an IP | `ip("1.2.3.4")`
 
 ### Transposition

--- a/web/docs/tql2/functions.md
+++ b/web/docs/tql2/functions.md
@@ -75,7 +75,7 @@ Function | Description | Example
 [`prepend`](functions/prepend.md) | Inserts an element at the front of a list | `xs.prepend(y)`
 [`concatenate`](functions/concatenate.md) | Merges two lists | `concatenate(xs, ys)`
 [`map`](functions/map.md) | Maps each list element to an expression | `xs.map(x, x + 3)`
-[`where`](functions/where.md) | Removes list elements based on a predicate | `xs.where(x, x > 5)`
+[`where`](functions/where.md) | Filters list elements based on a predicate | `xs.where(x, x > 5)`
 
 ## String
 
@@ -184,12 +184,14 @@ Function | Description | Example
 function | description | example
 :--------|:-------------|:-------
 [`encode_base64`](functions/encode_base64.md) | Encodes bytes as Base64 | `encode_base64("Tenzir")`
+[`encode_hex`](functions/encode_hex.md) | Encodes bytes as their hexadecimal representation | `encode_hex("Tenzir")`
 
 ## Decoding
 
 function | description | example
 :--------|:-------------|:-------
 [`decode_base64`](functions/decode_base64.md) | Decodes bytes as Base64 | `decode_base64("VGVuemly")`
+[`decode_hex`](functions/decode_hex.md) | Decodes bytes from their hexadecimal representation | `decode_hex("4e6f6E6365")`
 
 ## Type System
 

--- a/web/docs/tql2/functions/float.md
+++ b/web/docs/tql2/functions/float.md
@@ -34,4 +34,4 @@ from {x: float("4.2")}
 
 ## See Also
 
-[int](int.md), [uint](uint.md), [time](time.md), [str](str.md), [ip](ip.md)
+[int](int.md), [uint](uint.md), [time](time.md), [string](string.md), [ip](ip.md)

--- a/web/docs/tql2/functions/int.md
+++ b/web/docs/tql2/functions/int.md
@@ -35,4 +35,4 @@ from {x: int("42")}
 
 ## See Also
 
-[uint](uint.md), [float](float.md), [time](time.md), [str](str.md), [ip](ip.md)
+[uint](uint.md), [float](float.md), [time](time.md), [string](string.md), [ip](ip.md)

--- a/web/docs/tql2/functions/ip.md
+++ b/web/docs/tql2/functions/ip.md
@@ -24,4 +24,4 @@ from {x: ip("1.2.3.4")}
 
 ## See Also
 
-[int](int.md), [uint](uint.md), [float](float.md), [time](time.md), [str](str.md)
+[int](int.md), [uint](uint.md), [float](float.md), [time](time.md), [string](string.md)

--- a/web/docs/tql2/functions/string.md
+++ b/web/docs/tql2/functions/string.md
@@ -1,21 +1,21 @@
-# str
+# string
 
 Casts an expression to a string.
 
 ```tql
-str(x:any) -> string
+string(x:any) -> string
 ```
 
 ## Description
 
-The `str` function casts the given value `x` to a string.
+The `string` function casts the given value `x` to a string.
 
 ## Examples
 
 ### Cast an IP address to a string
 
 ```tql
-from {x: str(1.2.3.4)}
+from {x: string(1.2.3.4)}
 ```
 
 ```tql

--- a/web/docs/tql2/functions/time.md
+++ b/web/docs/tql2/functions/time.md
@@ -24,4 +24,4 @@ from {x: time("2020-03-15")}
 
 ## See Also
 
-[int](int.md), [uint](uint.md), [float](float.md), [str](str.md), [ip](ip.md)
+[int](int.md), [uint](uint.md), [float](float.md), [string](string.md), [ip](ip.md)

--- a/web/docs/tql2/functions/uint.md
+++ b/web/docs/tql2/functions/uint.md
@@ -25,4 +25,4 @@ from {x: uint(4.2)}
 
 ## See Also
 
-[int](int.md), [float](float.md), [time](time.md), [str](str.md), [ip](ip.md)
+[int](int.md), [float](float.md), [time](time.md), [string](string.md), [ip](ip.md)

--- a/web/docs/tql2/functions/where.md
+++ b/web/docs/tql2/functions/where.md
@@ -1,6 +1,6 @@
 # where
 
-Removes list elements based on a predicate.
+Filters list elements based on a predicate.
 
 ```tql
 where(xs:list, capture:field, predicate:bool) -> list
@@ -8,8 +8,8 @@ where(xs:list, capture:field, predicate:bool) -> list
 
 ## Description
 
-The `where` function removes all elements of a list for which a predicate
-evaluates to `false`.
+The `where` function keeps only elements of a list for which a predicate
+evaluates to `true`.
 
 ### `xs: list`
 
@@ -25,17 +25,17 @@ The predicate evaluated for each list element.
 
 ## Examples
 
-### Remove all list elements smaller than 3
+### Keep only elements greater than 3
 
 ```tql
 from {
   xs: [1, 2, 3, 4, 5]
 }
-xs = xs.where(x, x >= 3)
+xs = xs.where(x, x > 3)
 ```
 
 ```tql
-{xs: [3, 4, 5]}
+{xs: [4, 5]}
 ```
 
 ## See Also

--- a/web/docs/tql2/operators/load_kafka.md
+++ b/web/docs/tql2/operators/load_kafka.md
@@ -3,7 +3,7 @@
 Loads a byte stream from a Apache Kafka topic.
 
 ```tql
-load_kafka [topic=str, count=int, exit=bool, offset=int|str, options=record]
+load_kafka topic:string, [count=int, exit=bool, offset=int|string, options=record]
 ```
 
 ## Description
@@ -30,11 +30,9 @@ include them:
 - `client.id`: `tenzir`
 - `group.id`: `tenzir`
 
-### `topic = str (optional)`
+### `topic: string`
 
 The Kafka topic to use.
-
-Defaults to `"tenzir"`.
 
 ### `count = int (optional)`
 
@@ -47,7 +45,7 @@ Exit successfully after having received the last message.
 Without this option, the operator waits for new messages after having consumed the
 last one.
 
-### `offset = int|str (optional)`
+### `offset = int|string (optional)`
 
 The offset to start consuming from. Possible values are:
 
@@ -80,13 +78,13 @@ that they are indpendent of the `load_kafka` arguments.
 ### Read 100 JSON messages from the topic `tenzir`
 
 ```tql
-load_kafka count=100
+load_kafka "tenzir", count=100
 read_json
 ```
 
 ### Read Zeek Streaming JSON logs starting at the beginning
 
 ```tql
-load_kafka topic="zeek", offset="beginning"
+load_kafka "zeek", offset="beginning"
 read_zeek_json
 ```

--- a/web/docs/tql2/operators/save_kafka.md
+++ b/web/docs/tql2/operators/save_kafka.md
@@ -3,7 +3,7 @@
 Saves a byte stream to a Apache Kafka topic.
 
 ```tql
-save_kafka [topic=str, key=str, timestamp=time, options=record]
+save_kafka topic:string, [key=string, timestamp=time, options=record]
 ```
 
 ## Description
@@ -30,13 +30,11 @@ include them:
 - `client.id`: `tenzir`
 - `group.id`: `tenzir`
 
-### `topic = str (optional)`
+### `topic: string`
 
 The Kafka topic to use.
 
-Defaults to `"tenzir"`.
-
-### `key = str (optional)`
+### `key = string (optional)`
 
 Sets a fixed key for all messages.
 
@@ -64,7 +62,7 @@ that they are indpendent of the `save_kafka` arguments.
 ```tql
 version
 write_json
-save_kafka timestamp=1984-01-01
+save_kafka "tenzir", timestamp=1984-01-01
 ```
 
 ### Follow a CSV file and publish it to topic `data`
@@ -73,5 +71,5 @@ save_kafka timestamp=1984-01-01
 load_file "/tmp/data.csv"
 read_csv
 write_json
-save_kafka topic="data"
+save_kafka "data"
 ```


### PR DESCRIPTION
- Rename `str` to `string` and provide `str` as a deprecated fallback
- Improvements for where function docs: Use "keep" instead of remove, rename example to not use negation
- Missing `encode_hex` and `decode_hex` in function overview
- Change `{load,save}_kafka` topic argument to be positional and required
- Remove default of topic `tenzir` from TQL2 kafka operators
- Fix argument parser docs links for functions and things in packages
