### PR TITLE
Implement sub-duration functions

### DIFF
--- a/changelog/next/features/4985--duration-abs.md
+++ b/changelog/next/features/4985--duration-abs.md
@@ -1,0 +1,6 @@
+New functions `years`, `months`, `weeks`, `days`, `hours`, `minutes`, `seconds`,
+`milliseconds`, `microseconds` and `nanoseconds` convert a numeric value to the
+equivalent duration. Their counterpart `count_*` functions calculate how many
+units can the duration be broken into, i.e. `duration / unit`.
+
+The `abs` function calculates the absolute value for a number or a duration.

--- a/libtenzir/builtins/functions/abs.cpp
+++ b/libtenzir/builtins/functions/abs.cpp
@@ -1,0 +1,122 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2025 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "tenzir/multi_series.hpp"
+
+#include <tenzir/arrow_utils.hpp>
+#include <tenzir/concept/parseable/tenzir/time.hpp>
+#include <tenzir/series_builder.hpp>
+#include <tenzir/tql2/plugin.hpp>
+
+#include <arrow/compute/api.h>
+#include <arrow/type_fwd.h>
+
+namespace tenzir::plugins::abs {
+
+namespace {
+
+class abs final : public function_plugin {
+public:
+  auto name() const -> std::string override {
+    return "abs";
+  }
+
+  auto make_function(invocation inv, session ctx) const
+    -> failure_or<function_ptr> override {
+    auto expr = ast::expression{};
+    TRY(argument_parser2::function(name())
+          .positional("x", expr, "duration|number")
+          .parse(inv, ctx));
+    return function_use::make([expr = std::move(expr)](
+                                evaluator eval, session ctx) -> multi_series {
+      const auto evaluated = eval(expr);
+      return map_series(evaluated, [&](series arg) {
+        return match(
+          *arg.array,
+          [&](const arrow::NullArray&) -> series {
+            return arg;
+          },
+          [&](const arrow::UInt64Array&) -> series {
+            return arg;
+          },
+          [&](const arrow::Int64Array& array) -> series {
+            // TODO: Maybe slice the array for positive values
+            auto overflow = false;
+            auto b
+              = int64_type::make_arrow_builder(arrow::default_memory_pool());
+            for (auto v : values(int64_type{}, array)) {
+              if (not v) {
+                check(b->AppendNull());
+                continue;
+              }
+              const auto val = v.value();
+              if (val == std::numeric_limits<int64_t>::lowest()) {
+                check(b->AppendNull());
+                overflow = true;
+                continue;
+              }
+              check(b->Append(std::abs(val)));
+            }
+            if (overflow) {
+              diagnostic::warning("integer overflow").primary(expr).emit(ctx);
+            }
+            return series{int64_type{}, finish(*b)};
+          },
+          [&](const arrow::DoubleArray& array) -> series {
+            // TODO: Maybe slice the array for positive values
+            auto b
+              = double_type::make_arrow_builder(arrow::default_memory_pool());
+            for (auto v : values(double_type{}, array)) {
+              if (not v) {
+                check(b->AppendNull());
+                continue;
+              }
+              check(b->Append(std::abs(v.value())));
+            }
+            return series{double_type{}, finish(*b)};
+          },
+          [&](const arrow::DurationArray& array) {
+            // TODO: Maybe slice the array for positive values
+            auto overflow = false;
+            auto b
+              = duration_type::make_arrow_builder(arrow::default_memory_pool());
+            for (auto v : values(duration_type{}, array)) {
+              if (not v) {
+                check(b->AppendNull());
+                continue;
+              }
+              const auto val = v->count();
+              if (val == std::numeric_limits<duration::rep>::lowest()) {
+                check(b->AppendNull());
+                overflow = true;
+                continue;
+              }
+              check(b->Append(std::abs(val)));
+            }
+            if (overflow) {
+              diagnostic::warning("duration overflow").primary(expr).emit(ctx);
+            }
+            return series{duration_type{}, finish(*b)};
+          },
+          [&](const auto&) {
+            diagnostic::warning("expected `duration|number`, but got `{}`",
+                                arg.type.kind())
+              .primary(expr)
+              .emit(ctx);
+            return series::null(null_type{}, arg.length());
+          });
+      });
+    });
+  }
+};
+
+} // namespace
+
+} // namespace tenzir::plugins::abs
+
+TENZIR_REGISTER_PLUGIN(tenzir::plugins::abs::abs)

