### PR TITLE
Update uv from 0.3.0 to 0.5.21

### DIFF
--- a/python/uv-source-info.json
+++ b/python/uv-source-info.json
@@ -1,19 +1,19 @@
 {
-  "version": "0.3.0",
+  "version": "0.5.21",
   "aarch64-darwin": {
-    "url": "https://github.com/astral-sh/uv/releases/download/0.3.0/uv-aarch64-apple-darwin.tar.gz",
-    "sha256": "232935b3b2c187c4f8dc8bf533875bd7163d06a6fab625a1770689b337cbfded"
+    "url": "https://github.com/astral-sh/uv/releases/download/0.5.21/uv-aarch64-apple-darwin.tar.gz",
+    "sha256": "74f501d91b4db0b767d5d621086d3e2e8acc3f5356cf5527de80e97bb312a626"
   },
   "aarch64-linux": {
-    "url": "https://github.com/astral-sh/uv/releases/download/0.3.0/uv-aarch64-unknown-linux-musl.tar.gz",
-    "sha256": "55bc78ee396f3b9847d28a83edbeeb557edd78462b782459d95fa9cad86cca5e"
+    "url": "https://github.com/astral-sh/uv/releases/download/0.5.21/uv-aarch64-unknown-linux-musl.tar.gz",
+    "sha256": "26152b092f6ace9bec1fe91b39fe11f55428ce5fba87f5de0ec6b16e2c65928f"
   },
   "x86_64-darwin": {
-    "url": "https://github.com/astral-sh/uv/releases/download/0.3.0/uv-x86_64-apple-darwin.tar.gz",
-    "sha256": "8f3abf9bc7f49ddf85b1ebb4e5a5dd2032b6e7a4492fb5fce4b70ee4a9938733"
+    "url": "https://github.com/astral-sh/uv/releases/download/0.5.21/uv-x86_64-apple-darwin.tar.gz",
+    "sha256": "66a0f5ea3aee2d497450138ae1e99f734eed7457af5e839a41ef219d51e90e17"
   },
   "x86_64-linux": {
-    "url": "https://github.com/astral-sh/uv/releases/download/0.3.0/uv-x86_64-unknown-linux-musl.tar.gz",
-    "sha256": "194d2a550af3e334f693f6afd716d66adc90445805e72bfa8108f36714ed7431"
+    "url": "https://github.com/astral-sh/uv/releases/download/0.5.21/uv-x86_64-unknown-linux-musl.tar.gz",
+    "sha256": "71347d2fdda9e3e7105ecd3a8566e3b607da9fddf23ac83adafcf6451ea9139d"
   }
 }


### PR DESCRIPTION
This chagne was created automatically by running:

```bash
./python/update-uv-sources.sh
```