### PR TITLE
Make pipeline manager tests more reliable

### DIFF
--- a/.github/workflows/tenzir.yaml
+++ b/.github/workflows/tenzir.yaml
@@ -106,12 +106,12 @@ jobs:
           if git rev-parse "${limit_version}" --; then
             dated_versions=$(git for-each-ref --format="%(creatordate:format:%s)#%(refname:short)" "refs/tags/v[1-9]*" | grep -v '\-rc[0-9]\+$')
             dated_limit_version=$(printf "$dated_versions" | grep $limit_version)
-            # We filter out versions older than limit_version.
-            filtered_versions=$(printf "$dated_versions" | awk '-F#' '{if($0>="'$dated_limit_version'")print$2}')
+            # We filter out versions older than limit_version and v4.28.0
+            # because it was broken and failed to upload.
+            filtered_versions=$(printf "$dated_versions" | awk '-F#' '{if($0>="'$dated_limit_version'")print$2}' | grep -v 'v4.28.0')
             version_matrix="$(printf "$filtered_versions\nlatest\n" | jq -R | jq -sc 'map({version: .})')"
           else
-            # TODO: Restore "latest\n" after the next release and maybe come up with a better mechanism in the future.
-            version_matrix="$(printf "" | jq -R | jq -sc 'map({version: .})')"
+            version_matrix="$(printf "latest\n" | jq -R | jq -sc 'map({version: .})')"
           fi
           echo "version-matrix=${version_matrix}" >> $GITHUB_OUTPUT
           # Set a bunch of version numbers depending on how we triggered the PR

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "853956ddee3d79966d9afc29b7a98c55a48a7ddc",
+  "rev": "b8f041e8c880fbfdaa9e49085b090f9cbd67a77c",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tenzir"
-version = "4.28.0"
+version = "4.28.1"
 description = "A security telemetry engine for detection and response"
 authors = ["Tenzir <engineering@tenzir.com>"]
 maintainers = ["Tenzir <engineering@tenzir.com>"]

--- a/version.json
+++ b/version.json
@@ -4,7 +4,7 @@
     "annotated git tag without the leading 'v'.",
     "This value gets updated automatically by `scripts/prepare-release`."
   ],
-  "tenzir-version": "4.28.0",
+  "tenzir-version": "4.28.1",
   "tenzir-partition-version_COMMENT": [
     "The partition version. This number must be bumped alongside the release",
     "version for releases that contain major format changes to the on-disk",


### PR DESCRIPTION
The recent performance improvements caused a test to fail that was unfortunately timing-dependent because the pipeline it tested got faster. This has caused the release artifact uploads for v4.28 to fail, too.