### PR TITLE
Check mmapped chunks for required minimum size

### DIFF
--- a/changelog/next/4856--flatbuffer-file-size.md
+++ b/changelog/next/4856--flatbuffer-file-size.md
@@ -1,0 +1,2 @@
+Fixed many issues with malformed or empty flatbuffer files in the
+state directory that could lead to crashes.

--- a/changelog/next/4856--flatbuffer-file-size.md
+++ b/changelog/next/4856--flatbuffer-file-size.md
@@ -1,2 +1,0 @@
-Fixed many issues with malformed or empty flatbuffer files in the
-state directory that could lead to crashes.

--- a/changelog/next/bug-fixes/4856--flatbuffer-file-size.md
+++ b/changelog/next/bug-fixes/4856--flatbuffer-file-size.md
@@ -1,0 +1,2 @@
+We fixed a bug introduced with v4.24.0 causing crashes on startup when some
+of the files in the node's state directory were smaller than 12 bytes.

--- a/libtenzir/builtins/contexts/geoip.cpp
+++ b/libtenzir/builtins/contexts/geoip.cpp
@@ -597,13 +597,8 @@ struct v1_loader : public context_loader {
 
   auto load(chunk_ptr serialized) const
     -> caf::expected<std::unique_ptr<context>> {
-    const auto* serialized_data
-      = fbs::context::geoip::GetGeoIPData(serialized->data());
-    if (not serialized_data) {
-      return caf::make_error(ec::serialization_error,
-                             fmt::format("failed to deserialize geoip "
-                                         "context: invalid file content"));
-    }
+    TRY(auto serialized_data, flatbuffer<fbs::context::geoip::GeoIPData>::make(
+                                std::move(serialized)));
     const auto* serialized_string = serialized_data->url();
     if (not serialized_string) {
       return caf::make_error(ec::serialization_error,

--- a/libtenzir/src/fbs/flatbuffer_container.cpp
+++ b/libtenzir/src/fbs/flatbuffer_container.cpp
@@ -6,8 +6,11 @@
 namespace tenzir::fbs {
 
 flatbuffer_container::flatbuffer_container(tenzir::chunk_ptr chunk) {
-  if (!chunk || chunk->size() < 4)
+  using flatbuffers::soffset_t;
+  using flatbuffers::uoffset_t;
+  if (!chunk || chunk->size() < FLATBUFFERS_MIN_BUFFER_SIZE) {
     return;
+  }
   auto const* header = tenzir::fbs::GetSegmentedFileHeader(chunk->data());
   if (header->header_type()
       != tenzir::fbs::segmented_file::SegmentedFileHeader::v0)

--- a/libtenzir/src/index.cpp
+++ b/libtenzir/src/index.cpp
@@ -530,16 +530,15 @@ caf::error index_state::load_from_disk() {
         if (auto error = extract_partition_synopsis(part_path, synopsis_path))
           return error;
       }
-      auto chunk = chunk::mmap(synopsis_path);
-      if (!chunk)
-        return chunk.error();
-      const auto* ps_flatbuffer
-        = fbs::GetPartitionSynopsis(chunk->get()->data());
+      TRY(auto chunk, chunk::mmap(synopsis_path));
+      TRY(const auto ps_flatbuffer,
+          flatbuffer<fbs::PartitionSynopsis>::make(std::move(chunk)));
       partition_synopsis_ptr ps = caf::make_copy_on_write<partition_synopsis>();
       if (ps_flatbuffer->partition_synopsis_type()
           != fbs::partition_synopsis::PartitionSynopsis::legacy)
         return caf::make_error(ec::format_error, "invalid partition synopsis "
                                                  "version");
+      TENZIR_ASSERT(ps_flatbuffer->partition_synopsis_as_legacy());
       const auto& synopsis_legacy
         = *ps_flatbuffer->partition_synopsis_as_legacy();
       if (auto error = unpack(synopsis_legacy, ps.unshared()))
@@ -564,7 +563,7 @@ caf::error index_state::load_from_disk() {
             not err) {
           ps.unshared().sketches_file = {
             .url = fmt::format("file://{}", canonical_synopsis_path),
-            .size = chunk->get()->size(),
+            .size = ps_flatbuffer.chunk()->size(),
           };
         }
         auto f = store_map.find(partition_uuid);
@@ -1409,7 +1408,9 @@ index(index_actor::stateful_pointer<index_state> self,
                   TENZIR_DEBUG("{} mmapped partition {} to extract store path "
                                "for erasure",
                                *self, partition_id);
-                  if (!chunk) {
+                  using flatbuffers::uoffset_t;
+                  using flatbuffers::soffset_t;
+                  if (!chunk || chunk->size() < FLATBUFFERS_MIN_BUFFER_SIZE) {
                     erase_dense_index_file();
                     rp.deliver(caf::make_error( //
                       ec::filesystem_error,

--- a/libtenzir/src/posix_filesystem.cpp
+++ b/libtenzir/src/posix_filesystem.cpp
@@ -160,11 +160,7 @@ posix_filesystem(filesystem_actor::stateful_pointer<posix_filesystem_state> self
                                fmt::format("{} {}: {}", *self, path,
                                            err.message()));
       }
-      if (auto chk = chunk::mmap(path)) {
-        return chk;
-      } else {
-        return chk.error();
-      }
+      return chunk::mmap(path);
     },
     [self](atom::erase,
            const std::filesystem::path& filename) -> caf::result<atom::done> {

--- a/libtenzir/src/sketch/bloom_filter.cpp
+++ b/libtenzir/src/sketch/bloom_filter.cpp
@@ -9,6 +9,7 @@
 #include "tenzir/sketch/bloom_filter.hpp"
 
 #include "tenzir/error.hpp"
+#include "tenzir/flatbuffer.hpp"
 
 #include <fmt/format.h>
 
@@ -18,7 +19,7 @@ frozen_bloom_filter::frozen_bloom_filter(chunk_ptr table) noexcept
   : table_{std::move(table)} {
   TENZIR_ASSERT(table_ != nullptr);
   TENZIR_ASSERT(table_->data() != nullptr);
-  auto root = fbs::GetBloomFilter(table_->data());
+  auto root = check(flatbuffer<fbs::BloomFilter>::make(chunk_ptr{table_}));
   auto err = unpack(*root, view_);
   TENZIR_ASSERT(!err);
 }

--- a/libtenzir/src/table_slice.cpp
+++ b/libtenzir/src/table_slice.cpp
@@ -75,7 +75,9 @@ auto visit(Visitor&& visitor, const fbs::TableSlice* x) noexcept(
 /// Get a pointer to the `tenzir.fbs.TableSlice` inside the chunk.
 /// @param chunk The chunk to look at.
 const fbs::TableSlice* as_flatbuffer(const chunk_ptr& chunk) noexcept {
-  if (!chunk) {
+  using flatbuffers::soffset_t;
+  using flatbuffers::uoffset_t;
+  if (!chunk || chunk->size() < FLATBUFFERS_MIN_BUFFER_SIZE) {
     return nullptr;
   }
   return fbs::GetTableSlice(chunk->data());

--- a/libtenzir/src/type.cpp
+++ b/libtenzir/src/type.cpp
@@ -365,8 +365,10 @@ type::~type() noexcept = default;
 
 type::type(chunk_ptr&& table) noexcept {
 #if TENZIR_ENABLE_ASSERTIONS
+  using flatbuffers::soffset_t;
+  using flatbuffers::uoffset_t;
   TENZIR_ASSERT(table);
-  TENZIR_ASSERT(table->size() > 0);
+  TENZIR_ASSERT(table->size() >= FLATBUFFERS_MIN_BUFFER_SIZE);
   const auto* const data = reinterpret_cast<const uint8_t*>(table->data());
   auto verifier = flatbuffers::Verifier{data, table->size()};
   TENZIR_ASSERT_EXPENSIVE(fbs::GetType(data)->Verify(verifier),

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "b3e3739c968b40590933b9c1970d188e53c69554",
+  "rev": "4707af27f2749280f6922910757a20c62801559e",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
In #4778 we changes the behavior of `chunk::map()` to return
a true-ish empty chunk instead of an error.
    
This revealed a lot of bugs in many call sites of `chunk::mmap()`,
where we didn't correctly check that the mapped file was bigger
than the minimum expected file size.


