### PR TITLE
Slim down the regular nix-built docker image

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,16 @@ include(TenzirProvideFindModule)
 include(TenzirRegisterPlugin)
 include(TenzirUtilities)
 
+# -- extra installation dirs ---------------------------------------------------
+
+set(TENZIR_INSTALL_ARCHIVEDIR
+    "${CMAKE_INSTALL_LIBDIR}"
+    CACHE PATH "The Installation path of static archives")
+
+set(TENZIR_INSTALL_CMAKEDIR
+    "${CMAKE_INSTALL_LIBDIR}/cmake"
+    CACHE PATH "The Installation path of the cmake files")
+
 # -- project configuration -----------------------------------------------------
 
 # Determine whether we're building Tenzir a subproject. This is used to determine
@@ -962,7 +972,7 @@ export(
 
 install(
   EXPORT TenzirTargets
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/tenzir"
+  DESTINATION "${TENZIR_INSTALL_CMAKEDIR}/tenzir"
   NAMESPACE tenzir::
   COMPONENT Development)
 
@@ -974,7 +984,7 @@ write_basic_package_version_file(
 configure_package_config_file(
   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/TenzirConfig.cmake.in"
   "${CMAKE_CURRENT_BINARY_DIR}/TenzirConfig.cmake"
-  INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/tenzir")
+  INSTALL_DESTINATION "${TENZIR_INSTALL_CMAKEDIR}/tenzir")
 
 configure_file("${PROJECT_SOURCE_DIR}/cmake/TenzirMacDependencyPaths.cmake"
                ${CMAKE_BINARY_DIR} COPYONLY)
@@ -986,7 +996,7 @@ install(
         "${CMAKE_CURRENT_SOURCE_DIR}/cmake/TenzirMacDependencyPaths.cmake"
         "${CMAKE_CURRENT_BINARY_DIR}/TenzirConfig.cmake"
         "${CMAKE_CURRENT_BINARY_DIR}/TenzirConfigVersion.cmake"
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/tenzir"
+  DESTINATION "${TENZIR_INSTALL_CMAKEDIR}/tenzir"
   COMPONENT Development)
 
 # -- scripts -------------------------------------------------------------------

--- a/cmake/TenzirProvideFindModule.cmake
+++ b/cmake/TenzirProvideFindModule.cmake
@@ -6,6 +6,6 @@ macro (provide_find_module name)
                  ${CMAKE_BINARY_DIR} COPYONLY)
   install(
     FILES "${CMAKE_BINARY_DIR}/Find${name}.cmake"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/tenzir"
+    DESTINATION "${TENZIR_INSTALL_CMAKEDIR}/tenzir"
     COMPONENT Development)
 endmacro ()

--- a/cmake/TenzirRegisterPlugin.cmake
+++ b/cmake/TenzirRegisterPlugin.cmake
@@ -37,7 +37,7 @@ macro (TenzirNormalizeInstallDirs)
           "LOCALSTATE"
           "RUNSTATE"
           "LIB"
-          "INCLUDE"
+          # "INCLUDE" <- deliberately omitted
           # "OLDINCLUDE" <- deliberately omitted
           "DATAROOT"
           "DATA"
@@ -52,19 +52,26 @@ macro (TenzirNormalizeInstallDirs)
     if (IS_ABSOLUTE "${CMAKE_INSTALL_${_install}DIR}")
       string(
         REGEX
-        REPLACE "^${CMAKE_INSTALL_PREFIX}/" "" "CMAKE_INSTALL_${_install}DIR"
-                "${CMAKE_INSTALL_FULL_${_install}DIR}")
+        REPLACE "^${CMAKE_INSTALL_PREFIX}/" ""
+                "CMAKE_INSTALL_RELATIVE_${_install}DIR"
+                "${CMAKE_INSTALL_${_install}DIR}")
+    else ()
+      set(CMAKE_INSTALL_RELATIVE_${_install}DIR
+          "${CMAKE_INSTALL_${_install}DIR}")
     endif ()
-    # If the path is still absolute, e.g., because the full install dirs did
-    # were not subdirectories if the install prefix, give up and error. Nothing
-    # we can do here.
-    if (IS_ABSOLUTE "${CMAKE_INSTALL_${_install}DIR}")
+  endforeach ()
+  foreach (_install IN ITEMS "LIBEXEC" "SYSCONF" "LIB" "DATA")
+    # If the path is still absolute, e.g., because the full install dirs were
+    # not subdirectories if the install prefix, give up and error. Nothing we
+    # can do here.
+    if (IS_ABSOLUTE "${CMAKE_INSTALL_RELATIVE_${_install}DIR}")
       message(
         FATAL_ERROR
           "CMAKE_INSTALL_${_install}DIR must not be an absolute path for relocatable installations."
       )
     endif ()
   endforeach ()
