### PR TITLE
Fix operator parenthesis continuation

### DIFF
--- a/changelog/next/bug-fixes/4885-operator-parenthesis-continuation.md
+++ b/changelog/next/bug-fixes/4885-operator-parenthesis-continuation.md
@@ -1,0 +1,3 @@
+Operator invocations that directly use parenthesis but continue after the
+closing parenthesis are no longer rejected. For example, `where (x or y) and z`
+is now being parsed correctly.

--- a/tenzir/integration/data/reference/parser/test_operator_parenthesis_continuation/step_00.ref
+++ b/tenzir/integration/data/reference/parser/test_operator_parenthesis_continuation/step_00.ref
@@ -1,0 +1,17 @@
+[
+  invocation {
+    op: {
+      path: [
+        `where` @ 0..5
+      ],
+      ref: unresolved
+    },
+    args: [
+      binary_expr {
+        left: root_field `x` @ 7..8,
+        op: "or_" @ 9..11,
+        right: root_field `y` @ 12..13
+      }
+    ]
+  }
+]

--- a/tenzir/integration/data/reference/parser/test_operator_parenthesis_continuation/step_01.ref
+++ b/tenzir/integration/data/reference/parser/test_operator_parenthesis_continuation/step_01.ref
@@ -1,0 +1,21 @@
+[
+  invocation {
+    op: {
+      path: [
+        `where` @ 0..5
+      ],
+      ref: unresolved
+    },
+    args: [
+      binary_expr {
+        left: binary_expr {
+          left: root_field `x` @ 7..8,
+          op: "or_" @ 9..11,
+          right: root_field `y` @ 12..13
+        },
+        op: "and_" @ 15..18,
+        right: root_field `z` @ 19..20
+      }
+    ]
+  }
+]

--- a/tenzir/integration/data/reference/parser/test_operator_parenthesis_continuation/step_02.ref
+++ b/tenzir/integration/data/reference/parser/test_operator_parenthesis_continuation/step_02.ref
@@ -1,0 +1,26 @@
+[
+  invocation {
+    op: {
+      path: [
+        `from` @ 0..4
+      ],
+      ref: unresolved
+    },
+    args: [
+      record {
+        begin: 6..7,
+        items: [
+          
+        ],
+        end: 7..8
+      },
+      record {
+        begin: 11..12,
+        items: [
+          
+        ],
+        end: 12..13
+      }
+    ]
+  }
+]

--- a/tenzir/integration/data/reference/parser/test_operator_parenthesis_continuation/step_03.ref
+++ b/tenzir/integration/data/reference/parser/test_operator_parenthesis_continuation/step_03.ref
@@ -1,0 +1,27 @@
+[
+  invocation {
+    op: {
+      path: [
+        `from` @ 0..4
+      ],
+      ref: unresolved
+    },
+    args: [
+      binary_expr {
+        left: constant {
+          value: int64 1,
+          source: 5..6
+        },
+        op: "or_" @ 7..9,
+        right: constant {
+          value: int64 2,
+          source: 10..11
+        }
+      },
+      constant {
+        value: int64 3,
+        source: 13..14
+      }
+    ]
+  }
+]

--- a/tenzir/integration/tests/parser.bats
+++ b/tenzir/integration/tests/parser.bats
@@ -182,3 +182,10 @@ from {
 }
 EOF
 }
+
+@test "operator parenthesis continuation" {
+  check tenzir 'where (x or y)'
+  check tenzir 'where (x or y) and z'
+  check tenzir 'from ({}), {}'
+  check tenzir 'from 1 or 2, 3'
+}


### PR DESCRIPTION
Previously, `where (x or y) and z` led to a parsing error. This was because we allow parenthesis around operators, such that `where (x or y)` is a valid statement. However, the code path did not account for the possibility of continuing after the closing parenthesis, neither by extending the expression itself (` and z`) nor by adding another argument (`, z`).