### PR TITLE
Validate legacy expressions when splitting for predicate pushdown

### DIFF
--- a/changelog/next/bug-fixes/4861--fix-export-where.md
+++ b/changelog/next/bug-fixes/4861--fix-export-where.md
@@ -1,0 +1,3 @@
+Pipelines that begin with `export | where` followed by an expression that does
+not depend on the incoming events, such as `export | where 1 == 1`, no longer
+cause an internal error.

--- a/libtenzir/src/tql2/ast.cpp
+++ b/libtenzir/src/tql2/ast.cpp
@@ -311,9 +311,15 @@ auto split_legacy_expression(const ast::expression& x)
         if (not left || not right) {
           return std::pair{trivially_true_expression(), x};
         }
+        auto result
+          = expression{predicate{std::move(*left), *rel_op, std::move(*right)}};
+        if (not normalize_and_validate(result)) {
+          return std::pair{trivially_true_expression(), x};
+        }
         return std::pair{
-          expression{predicate{std::move(*left), *rel_op, std::move(*right)}},
-          ast::expression{ast::constant{true, location::unknown}}};
+          std::move(result),
+          ast::expression{ast::constant{true, location::unknown}},
+        };
       }
       if (y.op.inner == ast::binary_op::and_) {
         auto [lo, ln] = split_legacy_expression(y.left);


### PR DESCRIPTION
This fixes a panic when performing predicate pushdown for pipelines such as `export | where "foo" == "bar"`. The issue is that `"foo" == "bar"` is valid expression, but we perform a translation into a format that the catalog understands, which doesn't support expressions like that. Thus, this PR adds a check that validates the expression before returning it.