### PR TITLE
Prepare repository for Tenzir v4.25.1

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tenzir"
-version = "4.25.0"
+version = "4.25.1"
 description = "A security telemetry engine for detection and response"
 authors = ["Tenzir <engineering@tenzir.com>"]
 maintainers = ["Tenzir <engineering@tenzir.com>"]

--- a/version.json
+++ b/version.json
@@ -4,7 +4,7 @@
     "annotated git tag without the leading 'v'.",
     "This value gets updated automatically by `scripts/prepare-release`."
   ],
-  "tenzir-version": "4.25.0",
+  "tenzir-version": "4.25.1",
   "tenzir-partition-version_COMMENT": [
     "The partition version. This number must be bumped alongside the release",
     "version for releases that contain major format changes to the on-disk",


### PR DESCRIPTION
This commit was created with `/scripts/prepare-release`.

Here is a high-level summary of the changes:

* Updated `/version.json` to `v4.25.1`.
* Generated a new entry in the docs version selector list.
* Removed the docs for the previous release candidate.
* Moved all changelog entries from `/changelog/next` to `/changelog/v4.25.1`.
* Updated the python bindings version in `/python/pyproject.toml` to `v4.25.1`.
