### PR TITLE
Evict old caches when exceeding capacity limits

### DIFF
--- a/.github/workflows/tenzir.yaml
+++ b/.github/workflows/tenzir.yaml
@@ -316,7 +316,6 @@ jobs:
           echo "nix-matrix=${nix_matrix}" >> "$GITHUB_OUTPUT"
           echo "::notice nix-matrix = ${nix_matrix}"
 
-
   policy-enforcement:
     name: Policy Enforcement
     needs:
@@ -482,9 +481,10 @@ jobs:
           docker run \
             --pull=always --rm \
             "ghcr.io/tenzir/tenzir:${{ needs.configure.outputs.tenzir-container-ref }}" \
-            'openapi | to web/openapi/openapi.yaml'
+            --tql2 'openapi | to "web/openapi/openapi.yaml"'
+          git add --intent-to-add web/openapi/openapi.yaml
           git diff --quiet --exit-code || {
-            echo "The OpenAPI Spec is not aligned with the current sources. Please run *tenzir 'openapi | to web/openapi/openapi.yaml'* or apply the following diff directly:"
+            echo "The OpenAPI Spec is not aligned with the current sources. Please run *tenzir 'openapi | to "web/openapi/openapi.yaml"'* or apply the following diff directly:"
             git diff --exit-code
           }
 

--- a/changelog/next/bug-fixes/4984-serve-hang.md
+++ b/changelog/next/bug-fixes/4984-serve-hang.md
@@ -1,0 +1,3 @@
+We fixed an up to 60 seconds hang in requests to the `/serve` endpoint when the
+request was issued after the pipeline with the corresponding `serve` operator
+was started and before it finished with an error and without results.

--- a/changelog/next/changes/4984--cache-overuse.md
+++ b/changelog/next/changes/4984--cache-overuse.md
@@ -6,3 +6,7 @@ require at least 64MiB of caches.
 
 The default `write_timeout` of caches increased from 1 minute to 10 minutes, and
 can now be configured with the `tenzir.cache.lifetime` option.
+
+The `/serve` endpoint now returns an additional field `state`, which can be one
+of `running`, `completed`, or `failed`, indicating the status of the pipeline
+with the corresponding `serve` operator at the time of the request.

--- a/changelog/next/changes/4984--cache-overuse.md
+++ b/changelog/next/changes/4984--cache-overuse.md
@@ -1,0 +1,8 @@
+Unless specified explicitly, the `cache` has no more default capacity in terms
+of number of events per cache. Instead, the node now tracks the global cache
+capacity in number of bytes. This is limited to 1GiB by default, and can be
+configured with the `tenzir.cache.capacity` option. For practical reasons, we
+require at least 64MiB of caches.
+
+The default `write_timeout` of caches increased from 1 minute to 10 minutes, and
+can now be configured with the `tenzir.cache.lifetime` option.

--- a/libtenzir/builtins/operators/serve.cpp
+++ b/libtenzir/builtins/operators/serve.cpp
@@ -366,6 +366,10 @@ struct serve_manager_state {
         ops.erase(found);
       }
     };
+    if (err) {
+      delete_serve();
+      return;
+    }
     detail::weak_run_delayed(self, defaults::api::serve::retention_time,
                              delete_serve);
   }

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -32,6 +32,18 @@ tenzir:
     # diagnostics in the Tenzir Platform.
     #diagnostics: 30d
 
+  # Configure the behavior of the `cache` operator. The Tenzir Platform uses the
+  # cache operator to store and retrieve data efficiently.
+  cache:
+    # Specifies the default write-timeout for the `cache` operator.
+    #lifetime: 10min
+
+    # Specifies an upper bound for the total memory usage in bytes across all
+    # caches in a node. If the memory usage exceeds this limit, the node will
+    # start evicting caches to make room for new data. The node requires a
+    # minimum total cache capacity of 64MiB.
+    #capacity: 1Gi
+
   # Always use TQL2 for pipelines.
   #tql2: false
 

