### PR TITLE
Bump vscode-tql package for the docs site

### DIFF
--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -3,7 +3,7 @@
 
 const path = require('node:path');
 
-const tqlGrammar = require("@tenzir/vscode-tql/syntaxes/tql.tmLanguage.json");
+const tqlGrammar = require("vscode-tql/syntaxes/tql.tmLanguage.json");
 
 async function createConfig() {
   const rehypePrettyCode = (await import('rehype-pretty-code')).default;

--- a/web/package.json
+++ b/web/package.json
@@ -23,7 +23,6 @@
     "@giscus/react": "^2.3.0",
     "@mdx-js/react": "^1.6.22",
     "@rehype-pretty/transformers": "npm:@jsr/rehype-pretty__transformers",
-    "@tenzir/vscode-tql": "^0.0.3",
     "clsx": "^1.2.1",
     "docusaurus-plugin-sass": "^0.2.3",
     "raw-loader": "^4.0.2",
@@ -36,7 +35,8 @@
     "remark-inline-svg": "^1.1.0",
     "sass": "^1.58.0",
     "shiki": "^1.18.0",
-    "strip-markdown": "^5.0.0"
+    "strip-markdown": "^5.0.0",
+    "vscode-tql": "^1.0.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^2.4.1",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -2374,11 +2374,6 @@
     content-type "^1.0.5"
     tslib "^2.5.0"
 
-"@tenzir/vscode-tql@^0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@tenzir/vscode-tql/-/vscode-tql-0.0.3.tgz#b7966da2d3c6ddd4d8143d43bec85026fee54388"
-  integrity sha512-koicc+Q+dWAOkQM1kAa7JWBLBYhK8XLDshK6onPsgkCPm7C4haJPXjm6WNeTMw+DvOS8amOaHClpWHpza7AGkg==
-
 "@trysound/sax@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
@@ -9816,6 +9811,11 @@ vfile@^6.0.0:
   dependencies:
     "@types/unist" "^3.0.0"
     vfile-message "^4.0.0"
+
+vscode-tql@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-tql/-/vscode-tql-1.0.0.tgz#cc4ce4be4b63c8f9d9a8ab60523240db147843de"
+  integrity sha512-ottmcc79dJYZao/zgjKF85AXMdEkb2l3B7JafZge7gj424KihhJR7RAWrH4Lzq3goemSZDuUrczS27YJ6gIXeA==
 
 wait-on@^6.0.1:
   version "6.0.1"


### PR DESCRIPTION
Since VSCode marketplace doesn't allow namespaced packages like @tenzir/vscode-tql, we published the vscode-tql package without the namespace on npm.

Closes https://github.com/tenzir/issues/issues/2785.