### PR TITLE
Deprecate TQL1

### DIFF
--- a/changelog/next/changes/4954--deprecate-tql1.md
+++ b/changelog/next/changes/4954--deprecate-tql1.md
@@ -1,0 +1,3 @@
+TQL1 is now deprecated in favor of TQL2. Starting a TQL1 pipeline issues a
+warning on startup nudging towards upgrading to TQL2, which will become the
+default in the upcoming Tenzir v5.0 release. This warning cannot be turned off.

--- a/libtenzir/builtins/commands/exec.cpp
+++ b/libtenzir/builtins/commands/exec.cpp
@@ -82,6 +82,9 @@ auto exec_command(const invocation& inv, caf::actor_system& sys) -> bool {
     = caf::get_or(inv.options, "tenzir.exec.implicit-events-source",
                   cfg.implicit_events_source);
   cfg.tql2 = caf::get_or(inv.options, "tenzir.tql2", cfg.tql2);
+  cfg.silence_tql1_deprecation_notice
+    = caf::get_or(inv.options, "tenzir.silence-tql1-deprecation-notice",
+                  cfg.silence_tql1_deprecation_notice);
   cfg.strict = caf::get_or(inv.options, "tenzir.exec.strict", cfg.strict);
   auto filename = std::string{};
   auto content = std::string{};

--- a/libtenzir/include/tenzir/exec_pipeline.hpp
+++ b/libtenzir/include/tenzir/exec_pipeline.hpp
@@ -25,6 +25,7 @@ struct exec_config {
   bool dump_diagnostics = false;
   bool dump_metrics = false;
   bool tql2 = false;
+  bool silence_tql1_deprecation_notice = false;
   bool strict = false;
 };
 

--- a/libtenzir/src/exec_pipeline.cpp
+++ b/libtenzir/src/exec_pipeline.cpp
@@ -312,6 +312,17 @@ auto exec_pipeline(std::string content, diagnostic_handler& dh,
     auto success = exec2(std::move(content), dh, cfg, sys);
     return success ? caf::expected<void>{} : ec::silent;
   }
+  if (not cfg.silence_tql1_deprecation_notice) {
+    diagnostic::warning("TQL1 is deprecated and will be removed in the "
+                        "upcoming Tenzir Node v5.0 release")
+      .hint("set `TENZIR_TQL2=true` to always use TQL2")
+      .hint(
+        "use the `--tql2` command-line flag to enable TQL2 for this pipeline "
+        "only")
+      .hint("use the `legacy` operator to fall back to using TQL1 from TQL2")
+      .docs("https://docs.tenzir.com/tql2/operators/legacy")
+      .emit(dh);
+  }
   auto parsed = tql::parse(std::move(content), dh);
   if (not parsed) {
     return ec::silent;

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "6e7a9703b396c29b325dba25dcda54f1144fd472",
+  "rev": "a8823176301271985a54b343113055a13a75ddf3",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/tenzir/bats/data/reference/vast_server/test_yaml/step_01.ref
+++ b/tenzir/bats/data/reference/vast_server/test_yaml/step_01.ref
@@ -1,6 +1,6 @@
 ---
 tenzir:
-  abort-on-panic: 1
+  abort-on-panic: true
   automatic-rebuild: 0
   bare-mode: true
   exec:
@@ -11,4 +11,5 @@ tenzir:
       disable-timestamp-tags: true
   plugins:
     []
+  silence-tql1-deprecation-notice: true
 ...

--- a/tenzir/bats/lib/bats-tenzir/load.bash
+++ b/tenzir/bats/lib/bats-tenzir/load.bash
@@ -9,4 +9,5 @@ source "$(dirname "${BASH_SOURCE[0]}")/src/check.bash"
 source "$(dirname "${BASH_SOURCE[0]}")/src/fixtures.bash"
 source "$(dirname "${BASH_SOURCE[0]}")/src/import.bash"
 
-export TENZIR_ABORT_ON_PANIC=1
+export TENZIR_ABORT_ON_PANIC=true
+export TENZIR_SILENCE_TQL1_DEPRECATION_NOTICE=true

--- a/tenzir/bats/tests/version.bats
+++ b/tenzir/bats/tests/version.bats
@@ -3,6 +3,7 @@
 setup() {
   bats_load_library bats-support
   bats_load_library bats-assert
+  bats_load_library bats-tenzir
 }
 
 @test "print the version with the show operator" {

--- a/web/docs/tql2/operators/legacy.md
+++ b/web/docs/tql2/operators/legacy.md
@@ -1,8 +1,17 @@
 # legacy
 
-:::warning
-This operator will be removed once TQL2 is stable and all TQL1 functionality is
-ported over.
+:::warning Migrate to TQL2
+TQL1 is deprecated and will be removed with the upcoming **Tenzir Node v5.0**
+release, which will make TQL2 the default.
+
+Currently, TQL2 is opt-in. You probably got to this page because you've seen a
+warning in your TQL1 pipelines that pointed you to this page.
+
+To prepare for this migration and use TQL2 for all pipelines today, we recommend
+setting the environment variable `TENZIR_TQL2=true`.
+
+With **Tenzir Node v6.0**, the `legacy` operator and TQL1 will be removed
+entirely.
 :::
 
 Provides a compatibility fallback to TQL1 pipelines.


### PR DESCRIPTION
This deprecates TQL1, causing all TQL1 pipelines to emit a warning on startup that instructs the user to update to TQL2.

The warning can intentionally not be disabled. We want this to be a bit on the annoying side.

- Fixes https://github.com/tenzir/issues/issues/2329