--- a/web/docs/tql2/operators/cache.md
+++ b/web/docs/tql2/operators/cache.md
@@ -25,9 +25,10 @@ Set the `tenzir.cache` configuration section controls how caches behave in
 Tenzir Nodes:
 - `tenzir.cache.lifetime` sets the default write timeout for newly created
   caches.
-- `tenzir.cache.capacity` sets an upper bound for the total memory usage in
-  bytes across all caches in a node. If the memory usage exceeds this limit, the
-  node will start evicting caches to make room for new data. The node requires a
+- `tenzir.cache.capacity` sets an upper bound for the estimated total memory
+  usage in bytes across all caches in a node. If the memory usage exceeds this
+  limit, the node will start evicting caches to make room for new data. This
+  eviction process happens at most once every 30 seconds. The node requires a
   minimum total cache capacity of 64MiB.
 
 ```yaml

--- a/web/docs/tql2/operators/cache.md
+++ b/web/docs/tql2/operators/cache.md
@@ -1,10 +1,8 @@
 # cache
 
-:::warning Expert Operator
-We designed the `cache` operator for under-the-hood use of the Tenzir Platform
-on [app.tenzir.com](https://app.tenzir.com). We generally recommend not using
-the operator by yourself, but rather relying on the Tenzir Platform to
-automatically manage caches for you.
+:::info Used by the Tenzir Platform
+The Tenzir Platform heavily relies on the `cache` operator to make data access
+faster and more reliable in both the Explorer and on Dashboards.
 :::
 
 An in-memory cache shared between pipelines.
@@ -21,6 +19,24 @@ have a user-provided unique ID.
 The first pipeline to use a cache writes into the cache. All further pipelines
 using the same cache will read from the cache instead of executing the operators
 before the `cache` operator in the same pipeline.
+
+:::tip Cache Policy
+Set the `tenzir.cache` configuration section controls how caches behave in
+Tenzir Nodes:
+- `tenzir.cache.lifetime` sets the default write timeout for newly created
+  caches.
+- `tenzir.cache.capacity` sets an upper bound for the total memory usage in
+  bytes across all caches in a node. If the memory usage exceeds this limit, the
+  node will start evicting caches to make room for new data. The node requires a
+  minimum total cache capacity of 64MiB.
+
+```yaml
+tenzir:
+  cache:
+    lifetime: 10min
+    capacity: 1Gi
+```
+:::
 
 ### `id: string`
 
@@ -46,7 +62,7 @@ Defaults to `"readwrite"`.
 Stores how many events the cache can hold. Caches stop accepting events if the
 capacity is reached and emit a warning.
 
-Defaults to `4Mi`.
+Defaults to unlimited.
 
 ### `read_timeout = duration (optional)`
 
@@ -54,7 +70,8 @@ Defines the maximum inactivity time until the cache is evicted from memory. The
 timer starts when writing the cache completes (or runs into the capacity limit),
 and resets whenever the cache is read from.
 
-Defaults to `1min`.
+Defaults to `10min`, or the value specified in the `tenzir.cache.lifetme`
+option.
 
 ### `write_timeout = duration (optional)`
 

--- a/web/openapi/openapi.yaml
+++ b/web/openapi/openapi.yaml
@@ -45,7 +45,7 @@ components:
           type: string
           description: "A duration string specifying the maximum time for this pipeline to\nexist. No value means the pipeline is allowed to exist forever.\nThis parameter must be defined if the `hidden` parameter is true.\n"
           default: null
-          example: 5.0m
+          example: 5min
         autostart:
           $ref: "#/components/schemas/PipelineAutostart"
         autodelete:
@@ -53,8 +53,8 @@ components:
         retry_delay:
           type: string
           description: "A duration string specifying the minimum time between automatic restarts\nof a pipeline when an error occurs. Takes no effect if restarting on\nfailure is disabled.\n"
-          default: 1.0m
-          example: 500.0ms
+          default: 1min
+          example: 500ms
         unstoppable:
           type: boolean
           description: "A flag specifying whether this pipeline is unstoppable.\nUnstoppable pipelines start automatically, fail when they complete, and can not be paused or stopped manually.\n"
@@ -118,11 +118,11 @@ components:
             cache_read_timeout:
               type: string
               description: "The time to live of the cache. Resets when reading from the cache.\n"
-              example: 1.0m
+              example: 1min
             cache_write_timeout:
               type: string
               description: "The maximum time to live of the cache. Unlike the `cache_read_timeout`\nparameter, this does not reset when reading from the cache.\n"
-              example: 1.0h
+              example: 1h
             serve_id:
               type: string
               description: The identifier for the `serve` operator.
@@ -245,7 +245,7 @@ components:
         retry_delay:
           type: string
           description: "A duration string specifying the minimum time between automatic restarts\nof a pipeline when an error occurs. Takes no effect if restarting on\nfailure is disabled.\n"
-          example: 10.0s
+          example: 10s
         autostart:
           $ref: "#/components/schemas/PipelineAutostart"
         autodelete:
@@ -253,11 +253,11 @@ components:
         ttl:
           type: string
           description: If a TTL exists for this pipeline, the TTL as a duration string.
-          example: 2.0m
+          example: 2min
         remaining_ttl:
           type: string
           description: If a TTL exists for this pipeline, the remaining TTL as a duration string.
-          example: 10.0s
+          example: 10s
     PipelineLabel:
       type: object
       properties:
@@ -542,7 +542,7 @@ paths:
                 retry_delay:
                   type: string
                   description: "A duration string specifying the minimum time between automatic restarts\nof a pipeline when an error occurs. Takes no effect if restarting on\nfailure is disabled.\n"
-                  example: 500.0ms
+                  example: 500ms
                 unstoppable:
                   type: boolean
                   description: "A flag specifying whether this pipeline is unstoppable.\nUnstoppable pipelines start automatically, fail when they complete, and can not be paused or stopped manually.\n"
@@ -605,8 +605,8 @@ paths:
                   description: Wait for this number of events before returning.
                 timeout:
                   type: string
-                  example: 200.0ms
-                  default: 5.0s
+                  example: 200ms
+                  default: 5s
                   description: The maximum amount of time spent on the request. Hitting the timeout is not an error. The timeout must not be greater than 10 seconds.
       responses:
         200:
@@ -620,6 +620,10 @@ paths:
                     type: string
                     description: A token to access the next pipeline data batch, null if the pipeline is completed.
                     example: 340ce2j
+                  state:
+                    type: string
+                    description: The state of the corresponding pipeline at the time of the request. One of `running`, `completed`, or `failed`.
+                    example: running
                   schemas:
                     type: array
                     items:
@@ -676,13 +680,13 @@ paths:
                     example:
                       - schema_id: c631d301e4b18f4
                         data:
-                          timestamp: 2023-04-26T12:00:00.000000
+                          timestamp: 2023-04-26T12:00:00Z
                           schema: zeek.conn
                           schema_id: ab2371bas235f1
                           events: 50
                       - schema_id: c631d301e4b18f4
                         data:
-                          timestamp: 2023-04-26T12:05:00.000000
+                          timestamp: 2023-04-26T12:05:00Z
                           schema: suricata.dns
                           schema_id: cd4771bas235f1
                           events: 50


### PR DESCRIPTION
We're currently implementing a feature for the Tenzir Platform that heavily relies on caching in nodes. For that, we've made three changes to the `cache` operator:
1. Unless specified explicitly, caches have no more default capacity in terms of event.
2. Instead of (1), we now track the global cache capacity in number of bytes. This is limited to 1GiB by default, and can be configured with the `tenzir.cache.capacity` option. For practical reasons, we require at least 64MiB of caches.
3. The default `wrtie_timeout` of caches increased from 1 minute to 10 minutes, and can now be configured with the `tenzir.cache.lifetime` option.

Additionally, and this is tacked onto this PR for easier testing with the Tenzir Platform, this makes two changes to `/serve`:
1. We've added an additional field `state` to `/serve`, which can be one of `running`, `completed`, or `failed`, indicating the status of the pipeline with the corresponding `serve` operator at the time of the request.
2. We fixed an up to 60 seconds hang in requests to the `/serve` endpoint when the request was issued after the pipeline with the corresponding `serve` operator was started and before it finished with an error and without results.

- Fixes https://github.com/tenzir/issues/issues/2810