### PR TITLE
Use actor traits for `exec_node_actor`

### DIFF
--- a/libtenzir/src/execution_node.cpp
+++ b/libtenzir/src/execution_node.cpp
@@ -23,6 +23,7 @@
 #include <arrow/config.h>
 #include <arrow/util/byte_size.h>
 #include <caf/actor_addr.hpp>
+#include <caf/actor_from_state.hpp>
 #include <caf/anon_mail.hpp>
 #include <caf/exit_reason.hpp>
 #include <caf/typed_event_based_actor.hpp>
@@ -122,40 +123,38 @@ struct exec_node_state;
 
 template <class Input, class Output>
 struct exec_node_diagnostic_handler final : public diagnostic_handler {
-  exec_node_diagnostic_handler(
-    exec_node_actor::stateful_pointer<exec_node_state<Input, Output>> self,
-    receiver_actor<diagnostic> handle)
-    : self{self}, handle{std::move(handle)} {
+  exec_node_diagnostic_handler(exec_node_state<Input, Output>& state,
+                               receiver_actor<diagnostic> handle)
+    : state{state}, handle{std::move(handle)} {
   }
 
   void emit(diagnostic diag) override {
-    TENZIR_TRACE("{} {} emits diagnostic: {:?}", *self,
-                 self->state().op->name(), diag);
+    TENZIR_TRACE("{} {} emits diagnostic: {:?}", *state.self, state.op->name(),
+                 diag);
     if (diag.severity == severity::error) {
       throw std::move(diag);
     }
     if (deduplicator_.insert(diag)) {
-      self->mail(std::move(diag)).send(handle);
+      state.self->mail(std::move(diag)).send(handle);
     }
   }
 
 private:
-  exec_node_actor::stateful_pointer<exec_node_state<Input, Output>> self = {};
+  exec_node_state<Input, Output>& state;
   receiver_actor<diagnostic> handle = {};
   diagnostic_deduplicator deduplicator_;
 };
 
 template <class Input, class Output>
 struct exec_node_control_plane final : public operator_control_plane {
-  exec_node_control_plane(
-    exec_node_actor::stateful_pointer<exec_node_state<Input, Output>> self,
-    receiver_actor<diagnostic> diagnostic_handler,
-    metrics_receiver_actor metric_receiver, uint64_t op_index,
-    bool has_terminal, bool is_hidden)
-    : state{self->state()},
+  exec_node_control_plane(exec_node_state<Input, Output>& state,
+                          receiver_actor<diagnostic> diagnostic_handler,
+                          metrics_receiver_actor metric_receiver,
+                          uint64_t op_index, bool has_terminal, bool is_hidden)
+    : state{state},
       diagnostic_handler{
         std::make_unique<exec_node_diagnostic_handler<Input, Output>>(
-          self, std::move(diagnostic_handler))},
+          state, std::move(diagnostic_handler))},
       metrics_receiver_{std::move(metric_receiver)},
       operator_index_{op_index},
       has_terminal_{has_terminal},
