### PR TITLE
Add explicit `tls` options to `to_opensearch` and `to_splunk`

### DIFF
--- a/changelog/next/features/4983--opensearch-fixup.md
+++ b/changelog/next/features/4983--opensearch-fixup.md
@@ -1,0 +1,1 @@
+`to_opensearch` and `to_splunk` now feature an explicit `tls` option.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "d8fff72b97b66806306a484f259a100916fa48d1",
+  "rev": "6a4c44e4aa2313df28205a45c1534617f89aaf86",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/web/docs/tql2/operators/to_opensearch.md
+++ b/web/docs/tql2/operators/to_opensearch.md
@@ -4,9 +4,9 @@ Sends events to an OpenSearch-compatible Bulk API.
 
 ```tql
 to_opensearch url:string, action=string, [index=string, id=string, doc=record,
-    user=string, passwd=string, skip_peer_verification=bool, cacert=string,
-    certfile=string, keyfile=string, include_nulls=bool, max_content_length=int,
-    buffer_timeout=duration, compress=bool]
+    user=string, passwd=string, tls=bool, skip_peer_verification=bool,
+    cacert=string, certfile=string, keyfile=string, include_nulls=bool,
+    max_content_length=int, buffer_timeout=duration, compress=bool]
 ```
 
 ## Description
@@ -62,6 +62,13 @@ Optional user for HTTP Basic Authentication.
 ### `passwd = string (optional)`
 
 Optional password for HTTP Basic Authentication.
+
+### `tls = bool (optional)`
+
+Enables TLS.
+
+If the URL scheme is `https`, or any of the other TLS related
+options are set, the option defaults to `true`, otherwise it is `false`.
 
 ### `skip_peer_verification = bool (optional)`
 

--- a/web/docs/tql2/operators/to_splunk.md
+++ b/web/docs/tql2/operators/to_splunk.md
@@ -7,7 +7,7 @@ Sends events to a Splunk [HTTP Event Collector (HEC)][hec].
 ```tql
 to_splunk url:string, hec_token=string,
           [host=string, source=string, sourcetype=expr, index=expr,
-          cacert=string, certfile=string, keyfile=string,
+          tls=bool, cacert=string, certfile=string, keyfile=string,
           skip_peer_verification=bool, print_nulls=bool,
           max_content_length=int, buffer_timeout=duration, compress=bool]
 ```
@@ -63,6 +63,13 @@ An optional expression for the [Splunk
 If you do not provide this option, Splunk will use the default index.
 
 **NB**: HEC silently drops events with an invalid `index`.
+
+### `tls = bool (optional)`
+
+Enables TLS.
+
+If the URL scheme is `https`, or any of the other TLS related
+options are set, the option defaults to `true`, otherwise it is `false`.
 
 ### `cacert = string (optional)`
 


### PR DESCRIPTION
This adds an explicit `tls` option to `to_opensearch` allowing its usage with TLS in the generic `to`. For consistency, those arguments are also added to `to_splunk`.

Additionally, it fixes a few small, but not user-exposed bugs in `to_opensearch`.

- Fixes https://github.com/tenzir/issues/issues/2818
