### PR TITLE
Fix a rare crash in the index actor on startup

### DIFF
--- a/changelog/next/bug-fixes/4846--startup-index-crash.md
+++ b/changelog/next/bug-fixes/4846--startup-index-crash.md
@@ -1,0 +1,3 @@
+We fixed a rare crash on startup that would occur when starting the
+`tenzir-node` process was so slow that it would try to emit metrics before the
+component handling metrics was ready.

--- a/libtenzir/src/index.cpp
+++ b/libtenzir/src/index.cpp
@@ -1139,6 +1139,15 @@ index(index_actor::stateful_pointer<index_state> self,
            = detail::make_actor_metrics_builder()]() mutable {
       const auto importer
         = self->system().registry().get<importer_actor>("tenzir.importer");
+      // There exists a very unlikely scenario where the importer was not
+      // spawned within the metrics interval after the index was spawned. The
+      // importer requires a handle to the index on startup, and the index
+      // needs a handle to the index for forwarding metrics, so we cannot just
+      // reverse the startup order here. Instead, we just delay the first
+      // metrics until the importer is ready.
+      if (not importer) [[unlikely]] {
+        return;
+      }
       self->send(importer,
                  detail::generate_actor_metrics(actor_metrics_builder, self));
     });


### PR DESCRIPTION
On startup, the node actor starts its core components in order of how they depend on another. However, with the addition of the `tenzir.ingest` metrics, which are measured in the index component, we introduced a circular dependency between the importer and index components.

This change fixes a rare crash when the importer was started after the index tried emitting its first metrics. We observed this a few times in CI, and I have never heard of this happening in production.

Previously discussed here:
- https://github.com/tenzir/tenzir/pull/4845#issuecomment-2525575046