@@ -227,11 +226,136 @@ struct exec_node_control_plane final : public operator_control_plane {
 
 template <class Input, class Output>
 struct exec_node_state {
-  exec_node_state() = default;
-  exec_node_state(const exec_node_state&) = delete;
-  exec_node_state(exec_node_state&&) = delete;
-  exec_node_state& operator=(const exec_node_state&) = delete;
-  exec_node_state& operator=(exec_node_state&&) = delete;
+  exec_node_state(exec_node_actor::pointer self, operator_ptr op,
+                  const node_actor& node,
+                  const receiver_actor<diagnostic>& diagnostic_handler,
+                  const metrics_receiver_actor& metrics_receiver, int index,
+                  bool has_terminal, bool is_hidden, uuid run_id)
+    : self{self},
+      run_id{run_id},
+      op{std::move(op)},
+      metrics_receiver{metrics_receiver} {
+    auto read_config = [&](auto& key, std::string_view config, uint64_t min) {
+      key = caf::get_or(content(self->system().config()),
+                        fmt::format("tenzir.demand.{}", config), key);
+      key = caf::get_or(content(self->system().config()),
+                        fmt::format("tenzir.demand.{}.{}", config,
+                                    operator_type_name<Input>()),
+                        key);
+      key = std::max(min, key);
+    };
+    read_config(min_elements, "min-elements", 1);
+    read_config(max_elements, "max-elements", min_elements);
+    read_config(max_batches, "max-batches", 1);
+    auto time_starting_guard
+      = make_timer_guard(metrics.time_scheduled, metrics.time_starting);
+    metrics.operator_index = index;
+    metrics.operator_name = this->op->name();
+    metrics.inbound_measurement.unit = operator_type_name<Input>();
+    metrics.outbound_measurement.unit = operator_type_name<Output>();
+    // We make an exception here for transformations, which are always considered
+    // internal as they cannot transport data outside of the pipeline.
+    metrics.internal = this->op->internal()
+                       and (std::is_same_v<Input, std::monostate>
+                            or std::is_same_v<Output, std::monostate>);
+    ctrl = std::make_unique<exec_node_control_plane<Input, Output>>(
+      *this, diagnostic_handler, metrics_receiver, index, has_terminal,
+      is_hidden);
+    // The node actor must be set when the operator is not a source.
+    TENZIR_ASSERT(node or (this->op->location() != operator_location::remote));
+    weak_node = node;
+  }
+
+  auto make_behavior() -> exec_node_actor::behavior_type {
+    if (self->getf(caf::scheduled_actor::is_detached_flag)) {
+      const auto name = fmt::format("tnz.{}", this->op->name());
+      caf::detail::set_thread_name(name.c_str());
+    }
+    self->set_exception_handler(
+      [this](const std::exception_ptr& exception) -> caf::error {
+        auto error = std::invoke([&] {
+          try {
+            std::rethrow_exception(exception);
+          } catch (diagnostic& diag) {
+            return std::move(diag).to_error();
+          } catch (const std::exception& err) {
+            return diagnostic::error("{}", err.what())
+              .note("unhandled exception in {} {}", *self, op->name())
+              .to_error();
+          } catch (...) {
+            return diagnostic::error("unhandled exception in {} {}", *self,
+                                     op->name())
+              .to_error();
+          }
+        });
+        if (start_rp.pending()) {
+          start_rp.deliver(std::move(error));
+          return ec::silent;
+        }
+        return error;
+      });
+    return {
+      [this](atom::internal, atom::run) -> caf::result<void> {
+        auto time_scheduled_guard = make_timer_guard(metrics.time_scheduled);
+        return internal_run();
+      },
+      [this](atom::start,
+             std::vector<caf::actor>& all_previous) -> caf::result<void> {
+        auto time_scheduled_guard
+          = make_timer_guard(metrics.time_scheduled, metrics.time_starting);
+        return start(std::move(all_previous));
+      },
+      [this](atom::pause) -> caf::result<void> {
+        auto time_scheduled_guard = make_timer_guard(metrics.time_scheduled);
+        return pause();
+      },
+      [this](atom::resume) -> caf::result<void> {
+        auto time_scheduled_guard = make_timer_guard(metrics.time_scheduled);
+        return resume();
+      },
+      [this](diagnostic& diag) -> caf::result<void> {
+        auto time_scheduled_guard = make_timer_guard(metrics.time_scheduled);
+        ctrl->diagnostics().emit(std::move(diag));
+        return {};
+      },
+      [this](atom::push, table_slice& events) -> caf::result<void> {
+        auto time_scheduled_guard = make_timer_guard(metrics.time_scheduled);
+        if constexpr (std::is_same_v<Input, table_slice>) {
+          return push(std::move(events));
+        } else {
+          return caf::make_error(
+            ec::logic_error,
+            fmt::format("{} does not accept events as input", *self));
+        }
+      },
+      [this](atom::push, chunk_ptr& bytes) -> caf::result<void> {
+        auto time_scheduled_guard = make_timer_guard(metrics.time_scheduled);
+        if constexpr (std::is_same_v<Input, chunk_ptr>) {
+          return push(std::move(bytes));
+        } else {
+          return caf::make_error(
+            ec::logic_error,
+            fmt::format("{} does not accept bytes as input", *self));
+        }
+      },
+      [this](atom::pull, exec_node_sink_actor& sink,
+             uint64_t batch_size) -> caf::result<void> {
+        auto time_scheduled_guard = make_timer_guard(metrics.time_scheduled);
+        if constexpr (not std::is_same_v<Output, std::monostate>) {
+          return pull(std::move(sink), batch_size);
+        } else {
+          return caf::make_error(
+            ec::logic_error,
+            fmt::format("{} is a sink and must not be pulled from", *self));
+        }
+      },
+      [this](const caf::exit_msg& msg) -> caf::result<void> {
+        auto time_scheduled_guard = make_timer_guard(metrics.time_scheduled);
+        handle_exit_msg(msg);
+        return {};
+      },
+    };
+  }
 
   static constexpr auto name = "exec-node";
 
@@ -803,154 +927,6 @@ struct exec_node_state {
   }
 };
 
-template <class Input, class Output>
-auto exec_node(
-  exec_node_actor::stateful_pointer<exec_node_state<Input, Output>> self,
-  operator_ptr op, const node_actor& node,
-  const receiver_actor<diagnostic>& diagnostic_handler,
-  const metrics_receiver_actor& metrics_receiver, int index, bool has_terminal,
-  bool is_hidden, uuid run_id) -> exec_node_actor::behavior_type {
-  if (self->getf(caf::scheduled_actor::is_detached_flag)) {
-    const auto name = fmt::format("tnz.{}", op->name());
-    caf::detail::set_thread_name(name.c_str());
-  }
-  self->state().self = self;
-  self->state().run_id = run_id;
-  auto read_config = [&](auto& key, std::string_view config, uint64_t min) {
-    key = caf::get_or(content(self->system().config()),
-                      fmt::format("tenzir.demand.{}", config), key);
-    key = caf::get_or(content(self->system().config()),
-                      fmt::format("tenzir.demand.{}.{}", config,
-                                  operator_type_name<Input>()),
-                      key);
-    key = std::max(min, key);
-  };
-  read_config(self->state().min_elements, "min-elements", 1);
-  read_config(self->state().max_elements, "max-elements",
-              self->state().min_elements);
-  read_config(self->state().max_batches, "max-batches", 1);
-  self->state().op = std::move(op);
-  auto time_starting_guard = make_timer_guard(
-    self->state().metrics.time_scheduled, self->state().metrics.time_starting);
-  self->state().metrics_receiver = metrics_receiver;
-  self->state().metrics.operator_index = index;
-  self->state().metrics.operator_name = self->state().op->name();
-  self->state().metrics.inbound_measurement.unit = operator_type_name<Input>();
-  self->state().metrics.outbound_measurement.unit
-    = operator_type_name<Output>();
-  // We make an exception here for transformations, which are always considered
-  // internal as they cannot transport data outside of the pipeline.
-  self->state().metrics.internal
-    = self->state().op->internal()
-      and (std::is_same_v<Input, std::monostate>
-           or std::is_same_v<Output, std::monostate>);
-  self->state().ctrl = std::make_unique<exec_node_control_plane<Input, Output>>(
-    self, diagnostic_handler, self->state().metrics_receiver, index,
-    has_terminal, is_hidden);
-  // The node actor must be set when the operator is not a source.
-  if (self->state().op->location() == operator_location::remote and not node) {
-    self->state().on_error(caf::make_error(
-      ec::logic_error,
-      fmt::format("{} runs a remote operator and must have a node", *self)));
-    return exec_node_actor::behavior_type::make_empty_behavior();
-  }
-  self->state().weak_node = node;
-  self->set_exception_handler(
-    [self](const std::exception_ptr& exception) -> caf::error {
-      auto error = std::invoke([&] {
-        try {
-          std::rethrow_exception(exception);
-        } catch (diagnostic& diag) {
-          return std::move(diag).to_error();
-        } catch (const std::exception& err) {
-          return diagnostic::error("{}", err.what())
-            .note("unhandled exception in {} {}", *self,
-                  self->state().op->name())
-            .to_error();
-        } catch (...) {
-          return diagnostic::error("unhandled exception in {} {}", *self,
-                                   self->state().op->name())
-            .to_error();
-        }
-      });
-      if (self->state().start_rp.pending()) {
-        self->state().start_rp.deliver(std::move(error));
-        return ec::silent;
-      }
-      return error;
-    });
-  return {
-    [self](atom::internal, atom::run) -> caf::result<void> {
-      auto time_scheduled_guard
-        = make_timer_guard(self->state().metrics.time_scheduled);
-      return self->state().internal_run();
-    },
-    [self](atom::start,
-           std::vector<caf::actor>& all_previous) -> caf::result<void> {
-      auto time_scheduled_guard
-        = make_timer_guard(self->state().metrics.time_scheduled,
-                           self->state().metrics.time_starting);
-      return self->state().start(std::move(all_previous));
-    },
-    [self](atom::pause) -> caf::result<void> {
-      auto time_scheduled_guard
-        = make_timer_guard(self->state().metrics.time_scheduled);
-      return self->state().pause();
-    },
-    [self](atom::resume) -> caf::result<void> {
-      auto time_scheduled_guard
-        = make_timer_guard(self->state().metrics.time_scheduled);
-      return self->state().resume();
-    },
-    [self](diagnostic& diag) -> caf::result<void> {
-      auto time_scheduled_guard
-        = make_timer_guard(self->state().metrics.time_scheduled);
-      self->state().ctrl->diagnostics().emit(std::move(diag));
-      return {};
-    },
-    [self](atom::push, table_slice& events) -> caf::result<void> {
-      auto time_scheduled_guard
-        = make_timer_guard(self->state().metrics.time_scheduled);
-      if constexpr (std::is_same_v<Input, table_slice>) {
-        return self->state().push(std::move(events));
-      } else {
-        return caf::make_error(ec::logic_error,
-                               fmt::format("{} does not accept events as input",
-                                           *self));
-      }
-    },
-    [self](atom::push, chunk_ptr& bytes) -> caf::result<void> {
-      auto time_scheduled_guard
-        = make_timer_guard(self->state().metrics.time_scheduled);
-      if constexpr (std::is_same_v<Input, chunk_ptr>) {
-        return self->state().push(std::move(bytes));
-      } else {
-        return caf::make_error(ec::logic_error,
-                               fmt::format("{} does not accept bytes as input",
-                                           *self));
-      }
-    },
-    [self](atom::pull, exec_node_sink_actor& sink,
-           uint64_t batch_size) -> caf::result<void> {
-      auto time_scheduled_guard
-        = make_timer_guard(self->state().metrics.time_scheduled);
-      if constexpr (not std::is_same_v<Output, std::monostate>) {
-        return self->state().pull(std::move(sink), batch_size);
-      } else {
-        return caf::make_error(
-          ec::logic_error,
-          fmt::format("{} is a sink and must not be pulled from", *self));
-      }
-    },
-    [self](const caf::exit_msg& msg) -> caf::result<void> {
-      auto time_scheduled_guard
-        = make_timer_guard(self->state().metrics.time_scheduled);
-      self->state().handle_exit_msg(msg);
-      return {};
-    },
-  };
-}
-
 } // namespace
 
 auto spawn_exec_node(caf::scheduled_actor* self, operator_ptr op,
@@ -979,9 +955,9 @@ auto spawn_exec_node(caf::scheduled_actor* self, operator_ptr op,
       using output_type
         = std::conditional_t<std::is_void_v<Output>, std::monostate, Output>;
       auto result = self->spawn<SpawnOptions>(
-        exec_node<input_type, output_type>, std::move(op), std::move(node),
-        std::move(diagnostics_handler), std::move(metrics_receiver), index,
-        has_terminal, is_hidden, run_id);
+        caf::actor_from_state<exec_node_state<input_type, output_type>>,
+        std::move(op), std::move(node), std::move(diagnostics_handler),
+        std::move(metrics_receiver), index, has_terminal, is_hidden, run_id);
       return result;
     };
   };

