### PR TITLE
Stop collecting metrics for hidden pipelines

### DIFF
--- a/changelog/next/changes/4966--metrics-no-more-hidden.md
+++ b/changelog/next/changes/4966--metrics-no-more-hidden.md
@@ -1,0 +1,2 @@
+`metrics "operator"` no longer includes metrics from hidden pipelines, such as
+pipelines run under-the-hood by the Tenzir Platform.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "ae752bb9590b897ef3d8f9a2c05ec23d1c24d0e2",
+  "rev": "810a862adb9df1b5e867b461f60f5977a3ea8484",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
We collect way too many operator metrics. This helps cut down the noise by no longer collecting metrics for hidden pipelines.