+  unset(_install)
   # For the docdir especially, lowercase the project name.
   if ("${CMAKE_INSTALL_DOCDIR}" STREQUAL
       "${CMAKE_INSTALL_DATAROOTDIR}/doc/${PROJECT_NAME}")
@@ -74,7 +81,6 @@ macro (TenzirNormalizeInstallDirs)
         "${CMAKE_INSTALL_FULL_DATAROOTDIR}/doc/${_name}")
     unset(_name)
   endif ()
-  unset(_install)
 endmacro ()
 
 # A replacement for target_link_libraries that links static libraries using

--- a/flake.nix
+++ b/flake.nix
@@ -45,10 +45,13 @@
           type = "app";
           program = "${pkgs.dockerTools.streamLayeredImage {
             inherit name tag;
+            contents = [
+              pkg pkgs.bash pkgs.python3
+            ];
             config = let
               tenzir-dir = "/var/lib/tenzir";
             in {
-              Entrypoint = ["${pkgs.lib.getBin pkg}/bin/${entrypoint}"];
+              Entrypoint = ["/bin/${entrypoint}"];
               CMD = ["--help"];
               Env = [
                 # When changing these, make sure to also update the

--- a/libtenzir/CMakeLists.txt
+++ b/libtenzir/CMakeLists.txt
@@ -39,7 +39,7 @@ if (NOT tsl-robin-map_FOUND)
     COMMENT "Linking tsl-robin-map targets")
   install(
     EXPORT tsl-robin-mapTargets
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/tenzir"
+    DESTINATION "${TENZIR_INSTALL_CMAKEDIR}/tenzir"
     NAMESPACE tsl::
     COMPONENT Development)
   string(APPEND TENZIR_EXTRA_TARGETS_FILES
@@ -467,6 +467,8 @@ if (TENZIR_ENABLE_RELOCATABLE_INSTALLATIONS)
   configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/src/detail/installdirs_relocatable.cpp.in"
     "${CMAKE_CURRENT_BINARY_DIR}/src/detail/installdirs.cpp" @ONLY)
+  file(READ "${CMAKE_CURRENT_BINARY_DIR}/src/detail/installdirs.cpp" installdirs)
+  message(STATUS "installdirs:\n${installdirs}")
 else ()
   configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/detail/installdirs.cpp.in"
                  "${CMAKE_CURRENT_BINARY_DIR}/src/detail/installdirs.cpp" @ONLY)
@@ -540,7 +542,7 @@ endif ()
 install(
   TARGETS libtenzir libtenzir_builtins ${_tenzir_bundled_simdjson} ${_tenzir_bundled_pfs}
   EXPORT TenzirTargets
-  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT Development
+  ARCHIVE DESTINATION "${TENZIR_INSTALL_ARCHIVEDIR}" COMPONENT Development
   LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT Runtime
   RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT Runtime)
 

--- a/libtenzir/CMakeLists.txt
+++ b/libtenzir/CMakeLists.txt
@@ -467,8 +467,6 @@ if (TENZIR_ENABLE_RELOCATABLE_INSTALLATIONS)
   configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/src/detail/installdirs_relocatable.cpp.in"
     "${CMAKE_CURRENT_BINARY_DIR}/src/detail/installdirs.cpp" @ONLY)
-  file(READ "${CMAKE_CURRENT_BINARY_DIR}/src/detail/installdirs.cpp" installdirs)
-  message(STATUS "installdirs:\n${installdirs}")
 else ()
   configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/detail/installdirs.cpp.in"
                  "${CMAKE_CURRENT_BINARY_DIR}/src/detail/installdirs.cpp" @ONLY)

--- a/libtenzir/src/detail/installdirs_relocatable.cpp.in
+++ b/libtenzir/src/detail/installdirs_relocatable.cpp.in
@@ -11,6 +11,9 @@
 #include "tenzir/detail/process.hpp"
 #include "tenzir/detail/string.hpp"
 
