### PR TITLE
Fix out-of-process REST APIs

### DIFF
--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "40fe19eb3913babef48737098004f311bb8876ac",
+  "rev": "61c213fcfb551bdf2751572be6c09475ac9ce202",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
This fixes a regression introduced in a recent change I made that removed usage of the node actor's message handler to retrieve component handles in favor of using the regisrty where possible.

It turns out that we still have the possibility to spawn the REST API externally via `tenzir-ctl web server`, which under-the-hood spawns `rest_handler_actor` instances in a client process. After my recent change this now ran into an assertion failure, as I had naïvely assumed that the REST handlers were singletons in the node.

This change now reverts the recent changes for the two affected actors. A proper fix would be to change the actors to run inside the node, but as we do not support building the `web` plugin locally on macOS I am likely not the right person to be making that change.

To test this change, run `TENZIR_VERSION=topic-fix-external-api docker compose up` from the repository root after CI has finished uploading the image for this PR. If the `tenzir-api` service starts instead of running into an assertion failure (like it does on current main), then this change works.

No changelog entry as I introduced this regression only after the last release.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made in the pull request description in a way that
   is consumable by everyone, not just developers who know the context of the
   change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://docs.tenzir.com/next/contribute/changelog
3. Provide instructions for the reviewer.
4. Remove this comment so it doesn't show up in the merge commit.
-->
