### PR TITLE
Disable LTO for static builds except on Linux

### DIFF
--- a/nix/tenzir/default.nix
+++ b/nix/tenzir/default.nix
@@ -207,7 +207,7 @@
             "-UCMAKE_INSTALL_LIBEXECDIR"
             "-UCMAKE_INSTALL_LOCALEDIR"
             "-DCMAKE_INSTALL_PREFIX=/opt/tenzir"
-            "-DCMAKE_INTERPROCEDURAL_OPTIMIZATION:BOOL=ON"
+            "-DCMAKE_INTERPROCEDURAL_OPTIMIZATION:BOOL=${lib.boolToString stdenv.hostPlatform.isLinux}"
             "-DCPACK_GENERATOR=${if stdenv.hostPlatform.isDarwin then "TGZ;productbuild" else "TGZ;DEB;RPM"}"
             "-DTENZIR_UV_PATH:STRING=${lib.getExe uv}"
             "-DTENZIR_ENABLE_STATIC_EXECUTABLE:BOOL=ON"


### PR DESCRIPTION
LTO builds on darwin have become the bottleneck of our CI setup since we switched to LLVM19. Turning it of should recover at least some performance.

This is stacked on top of https://github.com/tenzir/tenzir/pull/4931, which should be merged first.
