### PR TITLE
Adjust developer-facing Docker setup to `TENZIR_TOKEN`

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,14 +2,14 @@
 # file for setup instructions.
 services:
   tenzir-node:
-    image: ${TENZIR_IMAGE:-tenzir/tenzir:main}
+    image: ${TENZIR_IMAGE:-ghcr.io/tenzir/tenzir:${TENZIR_VERSION:-main}}
     build:
       target: tenzir
     environment:
-      - TENZIR_PLUGINS__PLATFORM__CONTROL_ENDPOINT=${TENZIR_PLUGINS__PLATFORM__CONTROL_ENDPOINT:-}
-      - TENZIR_PLUGINS__PLATFORM__API_KEY=${TENZIR_PLUGINS__PLATFORM__API_KEY:-}
-      - TENZIR_PLUGINS__PLATFORM__TENANT_ID=${TENZIR_PLUGINS__PLATFORM__TENANT_ID:-}
+      - TENZIR_PLATFORM_CONTROL_ENDPOINT=${TENZIR_PLATFORM_CONTROL_ENDPOINT:-}
+      - TENZIR_TOKEN=${TENZIR_TOKEN:-}
       - TENZIR_ENDPOINT=tenzir-node:5158
+      - TENZIR_TQL2=true
     ports:
       - 5158:5158
     entrypoint:
@@ -23,7 +23,7 @@ services:
       retries: 1
 
   tenzir-api:
-    image: ${TENZIR_IMAGE:-tenzir/tenzir:main}
+    image: ${TENZIR_IMAGE:-ghcr.io/tenzir/tenzir:${TENZIR_VERSION:-main}}
     build:
       target: tenzir
     depends_on:
@@ -41,15 +41,18 @@ services:
       - --bind=0.0.0.0
 
   tenzir:
-    image: ${TENZIR_IMAGE:-tenzir/tenzir:main}
+    image: ${TENZIR_IMAGE:-ghcr.io/tenzir/tenzir:${TENZIR_VERSION:-main}}
     build:
       target: tenzir
     profiles:
       - donotstart
     depends_on:
       - tenzir-node
+    entrypoint:
+      - tenzir
     environment:
       - TENZIR_ENDPOINT=tenzir-node:5158
+      - TENZIR_TQL2=true
 
 volumes:
   tenzir-lib:

--- a/env.example
+++ b/env.example
@@ -3,11 +3,13 @@
 # 1. Copy this file to .env.
 # 2. In the copy, uncomment the below variables and fill out the three values
 # 3. Run one of the following depending on your needs:
-#    - `docker compose pull` followed by `docker compose up` to run the latest main branch
-#    - `docker compose up --build` to build your local branch
-#TENZIR_PLUGINS__PLATFORM__CONTROL_ENDPOINT=
-#TENZIR_PLUGINS__PLATFORM__API_KEY=
-#TENZIR_PLUGINS__PLATFORM__TENANT_ID=
-# Uncomment the following to use a custom image for the platform.
-# This is useful if you want to test a local build with changes from a particular branch.
+#    - `docker compose pull` followed by `docker compose up` to run the latest
+#       main branch.
+#    - `docker compose up --build` to build your local branch.
+#TENZIR_PLATFORM_CONTROL_ENDPOINT=
+#TENZIR_TOKEN=
+# Uncomment one of the following to use a custom image for the platform. This is
+# useful if you want to test a local build with changes from a particular
+# branch or run a specific version.
 #TENZIR_IMAGE=
+#TENZIR_VERSION=


### PR DESCRIPTION
This changes the developer-facing Docker Compose setup to make use of `TENZIR_TOKEN` instead of the old variables.

Additionally, this makes `TENZIR_VERSION=v4.27 docker compose up` a shorter way of writing `TENZIR_IMAGE=ghcr.io/tenzir/tenzir:v4.27 docker compose up` , which saves a bit of time when testing with different versions locally as a developer.