### PR TITLE
Fix all deprecation warnings in CAF 1.0+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,10 +306,6 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   target_compile_options(libtenzir_internal INTERFACE -Wno-unknown-warning)
 endif ()
 
-# FIXME: remove and fix warnings.
-target_compile_options(libtenzir_internal
-                       INTERFACE -Wno-deprecated-declarations)
-
 set(gcc12plus
     "$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,12>>"
 )

--- a/libtenzir/builtins/aspects/index.cpp
+++ b/libtenzir/builtins/aspects/index.cpp
@@ -42,8 +42,8 @@ public:
     auto [index] = std::move(*components);
     auto status = record{};
     ctrl.self()
-      .request(index, caf::infinite, atom::status_v, status_verbosity::debug,
-               duration::max())
+      .mail(atom::status_v, status_verbosity::debug, duration::max())
+      .request(index, caf::infinite)
       .await(
         [&](record& result) {
           status = std::move(result);

--- a/libtenzir/builtins/components/metrics_collector.cpp
+++ b/libtenzir/builtins/components/metrics_collector.cpp
@@ -72,7 +72,7 @@ struct metrics_collector_state {
         TENZIR_TRACE("{} sends out metrics", *self);
         for (auto& instance : instances) {
           for (auto&& slice : instance.builder.finish_as_table_slice()) {
-            self->send(importer, std::move(slice));
+            self->mail(std::move(slice)).send(importer);
           }
         }
       },

--- a/libtenzir/builtins/operators/api.cpp
+++ b/libtenzir/builtins/operators/api.cpp
@@ -35,7 +35,8 @@ public:
     auto response = std::optional<rest_response>{};
     const auto request_id = std::string{};
     ctrl.self()
-      .request(ctrl.node(), caf::infinite, atom::proxy_v, request, request_id)
+      .mail(atom::proxy_v, request, request_id)
+      .request(ctrl.node(), caf::infinite)
       .await(
         [&](rest_response& value) {
           response = std::move(value);

--- a/libtenzir/builtins/operators/cache.cpp
+++ b/libtenzir/builtins/operators/cache.cpp
@@ -332,8 +332,9 @@ public:
       // to avoid upstream operators starting up in the first place.
       auto blocking_self = caf::scoped_actor{ctrl.self().system()};
       blocking_self
-        ->request(cache_manager, caf::infinite, atom::get_v, id_.inner,
-                  /* exclusive */ true)
+        ->mail(atom::get_v, id_.inner,
+               /* exclusive */ true)
+        .request(cache_manager, caf::infinite)
         .receive(
           [&](caf::actor& handle) {
             cache = caf::actor_cast<cache_actor>(std::move(handle));
@@ -494,7 +495,8 @@ public:
       auto events = table_slice{};
       ctrl.set_waiting(true);
       ctrl.self()
-        .request(cache, caf::infinite, atom::read_v)
+        .mail(atom::read_v)
+        .request(cache, caf::infinite)
         .then(
           [&](table_slice& response) {
             ctrl.set_waiting(false);

--- a/libtenzir/builtins/operators/delay.cpp
+++ b/libtenzir/builtins/operators/delay.cpp
@@ -35,8 +35,8 @@ public:
   }
 
   auto
-  operator()(generator<table_slice> input,
-             operator_control_plane& ctrl) const -> generator<table_slice> {
+  operator()(generator<table_slice> input, operator_control_plane& ctrl) const
+    -> generator<table_slice> {
     auto alarm_clock = ctrl.self().spawn(detail::make_alarm_clock);
     auto resolved_fields = std::unordered_map<type, std::optional<offset>>{};
     auto start = start_;
@@ -103,7 +103,8 @@ public:
         if (delay > duration::zero()) {
           co_yield subslice(slice, begin, end);
           ctrl.self()
-            .request(alarm_clock, caf::infinite, delay)
+            .mail(delay)
+            .request(alarm_clock, caf::infinite)
             .await(
               [&]() {
                 begin = end;
@@ -121,8 +122,8 @@ public:
     }
   }
 
-  auto optimize(expression const&,
-                event_order order) const -> optimize_result override {
+  auto optimize(expression const&, event_order order) const
+    -> optimize_result override {
     return optimize_result::order_invariant(*this, order);
   }
 
@@ -153,8 +154,8 @@ public:
   }
 
   auto
-  operator()(generator<table_slice> input,
-             operator_control_plane& ctrl) const -> generator<table_slice> {
+  operator()(generator<table_slice> input, operator_control_plane& ctrl) const
+    -> generator<table_slice> {
     auto alarm_clock = ctrl.self().spawn(detail::make_alarm_clock);
     auto resolved_fields = std::unordered_map<type, std::optional<offset>>{};
     auto start = start_;
@@ -202,7 +203,8 @@ public:
           if (delay > duration::zero()) {
             co_yield subslice(slice, begin, end);
             ctrl.self()
-              .request(alarm_clock, caf::infinite, delay)
+              .mail(delay)
+              .request(alarm_clock, caf::infinite)
               .await(
                 [&]() {
                   begin = end;
@@ -221,8 +223,8 @@ public:
     }
   }
 
-  auto optimize(expression const&,
-                event_order order) const -> optimize_result override {
+  auto optimize(expression const&, event_order order) const
+    -> optimize_result override {
     return optimize_result::order_invariant(*this, order);
   }
 
@@ -266,8 +268,8 @@ public:
 };
 
 class plugin2 final : public virtual operator_plugin2<delay_operator2> {
-  auto
-  make(invocation inv, session ctx) const -> failure_or<operator_ptr> override {
+  auto make(invocation inv, session ctx) const
+    -> failure_or<operator_ptr> override {
     auto speed = std::optional<located<double>>{};
     auto start = std::optional<time>{};
     auto expr = ast::expression{};

--- a/libtenzir/builtins/operators/every_cron.cpp
+++ b/libtenzir/builtins/operators/every_cron.cpp
@@ -68,8 +68,8 @@ public:
       location_{location} {
   }
 
-  auto optimize(expression const& filter,
-                event_order order) const -> optimize_result override {
+  auto optimize(expression const& filter, event_order order) const
+    -> optimize_result override {
     auto result = pipe_.optimize(filter, order);
     if (not result.replacement) {
       return result;
@@ -82,8 +82,8 @@ public:
   }
 
   template <class Input, class Output>
-  auto run(operator_input input,
-           operator_control_plane& ctrl) const -> generator<Output> {
+  auto run(operator_input input, operator_control_plane& ctrl) const
+    -> generator<Output> {
     auto alarm_clock = ctrl.self().spawn(make_alarm_clock);
     auto next_run = scheduler_.next_after(time::clock::now());
     auto done = false;
@@ -138,7 +138,8 @@ public:
       }
       next_run = scheduler_.next_after(next_run);
       ctrl.self()
-        .request(alarm_clock, caf::infinite, delta)
+        .mail(delta)
+        .request(alarm_clock, caf::infinite)
         .await([]() { /*nop*/ },
                [&](const caf::error& err) {
                  diagnostic::error(err)
@@ -268,8 +269,8 @@ public:
     return f.object(x).fields(f.field("interval", x.interval_));
   }
 
-  auto
-  next_after(time::clock::time_point now) const -> time::clock::time_point {
+  auto next_after(time::clock::time_point now) const
+    -> time::clock::time_point {
     return std::chrono::time_point_cast<time::clock::time_point::duration>(
       now + interval_);
   }
@@ -306,8 +307,8 @@ public:
     : cronexpr_{std::move(expr)} {
   }
 
-  auto
-  next_after(time::clock::time_point now) const -> time::clock::time_point {
+  auto next_after(time::clock::time_point now) const
+    -> time::clock::time_point {
     const auto tt = time::clock::to_time_t(now);
     return time::clock::from_time_t(detail::cron::cron_next(cronexpr_, tt));
   }
@@ -362,8 +363,8 @@ public:
     return "tql2.every";
   }
 
-  auto
-  make(invocation inv, session ctx) const -> failure_or<operator_ptr> override {
+  auto make(invocation inv, session ctx) const
+    -> failure_or<operator_ptr> override {
     auto interval = located<duration>{};
     auto pipe = pipeline{};
     TRY(argument_parser2::operator_("every")
@@ -399,8 +400,8 @@ public:
     return "tql2.cron";
   }
 
-  auto
-  make(invocation inv, session ctx) const -> failure_or<operator_ptr> override {
+  auto make(invocation inv, session ctx) const
+    -> failure_or<operator_ptr> override {
     auto interval = located<std::string>{};
     auto pipe = pipeline{};
     TRY(argument_parser2::operator_(name())

--- a/libtenzir/builtins/operators/import.cpp
+++ b/libtenzir/builtins/operators/import.cpp
@@ -69,7 +69,8 @@ public:
       total_events += slice.rows();
       inflight_batches += 1;
       ctrl.self()
-        .request(importer, caf::infinite, std::move(slice))
+        .mail(std::move(slice))
+        .request(importer, caf::infinite)
         .then(
           [&]() {
             inflight_batches -= 1;
@@ -92,7 +93,8 @@ public:
     }
     ctrl.set_waiting(true);
     ctrl.self()
-      .request(importer, caf::infinite, atom::flush_v)
+      .mail(atom::flush_v)
+      .request(importer, caf::infinite)
       .then(
         [&] {
           ctrl.set_waiting(false);

--- a/libtenzir/builtins/operators/partitions.cpp
+++ b/libtenzir/builtins/operators/partitions.cpp
@@ -57,7 +57,8 @@ public:
     auto synopses = std::vector<partition_synopsis_pair>{};
     ctrl.set_waiting(true);
     ctrl.self()
-      .request(catalog, caf::infinite, atom::get_v, filter_)
+      .mail(atom::get_v, filter_)
+      .request(catalog, caf::infinite)
       .await(
         [&](std::vector<partition_synopsis_pair>& result) {
           ctrl.set_waiting(false);

--- a/libtenzir/builtins/operators/schemas.cpp
+++ b/libtenzir/builtins/operators/schemas.cpp
@@ -30,7 +30,8 @@ public:
     ctrl.set_waiting(true);
     auto schemas = std::unordered_set<type>{};
     ctrl.self()
-      .request(catalog, caf::infinite, atom::get_v)
+      .mail(atom::get_v)
+      .request(catalog, caf::infinite)
       .then(
         [&](std::vector<partition_synopsis_pair>& synopses) {
           for (const auto& [id, synopsis] : synopses) {

--- a/libtenzir/builtins/operators/tcp-listen.cpp
+++ b/libtenzir/builtins/operators/tcp-listen.cpp
@@ -22,6 +22,7 @@
 #include <boost/asio.hpp>
 #include <boost/asio/ssl.hpp>
 #include <boost/version.hpp>
+#include <caf/anon_mail.hpp>
 #include <caf/event_based_actor.hpp>
 #include <caf/stateful_actor.hpp>
 #include <caf/typed_event_based_actor.hpp>
@@ -351,7 +352,7 @@ auto make_connection(connection_actor::stateful_pointer<connection_state> self,
       // operator terminates. If the windows in which the connections relinquish
       // their handles don't overlap the bridge and all connections are kept
       // alive indefinitely.
-      caf::anon_send(handle, std::move(slice));
+      caf::anon_mail(std::move(slice)).send(handle);
     }
     ++self->state().it;
   });
@@ -546,7 +547,8 @@ public:
       auto slice = table_slice{};
       ctrl.set_waiting(true);
       ctrl.self()
-        .request(bridge, caf::infinite, atom::get_v)
+        .mail(atom::get_v)
+        .request(bridge, caf::infinite)
         .then(
           [&](table_slice& result) {
             ctrl.set_waiting(false);

--- a/libtenzir/builtins/operators/throttle.cpp
+++ b/libtenzir/builtins/operators/throttle.cpp
@@ -23,8 +23,8 @@ namespace {
 
 using float_seconds = std::chrono::duration<double>;
 
-auto split_chunk(const chunk_ptr& in, size_t head_offset,
-                 size_t position) -> std::pair<chunk_ptr, chunk_ptr> {
+auto split_chunk(const chunk_ptr& in, size_t head_offset, size_t position)
+  -> std::pair<chunk_ptr, chunk_ptr> {
   if (head_offset >= in->size()) {
     return {chunk::make_empty(), chunk::make_empty()};
   }
@@ -80,8 +80,8 @@ public:
         budget = 0;
         ctrl.set_waiting(true);
         ctrl.self()
-          .request(alarm_clock, caf::infinite,
-                   duration_cast<caf::timespan>(window_))
+          .mail(duration_cast<caf::timespan>(window_))
+          .request(alarm_clock, caf::infinite)
           .then(
             [&]() {
               ctrl.set_waiting(false);
@@ -106,8 +106,8 @@ public:
     return "throttle";
   }
 
-  auto optimize(expression const& filter,
-                event_order order) const -> optimize_result override {
+  auto optimize(expression const& filter, event_order order) const
+    -> optimize_result override {
     (void)filter, (void)order;
     return do_not_optimize(*this);
   }
@@ -153,8 +153,8 @@ public:
              : float_seconds{1});
   }
 
-  auto
-  make(invocation inv, session ctx) const -> failure_or<operator_ptr> override {
+  auto make(invocation inv, session ctx) const
+    -> failure_or<operator_ptr> override {
     auto bandwidth = located<uint64_t>{};
     auto window = std::optional<located<duration>>{};
     argument_parser2::operator_("throttle")

--- a/libtenzir/include/tenzir/component_registry.hpp
+++ b/libtenzir/include/tenzir/component_registry.hpp
@@ -56,7 +56,7 @@ public:
   /// @param comp The component to erase.
   /// @returns The deleted component or an error if *comp* is not an existing
   /// actor.
-  [[nodiscard]] caf::expected<component> remove(const caf::actor& comp);
+  [[nodiscard]] caf::expected<component> remove(const caf::actor_addr& comp);
 
   /// Finds the label of a given component actor.
   /// @param comp The component actor.
@@ -106,8 +106,9 @@ public:
       [this](auto&&... labels) -> std::array<caf::actor, sizeof...(Handles)> {
         auto find_component = [this](auto&& label) -> caf::actor {
           if (auto i = components_.find(std::forward<decltype(label)>(label));
-              i != components_.end())
+              i != components_.end()) {
             return i->second.actor;
+          }
           return {};
         };
         return {find_component(std::forward<decltype(labels)>(labels))...};

--- a/libtenzir/include/tenzir/connect_to_node.hpp
+++ b/libtenzir/include/tenzir/connect_to_node.hpp
@@ -52,14 +52,15 @@ void connect_to_node(caf::typed_event_based_actor<Sigs...>* self,
     = self->spawn(tenzir::connector, details::get_retry_delay(opts),
                   details::get_deadline(timeout));
   self
-    ->request(connector, caf::infinite, atom::connect_v,
-              connect_request{node_endpoint->port->number(),
-                              node_endpoint->host})
+    ->mail(atom::connect_v,
+           connect_request{node_endpoint->port->number(), node_endpoint->host})
+    .request(connector, caf::infinite)
     .then(
       [=](node_actor& node) {
         // We must keep the connector alive until after this request is completed.
         (void)connector;
-        self->request(node, timeout, atom::get_v, atom::version_v)
+        self->mail(atom::get_v, atom::version_v)
+          .request(node, timeout)
           .then(
             [self, callback,
              node = std::move(node)](record& remote_version) mutable {

--- a/libtenzir/include/tenzir/context.hpp
+++ b/libtenzir/include/tenzir/context.hpp
@@ -163,8 +163,8 @@ public:
     TENZIR_ASSERT(context_manager);
     ctrl.set_waiting(true);
     ctrl.self()
-      .request(context_manager, caf::infinite, atom::create_v, name_.inner,
-               std::string{Name.str()}, save_result_)
+      .mail(atom::create_v, name_.inner, std::string{Name.str()}, save_result_)
+      .request(context_manager, caf::infinite)
       .then(
         [&]() {
           ctrl.set_waiting(false);

--- a/libtenzir/include/tenzir/detail/serialize.hpp
+++ b/libtenzir/include/tenzir/detail/serialize.hpp
@@ -24,7 +24,7 @@ namespace tenzir::detail {
 /// @relates detail::deserialize
 template <class... Ts>
 auto serialize(caf::byte_buffer& buffer, Ts&&... xs) {
-  caf::binary_serializer serializer{nullptr, buffer};
+  caf::binary_serializer serializer{buffer};
   return apply_all(serializer, std::forward<Ts>(xs)...);
 }
 

--- a/libtenzir/include/tenzir/node_control.hpp
+++ b/libtenzir/include/tenzir/node_control.hpp
@@ -48,9 +48,8 @@ auto get_node_components(caf::scoped_actor& self, const node_actor& node)
   };
   auto labels = std::vector<std::string>{
     normalize(caf::type_name_by_id<caf::type_id<Actors>::value>::value)...};
-  self
-    ->request(node, caf::infinite, atom::get_v, atom::label_v,
-              std::move(labels))
+  self->mail(atom::get_v, atom::label_v, std::move(labels))
+    .request(node, caf::infinite)
     .receive(
       [&](std::vector<caf::actor>& components) {
         result = detail::tuple_map<result_t>(

--- a/libtenzir/include/tenzir/passive_partition.hpp
+++ b/libtenzir/include/tenzir/passive_partition.hpp
@@ -97,6 +97,9 @@ struct passive_partition_state {
   /// The store to retrieve the data from.
   store_actor store = {};
 
+  /// Whether this actor is currently shutting down.
+  bool is_shutting_down = false;
+
   /// Actor handle of the node.
   node_actor::pointer node = {};
 

--- a/libtenzir/include/tenzir/pipeline_executor.hpp
+++ b/libtenzir/include/tenzir/pipeline_executor.hpp
@@ -44,6 +44,9 @@ struct pipeline_executor_state {
   /// Indicates whether the pipeline is run in the background.
   bool is_hidden = {};
 
+  /// Determines whether the pipeline has been started.
+  bool is_started = {};
+
   auto start() -> caf::result<void>;
   auto pause() -> caf::result<void>;
   auto resume() -> caf::result<void>;

--- a/libtenzir/include/tenzir/shared_diagnostic_handler.hpp
+++ b/libtenzir/include/tenzir/shared_diagnostic_handler.hpp
@@ -14,6 +14,7 @@
 #include "tenzir/detail/weak_handle.hpp"
 #include "tenzir/diagnostics.hpp"
 
+#include <caf/anon_mail.hpp>
 #include <caf/typed_event_based_actor.hpp>
 
 namespace tenzir {
@@ -43,7 +44,7 @@ public:
     if (auto exec_node = weak_exec_node_.lock()) {
       // FIXME: The diagnostics sent by this do not appear at the target
       // actor when that utilizes request/await.
-      caf::anon_send<caf::message_priority::high>(exec_node, std::move(diag));
+      caf::anon_mail(std::move(diag)).urgent().send(exec_node);
     }
   }
 

--- a/libtenzir/src/component_registry.cpp
+++ b/libtenzir/src/component_registry.cpp
@@ -19,10 +19,13 @@ bool component_registry::add(caf::actor comp, std::string type,
                              std::string label) {
   TENZIR_ASSERT(comp);
   TENZIR_ASSERT(!type.empty());
-  if (label.empty())
+  if (label.empty()) {
     label = type;
+  }
 #if TENZIR_ENABLE_ASSERTIONS
-  auto pred = [&](auto& x) { return x.second.actor == comp; };
+  auto pred = [&](auto& x) {
+    return x.second.actor == comp;
+  };
   TENZIR_ASSERT_EXPENSIVE(
     std::none_of(components_.begin(), components_.end(), pred));
 #endif
@@ -34,15 +37,16 @@ bool component_registry::add(caf::actor comp, std::string type,
 caf::expected<component_registry::component>
 component_registry::remove(std::string_view label) {
   auto i = components_.find(label);
-  if (i == components_.end())
+  if (i == components_.end()) {
     return {caf::error{}};
+  }
   auto result = std::move(i->second);
   components_.erase(i);
   return result;
 }
 
 caf::expected<component_registry::component>
-component_registry::remove(const caf::actor& comp) {
+component_registry::remove(const caf::actor_addr& comp) {
   for (auto i = components_.begin(); i != components_.end(); ++i) {
     if (i->second.actor == comp) {
       auto result = std::move(i->second);
@@ -55,31 +59,38 @@ component_registry::remove(const caf::actor& comp) {
 
 const std::string*
 component_registry::find_label_for(const caf::actor& comp) const {
-  auto pred = [&](auto& x) { return x.second.actor == comp; };
+  auto pred = [&](auto& x) {
+    return x.second.actor == comp;
+  };
   auto i = std::find_if(components_.begin(), components_.end(), pred);
   return i != components_.end() ? &i->first : nullptr;
 }
 
 const std::string*
 component_registry::find_type_for(const caf::actor& comp) const {
-  auto pred = [&](auto& x) { return x.second.actor == comp; };
+  auto pred = [&](auto& x) {
+    return x.second.actor == comp;
+  };
   auto i = std::find_if(components_.begin(), components_.end(), pred);
   return i != components_.end() ? &i->second.type : nullptr;
 }
 
 caf::actor component_registry::find_by_label(std::string_view label) const {
   // TODO: remove string conversion in with C++20 transparent keys.
-  if (auto i = components_.find(std::string{label}); i != components_.end())
+  if (auto i = components_.find(std::string{label}); i != components_.end()) {
     return i->second.actor;
+  }
   return {};
 }
 
 std::vector<caf::actor>
 component_registry::find_by_type(std::string_view type) const {
   auto result = std::vector<caf::actor>{};
-  for ([[maybe_unused]] auto& [label, comp] : components_)
-    if (comp.type == type)
+  for ([[maybe_unused]] auto& [label, comp] : components_) {
+    if (comp.type == type) {
       result.push_back(comp.actor);
+    }
+  }
   return result;
 }
 

--- a/libtenzir/src/evaluator.cpp
+++ b/libtenzir/src/evaluator.cpp
@@ -168,7 +168,8 @@ evaluator(evaluator_actor::stateful_pointer<evaluator_state> self,
           continue;
         }
 
-        self->request(indexer, caf::infinite, atom::evaluate_v, curried_pred)
+        self->mail(atom::evaluate_v, curried_pred)
+          .request(indexer, caf::infinite)
           .then(
             [self, pos_ = pos](const ids& hits) {
               self->state().handle_result(pos_, hits);

--- a/libtenzir/src/metric_handler.cpp
+++ b/libtenzir/src/metric_handler.cpp
@@ -8,6 +8,7 @@
 
 #include "tenzir/metric_handler.hpp"
 
+#include <caf/anon_mail.hpp>
 #include <caf/send.hpp>
 
 namespace tenzir {
@@ -18,15 +19,16 @@ metric_handler::metric_handler(metrics_receiver_actor receiver,
   : receiver_{std::move(receiver)},
     op_index_{operator_index},
     metric_index_{metric_index} {
-  caf::anon_send(receiver_, op_index_, metric_index_,
-                 type{metric_type, {{"internal", ""}}});
+  caf::anon_mail(op_index_, metric_index_,
+                 type{metric_type, {{"internal", ""}}})
+    .send(receiver_);
 }
 
 auto metric_handler::emit(record&& r) -> void {
   // Explicitly create a data-from-time cast here to support macOS builds.
   r.emplace("timestamp", time{time::clock::now()});
   r.emplace("operator_id", op_index_);
-  caf::anon_send(receiver_, op_index_, metric_index_, std::move(r));
+  caf::anon_mail(op_index_, metric_index_, std::move(r)).send(receiver_);
 }
 
 } // namespace tenzir

--- a/libtenzir/src/pipeline.cpp
+++ b/libtenzir/src/pipeline.cpp
@@ -307,14 +307,14 @@ auto operator_base::copy() const -> operator_ptr {
     TENZIR_ASSERT(false);
   }
   auto buffer = caf::byte_buffer{};
-  auto f = caf::binary_serializer{nullptr, buffer};
+  auto f = caf::binary_serializer{buffer};
   auto success = p->serialize(f, *this);
   if (not success) {
     TENZIR_ERROR("failed to serialize `{}` operator: {}", name(),
                  f.get_error());
     TENZIR_ASSERT(false);
   }
-  auto g = caf::binary_deserializer{nullptr, buffer};
+  auto g = caf::binary_deserializer{buffer};
   auto copy = operator_ptr{};
   p->deserialize(g, copy);
   if (not copy) {

--- a/libtenzir/src/shutdown.cpp
+++ b/libtenzir/src/shutdown.cpp
@@ -24,16 +24,6 @@ namespace tenzir {
 template <class Policy>
 void shutdown(caf::event_based_actor* self, std::vector<caf::actor> xs,
               caf::error reason) {
-  // Ignore duplicate EXIT messages except for hard kills.
-  self->set_exit_handler([=](const caf::exit_msg& msg) {
-    if (msg.reason == caf::exit_reason::kill) {
-      TENZIR_WARN("{} received hard kill and terminates immediately", *self);
-      self->quit(msg.reason);
-    } else {
-      TENZIR_DEBUG("{} ignores duplicate EXIT message from {}", *self,
-                   msg.source);
-    }
-  });
   // Terminate actors as requested.
   terminate<Policy>(self, std::move(xs))
     .then(

--- a/libtenzir/src/signal_reflector.cpp
+++ b/libtenzir/src/signal_reflector.cpp
@@ -42,7 +42,7 @@ signal_reflector_actor::behavior_type signal_reflector(
       }
       std::cerr << "\rinitiating graceful shutdown... (repeat request to "
                    "terminate immediately)\n";
-      self->send(self->state().handler, atom::signal_v, signum);
+      self->mail(atom::signal_v, signum).send(self->state().handler);
     },
     [self](atom::subscribe) {
       self->state().handler

--- a/libtenzir/src/start_command.cpp
+++ b/libtenzir/src/start_command.cpp
@@ -196,7 +196,7 @@ auto start_command(const invocation& inv, caf::actor_system& sys)
       }
       auto runner = self->spawn<caf::detached>(command_runner);
       command_runners.push_back(runner);
-      self->send(runner, atom::run_v, *hook_invocation);
+      self->mail(atom::run_v, *hook_invocation).send(runner);
     }
   }
   self

--- a/libtenzir/test/detail/inspection_common.cpp
+++ b/libtenzir/test/detail/inspection_common.cpp
@@ -25,8 +25,8 @@ using dummy_saving_inspector = dummy_inspector<false>;
 
 } // namespace
 
-TEST(callback is invoked and the fields invocation returns true when all
-       fields and callback return true) {
+TEST(callback is invoked and the fields invocation
+       returns true when all fields and callback return true) {
   dummy_saving_inspector inspector;
   std::size_t callback_calls_count{0u};
   bool field1_invoked = false;
@@ -141,11 +141,11 @@ TEST(inspect_enum with caf binary inspectors) {
   // serialize
   auto in = enum_example::value_1;
   caf::byte_buffer buf;
-  caf::binary_serializer serializer{nullptr, buf};
+  caf::binary_serializer serializer{buf};
   tenzir::detail::inspect_enum(serializer, in);
   // deserialize
   auto out = enum_example::value_2;
-  caf::binary_deserializer deserializer{nullptr, buf};
+  caf::binary_deserializer deserializer{buf};
   tenzir::detail::inspect_enum(deserializer, out);
   CHECK_EQUAL(in, out);
 }

--- a/libtenzir/test/detail/legacy_deserialize.cpp
+++ b/libtenzir/test/detail/legacy_deserialize.cpp
@@ -33,8 +33,8 @@ using namespace std::string_literals;
 using namespace tenzir;
 
 template <class... Ts>
-  requires(!std::is_rvalue_reference_v<Ts> && ...) bool
-ldes(caf::byte_buffer& buf, Ts&... xs) {
+  requires(!std::is_rvalue_reference_v<Ts> && ...)
+bool ldes(caf::byte_buffer& buf, Ts&... xs) {
   return detail::legacy_deserialize(buf, xs...);
 }
 
@@ -359,7 +359,7 @@ struct custom {
 
 TEST(caf_optional) {
   caf::byte_buffer serialization_output;
-  caf::binary_serializer s{nullptr, serialization_output};
+  caf::binary_serializer s{serialization_output};
   auto in = std::optional<custom>{custom{"test str", 221}};
   REQUIRE(s.apply(in));
   auto out = std::optional<custom>{};
@@ -369,7 +369,7 @@ TEST(caf_optional) {
   // The empty optional should be also deserialized as empty one.
   in.reset();
   serialization_output.clear();
-  caf::binary_serializer s2{nullptr, serialization_output};
+  caf::binary_serializer s2{serialization_output};
   REQUIRE(s2.apply(in));
   // the out contains a set optional now so it should be reassigned to empty one
   // after deserialization
@@ -383,7 +383,7 @@ TEST(caf_config_value integer) {
   // variant
   auto legacy_integer_index = std::uint8_t{0u};
   caf::byte_buffer serialization_output;
-  caf::binary_serializer s{nullptr, serialization_output};
+  caf::binary_serializer s{serialization_output};
   REQUIRE(s.apply(legacy_integer_index) && s.apply(in));
   caf::config_value out;
   REQUIRE(ldes(serialization_output, out));
@@ -398,7 +398,7 @@ TEST(caf_config_value boolean) {
   // variant
   auto legacy_boolean_index = std::uint8_t{1u};
   caf::byte_buffer serialization_output;
-  caf::binary_serializer s{nullptr, serialization_output};
+  caf::binary_serializer s{serialization_output};
   REQUIRE(s.apply(legacy_boolean_index) && s.apply(in));
   caf::config_value out;
   REQUIRE(ldes(serialization_output, out));
@@ -413,7 +413,7 @@ TEST(caf_config_value real) {
   // variant
   auto legacy_real_index = std::uint8_t{2u};
   caf::byte_buffer serialization_output;
-  caf::binary_serializer s{nullptr, serialization_output};
+  caf::binary_serializer s{serialization_output};
   REQUIRE(s.apply(legacy_real_index) && s.apply(in));
   caf::config_value out;
   REQUIRE(ldes(serialization_output, out));
@@ -427,7 +427,7 @@ TEST(caf_config_value string) {
   // current config_value
   caf::config_value in{caf::config_value::string{"example_str"}};
   caf::byte_buffer serialization_output;
-  caf::binary_serializer s{nullptr, serialization_output};
+  caf::binary_serializer s{serialization_output};
   REQUIRE(s.apply(in));
   caf::config_value out;
   REQUIRE(ldes(serialization_output, out));

--- a/nix/caf/source.json
+++ b/nix/caf/source.json
@@ -1,7 +1,7 @@
 {
   "owner": "actor-framework",
   "repo": "actor-framework",
-  "rev": "6a38a9e95abce3a93ff6d2ea2153468b90fdbb5b",
-  "hash": "sha256-1DJ8VYBTC4Kd6IQZoj4AjP3CoHhb+bmtBEozc5T0R/0=",
-  "version": "1.0.2"
+  "rev": "916d957408e33de75c215c896b8752519ee8724d",
+  "hash": "sha256-6zNrq+IUhGf9Nqoxk9n+KS7PiKtJ4sVJZMzMIcDi5eY=",
+  "version": "1.0.2-46-g916d95740"
 }

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "69a168681d203049bf42d3f9b0f630967e820982",
+  "rev": "c811f337ffd7417dabce57a2d3c0969b7c68d1f3",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "c811f337ffd7417dabce57a2d3c0969b7c68d1f3",
+  "rev": "e000394d09ed502ef3af81326ddc06fafc845b0b",
   "submodules": true,
   "shallow": true,
   "allRefs": true

--- a/plugins/web/src/generate_token_command.cpp
+++ b/plugins/web/src/generate_token_command.cpp
@@ -21,10 +21,12 @@ auto generate_token_command(const tenzir::invocation& inv,
   // defined in the main tenzir namespace, so we have to work around manually.
   auto timeout = caf::infinite;
   auto authenticator = get_authenticator(self, node, timeout);
-  if (!authenticator)
+  if (!authenticator) {
     return caf::make_message(authenticator.error());
+  }
   auto result = caf::message{};
-  self->request(*authenticator, caf::infinite, atom::generate_v)
+  self->mail(atom::generate_v)
+    .request(*authenticator, caf::infinite)
     .receive(
       [](token_t token) {
         fmt::print("{}\n", token);

--- a/tenzir/tenzir.cpp
+++ b/tenzir/tenzir.cpp
@@ -27,6 +27,7 @@
 #include <arrow/util/compression.h>
 #include <caf/actor_registry.hpp>
 #include <caf/actor_system.hpp>
+#include <caf/anon_mail.hpp>
 #include <caf/fwd.hpp>
 #include <sys/resource.h>
 
@@ -278,9 +279,10 @@ auto main(int argc, char** argv) -> int {
         int signum = 0;
         sigwait(&sigset, &signum);
         TENZIR_DEBUG("received signal {}", signum);
-        if (!stop)
-          caf::anon_send<caf::message_priority::high>(
-            reflector.get(), atom::internal_v, atom::signal_v, signum);
+        if (!stop) {
+          caf::anon_mail(atom::internal_v, atom::signal_v, signum)
+            .urgent().send(reflector.get());
+        }
       });
   // clang-format on
   // Put it into the actor registry so any actor can communicate with it.


### PR DESCRIPTION
This fixes all deprecation warnings we've seen in CAF 1.0+, and bumps CAF to its most recent version as that contains a set of relevant bug fixes.

- Fixes https://github.com/tenzir/issues/issues/2791
- Fixes https://github.com/tenzir/issues/issues/2792
- Fixes https://github.com/tenzir/issues/issues/2793