--- a/libtenzir/builtins/functions/duration.cpp
+++ b/libtenzir/builtins/functions/duration.cpp
@@ -6,6 +6,8 @@
 // SPDX-FileCopyrightText: (c) 2024 The Tenzir Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+#include "tenzir/checked_math.hpp"
+
 #include <tenzir/arrow_utils.hpp>
 #include <tenzir/concept/parseable/tenzir/time.hpp>
 #include <tenzir/series_builder.hpp>
@@ -17,7 +19,7 @@ namespace tenzir::plugins::duration {
 
 namespace {
 
-class plugin final : public function_plugin {
+class duration_plugin final : public function_plugin {
 public:
   auto name() const -> std::string override {
     return "duration";
@@ -75,8 +77,193 @@ public:
     });
   }
 };
+
+template <class T>
+class into_duration_plugin final : public function_plugin {
+public:
+  into_duration_plugin() = default;
+
+  into_duration_plugin(std::string name) : name_{std::move(name)} {
+  }
+
+  auto name() const -> std::string override {
+    return name_;
+  }
+
+  auto make_function(invocation inv, session ctx) const
+    -> failure_or<function_ptr> override {
+    auto expr = ast::expression{};
+    TRY(argument_parser2::function(name())
+          .positional("x", expr, "number")
+          .parse(inv, ctx));
+    return function_use::make([this, expr = std::move(expr)](
+                                evaluator eval, session ctx) -> series {
+      const auto unit = std::chrono::duration_cast<tenzir::duration>(T{1});
+      auto b = duration_type::make_arrow_builder(arrow::default_memory_pool());
+      check(b->Reserve(eval.length()));
+      for (const auto& arg : eval(expr)) {
+        match(
+          arg.type,
+          [&](const null_type&) {
+            check(b->AppendNulls(arg.length()));
+          },
+          [&]<class U>(const U&)
+            requires concepts::one_of<U, int64_type, uint64_type, double_type>
+          {
+            constexpr auto min
+              = static_cast<double>(
+                  std::numeric_limits<tenzir::duration::rep>::lowest())
+                - 1.0;
+            constexpr auto max
+              = static_cast<double>(
+                  std::numeric_limits<tenzir::duration::rep>::max())
+                + 1.0;
+            auto overflow = false;
+            for (auto v :
+                 values(U{}, as<type_to_arrow_array_t<U>>(*arg.array))) {
+              if (not v) {
+                check(b->AppendNull());
+                continue;
+              }
+              if constexpr (not std::same_as<U, double_type>) {
+                const auto result = checked_mul(v.value(), unit.count());
+                if (not result) {
+                  check(b->AppendNull());
+                  overflow = true;
+                  continue;
+                }
+                check(b->Append(result.value()));
+              } else {
+                const auto result
+                  = static_cast<double>(v.value()) * unit.count();
+                if (not(result > min) || not(result < max)) {
+                  check(b->AppendNull());
+                  overflow = true;
+                  continue;
+                }
+                check(b->Append(result));
+              }
+            }
+            if (overflow) {
+              diagnostic::warning("duration overflow in `{}`", name_)
+                .primary(expr)
+                .emit(ctx);
+            }
+          },
+          [&](const auto&) {
+            diagnostic::warning("`{}` expected `number`, but got `{}`", name_,
+                                arg.type.kind())
+              .primary(expr)
+              .emit(ctx);
+            check(b->AppendNulls(arg.length()));
+          });
+      }
+      return series{duration_type{}, finish(*b)};
+    });
+  }
+
+private:
+  std::string name_;
+};
+
+template <class T>
+class count_duration_plugin final : public function_plugin {
+public:
+  count_duration_plugin() = default;
+
+  count_duration_plugin(std::string name) : name_{std::move(name)} {
+  }
+
+  auto name() const -> std::string override {
+    return name_;
+  }
+
+  auto make_function(invocation inv, session ctx) const
+    -> failure_or<function_ptr> override {
+    auto expr = ast::expression{};
+    TRY(argument_parser2::function(name())
+          .positional("x", expr, "duration")
+          .parse(inv, ctx));
+    return function_use::make([this, expr = std::move(expr)](
+                                evaluator eval, session ctx) -> series {
+      const auto unit = std::chrono::duration_cast<tenzir::duration>(T{1});
+      auto b = std::invoke([] {
+        if constexpr (std::same_as<T, std::chrono::nanoseconds>) {
+          return int64_type::make_arrow_builder(arrow::default_memory_pool());
+        } else {
+          return double_type::make_arrow_builder(arrow::default_memory_pool());
+        }
+      });
+      check(b->Reserve(eval.length()));
+      for (auto& arg : eval(expr)) {
+        match(
+          *arg.array,
+          [&](const arrow::NullArray& arg) {
+            check(b->AppendNulls(arg.length()));
+          },
+          [&](const arrow::DurationArray& arg) {
+            for (auto v : values(duration_type{}, arg)) {
+              if (not v) {
+                check(b->AppendNull());
+                continue;
+              }
+              if constexpr (std::same_as<T, std::chrono::nanoseconds>) {
+                static_assert(std::same_as<int64_t, tenzir::duration::rep>);
+                check(b->Append(v->count()));
+              } else {
+                check(
+                  b->Append(static_cast<double>(v->count()) / unit.count()));
+              }
+            }
+          },
+          [&](const auto&) {
+            diagnostic::warning("`{}` expected `duration`, but got `{}`", name_,
+                                arg.type.kind())
+              .primary(expr)
+              .emit(ctx);
+            check(b->AppendNulls(arg.length()));
+          });
+      }
+      if constexpr (std::same_as<T, std::chrono::nanoseconds>) {
+        return series{int64_type{}, finish(*b)};
+      }
+      return series{double_type{}, finish(*b)};
+    });
+  }
+
+private:
+  std::string name_;
+};
+
 } // namespace
 
 } // namespace tenzir::plugins::duration
 