--- a/web/docs/tql2/operators/cron.md
+++ b/web/docs/tql2/operators/cron.md
@@ -56,8 +56,8 @@ Pull an endpoint on every 10th minute, Monday through Friday:
 ```tql
 cron "* */10 * * * MON-FRI" {
   from "https://example.org/api"
-  publish "api"
 }
+publish "api"
 ```
 
 ## See Also


### PR DESCRIPTION
This rewrites `exec_node_actor` to use a traits class for its signature and the new class-based actor setup over the previous function-based setup. This makes no functional difference, but much improves the developer experience by shortening stacktraces by around 90%.

To test this, I've modified the `discard` operator to intentionally run into an assertion locally. On the current `main` branch, I get the following stacktrace:

<details>
<summary>Click to expand</summary>

```
0x4c6e800107148ca8: (tenzir::detail::panic_impl(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::source_location)+0x28)
0x2148000107149030: (tenzir::detail::fail_assertion_impl(char const*, std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::source_location)+0x64)
0x5e5680010335d5fc: (void tenzir::detail::fail_assertion<char const (&) [3]>(char const*, char const (&) [3], std::__1::source_location)+0x50)
0x830a00010335dbe0: (tenzir::generator<std::__1::monostate> tenzir::plugins::discard::(anonymous namespace)::discard_operator::operator()<tenzir::table_slice>(tenzir::generator<tenzir::table_slice>) const (.resume)+0x2c)
0x570e0001073363d4: (caf::detail::default_behavior_impl<std::__1::tuple<caf::typed_behavior<caf::result<void> (tenzir::atom::internal, tenzir::atom::run), caf::result<void> (tenzir::atom::start, std::__1::vector<caf::actor, std::__1::allocator<caf::actor>>), caf::result<void> (tenzir::atom::pause), caf::result<void> (tenzir::atom::resume), caf::result<void> (tenzir::diagnostic), caf::result<void> (tenzir::atom::pull, caf::typed_actor<caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>, unsigned long long), caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)> tenzir::(anonymous namespace)::exec_node<tenzir::table_slice, std::__1::monostate>(caf::stateful_actor<tenzir::(anonymous namespace)::exec_node_state<tenzir::table_slice, std::__1::monostate>, caf::typed_event_based_actor<caf::result<void> (tenzir::atom::internal, tenzir::atom::run), caf::result<void> (tenzir::atom::start, std::__1::vector<caf::actor, std::__1::allocator<caf::actor>>), caf::result<void> (tenzir::atom::pause), caf::result<void> (tenzir::atom::resume), caf::result<void> (tenzir::diagnostic), caf::result<void> (tenzir::atom::pull, caf::typed_actor<caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>, unsigned long long), caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>>*, std::__1::unique_ptr<tenzir::operator_base, std::__1::default_delete<tenzir::operator_base>>, caf::typed_actor<caf::result<tenzir::rest_response> (tenzir::atom::proxy, tenzir::http_request_description, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>), caf::result<std::__1::vector<caf::actor, std::__1::allocator<caf::actor>>> (caf::get_atom, tenzir::atom::label, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>), caf::result<tenzir::detail::vector_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data>>, tenzir::detail::stable_map_policy>> (caf::get_atom, tenzir::atom::version), caf::result<caf::typed_actor<caf::result<void> (tenzir::atom::internal, tenzir::atom::run), caf::result<void> (tenzir::atom::start, std::__1::vector<caf::actor, std::__1::allocator<caf::actor>>), caf::result<void> (tenzir::atom::pause), caf::result<void> (tenzir::atom::resume), caf::result<void> (tenzir::diagnostic), caf::result<void> (tenzir::atom::pull, caf::typed_actor<caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>, unsigned long long), caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>> (caf::spawn_atom, tenzir::operator_box, tenzir::tag_variant<void, tenzir::table_slice, caf::intrusive_ptr<tenzir::chunk>>, caf::typed_actor<caf::result<void> (tenzir::diagnostic)>, caf::typed_actor<caf::result<void> (unsigned long long, unsigned long long, tenzir::type), caf::result<void> (unsigned long long, unsigned long long, tenzir::detail::vector_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data>>, tenzir::detail::stable_map_policy>), caf::result<void> (tenzir::operator_metric)>, int, bool, tenzir::uuid)> const&, caf::typed_actor<caf::result<void> (tenzir::diagnostic)> const&, caf::typed_actor<caf::result<void> (unsigned long long, unsigned long long, tenzir::type), caf::result<void> (unsigned long long, unsigned long long, tenzir::detail::vector_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data>>, tenzir::detail::stable_map_policy>), caf::result<void> (tenzir::operator_metric)> const&, int, bool, bool, tenzir::uuid)::'lambda'(tenzir::atom::internal, tenzir::atom::run), caf::typed_behavior<caf::result<void> (tenzir::atom::internal, tenzir::atom::run), caf::result<void> (tenzir::atom::start, std::__1::vector<caf::actor, std::__1::allocator<caf::actor>>), caf::result<void> (tenzir::atom::pause), caf::result<void> (tenzir::atom::resume), caf::result<void> (tenzir::diagnostic), caf::result<void> (tenzir::atom::pull, caf::typed_actor<caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>, unsigned long long), caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)> tenzir::(anonymous namespace)::exec_node<tenzir::table_slice, std::__1::monostate>(caf::stateful_actor<tenzir::(anonymous namespace)::exec_node_state<tenzir::table_slice, std::__1::monostate>, caf::typed_event_based_actor<caf::result<void> (tenzir::atom::internal, tenzir::atom::run), caf::result<void> (tenzir::atom::start, std::__1::vector<caf::actor, std::__1::allocator<caf::actor>>), caf::result<void> (tenzir::atom::pause), caf::result<void> (tenzir::atom::resume), caf::result<void> (tenzir::diagnostic), caf::result<void> (tenzir::atom::pull, caf::typed_actor<caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>, unsigned long long), caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>>*, std::__1::unique_ptr<tenzir::operator_base, std::__1::default_delete<tenzir::operator_base>>, caf::typed_actor<caf::result<tenzir::rest_response> (tenzir::atom::proxy, tenzir::http_request_description, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>), caf::result<std::__1::vector<caf::actor, std::__1::allocator<caf::actor>>> (caf::get_atom, tenzir::atom::label, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>), caf::result<tenzir::detail::vector_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data>>, tenzir::detail::stable_map_policy>> (caf::get_atom, tenzir::atom::version), caf::result<caf::typed_actor<caf::result<void> (tenzir::atom::internal, tenzir::atom::run), caf::result<void> (tenzir::atom::start, std::__1::vector<caf::actor, std::__1::allocator<caf::actor>>), caf::result<void> (tenzir::atom::pause), caf::result<void> (tenzir::atom::resume), caf::result<void> (tenzir::diagnostic), caf::result<void> (tenzir::atom::pull, caf::typed_actor<caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>, unsigned long long), caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>> (caf::spawn_atom, tenzir::operator_box, tenzir::tag_variant<void, tenzir::table_slice, caf::intrusive_ptr<tenzir::chunk>>, caf::typed_actor<caf::result<void> (tenzir::diagnostic)>, caf::typed_actor<caf::result<void> (unsigned long long, unsigned long long, tenzir::type), caf::result<void> (unsigned long long, unsigned long long, tenzir::detail::vector_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data>>, tenzir::detail::stable_map_policy>), caf::result<void> (tenzir::operator_metric)>, int, bool, tenzir::uuid)> const&, caf::typed_actor<caf::result<void> (tenzir::diagnostic)> const&, caf::typed_actor<caf::result<void> (unsigned long long, unsigned long long, tenzir::type), caf::result<void> (unsigned long long, unsigned long long, tenzir::detail::vector_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data>>, tenzir::detail::stable_map_policy>), caf::result<void> (tenzir::operator_metric)> const&, int, bool, bool, tenzir::uuid)::'lambda'(tenzir::atom::start, std::__1::vector<caf::actor, std::__1::allocator<caf::actor>>&), caf::typed_behavior<caf::result<void> (tenzir::atom::internal, tenzir::atom::run), caf::result<void> (tenzir::atom::start, std::__1::vector<caf::actor, std::__1::allocator<caf::actor>>), caf::result<void> (tenzir::atom::pause), caf::result<void> (tenzir::atom::resume), caf::result<void> (tenzir::diagnostic), caf::result<void> (tenzir::atom::pull, caf::typed_actor<caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>, unsigned long long), caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)> tenzir::(anonymous namespace)::exec_node<tenzir::table_slice, std::__1::monostate>(caf::stateful_actor<tenzir::(anonymous namespace)::exec_node_state<tenzir::table_slice, std::__1::monostate>, caf::typed_event_based_actor<caf::result<void> (tenzir::atom::internal, tenzir::atom::run), caf::result<void> (tenzir::atom::start, std::__1::vector<caf::actor, std::__1::allocator<caf::actor>>), caf::result<void> (tenzir::atom::pause), caf::result<void> (tenzir::atom::resume), caf::result<void> (tenzir::diagnostic), caf::result<void> (tenzir::atom::pull, caf::typed_actor<caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>, unsigned long long), caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>>*, std::__1::unique_ptr<tenzir::operator_base, std::__1::default_delete<tenzir::operator_base>>, caf::typed_actor<caf::result<tenzir::rest_response> (tenzir::atom::proxy, tenzir::http_request_description, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>), caf::result<std::__1::vector<caf::actor, std::__1::allocator<caf::actor>>> (caf::get_atom, tenzir::atom::label, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>), caf::result<tenzir::detail::vector_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data>>, tenzir::detail::stable_map_policy>> (caf::get_atom, tenzir::atom::version), caf::result<caf::typed_actor<caf::result<void> (tenzir::atom::internal, tenzir::atom::run), caf::result<void> (tenzir::atom::start, std::__1::vector<caf::actor, std::__1::allocator<caf::actor>>), caf::result<void> (tenzir::atom::pause), caf::result<void> (tenzir::atom::resume), caf::result<void> (tenzir::diagnostic), caf::result<void> (tenzir::atom::pull, caf::typed_actor<caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>, unsigned long long), caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>> (caf::spawn_atom, tenzir::operator_box, tenzir::tag_variant<void, tenzir::table_slice, caf::intrusive_ptr<tenzir::chunk>>, caf::typed_actor<caf::result<void> (tenzir::diagnostic)>, caf::typed_actor<caf::result<void> (unsigned long long, unsigned long long, tenzir::type), caf::result<void> (unsigned long long, unsigned long long, tenzir::detail::vector_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data>>, tenzir::detail::stable_map_policy>), caf::result<void> (tenzir::operator_metric)>, int, bool, tenzir::uuid)> const&, caf::typed_actor<caf::result<void> (tenzir::diagnostic)> const&, caf::typed_actor<caf::result<void> (unsigned long long, unsigned long long, tenzir::type), caf::result<void> (unsigned long long, unsigned long long, tenzir::detail::vector_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data>>, tenzir::detail::stable_map_policy>), caf::result<void> (tenzir::operator_metric)> const&, int, bool, bool, tenzir::uuid)::'lambda'(tenzir::atom::pause), caf::typed_behavior<caf::result<void> (tenzir::atom::internal, tenzir::atom::run), caf::result<void> (tenzir::atom::start, std::__1::vector<caf::actor, std::__1::allocator<caf::actor>>), caf::result<void> (tenzir::atom::pause), caf::result<void> (tenzir::atom::resume), caf::result<void> (tenzir::diagnostic), caf::result<void> (tenzir::atom::pull, caf::typed_actor<caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>, unsigned long long), caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)> tenzir::(anonymous namespace)::exec_node<tenzir::table_slice, std::__1::monostate>(caf::stateful_actor<tenzir::(anonymous namespace)::exec_node_state<tenzir::table_slice, std::__1::monostate>, caf::typed_event_based_actor<caf::result<void> (tenzir::atom::internal, tenzir::atom::run), caf::result<void> (tenzir::atom::start, std::__1::vector<caf::actor, std::__1::allocator<caf::actor>>), caf::result<void> (tenzir::atom::pause), caf::result<void> (tenzir::atom::resume), caf::result<void> (tenzir::diagnostic), caf::result<void> (tenzir::atom::pull, caf::typed_actor<caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>, unsigned long long), caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>>*, std::__1::unique_ptr<tenzir::operator_base, std::__1::default_delete<tenzir::operator_base>>, caf::typed_actor<caf::result<tenzir::rest_response> (tenzir::atom::proxy, tenzir::http_request_description, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>), caf::result<std::__1::vector<caf::actor, std::__1::allocator<caf::actor>>> (caf::get_atom, tenzir::atom::label, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>), caf::result<tenzir::detail::vector_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data>>, tenzir::detail::stable_map_policy>> (caf::get_atom, tenzir::atom::version), caf::result<caf::typed_actor<caf::result<void> (tenzir::atom::internal, tenzir::atom::run), caf::result<void> (tenzir::atom::start, std::__1::vector<caf::actor, std::__1::allocator<caf::actor>>), caf::result<void> (tenzir::atom::pause), caf::result<void> (tenzir::atom::resume), caf::result<void> (tenzir::diagnostic), caf::result<void> (tenzir::atom::pull, caf::typed_actor<caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>, unsigned long long), caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>> (caf::spawn_atom, tenzir::operator_box, tenzir::tag_variant<void, tenzir::table_slice, caf::intrusive_ptr<tenzir::chunk>>, caf::typed_actor<caf::result<void> (tenzir::diagnostic)>, caf::typed_actor<caf::result<void> (unsigned long long, unsigned long long, tenzir::type), caf::result<void> (unsigned long long, unsigned long long, tenzir::detail::vector_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data>>, tenzir::detail::stable_map_policy>), caf::result<void> (tenzir::operator_metric)>, int, bool, tenzir::uuid)> const&, caf::typed_actor<caf::result<void> (tenzir::diagnostic)> const&, caf::typed_actor<caf::result<void> (unsigned long long, unsigned long long, tenzir::type), caf::result<void> (unsigned long long, unsigned long long, tenzir::detail::vector_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data>>, tenzir::detail::stable_map_policy>), caf::result<void> (tenzir::operator_metric)> const&, int, bool, bool, tenzir::uuid)::'lambda'(tenzir::atom::resume), caf::typed_behavior<caf::result<void> (tenzir::atom::internal, tenzir::atom::run), caf::result<void> (tenzir::atom::start, std::__1::vector<caf::actor, std::__1::allocator<caf::actor>>), caf::result<void> (tenzir::atom::pause), caf::result<void> (tenzir::atom::resume), caf::result<void> (tenzir::diagnostic), caf::result<void> (tenzir::atom::pull, caf::typed_actor<caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>, unsigned long long), caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)> tenzir::(anonymous namespace)::exec_node<tenzir::table_slice, std::__1::monostate>(caf::stateful_actor<tenzir::(anonymous namespace)::exec_node_state<tenzir::table_slice, std::__1::monostate>, caf::typed_event_based_actor<caf::result<void> (tenzir::atom::internal, tenzir::atom::run), caf::result<void> (tenzir::atom::start, std::__1::vector<caf::actor, std::__1::allocator<caf::actor>>), caf::result<void> (tenzir::atom::pause), caf::result<void> (tenzir::atom::resume), caf::result<void> (tenzir::diagnostic), caf::result<void> (tenzir::atom::pull, caf::typed_actor<caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>, unsigned long long), caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>>*, std::__1::unique_ptr<tenzir::operator_base, std::__1::default_delete<tenzir::operator_base>>, caf::typed_actor<caf::result<tenzir::rest_response> (tenzir::atom::proxy, tenzir::http_request_description, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>), caf::result<std::__1::vector<caf::actor, std::__1::allocator<caf::actor>>> (caf::get_atom, tenzir::atom::label, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>), caf::result<tenzir::detail::vector_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data>>, tenzir::detail::stable_map_policy>> (caf::get_atom, tenzir::atom::version), caf::result<caf::typed_actor<caf::result<void> (tenzir::atom::internal, tenzir::atom::run), caf::result<void> (tenzir::atom::start, std::__1::vector<caf::actor, std::__1::allocator<caf::actor>>), caf::result<void> (tenzir::atom::pause), caf::result<void> (tenzir::atom::resume), caf::result<void> (tenzir::diagnostic), caf::result<void> (tenzir::atom::pull, caf::typed_actor<caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>, unsigned long long), caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>> (caf::spawn_atom, tenzir::operator_box, tenzir::tag_variant<void, tenzir::table_slice, caf::intrusive_ptr<tenzir::chunk>>, caf::typed_actor<caf::result<void> (tenzir::diagnostic)>, caf::typed_actor<caf::result<void> (unsigned long long, unsigned long long, tenzir::type), caf::result<void> (unsigned long long, unsigned long long, tenzir::detail::vector_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data>>, tenzir::detail::stable_map_policy>), caf::result<void> (tenzir::operator_metric)>, int, bool, tenzir::uuid)> const&, caf::typed_actor<caf::result<void> (tenzir::diagnostic)> const&, caf::typed_actor<caf::result<void> (unsigned long long, unsigned long long, tenzir::type), caf::result<void> (unsigned long long, unsigned long long, tenzir::detail::vector_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data>>, tenzir::detail::stable_map_policy>), caf::result<void> (tenzir::operator_metric)> const&, int, bool, bool, tenzir::uuid)::'lambda'(tenzir::diagnostic&), caf::typed_behavior<caf::result<void> (tenzir::atom::internal, tenzir::atom::run), caf::result<void> (tenzir::atom::start, std::__1::vector<caf::actor, std::__1::allocator<caf::actor>>), caf::result<void> (tenzir::atom::pause), caf::result<void> (tenzir::atom::resume), caf::result<void> (tenzir::diagnostic), caf::result<void> (tenzir::atom::pull, caf::typed_actor<caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>, unsigned long long), caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)> tenzir::(anonymous namespace)::exec_node<tenzir::table_slice, std::__1::monostate>(caf::stateful_actor<tenzir::(anonymous namespace)::exec_node_state<tenzir::table_slice, std::__1::monostate>, caf::typed_event_based_actor<caf::result<void> (tenzir::atom::internal, tenzir::atom::run), caf::result<void> (tenzir::atom::start, std::__1::vector<caf::actor, std::__1::allocator<caf::actor>>), caf::result<void> (tenzir::atom::pause), caf::result<void> (tenzir::atom::resume), caf::result<void> (tenzir::diagnostic), caf::result<void> (tenzir::atom::pull, caf::typed_actor<caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>, unsigned long long), caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>>*, std::__1::unique_ptr<tenzir::operator_base, std::__1::default_delete<tenzir::operator_base>>, caf::typed_actor<caf::result<tenzir::rest_response> (tenzir::atom::proxy, tenzir::http_request_description, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>), caf::result<std::__1::vector<caf::actor, std::__1::allocator<caf::actor>>> (caf::get_atom, tenzir::atom::label, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>), caf::result<tenzir::detail::vector_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data>>, tenzir::detail::stable_map_policy>> (caf::get_atom, tenzir::atom::version), caf::result<caf::typed_actor<caf::result<void> (tenzir::atom::internal, tenzir::atom::run), caf::result<void> (tenzir::atom::start, std::__1::vector<caf::actor, std::__1::allocator<caf::actor>>), caf::result<void> (tenzir::atom::pause), caf::result<void> (tenzir::atom::resume), caf::result<void> (tenzir::diagnostic), caf::result<void> (tenzir::atom::pull, caf::typed_actor<caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>, unsigned long long), caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>> (caf::spawn_atom, tenzir::operator_box, tenzir::tag_variant<void, tenzir::table_slice, caf::intrusive_ptr<tenzir::chunk>>, caf::typed_actor<caf::result<void> (tenzir::diagnostic)>, caf::typed_actor<caf::result<void> (unsigned long long, unsigned long long, tenzir::type), caf::result<void> (unsigned long long, unsigned long long, tenzir::detail::vector_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data>>, tenzir::detail::stable_map_policy>), caf::result<void> (tenzir::operator_metric)>, int, bool, tenzir::uuid)> const&, caf::typed_actor<caf::result<void> (tenzir::diagnostic)> const&, caf::typed_actor<caf::result<void> (unsigned long long, unsigned long long, tenzir::type), caf::result<void> (unsigned long long, unsigned long long, tenzir::detail::vector_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data>>, tenzir::detail::stable_map_policy>), caf::result<void> (tenzir::operator_metric)> const&, int, bool, bool, tenzir::uuid)::'lambda'(tenzir::atom::push, tenzir::table_slice&), caf::typed_behavior<caf::result<void> (tenzir::atom::internal, tenzir::atom::run), caf::result<void> (tenzir::atom::start, std::__1::vector<caf::actor, std::__1::allocator<caf::actor>>), caf::result<void> (tenzir::atom::pause), caf::result<void> (tenzir::atom::resume), caf::result<void> (tenzir::diagnostic), caf::result<void> (tenzir::atom::pull, caf::typed_actor<caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>, unsigned long long), caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)> tenzir::(anonymous namespace)::exec_node<tenzir::table_slice, std::__1::monostate>(caf::stateful_actor<tenzir::(anonymous namespace)::exec_node_state<tenzir::table_slice, std::__1::monostate>, caf::typed_event_based_actor<caf::result<void> (tenzir::atom::internal, tenzir::atom::run), caf::result<void> (tenzir::atom::start, std::__1::vector<caf::actor, std::__1::allocator<caf::actor>>), caf::result<void> (tenzir::atom::pause), caf::result<void> (tenzir::atom::resume), caf::result<void> (tenzir::diagnostic), caf::result<void> (tenzir::atom::pull, caf::typed_actor<caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>, unsigned long long), caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>>*, std::__1::unique_ptr<tenzir::operator_base, std::__1::default_delete<tenzir::operator_base>>, caf::typed_actor<caf::result<tenzir::rest_response> (tenzir::atom::proxy, tenzir::http_request_description, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>), caf::result<std::__1::vector<caf::actor, std::__1::allocator<caf::actor>>> (caf::get_atom, tenzir::atom::label, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>), caf::result<tenzir::detail::vector_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data>>, tenzir::detail::stable_map_policy>> (caf::get_atom, tenzir::atom::version), caf::result<caf::typed_actor<caf::result<void> (tenzir::atom::internal, tenzir::atom::run), caf::result<void> (tenzir::atom::start, std::__1::vector<caf::actor, std::__1::allocator<caf::actor>>), caf::result<void> (tenzir::atom::pause), caf::result<void> (tenzir::atom::resume), caf::result<void> (tenzir::diagnostic), caf::result<void> (tenzir::atom::pull, caf::typed_actor<caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>, unsigned long long), caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>> (caf::spawn_atom, tenzir::operator_box, tenzir::tag_variant<void, tenzir::table_slice, caf::intrusive_ptr<tenzir::chunk>>, caf::typed_actor<caf::result<void> (tenzir::diagnostic)>, caf::typed_actor<caf::result<void> (unsigned long long, unsigned long long, tenzir::type), caf::result<void> (unsigned long long, unsigned long long, tenzir::detail::vector_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data>>, tenzir::detail::stable_map_policy>), caf::result<void> (tenzir::operator_metric)>, int, bool, tenzir::uuid)> const&, caf::typed_actor<caf::result<void> (tenzir::diagnostic)> const&, caf::typed_actor<caf::result<void> (unsigned long long, unsigned long long, tenzir::type), caf::result<void> (unsigned long long, unsigned long long, tenzir::detail::vector_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data>>, tenzir::detail::stable_map_policy>), caf::result<void> (tenzir::operator_metric)> const&, int, bool, bool, tenzir::uuid)::'lambda'(tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>&), caf::typed_behavior<caf::result<void> (tenzir::atom::internal, tenzir::atom::run), caf::result<void> (tenzir::atom::start, std::__1::vector<caf::actor, std::__1::allocator<caf::actor>>), caf::result<void> (tenzir::atom::pause), caf::result<void> (tenzir::atom::resume), caf::result<void> (tenzir::diagnostic), caf::result<void> (tenzir::atom::pull, caf::typed_actor<caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>, unsigned long long), caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)> tenzir::(anonymous namespace)::exec_node<tenzir::table_slice, std::__1::monostate>(caf::stateful_actor<tenzir::(anonymous namespace)::exec_node_state<tenzir::table_slice, std::__1::monostate>, caf::typed_event_based_actor<caf::result<void> (tenzir::atom::internal, tenzir::atom::run), caf::result<void> (tenzir::atom::start, std::__1::vector<caf::actor, std::__1::allocator<caf::actor>>), caf::result<void> (tenzir::atom::pause), caf::result<void> (tenzir::atom::resume), caf::result<void> (tenzir::diagnostic), caf::result<void> (tenzir::atom::pull, caf::typed_actor<caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>, unsigned long long), caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>>*, std::__1::unique_ptr<tenzir::operator_base, std::__1::default_delete<tenzir::operator_base>>, caf::typed_actor<caf::result<tenzir::rest_response> (tenzir::atom::proxy, tenzir::http_request_description, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>), caf::result<std::__1::vector<caf::actor, std::__1::allocator<caf::actor>>> (caf::get_atom, tenzir::atom::label, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>), caf::result<tenzir::detail::vector_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data>>, tenzir::detail::stable_map_policy>> (caf::get_atom, tenzir::atom::version), caf::result<caf::typed_actor<caf::result<void> (tenzir::atom::internal, tenzir::atom::run), caf::result<void> (tenzir::atom::start, std::__1::vector<caf::actor, std::__1::allocator<caf::actor>>), caf::result<void> (tenzir::atom::pause), caf::result<void> (tenzir::atom::resume), caf::result<void> (tenzir::diagnostic), caf::result<void> (tenzir::atom::pull, caf::typed_actor<caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>, unsigned long long), caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>> (caf::spawn_atom, tenzir::operator_box, tenzir::tag_variant<void, tenzir::table_slice, caf::intrusive_ptr<tenzir::chunk>>, caf::typed_actor<caf::result<void> (tenzir::diagnostic)>, caf::typed_actor<caf::result<void> (unsigned long long, unsigned long long, tenzir::type), caf::result<void> (unsigned long long, unsigned long long, tenzir::detail::vector_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data>>, tenzir::detail::stable_map_policy>), caf::result<void> (tenzir::operator_metric)>, int, bool, tenzir::uuid)> const&, caf::typed_actor<caf::result<void> (tenzir::diagnostic)> const&, caf::typed_actor<caf::result<void> (unsigned long long, unsigned long long, tenzir::type), caf::result<void> (unsigned long long, unsigned long long, tenzir::detail::vector_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, tenzir::data>>, tenzir::detail::stable_map_policy>), caf::result<void> (tenzir::operator_metric)> const&, int, bool, bool, tenzir::uuid)::'lambda'(tenzir::atom::pull, caf::typed_actor<caf::result<void> (tenzir::atom::push, tenzir::table_slice), caf::result<void> (tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>)>&, unsigned long long)>, caf::detail::dummy_timeout_definition>::invoke(caf::detail::invoke_result_visitor&, caf::message&)+0x14f0)
0x6b40800104bdb794: (caf::scheduled_actor::consume(caf::mailbox_element&)+0x294)
0xa161000104bdc02c: (caf::scheduled_actor::reactivate(caf::mailbox_element&)+0x1c)
0x3c14000104bd82b8: (caf::scheduled_actor::resume(caf::scheduler*, unsigned long)+0xb0)
0xd04c800104be6e5c: (void* std::__1::__thread_proxy[abi:ne190107]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, std::__1::thread caf::actor_system::launch_thread<void caf::(anonymous namespace)::work_stealing::worker::start<caf::(anonymous namespace)::work_stealing::scheduler_impl>(caf::(anonymous namespace)::work_stealing::scheduler_impl*)::'lambda'()>(char const*, caf::thread_owner, caf::(anonymous namespace)::work_stealing::scheduler_impl)::'lambda'(caf::(anonymous namespace)::work_stealing::scheduler_impl), caf::intrusive_ptr<caf::ref_counted>>>(void*)+0xdc0)
0x9d27800191a002e4: (_pthread_start+0x88)
[19:33:25.414] panic: assertion `false` failed: :(
[19:33:25.414] version: 4.26.0+g8d7bc80443-dirty g8d7bc80443-dirty
[19:33:25.414] source: libtenzir/builtins/operators/discard.cpp:27
[19:33:25.414] this is a bug, we would appreciate a report - thank you!
error: assertion `false` failed: :( @ libtenzir/builtins/operators/discard.cpp:27
 = note: unhandled exception in exec-node discard
```

