### PR TITLE
Disable macOS Nix CI job

### DIFF
--- a/.github/workflows/nix-config-base.json
+++ b/.github/workflows/nix-config-base.json
@@ -12,14 +12,6 @@
         "ghcr.io",
         "docker.io"
       ]
-    },
-    {
-      "name": "tenzir",
-      "gha-runner-labels": ["macOS", "ARM64"],
-      "static": true,
-      "upload-package-to-github": true,
-      "package-stores": [],
-      "image-registries": []
     }
   ]
 }


### PR DESCRIPTION
To be reverted once the runner is back up.