### PR TITLE
Follow ups for #4931

### DIFF
--- a/nix/tenzir/check.nix
+++ b/nix/tenzir/check.nix
@@ -25,11 +25,11 @@ stdenvNoCC.mkDerivation {
       template = path: ''
         if [ -d "${path}/bats/tests" ]; then
           echo "running ${path} BATS tests"
-          bats -T -j $(nproc) "${path}/bats/tests"
+          bats -T -j $NIX_BUILD_CORES "${path}/bats/tests"
         fi
         if [ -f "${path}/tests/run.py" ]; then
           echo "running ${path} integration tests"
-          ${path}/tests/run.py -j $(nproc)
+          ${path}/tests/run.py -j $NIX_BUILD_CORES
         fi
       '';
     in

--- a/nix/tenzir/default.nix
+++ b/nix/tenzir/default.nix
@@ -167,15 +167,6 @@
 
         env = {
           POETRY_VIRTUALENVS_IN_PROJECT = 1;
-          NIX_LDFLAGS = let
-            lto-cache = {
-              cctools = "-cache_path_lto,$TMPDIR";
-              gold = "-plugin-opt,cache-dir=$TMPDIR";
-              lld = "--thinlto-cache-dir=$TMPDIR";
-            };
-          in
-            # Speed up the second linking for the packag
-            lib.optionalString (stdenv.cc.isClang) (lto-cache.${stdenv.hostPlatform.linker} or "");
         };
         cmakeFlags =
           [

--- a/nix/tenzir/default.nix
+++ b/nix/tenzir/default.nix
@@ -343,7 +343,7 @@
         buildPhase = ''
           runHook preBuild
         ''
-          # TODO: Check if we need this and comment if yes.
+          # Append /usr/bin to PATH so CPack can find `pkgbuild`.
           + lib.optionalString stdenv.hostPlatform.isDarwin
         ''
           PATH=$PATH:/usr/bin


### PR DESCRIPTION
A few minor cleanups.
The removal of the thinLTO compile cache might actually reduce the memory pressure and speed up builds on systems that used it before.