-TENZIR_REGISTER_PLUGIN(tenzir::plugins::duration::plugin)
+template <class T>
+using count = tenzir::plugins::duration::count_duration_plugin<T>;
+
+template <class T>
+using into = tenzir::plugins::duration::into_duration_plugin<T>;
+
+TENZIR_REGISTER_PLUGIN(tenzir::plugins::duration::duration_plugin)
+TENZIR_REGISTER_PLUGIN(into<std::chrono::nanoseconds>{"nanoseconds"})
+TENZIR_REGISTER_PLUGIN(into<std::chrono::microseconds>{"microseconds"})
+TENZIR_REGISTER_PLUGIN(into<std::chrono::milliseconds>{"milliseconds"})
+TENZIR_REGISTER_PLUGIN(into<std::chrono::seconds>{"seconds"})
+TENZIR_REGISTER_PLUGIN(into<std::chrono::minutes>{"minutes"})
+TENZIR_REGISTER_PLUGIN(into<std::chrono::hours>{"hours"})
+TENZIR_REGISTER_PLUGIN(into<std::chrono::days>{"days"})
+TENZIR_REGISTER_PLUGIN(into<std::chrono::weeks>{"weeks"})
+TENZIR_REGISTER_PLUGIN(into<std::chrono::months>{"months"})
+TENZIR_REGISTER_PLUGIN(into<std::chrono::years>{"years"})
+
+TENZIR_REGISTER_PLUGIN(count<std::chrono::nanoseconds>{"count_nanoseconds"})
+TENZIR_REGISTER_PLUGIN(count<std::chrono::microseconds>{"count_microseconds"})
+TENZIR_REGISTER_PLUGIN(count<std::chrono::milliseconds>{"count_milliseconds"})
+TENZIR_REGISTER_PLUGIN(count<std::chrono::seconds>{"count_seconds"})
+TENZIR_REGISTER_PLUGIN(count<std::chrono::minutes>{"count_minutes"})
+TENZIR_REGISTER_PLUGIN(count<std::chrono::hours>{"count_hours"})
+TENZIR_REGISTER_PLUGIN(count<std::chrono::days>{"count_days"})
+TENZIR_REGISTER_PLUGIN(count<std::chrono::weeks>{"count_weeks"})
+TENZIR_REGISTER_PLUGIN(count<std::chrono::months>{"count_months"})
+TENZIR_REGISTER_PLUGIN(count<std::chrono::years>{"count_years"})

