### PR TITLE
Hide build directory paths in source location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ set(TENZIR_EDITION_NAME
     "Tenzir"
     CACHE STRING "Set the edition name")
 
+add_compile_options("-ffile-prefix-map=${CMAKE_CURRENT_SOURCE_DIR}/=")
+
 # -- sanity checks -------------------------------------------------------------
 
 # Prohibit in-source builds.

--- a/cmake/TenzirRegisterPlugin.cmake
+++ b/cmake/TenzirRegisterPlugin.cmake
@@ -539,6 +539,11 @@ function (TenzirRegisterPlugin)
   # when there are no sources for target, but since the plugins have sources, we
   # manually specify this here. `CXX` because we only use C/C++ currently.
   set_target_properties(${PLUGIN_TARGET} PROPERTIES LINKER_LANGUAGE CXX)
+  target_compile_options(
+    ${PLUGIN_TARGET}
+    PUBLIC
+      "-ffile-prefix-map=${CMAKE_CURRENT_SOURCE_DIR}/=plugins/${PLUGIN_TARGET}/"
+  )
   TenzirTargetEnableTooling(${PLUGIN_TARGET})
   target_link_libraries(
     ${PLUGIN_TARGET}


### PR DESCRIPTION
This change makes the path shown in our assertions deterministic, hiding information about the environment that the build was compiled in.