### PR TITLE
Add a 60s node shutdown timeout

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,8 +21,8 @@
 	shallow = true
 [submodule "libtenzir/aux/caf"]
 	path = libtenzir/aux/caf
-	url = https://github.com/actor-framework/actor-framework
-	shallow = true
+	url = https://github.com/tenzir/actor-framework
+	shallow = false
 [submodule "libtenzir/aux/pfs"]
 	path = libtenzir/aux/pfs
 	url = https://github.com/tenzir/pfs.git

--- a/nix/caf/source.json
+++ b/nix/caf/source.json
@@ -1,7 +1,7 @@
 {
-  "owner": "actor-framework",
+  "owner": "tenzir",
   "repo": "actor-framework",
-  "rev": "916d957408e33de75c215c896b8752519ee8724d",
-  "hash": "sha256-6zNrq+IUhGf9Nqoxk9n+KS7PiKtJ4sVJZMzMIcDi5eY=",
-  "version": "1.0.2-46-g916d95740"
+  "rev": "c60f961111b01944549e4300e52aac6b93f70fa1",
+  "hash": "sha256-NALUfRHlhwMnJAJSgZhbO/3bzDnMeXibAsk3MlcCV1o=",
+  "version": "1.0.2-59-gc60f96111"
 }

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -229,11 +229,17 @@ in {
           export LD_LIBRARY_PATH=$PWD/lib
           export DYLD_LIBRARY_PATH=$PWD/lib
         '';
+        cmakeFlags =
+          old.cmakeFlags
+          ++ [
+            "-DCAF_CXX_VERSION=20"
+          ];
       }
       // lib.optionalAttrs isStatic {
         cmakeFlags =
           old.cmakeFlags
           ++ [
+            "-DCAF_CXX_VERSION=20"
             "-DCAF_BUILD_STATIC=ON"
             "-DCAF_BUILD_STATIC_ONLY=ON"
             "-DCAF_ENABLE_TESTING=OFF"

--- a/nix/update-impl.sh
+++ b/nix/update-impl.sh
@@ -8,6 +8,8 @@ dir=$(dirname "$(readlink -f "$0")")
 toplevel=$(git -C "${dir}" rev-parse --show-toplevel)
 mainroot="$(git -C "${dir}" rev-parse --path-format=absolute --show-toplevel)"
 
+set -x
+
 get-submodule-rev() {
   local _submodule="$1"
   git -C "${toplevel}" submodule status -- "${_submodule}" | cut -c2- | cut -d' ' -f 1
@@ -24,7 +26,10 @@ update-source-github() {
   _rev="$(get-submodule-rev "${_submodule}")"
   if [[ "${_version}" == "" ]]; then
     git -C "${toplevel}" submodule update --init "${_submodule}"
-    git -C "${_path}" fetch --tags
+    local _upstream
+    _upstream="$(curl https://api.github.com/repos/tenzir/actor-framework | jq -r .parent.html_url)"
+    git -C "${_path}" remote add upstream "${_upstream}"
+    git -C "${_path}" fetch --tags --all
     _version="$(git -C "${_path}" describe --tag)"
   fi
 
@@ -59,5 +64,7 @@ update-source() {
     exit 1
   fi
 }
+
+git config --list --show-origin
 
 update-source caf "libtenzir/aux/caf"


### PR DESCRIPTION
This changes the shutdown path to wait for up to 60 seconds for the actor system to exit before forcing termination. In this case the contents of the actor registry will be printed in a log message.

Alternative to / replacement for https://github.com/tenzir/tenzir/pull/4965.