--- a/web/docs/tql2/functions.md
+++ b/web/docs/tql2/functions.md
@@ -164,6 +164,26 @@ Function | Description | Example
 [`now`](functions/now.md) | Gets the current wallclock time | `now()`
 [`since_epoch`](functions/since_epoch.md) | Turns a time into a duration since the Unix epoch | `since_epoch(2021-02-24)`
 [`parse_time`](functions/parse_time.md) | Parses a timestamp following a given format | `"10/11/2012".parse_time("%d/%m/%Y")`
+[`years`](functions/years.mdx) | Converts a number to equivalent years | `years(100)`
+[`months`](functions/months.mdx) | Converts a number to equivalent months | `months(100)`
+[`weeks`](functions/weeks.mdx) | Converts a number to equivalent weeks | `weeks(100)`
+[`days`](functions/days.mdx) | Converts a number to equivalent days | `days(100)`
+[`hours`](functions/hours.mdx) | Converts a number to equivalent hours | `hours(100)`
+[`minutes`](functions/minutes.mdx) | Converts a number to equivalent minutes | `minutes(100)`
+[`seconds`](functions/seconds.mdx) | Converts a number to equivalent seconds | `seconds(100)`
+[`milliseconds`](functions/milliseconds.mdx) | Converts a number to equivalent milliseconds | `milliseconds(100)`
+[`microseconds`](functions/microseconds.mdx) | Converts a number to equivalent microseconds | `microseconds(100)`
+[`nanoseconds`](functions/nanoseconds.mdx) | Converts a number to equivalent nanoseconds | `nanoseconds(100)`
+[`count_years`](functions/count_years.mdx) | Counts the number of years in a duration | `count_years(100d)`
+[`count_months`](functions/count_months.mdx) | Counts the number of months in a duration | `count_months(100d)`
+[`count_weeks`](functions/count_weeks.mdx) | Counts the number of weeks in a duration | `count_weeks(100d)`
+[`count_days`](functions/count_days.mdx) | Counts the number of days in a duration | `count_days(100d)`
+[`count_hours`](functions/count_hours.mdx) | Counts the number of hours in a duration | `count_hours(100d)`
+[`count_minutes`](functions/count_minutes.mdx) | Counts the number of minutes in a duration | `count_minutes(100d)`
+[`count_seconds`](functions/count_seconds.mdx) | Counts the number of seconds in a duration | `count_seconds(100d)`
+[`count_milliseconds`](functions/count_milliseconds.mdx) | Counts the number of milliseconds in a duration | `count_milliseconds(100d)`
+[`count_microseconds`](functions/count_microseconds.mdx) | Counts the number of microseconds in a duration | `count_microseconds(100d)`
+[`count_nanoseconds`](functions/count_nanoseconds.mdx) | Counts the number of nanoseconds in a duration | `count_nanoseconds(100d)`
 <!--
 This is hidden because there is an issue with the timezone DB.
 [`format_time`](functions/format_time.md) | Format a timestamp following a given format | `2012-11-10.format_time("%d/%m/%Y")`

--- a/web/docs/tql2/functions.md
+++ b/web/docs/tql2/functions.md
@@ -113,6 +113,7 @@ Function | Description | Example
 [`is_title`](functions/is_title.md) | Checks if a string follows title case | `"Hello World".is_title()`
 [`is_upper`](functions/is_upper.md) | Checks if a string is in uppercase | `"HELLO".is_upper()`
 [`match_regex`](functions/match_regex.md) | Checks if a string partially matches a regular expression | `"Hi".match_regex("[Hh]i")`
