### PR TITLE
Fix overeager fallback in `any` and `all`

### DIFF
--- a/libtenzir/builtins/aggregation-functions/all.cpp
+++ b/libtenzir/builtins/aggregation-functions/all.cpp
@@ -78,7 +78,7 @@ public:
             state_ = state::nulled;
           }
         },
-        [&](auto&&) {
+        [&](const auto&) {
           diagnostic::warning("expected type `bool`, got `{}`", arg.type.kind())
             .primary(expr_)
             .emit(ctx);

--- a/libtenzir/builtins/aggregation-functions/any.cpp
+++ b/libtenzir/builtins/aggregation-functions/any.cpp
@@ -78,7 +78,7 @@ public:
             state_ = state::nulled;
           }
         },
-        [&](auto&&) {
+        [&](const auto&) {
           diagnostic::warning("expected type `bool`, got `{}`", arg.type.kind())
             .primary(expr_)
             .emit(ctx);


### PR DESCRIPTION
This led to a very curious "expected `bool`, got `bool`" warning and returned nulls. This appears to have been introduced with our new variant traits, which behave a bit different from CAF's sum type access that we used before.

No changelog entry necessary, as we didn't release this yet. However, we should very carefully check whether there are other places affected by this that aren't covered by tests.