### PR TITLE
Make finding cppzmq required

### DIFF
--- a/plugins/zmq/CMakeLists.txt
+++ b/plugins/zmq/CMakeLists.txt
@@ -16,7 +16,7 @@ TenzirRegisterPlugin(
   INCLUDE_DIRECTORIES include
   BUILTINS GLOB "${CMAKE_CURRENT_SOURCE_DIR}/builtins/*.cpp")
 
-find_package(cppzmq QUIET)
+find_package(cppzmq QUIET REQUIRED)
 
 if (TARGET libzmq)
   # libzmq declares its link dependencies as public, but in reality they are all


### PR DESCRIPTION
Prior to this change it was possible to not find the `cppzmq` dependency and run into a compilation error because `#include <zmq.hpp>` doesn't exist (which `cppzmq` provides).
