### PR TITLE
Add user-defined operators to TQL2

### DIFF
--- a/changelog/next/features/4884--tql2-udos.md
+++ b/changelog/next/features/4884--tql2-udos.md
@@ -1,0 +1,3 @@
+User-defined operators can now be written and used in TQL2. To use TQL2, start
+your definition with the comment `// tql2`, or use the `--tql2` flag to opt into
+TQL2 as the default.

--- a/libtenzir/include/tenzir/tql2/entity_path.hpp
+++ b/libtenzir/include/tenzir/tql2/entity_path.hpp
@@ -13,20 +13,25 @@
 
 namespace tenzir {
 
-TENZIR_ENUM(
-  /// Models the available entity namespaces.
-  entity_ns,
-  /// The operator namespace contains only operators.
-  op,
-  /// The function namespace contains both functions and methods.
-  fn);
+/// Entities are currently either rooted in the standard package, or in the
+/// config package. Once we support modules from user-defined packages, this
+/// closed enum should be opened up to allow referencing them.
+TENZIR_ENUM(entity_pkg, std, cfg);
 
+/// Models the available entity namespaces.
+TENZIR_ENUM(entity_ns, op, fn, mod);
+
+/// Every entity is identified by a combination of three things:
+/// - The package where the lookup is started.
+/// - The path within that package that leads the entity.
+/// - The namespace of the entity, because the same name can be used multiple
+///   times in different namespaces.
 class entity_path {
 public:
   entity_path() = default;
 
-  explicit entity_path(std::vector<std::string> segments, entity_ns ns)
-    : segments_{std::move(segments)}, ns_{ns} {
+  entity_path(entity_pkg pkg, std::vector<std::string> segments, entity_ns ns)
+    : pkg_{pkg}, segments_{std::move(segments)}, ns_{ns} {
     TENZIR_ASSERT(resolved());
   }
 
@@ -34,9 +39,9 @@ public:
     return not segments_.empty();
   }
 
-  auto ns() const -> entity_ns {
+  auto pkg() const -> entity_pkg {
     TENZIR_ASSERT(resolved());
-    return ns_;
+    return pkg_;
   }
 
   auto segments() const -> std::span<const std::string> {
@@ -44,18 +49,26 @@ public:
     return segments_;
   }
 
+  auto ns() const -> entity_ns {
+    TENZIR_ASSERT(resolved());
+    return ns_;
+  }
+
   friend auto inspect(auto& f, entity_path& x) -> bool {
     if (auto dbg = as_debug_writer(f)) {
       if (not x.resolved()) {
         return dbg->fmt_value("unresolved");
       }
-      return dbg->fmt_value("{}/{}", fmt::join(x.segments_, "::"), x.ns_);
+      return dbg->fmt_value("{}::{}/{}", x.pkg_, fmt::join(x.segments_, "::"),
+                            x.ns_);
     }
-    return f.object(x).fields(f.field("path", x.segments_),
+    return f.object(x).fields(f.field("pkg", x.pkg_),
+                              f.field("segments", x.segments_),
                               f.field("ns", x.ns_));
   }
 
 private:
+  entity_pkg pkg_{};
   std::vector<std::string> segments_;
   entity_ns ns_{};
 };

--- a/tenzir/integration/data/reference/user_defined_operators/test_shadowing_udo/step_00.ref
+++ b/tenzir/integration/data/reference/user_defined_operators/test_shadowing_udo/step_00.ref
@@ -1,0 +1,11 @@
+[
+  tql2.from_events [
+    record {
+      begin: 0..0,
+      items: [
+        
+      ],
+      end: 0..0
+    }
+  ]
+]

--- a/tenzir/integration/data/reference/user_defined_operators/test_unknown_udo/step_00.ref
+++ b/tenzir/integration/data/reference/user_defined_operators/test_unknown_udo/step_00.ref
@@ -1,0 +1,7 @@
+error: operator `one` not found
+ --> <input>:1:1
+  |
+1 | one
+  | ^^^ 
+  |
+  = hint: must be one of: api, assert, batch, buffer, cache, compress, config, context::create_bloom_filter, context::create_geoip, context::create_lookup_table, decompress, deduplicate, delay, diagnostics, discard, drop, enumerate, every, export, fields, files, fork, from, head, if, import, legacy, load_balance, load_file, load_ftp, load_http, load_tcp, load_udp, local, measure, metrics, openapi, partitions, pass, plugins, processes, python, rare, read_bitz, read_cef, read_csv, read_feather, read_gelf, read_grok, read_json, read_kv, read_leef, read_lines, read_ndjson, read_pcap, read_ssv, read_suricata, read_syslog, read_tsv, read_xsv, read_yaml, read_zeek_json, read_zeek_tsv, remote, repeat, reverse, sample, save_email, save_file, save_ftp, save_http, save_tcp, save_udp, schemas, select, serve, set, shell, slice, sockets, sort, summarize, tail, taste, throttle, timeshift, to, to_hive, to_opensearch, top, unordered, unroll, version, where, write_bitz, write_csv, write_feather, write_json, write_lines, write_ndjson, write_pcap, write_ssv, write_tsv, write_xsv, write_yaml, write_zeek_tsv

--- a/tenzir/integration/data/reference/user_defined_operators/test_valid_udo/step_00.ref
+++ b/tenzir/integration/data/reference/user_defined_operators/test_valid_udo/step_00.ref
@@ -1,0 +1,12 @@
+[
+  tql2.from_events [
+    record {
+      begin: 0..0,
+      items: [
+        
+      ],
+      end: 0..0
+    }
+  ],
+  repeat 2
+]

--- a/tenzir/integration/tests/user_defined_operators.bats
+++ b/tenzir/integration/tests/user_defined_operators.bats
@@ -1,0 +1,28 @@
+: "${BATS_TEST_TIMEOUT:=60}"
+
+setup() {
+  bats_load_library bats-support
+  bats_load_library bats-assert
+  bats_load_library bats-tenzir
+  export TENZIR_EXEC__DUMP_PIPELINE=true
+  export TENZIR_TQL2=true
+}
+
+@test "unknown udo" {
+  check ! tenzir 'one'
+}
+
+@test "invalid udo" {
+  export TENZIR_OPERATORS__one="from {"
+  check ! tenzir 'from {}'
+}
+
+@test "valid udo" {
+  export TENZIR_OPERATORS__two="let \$two = 2 | from {} | repeat \$two"
+  check tenzir 'two'
+}
+
+@test "shadowing udo" {
+  export TENZIR_OPERATORS__api="from {}"
+  check tenzir 'api'
+}

--- a/web/docs/integrations/zeek/README.md
+++ b/web/docs/integrations/zeek/README.md
@@ -125,13 +125,13 @@ in the same pipeline. A stock Tenzir installation comes with a user-defined
 ```yaml title=tenzir.yaml
 tenzir:
   operators:
-    zeek:
+    zeek: |
       shell "eval \"$(zkg env)\" &&
              zeek -r - LogAscii::output_to_stdout=T
              JSONStreaming::disable_default_logs=T
              JSONStreaming::enable_log_rotation=F
              json-streaming-logs"
-      | read_zeek_json
+      read_zeek_json
 ```
 
 This allows you run Zeek on a packet trace as follows:
@@ -145,11 +145,11 @@ You can also perform more elaborate packet filtering after light-weight
 
 ```bash
 tenzir 'load_file "/path/to/trace.pcap"
-       read_pcap
-       this = decapsulate(this)
-       where ip.src in 10.0.0.0/8 || community == "1:YXWfTYEyYLKVv5Ge4WqijUnKTrM="
-       write_pcap
-       zeek'
+        read_pcap
+        this = decapsulate(this)
+        where ip.src in 10.0.0.0/8 || community == "1:YXWfTYEyYLKVv5Ge4WqijUnKTrM="
+        write_pcap
+        zeek'
 ```
 
 Read the [in-depth blog


### PR DESCRIPTION
With this PR, user-defined operators can be written and used in TQL2. To use TQL2, start your definition with the comment `// tql2`, or use the `--tql2` flag to opt into TQL2 as the default.