### PR TITLE
Improve diagnostics for connection failures in tcp operator

### DIFF
--- a/libtenzir/builtins/connectors/tcp.cpp
+++ b/libtenzir/builtins/connectors/tcp.cpp
@@ -537,7 +537,9 @@ public:
                 // nop
               },
               [&](const caf::error& err) {
-                diagnostic::error("failed to connect: {}", err)
+                diagnostic::error("tcp loader failed to connect")
+                  .note("with error: {}", err)
+                  .note("while connecting to {}:{}", args.hostname, args.port)
                   .emit(ctrl.diagnostics());
               });
         } else {
@@ -655,7 +657,9 @@ public:
             // nop
           },
           [&](const caf::error& err) {
-            diagnostic::error("failed to connect: {}", err)
+            diagnostic::error("tcp saver failed to connect")
+              .note("with error: {}", err)
+              .note("while connecting to {}:{}", args_.hostname, args_.port)
               .emit(ctrl.diagnostics());
           });
     } else {


### PR DESCRIPTION
This is motivated by a recent bug-hunting session, where we had to invest a bit of time into figuring out which of the various configured pipelines was failing with a connection error.