### PR TITLE
Ensure that `let` resolving phase fails when `let` expression errors

### DIFF
--- a/libtenzir/src/tql2/exec.cpp
+++ b/libtenzir/src/tql2/exec.cpp
@@ -58,6 +58,7 @@ public:
             TENZIR_UNREACHABLE();
           });
       } else {
+        failure_ = value.error();
         map_[let->name.name] = std::nullopt;
       }
       it = x.body.erase(it);


### PR DESCRIPTION
The `let` resolver returns `failure_or<void>`. If it returns a failure, all subsequent compilation steps are not attempted. If we cannot evaluate an expression on the right side of `let`, we previously emitted an error, but did not return a failure, which meant that the rest of the compilation was performed. However, this produces confusing diagnostics due to unresolved `$` variables. This PR makes it so that we return a failure such that the compilation process is aborted after `let` resolving.