+#include <fmt/format.h>
+#include <fmt/std.h>
+
 #include <string_view>
 
 namespace tenzir::detail {
@@ -51,30 +54,24 @@ std::filesystem::path install_configdir() {
   // We are permissive for the config file paths, in case the prefix does not
   // contain the package name.
   if (prefix == "/usr") {
-    if (std::filesystem::exists("/etc/tenzir", err) &&
-        !std::filesystem::exists("/etc/tenzir", err))
-      return "/etc/tenzir";
     return "/etc/tenzir";
   }
-  if (std::filesystem::exists(prefix / "@CMAKE_INSTALL_SYSCONFDIR@/tenzir", err) &&
-      !std::filesystem::exists(prefix / "@CMAKE_INSTALL_SYSCONFDIR@/tenzir", err))
-    return prefix / "@CMAKE_INSTALL_SYSCONFDIR@/tenzir";
-  return prefix / "@CMAKE_INSTALL_SYSCONFDIR@/tenzir";
+  return prefix / "@CMAKE_INSTALL_RELATIVE_SYSCONFDIR@/tenzir";
 }
 
 std::filesystem::path install_datadir() {
   const auto [prefix, _] = install_prefix_and_suffix();
-  return prefix / "@CMAKE_INSTALL_DATADIR@/tenzir";
+  return prefix / "@CMAKE_INSTALL_RELATIVE_DATADIR@/tenzir";
 }
 
 std::filesystem::path install_libexecdir() {
   const auto [prefix, suffix] = install_prefix_and_suffix();
-  return prefix / "@CMAKE_INSTALL_LIBEXECDIR@" / suffix;
+  return prefix / "@CMAKE_INSTALL_RELATIVE_LIBEXECDIR@" / suffix;
 }
 
 std::filesystem::path install_plugindir() {
   const auto [prefix, suffix] = install_prefix_and_suffix();
-  return prefix / "@CMAKE_INSTALL_LIBDIR@/tenzir/plugins" / suffix;
+  return prefix / "@CMAKE_INSTALL_RELATIVE_LIBDIR@/tenzir/plugins" / suffix;
 }
 
 } // namespace tenzir::detail

--- a/libtenzir/src/detail/installdirs_relocatable.cpp.in
+++ b/libtenzir/src/detail/installdirs_relocatable.cpp.in
@@ -11,9 +11,6 @@
 #include "tenzir/detail/process.hpp"
 #include "tenzir/detail/string.hpp"
 
-#include <fmt/format.h>
-#include <fmt/std.h>
-
 #include <string_view>
 
 namespace tenzir::detail {

--- a/nix/tenzir/default.nix
+++ b/nix/tenzir/default.nix
@@ -107,7 +107,7 @@
           chmod -R u+w source/extra-plugins
         '';
 
-        outputs = ["out"] ++ lib.optionals isStatic ["package"];
+        outputs = ["out"] ++ (if isStatic then ["package"] else ["dev"]);
 
         nativeBuildInputs = [
           cmake
@@ -186,6 +186,9 @@
             "-DTENZIR_ENABLE_UNIT_TESTS=OFF"
             "-DTENZIR_ENABLE_BATS_TENZIR_INSTALLATION=OFF"
             "-DTENZIR_GRPC_CPP_PLUGIN=${lib.getBin pkgsBuildHost.grpc}/bin/grpc_cpp_plugin"
+          ] ++ lib.optionals (builtins.any (x: x == "dev") finalAttrs.outputs) [
+            "-DTENZIR_INSTALL_ARCHIVEDIR=${placeholder "dev"}/lib"
+            "-DTENZIR_INSTALL_CMAKEDIR=${placeholder "dev"}/lib/cmake"
           ] ++ lib.optionals isStatic [
             "-UCMAKE_INSTALL_BINDIR"
             "-UCMAKE_INSTALL_SBINDIR"

--- a/nix/tenzir/plugins/default.nix
+++ b/nix/tenzir/plugins/default.nix
@@ -9,7 +9,7 @@
   versions = import ./names.nix;
   f = name:
     callPackage ./generic.nix {
-      inherit name;
+      name = "tenzir-plugin-${name}";
       src = "${tenzir-plugins}/${name}";
       inherit tenzir;
     };

--- a/nix/tenzir/plugins/generic.nix
+++ b/nix/tenzir/plugins/generic.nix
@@ -9,6 +9,8 @@
 stdenv.mkDerivation {
   inherit name src;
 
+  outputs = ["out" "dev"];
+
   nativeBuildInputs = [cmake];
   buildInputs = [tenzir];
 

--- a/tenzir/CMakeLists.txt
+++ b/tenzir/CMakeLists.txt
@@ -37,7 +37,7 @@ macro (create_tenzir_symlink name)
   # different depending on whether the CMAKE_INSTALL_BINDIR is set to an
   # absolute path or not. We emulate this behavior for the symlinks here so they
   # will always end up in the same location.
-  if (TENZIR_ENABLE_RELOCATABLE_INSTALLATIONS)
+  if (NOT IS_ABSOLUTE "${CMAKE_INSTALL_BINDIR}")
     install(
       CODE "
       execute_process(COMMAND


### PR DESCRIPTION
This change makes it possible to install library archives into a different path than shared libraries. We then make use of it in the non-static Nix build which shaves off ~500 MB of the runtime closure.
