### PR TITLE
Split `compress`/`decompress` into separate operators

### DIFF
--- a/changelog/next/changes/4876--new-compression.md
+++ b/changelog/next/changes/4876--new-compression.md
@@ -1,0 +1,3 @@
+The `compress` and `decompress` operators have been deprecated in favor of
+separate operators for each compression. These new operators expose some
+additional options, such as `compress_gzip level=10, format="deflate"`.

--- a/changelog/next/changes/4876--new-compression.md
+++ b/changelog/next/changes/4876--new-compression.md
@@ -1,3 +1,3 @@
 The `compress` and `decompress` operators have been deprecated in favor of
-separate operators for each compression. These new operators expose some
+separate operators for each compression algorithm. These new operators expose
 additional options, such as `compress_gzip level=10, format="deflate"`.

--- a/libtenzir/builtins/operators/from_to_2.cpp
+++ b/libtenzir/builtins/operators/from_to_2.cpp
@@ -84,12 +84,17 @@ template <>
 struct from_to_trait<true> {
   constexpr static std::string_view operator_name = "from";
   constexpr static std::string_view default_io_operator = "tql2.load_file";
-  constexpr static std::string_view compression_operator_name = "decompress";
   using io_properties_t = operator_factory_plugin::load_properties_t;
   constexpr static auto io_properties_getter
     = &operator_factory_plugin::load_properties;
   constexpr static auto io_properties_range_member
     = &operator_factory_plugin::load_properties_t::schemes;
+  using compression_properties_t
+    = operator_factory_plugin::decompress_properties_t;
+  constexpr static auto compression_properties_getter
+    = &operator_factory_plugin::decompress_properties;
+  constexpr static auto compression_properties_range_member
+    = &operator_factory_plugin::decompress_properties_t::extensions;
   using rw_properties_t = operator_factory_plugin::read_properties_t;
   constexpr static auto rw_properties_getter
     = &operator_factory_plugin::read_properties;
@@ -100,12 +105,17 @@ template <>
 struct from_to_trait<false> {
   constexpr static std::string_view operator_name = "to";
   constexpr static std::string_view default_io_operator = "tql2.save_file";
-  constexpr static std::string_view compression_operator_name = "compress";
   using io_properties_t = operator_factory_plugin::save_properties_t;
   constexpr static auto io_properties_getter
     = &operator_factory_plugin::save_properties;
   constexpr static auto io_properties_range_member
     = &operator_factory_plugin::save_properties_t::schemes;
+  using compression_properties_t
+    = operator_factory_plugin::compress_properties_t;
+  constexpr static auto compression_properties_getter
+    = &operator_factory_plugin::compress_properties;
+  constexpr static auto compression_properties_range_member
+    = &operator_factory_plugin::compress_properties_t::extensions;
   using rw_properties_t = operator_factory_plugin::write_properties_t;
   constexpr static auto rw_properties_range_member
     = &operator_factory_plugin::write_properties_t::extensions;
@@ -155,60 +165,63 @@ auto find_connector_given(std::string_view what, std::string_view path,
   return {};
 }
 
-constexpr static auto extension_to_compression_map
-  = std::array<std::pair<std::string_view, std::string_view>, 8>{{
-    {".br", "brotli"},
-    {".brotli", "brotli"},
-    {".bz2", "bz2"},
-    {".gz", "gzip"},
-    {".gzip", "gzip"},
-    {".lz4", "lz4"},
-    {".zst", "zstd"},
-    {".zstd", "zstd"},
-  }};
+template <bool is_loading>
+auto find_compression_and_format(std::string_view extension,
+                                 std::string_view path, location loc,
+                                 const char* docs, bool emit, session ctx)
+  -> std::tuple<const operator_factory_plugin*, const operator_factory_plugin*> {
+  using traits = from_to_trait<is_loading>;
+  auto format_extensions = std::vector<std::string>{};
+  auto compression_extensions = std::vector<std::string>{};
 
-auto determine_compression(std::string_view& file_ending)
-  -> std::pair<std::string_view, std::string_view> {
-  for (const auto& kvp : extension_to_compression_map) {
-    const auto [extension, name] = kvp;
-    if (file_ending.ends_with(extension)) {
-      file_ending.remove_suffix(extension.size());
-      return kvp;
+  const operator_factory_plugin* found_compression_plugin = nullptr;
+  const operator_factory_plugin* found_rw_plugin = nullptr;
+  auto compression_extension = std::string{};
+  for (const auto& p : plugins::get<operator_factory_plugin>()) {
+    auto comp_properties = (p->*traits::compression_properties_getter)();
+    auto rw_properties = (p->*traits::rw_properties_getter)();
+    for (auto& possibility :
+         comp_properties.*traits::compression_properties_range_member) {
+      if (extension.ends_with(possibility)) {
+        found_rw_plugin = p;
+        break;
+      }
+      format_extensions.push_back(std::move(possibility));
+    }
+    if (found_rw_plugin) {
+      break;
+    }
+    for (auto& possibility :
+         rw_properties.*traits::rw_properties_range_member) {
+      if (extension.ends_with(possibility)) {
+        TENZIR_ASSERT(compression_extension.empty());
+        compression_extension = possibility;
+        extension.remove_suffix(possibility.size() + 1);
+        found_compression_plugin = p;
+      }
+      compression_extensions.push_back(std::move(possibility));
     }
   }
-  return {};
-}
-
-template <bool is_loading>
-auto find_formatter_given(std::string_view what, std::string_view path,
-                          std::string_view compression, location loc,
-                          const char* docs, bool emit, session ctx)
-  -> std::pair<const operator_factory_plugin*,
-               typename from_to_trait<is_loading>::rw_properties_t> {
-  using traits = from_to_trait<is_loading>;
-  auto possibilities = std::vector<std::string>{};
-  auto res = find_given(what, traits::rw_properties_getter,
-                        traits::rw_properties_range_member, possibilities);
-  if (res.first) {
-    return res;
+  if (found_rw_plugin) {
+    return {found_compression_plugin, found_rw_plugin};
   }
-  std::ranges::sort(possibilities);
+  std::ranges::sort(format_extensions);
   if (loc.end - loc.begin == path.size() + 2) {
-    auto file_start = path.find(what);
+    auto file_start = path.find(compression_extension);
     loc.begin += file_start + 1;
     loc.end -= 1;
-    loc.end -= compression.size();
+    loc.end -= compression_extension.size();
   }
   if (emit) {
-    auto diag = diagnostic::error("no known format for extension `{}`", what)
-                  .primary(loc)
-                  .note("supported extensions for format deduction: `{}`",
-                        fmt::join(possibilities, "`, `"));
-
-    if (compression.empty()) {
-      diag = std::move(diag).note(
-        "supported extensions for compression deduction: `{}`",
-        fmt::join(extension_to_compression_map | std::views::keys, "`, `"));
+    auto diag
+      = diagnostic::error("no known format for extension `{}`", extension)
+          .primary(loc)
+          .note("supported extensions for format deduction: `{}`",
+                fmt::join(format_extensions, "`, `"));
+    if (compression_extension.empty()) {
+      diag = std::move(diag).note("supported extensions for compression "
+                                  "deduction: `{}`",
+                                  fmt::join(compression_extensions, "`, `"));
     }
     diag = std::move(diag)
              .hint("you can pass a pipeline to handle compression and format")
@@ -373,19 +386,10 @@ auto create_pipeline_from_uri(std::string path,
       goto post_deduction_reporting;
     }
     auto file_ending = std::string_view{file}.substr(first_dot);
-    // determine compression based on ending
-    auto compression_extension = std::string_view{};
-    std::tie(compression_extension, compression_name)
-      = determine_compression(file_ending);
-    if (not compression_name.empty()) {
-      compression_plugin = plugins::find<operator_factory_plugin>(
-        traits::compression_operator_name);
-      TENZIR_ASSERT(compression_plugin);
-    }
-    // determine read operator based on file ending
-    std::tie(rw_plugin, rw_properties) = find_formatter_given<is_loading>(
-      file_ending, path, compression_extension, inv.args.front().get_location(),
-      docs, io_properties.default_format == nullptr, ctx);
+    std::tie(compression_plugin, rw_plugin)
+      = find_compression_and_format<is_loading>(
+        file_ending, path, inv.args.front().get_location(), docs,
+        io_properties.default_format == nullptr, ctx);
   }
 post_deduction_reporting:
   TENZIR_TRACE("{} operator: given pipeline size   : {}", traits::operator_name,

--- a/libtenzir/include/tenzir/tql2/plugin.hpp
+++ b/libtenzir/include/tenzir/tql2/plugin.hpp
@@ -78,6 +78,18 @@ public:
     return {};
   }
 
+  struct compression_properties_t {
+    std::vector<std::string> extensions = {};
+  };
+  using decompress_properties_t = compression_properties_t;
+  using compress_properties_t = compression_properties_t;
+  virtual auto decompress_properties() const -> decompress_properties_t {
+    return {};
+  }
+  virtual auto compress_properties() const -> decompress_properties_t {
+    return {};
+  }
+
   struct format_properties_t {
     std::vector<std::string> extensions = {};
   };

--- a/libtenzir/src/plugin.cpp
+++ b/libtenzir/src/plugin.cpp
@@ -394,6 +394,8 @@ caf::error initialize(caf::actor_system_config& cfg) {
   map_t save_schemes;
   map_t read_extensions;
   map_t write_extensions;
+  map_t compress_extensions;
+  map_t decompress_extensions;
   constexpr static auto check
     = [](std::string_view what, std::string_view name,
          std::span<const std::string> list, map_t& map) -> caf::error {
@@ -413,12 +415,22 @@ caf::error initialize(caf::actor_system_config& cfg) {
     const auto name = l->name();
     const auto load_prop = l->load_properties();
     const auto save_prop = l->save_properties();
+    const auto compress_prop = l->compress_properties();
+    const auto decompress_prop = l->decompress_properties();
     const auto read_prop = l->read_properties();
     const auto write_prop = l->write_properties();
     if (auto e = check("load scheme", name, load_prop.schemes, load_schemes)) {
       return e;
     }
     if (auto e = check("save scheme", name, save_prop.schemes, save_schemes)) {
+      return e;
+    }
+    if (auto e = check("compress extension", name, compress_prop.extensions,
+                       compress_extensions)) {
+      return e;
+    }
+    if (auto e = check("decompress extension", name, decompress_prop.extensions,
+                       decompress_extensions)) {
       return e;
     }
     if (auto e = check("read extension", name, read_prop.extensions,

--- a/tenzir/integration/data/reference/from_to/test_from_deduction/step_02.ref
+++ b/tenzir/integration/data/reference/from_to/test_from_deduction/step_02.ref
@@ -3,7 +3,8 @@
     path: "example.json.gz" @ 5..22
   },
   decompress {
-    type: "gzip" @ 0..0
+    type: "gzip" @ 0..0,
+    gzip_format: "gzip" @ 0..0
   },
   read_json {
     parser_name: "json",

--- a/tenzir/integration/data/reference/from_to/test_from_deduction/step_03.ref
+++ b/tenzir/integration/data/reference/from_to/test_from_deduction/step_03.ref
@@ -3,7 +3,8 @@
     path: "example.csv.gz" @ 5..21
   },
   decompress {
-    type: "gzip" @ 0..0
+    type: "gzip" @ 0..0,
+    gzip_format: "gzip" @ 0..0
   },
   read_xsv {
     name: "csv",

--- a/tenzir/integration/data/reference/from_to/test_from_deduction/step_04.ref
+++ b/tenzir/integration/data/reference/from_to/test_from_deduction/step_04.ref
@@ -3,7 +3,8 @@
     path: "example.yaml.bz2" @ 5..23
   },
   decompress {
-    type: "bz2" @ 0..0
+    type: "bz2" @ 0..0,
+    gzip_format: "gzip" @ 0..0
   },
   read_yaml {
     policy: policy_default {

--- a/tenzir/integration/data/reference/from_to/test_from_deduction/step_05.ref
+++ b/tenzir/integration/data/reference/from_to/test_from_deduction/step_05.ref
@@ -20,7 +20,8 @@
     }
   },
   decompress {
-    type: "bz2" @ 0..0
+    type: "bz2" @ 0..0,
+    gzip_format: "gzip" @ 0..0
   },
   read_yaml {
     policy: policy_default {

--- a/tenzir/integration/data/reference/from_to/test_from_failure/step_01.ref
+++ b/tenzir/integration/data/reference/from_to/test_from_failure/step_01.ref
@@ -5,6 +5,6 @@ error: no known format for extension `.extension`
   |              ^^^^^^^^^^ 
   |
   = note: supported extensions for format deduction: `arrow`, `csv`, `feather`, `json`, `jsonl`, `ndjson`, `pcap`, `ssv`, `tsv`, `yaml`
-  = note: supported extensions for compression deduction: `.br`, `.brotli`, `.bz2`, `.gz`, `.gzip`, `.lz4`, `.zst`, `.zstd`
+  = note: supported extensions for compression deduction: `br`, `brotli`, `bz2`, `gz`, `gzip`, `lz4`, `zst`, `zstd`
   = hint: you can pass a pipeline to handle compression and format
   = docs: https://docs.tenzir.com/tql2/operators/from

--- a/tenzir/integration/data/reference/from_to/test_to_deduction/step_02.ref
+++ b/tenzir/integration/data/reference/from_to/test_to_deduction/step_02.ref
@@ -3,7 +3,8 @@
     
   },
   compress {
-    type: "gzip" @ 0..0
+    type: "gzip" @ 0..0,
+    gzip_format: "gzip" @ 0..0
   },
   tql2.save_file {
     path: "example.json.gz" @ 3..20

--- a/tenzir/integration/data/reference/from_to/test_to_deduction/step_03.ref
+++ b/tenzir/integration/data/reference/from_to/test_to_deduction/step_03.ref
@@ -26,7 +26,8 @@
     }
   },
   compress {
-    type: "gzip" @ 0..0
+    type: "gzip" @ 0..0,
+    gzip_format: "gzip" @ 0..0
   },
   tql2.save_file {
     path: "example.csv.gz" @ 3..19

--- a/tenzir/integration/data/reference/from_to/test_to_deduction/step_04.ref
+++ b/tenzir/integration/data/reference/from_to/test_to_deduction/step_04.ref
@@ -3,7 +3,8 @@
     
   },
   compress {
-    type: "bz2" @ 0..0
+    type: "bz2" @ 0..0,
+    gzip_format: "gzip" @ 0..0
   },
   tql2.save_file {
     path: "example.yaml.bz2" @ 3..21

--- a/tenzir/integration/data/reference/from_to/test_to_deduction/step_05.ref
+++ b/tenzir/integration/data/reference/from_to/test_to_deduction/step_05.ref
@@ -3,7 +3,8 @@
     
   },
   compress {
-    type: "bz2" @ 0..0
+    type: "bz2" @ 0..0,
+    gzip_format: "gzip" @ 0..0
   },
   tql2.save_http {
     url: "https://example.org/example.yaml.bz2",

--- a/tenzir/integration/data/reference/from_to/test_to_failure/step_01.ref
+++ b/tenzir/integration/data/reference/from_to/test_to_failure/step_01.ref
@@ -5,6 +5,6 @@ error: no known format for extension `.extension`
   |            ^^^^^^^^^^ 
   |
   = note: supported extensions for format deduction: `arrow`, `csv`, `feather`, `json`, `jsonl`, `ndjson`, `pcap`, `ssv`, `tsv`, `yaml`
-  = note: supported extensions for compression deduction: `.br`, `.brotli`, `.bz2`, `.gz`, `.gzip`, `.lz4`, `.zst`, `.zstd`
+  = note: supported extensions for compression deduction: `br`, `brotli`, `bz2`, `gz`, `gzip`, `lz4`, `zst`, `zstd`
   = hint: you can pass a pipeline to handle compression and format
   = docs: https://docs.tenzir.com/tql2/operators/to

--- a/tenzir/integration/data/reference/pipelines_local/test_legacy_operator/step_02.ref
+++ b/tenzir/integration/data/reference/pipelines_local/test_legacy_operator/step_02.ref
@@ -3,7 +3,8 @@
     path: "example.json.gz" @ 0..0
   },
   decompress {
-    type: "gzip" @ 0..0
+    type: "gzip" @ 0..0,
+    gzip_format: "gzip" @ 0..0
   },
   read json {
     parser_name: "json",

--- a/web/docs/tql2/operators.md
+++ b/web/docs/tql2/operators.md
@@ -236,16 +236,16 @@ Operator | Description | Example
 
 Operator | Description | Example
 :--------|:------------|:-------
-[`compress_brotli`](./operators/compress_brotli.md) | Compresses a stream of bytes | `compress_zstd, level=18`
-[`compress_bz2`](./operators/compress_bz2.md) | Compresses a stream of bytes | `compress_bz2, level=18`
-[`compress_gzip`](./operators/compress_gzip.md) | Compresses a stream of bytes | `compress_gzip, level=18`
-[`compress_lz4`](./operators/compress_lz4.md) | Compresses a stream of bytes | `compress_lz4, level=18`
-[`compress_zstd`](./operators/compress_zstd.md) | Compresses a stream of bytes | `compress_zstd, level=18`
-[`decompress_brotli`](./operators/decompress_brotli.md) | Decompresses a stream of bytes | `decompress_zstd`
-[`decompress_bz2`](./operators/decompress_bz2.md) | Decompresses a stream of bytes | `decompress_bz2`
-[`decompress_gzip`](./operators/decompress_gzip.md) | Decompresses a stream of bytes | `decompress_gzip`
-[`decompress_lz4`](./operators/decompress_lz4.md) | Decompresses a stream of bytes | `decompress_lz4`
-[`decompress_zstd`](./operators/decompress_zstd.md) | Decompresses a stream of bytes | `decompress_zstd`
+[`compress_brotli`](./operators/compress_brotli.md) | Compresses bytes using Brotli compression | `compress_zstd, level=10`
+[`compress_bz2`](./operators/compress_bz2.md) | Compresses bytes using Bzip compression | `compress_bz2, level=9`
+[`compress_gzip`](./operators/compress_gzip.md) | Compresses bytes using Gzip compression | `compress_gzip, level=8`
+[`compress_lz4`](./operators/compress_lz4.md) | Compresses bytes using lz4 compression | `compress_lz4, level=7`
+[`compress_zstd`](./operators/compress_zstd.md) | Compresses bytes using Gzip compression | `compress_zstd, level=6`
+[`decompress_brotli`](./operators/decompress_brotli.md) | Decompresses Brotli compressed bytes | `decompress_zstd`
+[`decompress_bz2`](./operators/decompress_bz2.md) | Decompresses Bzip2 compressed bytes | `decompress_bz2`
+[`decompress_gzip`](./operators/decompress_gzip.md) | Decompresses Gzip compressed bytes | `decompress_gzip`
+[`decompress_lz4`](./operators/decompress_lz4.md) | Decompresses lz4 compressed bytes | `decompress_lz4`
+[`decompress_zstd`](./operators/decompress_zstd.md) | Decompresses Zstd compressed bytes | `decompress_zstd`
 
 ## Contexts
 

--- a/web/docs/tql2/operators.md
+++ b/web/docs/tql2/operators.md
@@ -236,8 +236,17 @@ Operator | Description | Example
 
 Operator | Description | Example
 :--------|:------------|:-------
-[`compress`](./operators/compress.md) | Compresses a stream of bytes | `compress "zstd", level=18`
-[`decompress`](./operators/decompress.md) | Decompresses a stream of bytes | `decompress "brotli"`
+[`compress_brotli`](./operators/compress_brotli.md) | Compresses a stream of bytes | `compress_zstd, level=18`
+[`compress_bz2`](./operators/compress_bz2.md) | Compresses a stream of bytes | `compress_bz2, level=18`
+[`compress_gzip`](./operators/compress_gzip.md) | Compresses a stream of bytes | `compress_gzip, level=18`
+[`compress_lz4`](./operators/compress_lz4.md) | Compresses a stream of bytes | `compress_lz4, level=18`
+[`compress_zstd`](./operators/compress_zstd.md) | Compresses a stream of bytes | `compress_zstd, level=18`
+[`decompress_brotli`](./operators/decompress_brotli.md) | Decompresses a stream of bytes | `decompress_zstd`
+[`decompress_bz2`](./operators/decompress_bz2.md) | Decompresses a stream of bytes | `decompress_bz2`
+[`decompress_gzip`](./operators/decompress_gzip.md) | Decompresses a stream of bytes | `decompress_gzip`
+[`decompress_lz4`](./operators/decompress_lz4.md) | Decompresses a stream of bytes | `decompress_lz4`
+[`decompress_zstd`](./operators/decompress_zstd.md) | Decompresses a stream of bytes | `decompress_zstd`
+
 
 ## Contexts
 

--- a/web/docs/tql2/operators.md
+++ b/web/docs/tql2/operators.md
@@ -247,7 +247,6 @@ Operator | Description | Example
 [`decompress_lz4`](./operators/decompress_lz4.md) | Decompresses a stream of bytes | `decompress_lz4`
 [`decompress_zstd`](./operators/decompress_zstd.md) | Decompresses a stream of bytes | `decompress_zstd`
 
-
 ## Contexts
 
 Function | Description | Example

--- a/web/docs/tql2/operators/compress.md
+++ b/web/docs/tql2/operators/compress.md
@@ -6,6 +6,12 @@ Compresses a stream of bytes.
 compress codec:string, [level=int]
 ```
 
+:::warning Deprecated
+The `compress` operator is deprecated. You should use the
+[bespoke operators](../operators.md#encode--decode) instead.
+These operators offer more options for some of the formats.
+:::
+
 ## Description
 
 The `compress` operator compresses bytes in a pipeline incrementally with a

--- a/web/docs/tql2/operators/compress_brotli.md
+++ b/web/docs/tql2/operators/compress_brotli.md
@@ -1,0 +1,48 @@
+# compress_brotli
+
+Compresses a stream of bytes using Brotli compression.
+
+```tql
+compress_brotli [level=int, window_bits=int]
+```
+
+## Description
+
+The `compress_brotli` operator compresses bytes in a pipeline incrementally.
+
+:::note Streaming Compression
+The operator uses [Apache Arrow's compression
+utilities][apache-arrow-compression] under the hood, and transparently supports
+all options that Apache Arrow supports for streaming compression.
+:::
+
+[apache-arrow-compression]: https://arrow.apache.org/docs/cpp/api/utilities.html#compression
+
+### `level = int (optional)`
+
+The compression level to use. The supported values depend on the codec used. If
+omitted, the default level for the codec is used.
+
+### `window_bits = int (optional)`
+
+A number representing the encoder window bits.
+
+## Examples
+
+### Export all events in a Brotli-compressed NDJSON file
+
+```tql
+export
+write_ndjson
+compress_brotli
+save_file "/tmp/backup.json.gz"
+```
+
+###  Recompress a Brotli-compressed file at a higher compression level
+
+```tql
+load_file "in.brotli"
+decompress_brotli
+compress_brotli level=18
+save_file "out.brotli"
+```

--- a/web/docs/tql2/operators/compress_brotli.md
+++ b/web/docs/tql2/operators/compress_brotli.md
@@ -10,14 +10,6 @@ compress_brotli [level=int, window_bits=int]
 
 The `compress_brotli` operator compresses bytes in a pipeline incrementally.
 
-:::note Streaming Compression
-The operator uses [Apache Arrow's compression
-utilities][apache-arrow-compression] under the hood, and transparently supports
-all options that Apache Arrow supports for streaming compression.
-:::
-
-[apache-arrow-compression]: https://arrow.apache.org/docs/cpp/api/utilities.html#compression
-
 ### `level = int (optional)`
 
 The compression level to use. The supported values depend on the codec used. If
@@ -35,10 +27,10 @@ A number representing the encoder window bits.
 export
 write_ndjson
 compress_brotli
-save_file "/tmp/backup.json.gz"
+save_file "/tmp/backup.json.bt"
 ```
 
-###  Recompress a Brotli-compressed file at a higher compression level
+### Recompress a Brotli-compressed file at a different compression level
 
 ```tql
 load_file "in.brotli"

--- a/web/docs/tql2/operators/compress_bz2.md
+++ b/web/docs/tql2/operators/compress_bz2.md
@@ -1,0 +1,44 @@
+# compress_bz2
+
+Compresses a stream of bytes using bz2 compression.
+
+```tql
+compress_bz2 [level=int]
+```
+
+## Description
+
+The `compress_bz2` operator compresses bytes in a pipeline incrementally.
+
+:::note Streaming Compression
+The operator uses [Apache Arrow's compression
+utilities][apache-arrow-compression] under the hood, and transparently supports
+all options that Apache Arrow supports for streaming compression.
+:::
+
+[apache-arrow-compression]: https://arrow.apache.org/docs/cpp/api/utilities.html#compression
+
+### `level = int (optional)`
+
+The compression level to use. The supported values depend on the codec used. If
+omitted, the default level for the codec is used.
+
+## Examples
+
+### Export all events in a Bzip2-compressed NDJSON file
+
+```tql
+export
+write_ndjson
+compress_bz2
+save_file "/tmp/backup.json.gz"
+```
+
+###  Recompress a Bzip2-compressed file at a higher compression level
+
+```tql
+load_file "in.bz2"
+decompress_bz2
+compress_bz2 level=18
+save_file "out.bz2"
+```

--- a/web/docs/tql2/operators/compress_bz2.md
+++ b/web/docs/tql2/operators/compress_bz2.md
@@ -10,14 +10,6 @@ compress_bz2 [level=int]
 
 The `compress_bz2` operator compresses bytes in a pipeline incrementally.
 
-:::note Streaming Compression
-The operator uses [Apache Arrow's compression
-utilities][apache-arrow-compression] under the hood, and transparently supports
-all options that Apache Arrow supports for streaming compression.
-:::
-
-[apache-arrow-compression]: https://arrow.apache.org/docs/cpp/api/utilities.html#compression
-
 ### `level = int (optional)`
 
 The compression level to use. The supported values depend on the codec used. If
@@ -31,10 +23,10 @@ omitted, the default level for the codec is used.
 export
 write_ndjson
 compress_bz2
-save_file "/tmp/backup.json.gz"
+save_file "/tmp/backup.json.bz2"
 ```
 
-###  Recompress a Bzip2-compressed file at a higher compression level
+### Recompress a Bzip2-compressed file at a different compression level
 
 ```tql
 load_file "in.bz2"

--- a/web/docs/tql2/operators/compress_gzip.md
+++ b/web/docs/tql2/operators/compress_gzip.md
@@ -10,14 +10,6 @@ compress_gzip [level=int, window_bits=int, format=string]
 
 The `compress_gzip` operator compresses bytes in a pipeline incrementally.
 
-:::note Streaming Compression
-The operator uses [Apache Arrow's compression
-utilities][apache-arrow-compression] under the hood, and transparently supports
-all options that Apache Arrow supports for streaming compression.
-:::
-
-[apache-arrow-compression]: https://arrow.apache.org/docs/cpp/api/utilities.html#compression
-
 ### `level = int (optional)`
 
 The compression level to use. The supported values depend on the codec used. If
@@ -45,7 +37,15 @@ compress_gzip
 save_file "/tmp/backup.json.gz"
 ```
 
-###  Recompress a Gzip-compressed file at a higher compression level
+### Compress using Gzip deflate
+
+```tql
+export
+write_ndjson
+compress_gzip format="deflate"
+```
+
+### Recompress a Gzip-compressed file at a different compression level
 
 ```tql
 load_file "in.gzip"

--- a/web/docs/tql2/operators/compress_gzip.md
+++ b/web/docs/tql2/operators/compress_gzip.md
@@ -1,0 +1,55 @@
+# compress_gzip
+
+Compresses a stream of bytes using gzip compression.
+
+```tql
+compress_gzip [level=int, window_bits=int, format=string]
+```
+
+## Description
+
+The `compress_gzip` operator compresses bytes in a pipeline incrementally.
+
+:::note Streaming Compression
+The operator uses [Apache Arrow's compression
+utilities][apache-arrow-compression] under the hood, and transparently supports
+all options that Apache Arrow supports for streaming compression.
+:::
+
+[apache-arrow-compression]: https://arrow.apache.org/docs/cpp/api/utilities.html#compression
+
+### `level = int (optional)`
+
+The compression level to use. The supported values depend on the codec used. If
+omitted, the default level for the codec is used.
+
+### `window_bits = int (optional)`
+
+A number representing the encoder window bits.
+
+### `format = string (optional)`
+
+A string representing the used format. Possible values are `zlib`, `deflate` and
+`gzip`.
+
+Defaults to `gzip`.
+
+## Examples
+
+### Export all events in a Gzip-compressed NDJSON file
+
+```tql
+export
+write_ndjson
+compress_gzip
+save_file "/tmp/backup.json.gz"
+```
+
+###  Recompress a Gzip-compressed file at a higher compression level
+
+```tql
+load_file "in.gzip"
+decompress_gzip
+compress_gzip level=18
+save_file "out.gzip"
+```

--- a/web/docs/tql2/operators/compress_lz4.md
+++ b/web/docs/tql2/operators/compress_lz4.md
@@ -1,0 +1,44 @@
+# compress_lz4
+
+Compresses a stream of bytes using lz4 compression.
+
+```tql
+compress_lz4 [level=int]
+```
+
+## Description
+
+The `compress_lz4` operator compresses bytes in a pipeline incrementally.
+
+:::note Streaming Compression
+The operator uses [Apache Arrow's compression
+utilities][apache-arrow-compression] under the hood, and transparently supports
+all options that Apache Arrow supports for streaming compression.
+:::
+
+[apache-arrow-compression]: https://arrow.apache.org/docs/cpp/api/utilities.html#compression
+
+### `level = int (optional)`
+
+The compression level to use. The supported values depend on the codec used. If
+omitted, the default level for the codec is used.
+
+## Examples
+
+### Export all events in a Lz4-compressed NDJSON file
+
+```tql
+export
+write_ndjson
+compress_lz4
+save_file "/tmp/backup.json.gz"
+```
+
+###  Recompress a Lz4-compressed file at a higher compression level
+
+```tql
+load_file "in.lz4"
+decompress_lz4
+compress_lz4 level=18
+save_file "out.lz4"
+```

--- a/web/docs/tql2/operators/compress_lz4.md
+++ b/web/docs/tql2/operators/compress_lz4.md
@@ -10,14 +10,6 @@ compress_lz4 [level=int]
 
 The `compress_lz4` operator compresses bytes in a pipeline incrementally.
 
-:::note Streaming Compression
-The operator uses [Apache Arrow's compression
-utilities][apache-arrow-compression] under the hood, and transparently supports
-all options that Apache Arrow supports for streaming compression.
-:::
-
-[apache-arrow-compression]: https://arrow.apache.org/docs/cpp/api/utilities.html#compression
-
 ### `level = int (optional)`
 
 The compression level to use. The supported values depend on the codec used. If
@@ -31,10 +23,10 @@ omitted, the default level for the codec is used.
 export
 write_ndjson
 compress_lz4
-save_file "/tmp/backup.json.gz"
+save_file "/tmp/backup.json.lz4"
 ```
 
-###  Recompress a Lz4-compressed file at a higher compression level
+### Recompress a Lz4-compressed file at a different compression level
 
 ```tql
 load_file "in.lz4"

--- a/web/docs/tql2/operators/compress_zstd.md
+++ b/web/docs/tql2/operators/compress_zstd.md
@@ -10,14 +10,6 @@ compress_zstd [level=int]
 
 The `compress_zstd` operator compresses bytes in a pipeline incrementally.
 
-:::note Streaming Compression
-The operator uses [Apache Arrow's compression
-utilities][apache-arrow-compression] under the hood, and transparently supports
-all options that Apache Arrow supports for streaming compression.
-:::
-
-[apache-arrow-compression]: https://arrow.apache.org/docs/cpp/api/utilities.html#compression
-
 ### `level = int (optional)`
 
 The compression level to use. The supported values depend on the codec used. If
@@ -31,10 +23,10 @@ omitted, the default level for the codec is used.
 export
 write_ndjson
 compress_zstd
-save_file "/tmp/backup.json.gz"
+save_file "/tmp/backup.json.zstd"
 ```
 
-###  Recompress a Zstd-compressed file at a higher compression level
+### Recompress a Zstd-compressed file at a different compression level
 
 ```tql
 load_file "in.zstd"

--- a/web/docs/tql2/operators/compress_zstd.md
+++ b/web/docs/tql2/operators/compress_zstd.md
@@ -1,0 +1,44 @@
+# compress_zstd
+
+Compresses a stream of bytes using zstd compression.
+
+```tql
+compress_zstd [level=int]
+```
+
+## Description
+
+The `compress_zstd` operator compresses bytes in a pipeline incrementally.
+
+:::note Streaming Compression
+The operator uses [Apache Arrow's compression
+utilities][apache-arrow-compression] under the hood, and transparently supports
+all options that Apache Arrow supports for streaming compression.
+:::
+
+[apache-arrow-compression]: https://arrow.apache.org/docs/cpp/api/utilities.html#compression
+
+### `level = int (optional)`
+
+The compression level to use. The supported values depend on the codec used. If
+omitted, the default level for the codec is used.
+
+## Examples
+
+### Export all events in a Zstd-compressed NDJSON file
+
+```tql
+export
+write_ndjson
+compress_zstd
+save_file "/tmp/backup.json.gz"
+```
+
+###  Recompress a Zstd-compressed file at a higher compression level
+
+```tql
+load_file "in.zstd"
+decompress_zstd
+compress_zstd level=18
+save_file "out.zstd"
+```

--- a/web/docs/tql2/operators/decompress.md
+++ b/web/docs/tql2/operators/decompress.md
@@ -6,6 +6,11 @@ Decompresses a stream of bytes.
 decompress codec:string
 ```
 
+:::warning Deprecated
+The `decompress` operator is deprecated. You should use the
+[bespoke operators](../operators.md#encode--decode) instead.
+:::
+
 ## Description
 
 The `decompress` operator decompresses bytes in a pipeline incrementally with a

--- a/web/docs/tql2/operators/decompress_brotli.md
+++ b/web/docs/tql2/operators/decompress_brotli.md
@@ -1,0 +1,32 @@
+# decompress_brotli
+
+Decompresses a stream of bytes in the Bzip2 format.
+
+```tql
+decompress_brotli
+```
+
+## Description
+
+The `decompress_brotli` operator decompresses bytes in a pipeline incrementally.
+The operator supports decompressing multiple concatenated streams
+of the same codec transparently.
+
+:::note Streaming Decompression
+The operator uses [Apache Arrow's compression
+utilities][apache-arrow-compression] under the hood, and transparently supports
+all options that Apache Arrow supports for streaming decompression.
+:::
+
+[apache-arrow-compression]: https://arrow.apache.org/docs/cpp/api/utilities.html#compression
+
+## Examples
+
+### Import Suricata events from a Brotli-compressed file
+
+```tql
+load_file "eve.json.brotli"
+decompress_brotli
+read_suricata
+import
+```

--- a/web/docs/tql2/operators/decompress_brotli.md
+++ b/web/docs/tql2/operators/decompress_brotli.md
@@ -1,6 +1,6 @@
 # decompress_brotli
 
-Decompresses a stream of bytes in the Bzip2 format.
+Decompresses a stream of bytes in the Brotli format.
 
 ```tql
 decompress_brotli
@@ -11,14 +11,6 @@ decompress_brotli
 The `decompress_brotli` operator decompresses bytes in a pipeline incrementally.
 The operator supports decompressing multiple concatenated streams
 of the same codec transparently.
-
-:::note Streaming Decompression
-The operator uses [Apache Arrow's compression
-utilities][apache-arrow-compression] under the hood, and transparently supports
-all options that Apache Arrow supports for streaming decompression.
-:::
-
-[apache-arrow-compression]: https://arrow.apache.org/docs/cpp/api/utilities.html#compression
 
 ## Examples
 

--- a/web/docs/tql2/operators/decompress_bz2.md
+++ b/web/docs/tql2/operators/decompress_bz2.md
@@ -12,14 +12,6 @@ The `decompress_bz2` operator decompresses bytes in a pipeline incrementally.
 The operator supports decompressing multiple concatenated streams
 of the same codec transparently.
 
-:::note Streaming Decompression
-The operator uses [Apache Arrow's compression
-utilities][apache-arrow-compression] under the hood, and transparently supports
-all options that Apache Arrow supports for streaming decompression.
-:::
-
-[apache-arrow-compression]: https://arrow.apache.org/docs/cpp/api/utilities.html#compression
-
 ## Examples
 
 ### Import Suricata events from a Bzip2-compressed file

--- a/web/docs/tql2/operators/decompress_bz2.md
+++ b/web/docs/tql2/operators/decompress_bz2.md
@@ -1,0 +1,32 @@
+# decompress_bz2
+
+Decompresses a stream of bytes in the Bzip2 format.
+
+```tql
+decompress_bz2
+```
+
+## Description
+
+The `decompress_bz2` operator decompresses bytes in a pipeline incrementally.
+The operator supports decompressing multiple concatenated streams
+of the same codec transparently.
+
+:::note Streaming Decompression
+The operator uses [Apache Arrow's compression
+utilities][apache-arrow-compression] under the hood, and transparently supports
+all options that Apache Arrow supports for streaming decompression.
+:::
+
+[apache-arrow-compression]: https://arrow.apache.org/docs/cpp/api/utilities.html#compression
+
+## Examples
+
+### Import Suricata events from a Bzip2-compressed file
+
+```tql
+load_file "eve.json.bz"
+decompress_bz2
+read_suricata
+import
+```

--- a/web/docs/tql2/operators/decompress_gzip.md
+++ b/web/docs/tql2/operators/decompress_gzip.md
@@ -1,0 +1,32 @@
+# decompress_gzip
+
+Decompresses a stream of bytes in the Brotli format.
+
+```tql
+decompress_gzip
+```
+
+## Description
+
+The `decompress_gzip` operator decompresses bytes in a pipeline incrementally.
+The operator supports decompressing multiple concatenated streams
+of the same codec transparently.
+
+:::note Streaming Decompression
+The operator uses [Apache Arrow's compression
+utilities][apache-arrow-compression] under the hood, and transparently supports
+all options that Apache Arrow supports for streaming decompression.
+:::
+
+[apache-arrow-compression]: https://arrow.apache.org/docs/cpp/api/utilities.html#compression
+
+## Examples
+
+### Import Suricata events from a Gzip-compressed file
+
+```tql
+load_file "eve.json.gz"
+decompress_brotli
+decompress_gzip
+import
+```

--- a/web/docs/tql2/operators/decompress_gzip.md
+++ b/web/docs/tql2/operators/decompress_gzip.md
@@ -1,6 +1,6 @@
 # decompress_gzip
 
-Decompresses a stream of bytes in the Brotli format.
+Decompresses a stream of bytes in the Gzip format.
 
 ```tql
 decompress_gzip
@@ -11,14 +11,6 @@ decompress_gzip
 The `decompress_gzip` operator decompresses bytes in a pipeline incrementally.
 The operator supports decompressing multiple concatenated streams
 of the same codec transparently.
-
-:::note Streaming Decompression
-The operator uses [Apache Arrow's compression
-utilities][apache-arrow-compression] under the hood, and transparently supports
-all options that Apache Arrow supports for streaming decompression.
-:::
-
-[apache-arrow-compression]: https://arrow.apache.org/docs/cpp/api/utilities.html#compression
 
 ## Examples
 

--- a/web/docs/tql2/operators/decompress_lz4.md
+++ b/web/docs/tql2/operators/decompress_lz4.md
@@ -1,6 +1,6 @@
 # decompress_lz4
 
-Decompresses a stream of bytes in the Brotli format.
+Decompresses a stream of bytes in the Lz4 format.
 
 ```tql
 decompress_lz4
@@ -11,14 +11,6 @@ decompress_lz4
 The `decompress_lz4` operator decompresses bytes in a pipeline incrementally.
 The operator supports decompressing multiple concatenated streams
 of the same codec transparently.
-
-:::note Streaming Decompression
-The operator uses [Apache Arrow's compression
-utilities][apache-arrow-compression] under the hood, and transparently supports
-all options that Apache Arrow supports for streaming decompression.
-:::
-
-[apache-arrow-compression]: https://arrow.apache.org/docs/cpp/api/utilities.html#compression
 
 ## Examples
 

--- a/web/docs/tql2/operators/decompress_lz4.md
+++ b/web/docs/tql2/operators/decompress_lz4.md
@@ -1,0 +1,32 @@
+# decompress_lz4
+
+Decompresses a stream of bytes in the Brotli format.
+
+```tql
+decompress_lz4
+```
+
+## Description
+
+The `decompress_lz4` operator decompresses bytes in a pipeline incrementally.
+The operator supports decompressing multiple concatenated streams
+of the same codec transparently.
+
+:::note Streaming Decompression
+The operator uses [Apache Arrow's compression
+utilities][apache-arrow-compression] under the hood, and transparently supports
+all options that Apache Arrow supports for streaming decompression.
+:::
+
+[apache-arrow-compression]: https://arrow.apache.org/docs/cpp/api/utilities.html#compression
+
+## Examples
+
+### Import Suricata events from a LZ4-compressed file
+
+```tql
+load_file "eve.json.lz4"
+decompress_lz4
+read_suricata
+import
+```

--- a/web/docs/tql2/operators/decompress_zstd.md
+++ b/web/docs/tql2/operators/decompress_zstd.md
@@ -1,0 +1,32 @@
+# decompress_zstd
+
+Decompresses a stream of bytes in the Zstd format.
+
+```tql
+decompress_zstd
+```
+
+## Description
+
+The `decompress_zstd` operator decompresses bytes in a pipeline incrementally.
+The operator supports decompressing multiple concatenated streams
+of the same codec transparently.
+
+:::note Streaming Decompression
+The operator uses [Apache Arrow's compression
+utilities][apache-arrow-compression] under the hood, and transparently supports
+all options that Apache Arrow supports for streaming decompression.
+:::
+
+[apache-arrow-compression]: https://arrow.apache.org/docs/cpp/api/utilities.html#compression
+
+## Examples
+
+### Import Suricata events from a Zstd-compressed file
+
+```tql
+load_file "eve.json.zstd"
+decompress_zstd
+read_suricata
+import
+```

--- a/web/docs/tql2/operators/decompress_zstd.md
+++ b/web/docs/tql2/operators/decompress_zstd.md
@@ -12,14 +12,6 @@ The `decompress_zstd` operator decompresses bytes in a pipeline incrementally.
 The operator supports decompressing multiple concatenated streams
 of the same codec transparently.
 
-:::note Streaming Decompression
-The operator uses [Apache Arrow's compression
-utilities][apache-arrow-compression] under the hood, and transparently supports
-all options that Apache Arrow supports for streaming decompression.
-:::
-
-[apache-arrow-compression]: https://arrow.apache.org/docs/cpp/api/utilities.html#compression
-
 ## Examples
 
 ### Import Suricata events from a Zstd-compressed file


### PR DESCRIPTION
This PR deprecates `compress` and `decompress` in favor of separate operators, exposing more options for Brotli and Gzip.

- Fixes: https://github.com/tenzir/issues/issues/2412