### PR TITLE
Add plugin options to enable self-signed platform certificates

### DIFF
--- a/changelog/next/features/4918--platform-tls-options.md
+++ b/changelog/next/features/4918--platform-tls-options.md
@@ -1,0 +1,3 @@
+The `platform` plugin now understands the `skip-peer-verification`
+and `cacert` options in order to enable connections to self-hosted
+platform instances with self-signed TLS certificates.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "5879e3b51c1b00dce04efdb8fa8a95c8879806e4",
+  "rev": "46dbe5f5f1e064717edd3b848d346ee73ffa717c",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/web/docs/installation/deploy-the-platform.md
+++ b/web/docs/installation/deploy-the-platform.md
@@ -201,3 +201,33 @@ TENZIR_PLATFORM_POSTGRES_PASSWORD=YOUR_POSTGRES_PASSWORD
 TENZIR_PLATFORM_POSTGRES_DB=YOUR_POSTGRES_DB
 TENZIR_PLATFORM_POSTGRES_HOSTNAME=YOUR_POSTGRES_HOSTNAME
 ```
+
+### TLS Settings
+
+We strongly recommend using signed TLS certificates which are trusted by the machines
+running the Tenzir Nodes.
+
+However, it can sometimes be necessary to use self-signed certificates for the Tenzir Platform.
+If possible, we recommend the creation of a local certificate authority using e.g. the
+[trustme](https://pypi.org/project/trustme/) project in this situation. Compared to
+a self-signed certificate, this has the advantage of not having to disable TLS certificate
+validation on the client, preventing man-in-the-middle attacks.
+
+If that is not possible, a self-signed certificate can be generated using `openssl`
+by following [this procedure](https://stackoverflow.com/a/10176685/92560).
+
+#### Node Settings
+
+On the node, in order to trust a custom CA certificate, the follwing option
+needs to point to a non-password protected CA certificate in PEM format:
+
+```env
+TENZIR_PLATFORM_CACERT=/path/to/ca-certificate.pem
+```
+
+If you want to use a self-signed TLS certificate, you need to disable
+certificate validation by setting:
+
+```env
+TENZIR_PLATFORM_SKIP_PEER_VERIFICATION=true
+```

--- a/web/docs/installation/deploy-the-platform.md
+++ b/web/docs/installation/deploy-the-platform.md
@@ -208,26 +208,30 @@ We strongly recommend using signed TLS certificates which are trusted by the mac
 running the Tenzir Nodes.
 
 However, it can sometimes be necessary to use self-signed certificates for the Tenzir Platform.
-If possible, we recommend the creation of a local certificate authority using e.g. the
-[trustme](https://pypi.org/project/trustme/) project in this situation. Compared to
-a self-signed certificate, this has the advantage of not having to disable TLS certificate
-validation on the client, preventing man-in-the-middle attacks.
+ in this situation we recommend the creation of a local certificate authority, e.g., using the
+[trustme](https://pypi.org/project/trustme/) project. This approach has the advantage of not
+requiring the client to disable TLS certificate validation, thus preventing man-in-the-middle
+attacks when compared to a self-signed certificate..
 
 If that is not possible, a self-signed certificate can be generated using `openssl`
 by following [this procedure](https://stackoverflow.com/a/10176685/92560).
 
 #### Node Settings
 
-On the node, in order to trust a custom CA certificate, the follwing option
-needs to point to a non-password protected CA certificate in PEM format:
+On the node, in order to trust a custom CA certificate, the following option
+needs to point to a CA certificate file in PEM format without password protection:
 
 ```env
 TENZIR_PLATFORM_CACERT=/path/to/ca-certificate.pem
 ```
 
 If you want to use a self-signed TLS certificate, you need to disable
-certificate validation by setting:
+TLS certificate validation by setting:
 
 ```env
 TENZIR_PLATFORM_SKIP_PEER_VERIFICATION=true
 ```
+
+Note that these settings only apply to the connection that is established
+between the node and the platform, not to any TLS connections that may
+be created by running pipelines on the node.


### PR DESCRIPTION
In order to enable the node to work with platform instances using self-signed certificates, this PR adds two options

```
TENZIR_PLUGINS__PLATFORM__SKIP_PEER_VERIFICATION=true/false
TENZIR_PLUGINS__PLATFORM__CACERT=/path/to/ca.cert
```

in order to skip certificate verification (for true self-signed certificates) or to use a custom CA certificate as trust anchor (for internal certificate authorities or self-signed certificates generated with `trustme`)