+[`slice`](functions/slice.md) | Slices a string with offsets and strides | `"Hi".slice(begin=2, stride=4)`
 
 ### Transformation
 

--- a/web/docs/tql2/functions/_count_duration.mdx
+++ b/web/docs/tql2/functions/_count_duration.mdx
@@ -1,0 +1,23 @@
+## Description
+
+<span>
+This function returns the number of {props.name} in a duration, i.e., <code>
+duration / 1{props.unit}</code>.
+</span>
+
+### `x: duration`
+
+The duration to count in.
+
+## See Also
+
+[`count_years`](count_years.mdx),
+[`count_months`](count_months.mdx),
+[`count_weeks`](count_weeks.mdx),
+[`count_days`](count_days.mdx),
+[`count_hours`](count_hours.mdx),
+[`count_minutes`](count_minutes.mdx),
+[`count_seconds`](count_seconds.mdx),
+[`count_milliseconds`](count_milliseconds.mdx),
+[`count_microseconds`](count_microseconds.mdx),
+[`count_nanoseconds`](count_nanoseconds.mdx)

--- a/web/docs/tql2/functions/_duration.mdx
+++ b/web/docs/tql2/functions/_duration.mdx
@@ -1,0 +1,23 @@
+## Description
+
+<span>
+This function returns {props.name} equivalent to a number, i.e., <code> number *
+1{props.unit}</code>.
+</span>
+
+### `x: number`
+
+The number to convert.
+
+## See Also
+
+[`years`](years.mdx),
+[`months`](months.mdx),
+[`weeks`](weeks.mdx),
+[`days`](days.mdx),
+[`hours`](hours.mdx),
+[`minutes`](minutes.mdx),
+[`seconds`](seconds.mdx),
+[`milliseconds`](milliseconds.mdx),
+[`microseconds`](microseconds.mdx),
+[`nanoseconds`](nanoseconds.mdx)

