### PR TITLE
Add `tenzir.retention` configuration

### DIFF
--- a/changelog/next/features/4949--retention-policy.md
+++ b/changelog/next/features/4949--retention-policy.md
@@ -1,0 +1,3 @@
+The new `tenzir.retention.metrics` and `tenzir.retention.diagnostics`
+configuration options configure how long Tenzir Nodes retain metrics and
+diagnostics. The policies are checked once every hour.

--- a/libtenzir/include/tenzir/diagnostics.hpp
+++ b/libtenzir/include/tenzir/diagnostics.hpp
@@ -365,6 +365,10 @@ public:
     return std::move(result);
   }
 
+  auto to_error() && -> caf::error {
+    return caf::make_error(ec::diagnostic, std::move(result));
+  }
+
   auto empty() const -> bool {
     return result.empty();
   }

--- a/libtenzir/include/tenzir/importer.hpp
+++ b/libtenzir/include/tenzir/importer.hpp
@@ -46,7 +46,7 @@ struct importer_state {
 
   /// The index actor and the policy for retention.
   index_actor index;
-  retention_policy retention_policy = {};
+  struct retention_policy retention_policy = {};
 
   /// Potentially unpersisted events.
   std::vector<table_slice> unpersisted_events = {};

--- a/libtenzir/include/tenzir/importer.hpp
+++ b/libtenzir/include/tenzir/importer.hpp
@@ -11,43 +11,22 @@
 #include "tenzir/fwd.hpp"
 
 #include "tenzir/actors.hpp"
-#include "tenzir/aliases.hpp"
 #include "tenzir/detail/flat_map.hpp"
-#include "tenzir/instrumentation.hpp"
+#include "tenzir/retention_policy.hpp"
 #include "tenzir/table_slice.hpp"
 
 #include <caf/typed_event_based_actor.hpp>
 #include <caf/typed_response_promise.hpp>
 
-#include <chrono>
 #include <filesystem>
 #include <vector>
 
 namespace tenzir {
 
 /// Receives chunks from SOURCEs, imbues them with an ID, and relays them to
-///  INDEX and continuous queries.
+/// INDEX and continuous queries.
 struct importer_state {
   // -- member types -----------------------------------------------------------
-
-  /// Used to signal how much information should be persisted in write_state().
-  enum class write_mode : bool {
-    /// Persist the next assignable id, used during a regular shutdown.
-    with_next,
-    /// Persist only the end of the block, used during regular operation to
-    /// prevent state corruption if an irregular shutdown occurs.
-    without_next
-  };
-
-  /// A helper structure to partition the id space into blocks.
-  /// An importer uses one currently active block.
-  struct id_block {
-    /// The next available id of this block.
-    id next;
-
-    /// The last + 1 id of this block.
-    id end;
-  };
 
   explicit importer_state(importer_actor::pointer self);
 
@@ -60,18 +39,14 @@ struct importer_state {
   /// Process a slice and forward it to the index.
   void handle_slice(table_slice&& slice);
 
-  /// The active id block.
-  id_block current;
-
   /// Pointer to the owning actor.
   importer_actor::pointer self;
 
-  measurement measurement_ = {};
-  stopwatch::time_point last_report = {};
   detail::flat_map<type, uint64_t> schema_counters = {};
 
-  /// The index actor.
+  /// The index actor and the policy for retention.
   index_actor index;
+  retention_policy retention_policy = {};
 
   /// Potentially unpersisted events.
   std::vector<table_slice> unpersisted_events = {};
@@ -88,7 +63,7 @@ struct importer_state {
 /// @param self The actor handle.
 /// @param dir The directory for persistent state.
 /// @param index A handle to the INDEX.
-/// @param batch_size The initial number of IDs to request when replenishing.
+/// @param retention_policy The retention policy to apply.
 importer_actor::behavior_type
 importer(importer_actor::stateful_pointer<importer_state> self,
          const std::filesystem::path& dir, index_actor index);

--- a/libtenzir/include/tenzir/retention_policy.hpp
+++ b/libtenzir/include/tenzir/retention_policy.hpp
@@ -65,7 +65,7 @@ struct retention_policy {
     if (not schema.attribute("internal")) {
       return true;
     }
-    if (schema.name() == "tenzir.diagnostics") {
+    if (schema.name() == "tenzir.diagnostic") {
       return not diagnostics_period or * diagnostics_period > duration::zero();
     }
     if (schema.name().starts_with("tenzir.metrics.")) {

--- a/libtenzir/include/tenzir/retention_policy.hpp
+++ b/libtenzir/include/tenzir/retention_policy.hpp
@@ -1,0 +1,88 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2025 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "tenzir/fwd.hpp"
+
+#include "tenzir/concept/parseable/tenzir/time.hpp"
+#include "tenzir/diagnostics.hpp"
+#include "tenzir/session.hpp"
+
+namespace tenzir {
+
+struct retention_policy {
+  retention_policy() = default;
+
+  static auto make(const record& cfg, session ctx)
+    -> failure_or<retention_policy> {
+    auto result = retention_policy{};
+    auto failed = false;
+    const auto try_parse = [&](auto& out, const auto key) -> void {
+      if (const auto* opt_duration = get_if<duration>(&cfg, key)) {
+        out.emplace(*opt_duration);
+      } else if (const auto* opt_string = get_if<std::string>(&cfg, key)) {
+        if (not parsers::duration(*opt_string, out.emplace())) {
+          diagnostic::error("expected type `duration` for option `{}`", key)
+            .hint("got `{}`", *opt_string)
+            .emit(ctx);
+          failed = true;
+          return;
+        }
+      }
+      if (out and *out < duration::zero()) {
+        diagnostic::warning("expected positive value for option `{}`", key)
+          .hint("got `{}`", *out)
+          .emit(ctx);
+        failed = true;
+      }
+    };
+    try_parse(result.metrics_period, "tenzir.retention.metrics");
+    try_parse(result.diagnostics_period, "tenzir.retention.diagnostics");
+    if (failed) {
+      return failure::promise();
+    }
+    return result;
+  }
+
+  static auto make(const record& cfg) -> caf::expected<retention_policy> {
+    auto dh = collecting_diagnostic_handler{};
+    auto sp = session_provider::make(dh);
+    auto result = make(cfg, sp.as_session());
+    if (not result) {
+      return std::move(dh).to_error();
+    }
+    return std::move(*result);
+  }
+
+  auto should_be_persisted(const table_slice& slice) const -> bool {
+    const auto& schema = slice.schema();
+    if (not schema.attribute("internal")) {
+      return true;
+    }
+    if (schema.name() == "tenzir.diagnostics") {
+      return not diagnostics_period or * diagnostics_period > duration::zero();
+    }
+    if (schema.name().starts_with("tenzir.metrics.")) {
+      return not metrics_period or * metrics_period > duration::zero();
+    }
+    return true;
+  }
+
+  friend auto inspect(auto& f, retention_policy& x) -> bool {
+    return f.object(x)
+      .pretty_name("tenzir.retention_policy")
+      .fields(f.field("metrics_period", x.metrics_period),
+              f.field("diagnostics_period", x.diagnostics_period));
+  }
+
+  std::optional<duration> metrics_period = {};
+  std::optional<duration> diagnostics_period = {};
+};
+
+} // namespace tenzir

--- a/libtenzir/include/tenzir/try.hpp
+++ b/libtenzir/include/tenzir/try.hpp
@@ -70,6 +70,21 @@ struct tenzir::tryable<std::optional<T>> {
   }
 };
 
+template <>
+struct tenzir::tryable<caf::error> {
+  static auto is_success(const caf::error& x) -> bool {
+    return !x;
+  }
+
+  static void get_success(caf::error&& x) {
+    TENZIR_UNUSED(x);
+  }
+
+  static auto get_error(caf::error&& x) -> caf::error {
+    return std::move(x);
+  }
+};
+
 template <class T>
 struct tenzir::tryable<caf::expected<T>> {
   static auto is_success(const caf::expected<T>& x) -> bool {

--- a/libtenzir/src/catalog.cpp
+++ b/libtenzir/src/catalog.cpp
@@ -26,7 +26,6 @@
 #include "tenzir/pipeline.hpp"
 #include "tenzir/prune.hpp"
 #include "tenzir/query_context.hpp"
-#include "tenzir/retention_policy.hpp"
 #include "tenzir/status.hpp"
 #include "tenzir/synopsis.hpp"
 #include "tenzir/taxonomies.hpp"

--- a/libtenzir/src/importer.cpp
+++ b/libtenzir/src/importer.cpp
@@ -14,7 +14,9 @@
 #include "tenzir/defaults.hpp"
 #include "tenzir/detail/actor_metrics.hpp"
 #include "tenzir/detail/weak_run_delayed.hpp"
+#include "tenzir/diagnostics.hpp"
 #include "tenzir/logger.hpp"
+#include "tenzir/retention_policy.hpp"
 #include "tenzir/series_builder.hpp"
 #include "tenzir/status.hpp"
 #include "tenzir/table_slice.hpp"
@@ -33,7 +35,6 @@ importer_state::importer_state(importer_actor::pointer self) : self{self} {
 importer_state::~importer_state() = default;
 
 void importer_state::on_process(const table_slice& slice) {
-  auto t = timer::start(measurement_);
   const auto rows = slice.rows();
   TENZIR_ASSERT(rows > 0);
   const auto is_internal = slice.schema().attribute("internal").has_value();
@@ -46,13 +47,14 @@ void importer_state::on_process(const table_slice& slice) {
     }
   }
   unpersisted_events.push_back(std::move(slice));
-  t.stop(rows);
 }
 
 void importer_state::handle_slice(table_slice&& slice) {
   slice.import_time(time::clock::now());
   on_process(slice);
-  self->send(index, std::move(slice));
+  if (retention_policy.should_be_persisted(slice)) {
+    self->send(index, std::move(slice));
+  }
 }
 
 importer_actor::behavior_type
@@ -68,6 +70,13 @@ importer(importer_actor::stateful_pointer<importer_state> self,
   });
   if (index) {
     self->state().index = std::move(index);
+  }
+  if (auto policy
+      = retention_policy::make(check(to<record>(content(self->config()))))) {
+    self->state().retention_policy = std::move(*policy);
+  } else {
+    self->quit(std::move(policy.error()));
+    return {};
   }
   self->set_down_handler([self](const caf::down_msg& msg) {
     const auto subscriber

--- a/libtenzir/src/importer.cpp
+++ b/libtenzir/src/importer.cpp
@@ -76,7 +76,7 @@ importer(importer_actor::stateful_pointer<importer_state> self,
     self->state().retention_policy = std::move(*policy);
   } else {
     self->quit(std::move(policy.error()));
-    return {};
+    return importer_actor::behavior_type::make_empty_behavior();
   }
   self->set_down_handler([self](const caf::down_msg& msg) {
     const auto subscriber

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "91a52e9e8f23cd99e3864dba6f38df7477f7becd",
+  "rev": "cd1c19fa89742a973a559e53b6d7ae1629cef5e1",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -18,6 +18,20 @@ tenzir:
   # without retries.
   connection-retry-delay: 3s
 
+  # Configure retention policies.
+  retention:
+    # How long to keep metrics for. Set to 0s to disable metrics retention
+    # entirely.
+    # WARNING: A low retention period may negatively impact the usability of
+    # pipeline activity in the Tenzir Platform.
+    #metrics: 7d
+
+    # How long to keep diagnostics for. Set to 0s to disable diagnostics
+    # retention entirely.
+    # WARNING: A low retention period may negatively impact the usability of
+    # diagnostics in the Tenzir Platform.
+    #diagnostics: 30d
+
   # Always use TQL2 for pipelines.
   #tql2: false
 

--- a/tenzir/tenzir.cpp
+++ b/tenzir/tenzir.cpp
@@ -122,7 +122,7 @@ auto main(int argc, char** argv) -> int {
     }
   }
 #if TENZIR_POSIX
-  struct rlimit rlimit {};
+  struct rlimit rlimit{};
   if (::getrlimit(RLIMIT_NOFILE, &rlimit) < 0) {
     TENZIR_ERROR("failed to get RLIMIT_NOFILE: {}", detail::describe_errno());
     return -errno;

--- a/web/docs/tql2/operators/diagnostics.md
+++ b/web/docs/tql2/operators/diagnostics.md
@@ -11,6 +11,17 @@ diagnostics [live=bool, retro=bool]
 The `diagnostics` operator retrieves diagnostic events from a Tenzir
 node.
 
+:::tip Retention Policy
+Set the `tenzir.retention.diagnostics` configuration option to change how long
+Tenzir Nodes store diagnostics:
+
+```yaml
+tenzir:
+  retention:
+    diagnostics: 30d
+```
+:::
+
 ### `live = bool (optional)`
 
 If `true`, emits diagnostic events as they are generated in real-time. Unless

--- a/web/docs/tql2/operators/metrics.md
+++ b/web/docs/tql2/operators/metrics.md
@@ -11,6 +11,17 @@ metrics [name:string, live=bool, retro=bool]
 The `metrics` operator retrieves metrics events from a Tenzir node. Metrics
 events are collected every second.
 
+:::tip Retention Policy
+Set the `tenzir.retention.metrics` configuration option to change how long
+Tenzir Nodes store metrics:
+
+```yaml
+tenzir:
+  retention:
+    metrics: 7d
+```
+:::
+
 ### `name: string (optional)`
 
 Show only metrics with the specified name. For example, `metrics "cpu"` only shows


### PR DESCRIPTION
This adds two new configuration options `tenzir.retention.metrics` and `tenzir.retention.diagnostics`, which control how Tenzir stores metrics and diagnostics, respectively.

The options are checked in two places:
- The compactor maps them to time-based compaction rules.
- The importer does not forward metrics or diagnostics for which the retention policy is set to zero seconds.