### PR TITLE
Reduce scheduler roundtrips in execution nodes

### DIFF
--- a/libtenzir/include/tenzir/actors.hpp
+++ b/libtenzir/include/tenzir/actors.hpp
@@ -313,8 +313,6 @@ using exec_node_sink_actor = typed_actor_fwd<
 
 /// The interface of a EXEC NODE actor.
 using exec_node_actor = typed_actor_fwd<
-  // Resume the internal event loop.
-  auto(atom::internal, atom::run)->caf::result<void>,
   // Start an execution node. Returns after the operator has yielded for the
   // first time.
   auto(atom::start, std::vector<caf::actor> all_previous)->caf::result<void>,

--- a/libtenzir/src/execution_node.cpp
+++ b/libtenzir/src/execution_node.cpp
@@ -643,19 +643,16 @@ struct exec_node_state {
     TENZIR_TRACE("{} {} schedules run with a delay of {}", *self, op->name(),
                  data{backoff});
     run_scheduled = true;
+    auto do_run = [this] {
+      auto time_scheduled_guard = make_timer_guard(metrics.time_scheduled);
+      run_scheduled = false;
+      run();
+    };
     if (backoff == duration::zero()) {
-      self->send(self, atom::internal_v, atom::run_v);
+      self->schedule_fn(std::move(do_run));
     } else {
-      backoff_disposable = detail::weak_run_delayed(self, backoff, [this] {
-        self->send(self, atom::internal_v, atom::run_v);
-      });
+      backoff_disposable = self->run_delayed_weak(backoff, std::move(do_run));
     }
-  }
-
-  auto internal_run() -> caf::result<void> {
-    run_scheduled = false;
-    run();
-    return {};
   }
 
   auto issue_demand() -> void {
@@ -868,11 +865,6 @@ auto exec_node(
       return error;
     });
   return {
-    [self](atom::internal, atom::run) -> caf::result<void> {
-      auto time_scheduled_guard
-        = make_timer_guard(self->state().metrics.time_scheduled);
-      return self->state().internal_run();
-    },
     [self](atom::start,
            std::vector<caf::actor>& all_previous) -> caf::result<void> {
       auto time_scheduled_guard


### PR DESCRIPTION
This removes some of the scheduling overhead for execution nodes when they're not in backoff. It's not the grand performance improvement we're looking for from the current rewrite effort for the execution engine, but it's a small change that helps a bit right now while that is still underway.