--- a/web/docs/tql2/functions/abs.md
+++ b/web/docs/tql2/functions/abs.md
@@ -1,0 +1,28 @@
+# abs
+
+Returns the absolute value.
+
+```tql
+abs(x:number) -> number
+abs(x:duration) -> duration
+```
+
+## Description
+
+This function returns the [absolute
+value](https://en.wikipedia.org/wiki/Absolute_value) for a number or a duration.
+
+### `x: duration|number`
+
+The value to compute absolute value for.
+
+## Examples
+
+```tql
+from {x: -13.3}
+x = x.abs()
+```
+
+```tql
+{x: 13.3}
+```

--- a/web/docs/tql2/functions/count_days.mdx
+++ b/web/docs/tql2/functions/count_days.mdx
@@ -1,0 +1,9 @@
+import Body from './_count_duration.mdx';
+
+Counts the number of `days` in a duration.
+
+```tql
+count_days(x:duration) -> float
+```
+
+<Body name = "days" unit = "d" />

--- a/web/docs/tql2/functions/count_hours.mdx
+++ b/web/docs/tql2/functions/count_hours.mdx
@@ -1,0 +1,9 @@
+import Body from './_count_duration.mdx';
+
+Counts the number of `hours` in a duration.
+
+```tql
+count_hours(x:duration) -> float
+```
+
+<Body name = "hours" unit = "h" />

--- a/web/docs/tql2/functions/count_microseconds.mdx
+++ b/web/docs/tql2/functions/count_microseconds.mdx
@@ -1,0 +1,9 @@
+import Body from './_count_duration.mdx';
+
+Counts the number of `microseconds` in a duration.
+
+```tql
+count_microseconds(x:duration) -> float
+```
+
+<Body name = "microseconds" unit = "us" />

--- a/web/docs/tql2/functions/count_milliseconds.mdx
+++ b/web/docs/tql2/functions/count_milliseconds.mdx
@@ -1,0 +1,9 @@
+import Body from './_count_duration.mdx';
+
+Counts the number of `milliseconds` in a duration.
+
+```tql
+count_milliseconds(x:duration) -> float
+```
+
+<Body name = "milliseconds" unit = "ms" />

--- a/web/docs/tql2/functions/count_minutes.mdx
+++ b/web/docs/tql2/functions/count_minutes.mdx
@@ -1,0 +1,9 @@
+import Body from './_count_duration.mdx';
+
+Counts the number of `minutes` in a duration.
+
+```tql
+count_minutes(x:duration) -> float
+```
+
+<Body name = "minutes" unit = "min" />

--- a/web/docs/tql2/functions/count_months.mdx
+++ b/web/docs/tql2/functions/count_months.mdx
@@ -1,0 +1,9 @@
+import Body from './_count_duration.mdx';
+
+Counts the number of `months` in a duration.
+
+```tql
+count_months(x:duration) -> float
+```
+
+<Body name = "months" unit = "/12 * 1y" />

--- a/web/docs/tql2/functions/count_nanoseconds.mdx
+++ b/web/docs/tql2/functions/count_nanoseconds.mdx
@@ -1,0 +1,9 @@
+import Body from './_count_duration.mdx';
+
+Counts the number of `nanoseconds` in a duration.
+
+```tql
+count_nanoseconds(x:duration) -> int
+```
+
+<Body name = "nanoseconds" unit = "ns" />

--- a/web/docs/tql2/functions/count_seconds.mdx
+++ b/web/docs/tql2/functions/count_seconds.mdx
@@ -1,0 +1,9 @@
+import Body from './_count_duration.mdx';
+
+Counts the number of `seconds` in a duration.
+
+```tql
+count_seconds(x:duration) -> float
+```
+
+<Body name = "seconds" unit = "s" />

--- a/web/docs/tql2/functions/count_weeks.mdx
+++ b/web/docs/tql2/functions/count_weeks.mdx
@@ -1,0 +1,9 @@
+import Body from './_count_duration.mdx';
+
+Counts the number of `weeks` in a duration.
+
+```tql
+count_weeks(x:duration) -> float
+```
+
+<Body name = "weeks" unit = "w" />

--- a/web/docs/tql2/functions/count_years.mdx
+++ b/web/docs/tql2/functions/count_years.mdx
@@ -1,0 +1,9 @@
+import Body from './_count_duration.mdx';
+
+Counts the number of `years` in a duration.
+
+```tql
+count_years(x:duration) -> float
+```
+
+<Body name = "years" unit = "y" />

--- a/web/docs/tql2/functions/days.mdx
+++ b/web/docs/tql2/functions/days.mdx
@@ -1,0 +1,9 @@
+import Body from './_duration.mdx';
+
+Converts a number to equivalent days.
+
+```tql
+days(x:number) -> duration
+```
+
+<Body name = "days" unit = "d" />

--- a/web/docs/tql2/functions/hours.mdx
+++ b/web/docs/tql2/functions/hours.mdx
@@ -1,0 +1,9 @@
+import Body from './_duration.mdx';
+
+Converts a number to equivalent hours.
+
+```tql
+hours(x:number) -> duration
+```
+
+<Body name = "hours" unit = "h" />

--- a/web/docs/tql2/functions/microseconds.mdx
+++ b/web/docs/tql2/functions/microseconds.mdx
@@ -1,0 +1,9 @@
+import Body from './_duration.mdx';
+
+Converts a number to equivalent microseconds.
+
+```tql
+microseconds(x:number) -> duration
+```
+
+<Body name = "microseconds" unit = "us" />

--- a/web/docs/tql2/functions/milliseconds.mdx
+++ b/web/docs/tql2/functions/milliseconds.mdx
@@ -1,0 +1,9 @@
+import Body from './_duration.mdx';
+
+Converts a number to equivalent milliseconds.
+
+```tql
+milliseconds(x:number) -> duration
+```
+
+<Body name = "milliseconds" unit = "ms" />

--- a/web/docs/tql2/functions/minutes.mdx
+++ b/web/docs/tql2/functions/minutes.mdx
@@ -1,0 +1,9 @@
+import Body from './_duration.mdx';
+
+Converts a number to equivalent minutes.
+
+```tql
+minutes(x:number) -> duration
+```
+
+<Body name = "minutes" unit = "min" />

--- a/web/docs/tql2/functions/months.mdx
+++ b/web/docs/tql2/functions/months.mdx
@@ -1,0 +1,9 @@
+import Body from './_duration.mdx';
+
+Converts a number to equivalent months.
+
+```tql
+months(x:number) -> duration
+```
+
+<Body name = "months" unit = "/12 * 1y" />

--- a/web/docs/tql2/functions/nanoseconds.mdx
+++ b/web/docs/tql2/functions/nanoseconds.mdx
@@ -1,0 +1,9 @@
+import Body from './_duration.mdx';
+
+Converts a number to equivalent nanoseconds.
+
+```tql
+nanoseconds(x:number) -> duration
+```
+
+<Body name = "nanoseconds" unit = "ns" />

--- a/web/docs/tql2/functions/seconds.mdx
+++ b/web/docs/tql2/functions/seconds.mdx
@@ -1,0 +1,9 @@
+import Body from './_duration.mdx';
+
+Converts a number to equivalent seconds.
+
+```tql
+seconds(x:number) -> duration
+```
+
+<Body name = "seconds" unit = "s" />

--- a/web/docs/tql2/functions/slice.md
+++ b/web/docs/tql2/functions/slice.md
@@ -1,0 +1,75 @@
+# slice
+
+Slices a string with offsets and strides.
+
+```tql
+slice(x:string, [begin=int, end=int, stride=int])
+```
+
+## Description
+
+The `slice` function takes a string as input and selects parts from it.
+
+### `x: string`
+
+The string to slice.
+
+### `begin = int (optional)`
+
+The offset to start slice from.
+
+If negative, offset is calculated from the end of string.
+
+Defaults to `0`.
+
+### `end = int (optional)`
+
+The offset to end the slice at.
+
+If negative, offset is calculated from the end of string.
+
+If unspecified, ends at the `input`'s end.
+
+### `stride = int (optional)`
+
+The difference between the current character to take and the next character to
+take.
+
+If negative, characters are chosen in reverse.
+
+Defaults to `1`.
+
+## Examples
+
+### Get the first 3 characters of a string
+
+```tql
+from {x: "123456789"}
+x = x.slice(end=3)
+```
+
+```tql
+{x: "123"}
+```
+
+### Get the 1st, 3rd, and 5th characters
+
+```tql
+from {x: "1234567890"}
+x = x.slice(stride=2, end=6)
+```
+
+```tql
+{x: "135"}
+```
+
+### Select a substring from the 2nd character up to the 8th character
+
+```tql
+from {x: "1234567890"}
+x = x.slice(begin=1, end=8)
+```
+
+```tql
+{x: "2345678"}
+```

--- a/web/docs/tql2/functions/weeks.mdx
+++ b/web/docs/tql2/functions/weeks.mdx
@@ -1,0 +1,9 @@
+import Body from './_duration.mdx';
+
+Converts a number to equivalent weeks.
+
+```tql
+weeks(x:number) -> duration
+```
+
+<Body name = "weeks" unit = "w" />

--- a/web/docs/tql2/functions/years.mdx
+++ b/web/docs/tql2/functions/years.mdx
@@ -1,0 +1,9 @@
+import Body from './_duration.mdx';
+
+Converts a number to equivalent years.
+
+```tql
+years(x:number) -> duration
+```
+
+<Body name = "years" unit = "y" />


### PR DESCRIPTION
New functions `years`, `months`, `weeks`, `days`, `hours`, `minutes`, `seconds`,
`milliseconds`, `microseconds` and `nanoseconds` convert a numeric value to the
equivalent duration.

The `count_*` functions calculate how many units can the duration be broken
into, i.e. `duration / unit`.