</details>

That's a total of 38552 characters.

On this branch, I get the following instead:

<details>
<summary>Click to expand</summary>

```
0xe866000104769e3c: (tenzir::detail::panic_impl(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::source_location)+0x28)
0x2e4200010476a1c4: (tenzir::detail::fail_assertion_impl(char const*, std::__1::basic_string_view<char, std::__1::char_traits<char>>, std::__1::source_location)+0x64)
0xe13b00010092af1c: (void tenzir::detail::fail_assertion<char const (&) [3]>(char const*, char const (&) [3], std::__1::source_location)+0x50)
0x83700010092b500: (tenzir::generator<std::__1::monostate> tenzir::plugins::discard::(anonymous namespace)::discard_operator::operator()<tenzir::table_slice>(tenzir::generator<tenzir::table_slice>) const (.resume)+0x2c)
0xb9468001049567ac: (caf::detail::default_behavior_impl<std::__1::tuple<tenzir::(anonymous namespace)::exec_node_state<tenzir::table_slice, std::__1::monostate>::make_behavior()::'lambda'(tenzir::atom::internal, tenzir::atom::run), tenzir::(anonymous namespace)::exec_node_state<tenzir::table_slice, std::__1::monostate>::make_behavior()::'lambda'(tenzir::atom::start, std::__1::vector<caf::actor, std::__1::allocator<caf::actor>>&), tenzir::(anonymous namespace)::exec_node_state<tenzir::table_slice, std::__1::monostate>::make_behavior()::'lambda'(tenzir::atom::pause), tenzir::(anonymous namespace)::exec_node_state<tenzir::table_slice, std::__1::monostate>::make_behavior()::'lambda'(tenzir::atom::resume), tenzir::(anonymous namespace)::exec_node_state<tenzir::table_slice, std::__1::monostate>::make_behavior()::'lambda'(tenzir::diagnostic&), tenzir::(anonymous namespace)::exec_node_state<tenzir::table_slice, std::__1::monostate>::make_behavior()::'lambda'(tenzir::atom::push, tenzir::table_slice&), tenzir::(anonymous namespace)::exec_node_state<tenzir::table_slice, std::__1::monostate>::make_behavior()::'lambda'(tenzir::atom::push, caf::intrusive_ptr<tenzir::chunk>&), tenzir::(anonymous namespace)::exec_node_state<tenzir::table_slice, std::__1::monostate>::make_behavior()::'lambda'(tenzir::atom::pull, caf::typed_actor<tenzir::exec_node_sink_actor_traits>&, unsigned long long), tenzir::(anonymous namespace)::exec_node_state<tenzir::table_slice, std::__1::monostate>::make_behavior()::'lambda'(caf::exit_msg const&)>, caf::detail::dummy_timeout_definition>::invoke(caf::detail::invoke_result_visitor&, caf::message&)+0x15b0)
0x48410001021ef8fc: (caf::scheduled_actor::consume(caf::mailbox_element&)+0x294)
0x93c8001021f0194: (caf::scheduled_actor::reactivate(caf::mailbox_element&)+0x1c)
0xd55b0001021ec420: (caf::scheduled_actor::resume(caf::scheduler*, unsigned long)+0xb0)
0x3e210001021faf08: (void* std::__1::__thread_proxy[abi:ne190107]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, std::__1::thread caf::actor_system::launch_thread<void caf::(anonymous namespace)::work_stealing::worker::start<caf::(anonymous namespace)::work_stealing::scheduler_impl>(caf::(anonymous namespace)::work_stealing::scheduler_impl*)::'lambda'()>(char const*, caf::thread_owner, caf::(anonymous namespace)::work_stealing::scheduler_impl)::'lambda'(caf::(anonymous namespace)::work_stealing::scheduler_impl), caf::intrusive_ptr<caf::ref_counted>>>(void*)+0xdc0)
0x4d21800191a002e4: (_pthread_start+0x88)
[19:35:09.601] panic: assertion `false` failed: :)
[19:35:09.601] version: 4.26.0+gdb092d55e5-dirty gdb092d55e5-dirty
[19:35:09.601] source: libtenzir/builtins/operators/discard.cpp:27
[19:35:09.601] this is a bug, we would appreciate a report - thank you!
error: assertion `false` failed: :) @ libtenzir/builtins/operators/discard.cpp:27
 = note: unhandled exception in exec-node discard
```

</details>

That's just 3664 characters, or a reduction of 90.5%.

Now to do this for all the other actors as well… 

- Contributes to https://github.com/tenzir/issues/issues/2760