### PR TITLE
Add a WebSocket loader

### DIFF
--- a/libtenzir/include/tenzir/curl.hpp
+++ b/libtenzir/include/tenzir/curl.hpp
@@ -320,7 +320,7 @@ public:
   /// @param size The size of the file.
   auto set_infilesize(long size) -> code;
 
-  /// Sets ` CURLOPT_POSTFIELDSIZE` and `CURLOPT_POSTFIELDSIZE_LARGE` based on
+  /// Sets `CURLOPT_POSTFIELDSIZE` and `CURLOPT_POSTFIELDSIZE_LARGE` based on
   /// the input value.
   /// @param size The size of the post data.
   auto set_postfieldsize(long size) -> code;
@@ -338,6 +338,13 @@ public:
 
   /// Enumerates the list of all added headers.
   auto headers() -> generator<std::pair<std::string_view, std::string_view>>;
+
+  /// Retrieves as much as possible of a received WebSocket data fragment into
+  /// the provided span.
+  /// Equivalent to `curl_ws_recv`.
+  /// @param buffer The buffer to receive into.
+  /// @returns A pair of error code and returned bytes.
+  auto ws_recv(std::span<std::byte> buffer) -> std::pair<code, size_t>;
 
   /// `curl_easy_perform`
   auto perform() -> code;

--- a/libtenzir/src/curl.cpp
+++ b/libtenzir/src/curl.cpp
@@ -171,6 +171,15 @@ auto easy::headers()
   }
 }
 
+auto easy::ws_recv(std::span<std::byte> buffer) -> std::pair<code, size_t> {
+  auto bytes_received = size_t{0};
+  const curl_ws_frame *meta = nullptr; // unused for now
+  auto curl_code = curl_ws_recv(easy_.get(), buffer.data(), buffer.size(),
+      &bytes_received, &meta);
+  auto result = static_cast<code>(curl_code);
+  return {result, bytes_received};
+}
+
 auto easy::perform() -> code {
   auto curl_code = curl_easy_perform(easy_.get());
   return static_cast<code>(curl_code);


### PR DESCRIPTION
This PR adds a new `load_ws` operator to read from a WebSocket.

Should be tried with:

```bash
tenzir 'load_ws "wss://certstream.calidog.io/"'
```

Unfortunately, this doesn't work on macOS via Homebrew, as it lacks a libcurl with WebSocket support. 😞 

