### PR TITLE
Do not expose the CAF port in Docker Compose setup

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,8 +10,6 @@ services:
       - TENZIR_TOKEN=${TENZIR_TOKEN:-}
       - TENZIR_ENDPOINT=tenzir-node:5158
       - TENZIR_TQL2=true
-    ports:
-      - 5158:5158
     entrypoint:
       - tenzir-node
     volumes:
@@ -26,6 +24,8 @@ services:
     image: ${TENZIR_IMAGE:-ghcr.io/tenzir/tenzir:${TENZIR_VERSION:-main}}
     build:
       target: tenzir
+    profiles:
+      - donotstart
     depends_on:
       - tenzir-node
     environment:


### PR DESCRIPTION
We have `docker compose run tenzir` to interact with the Tenzir Node from within the Docker network already, so there's no reason to expose the port to the outside world.

This makes to easier to run `docker compose up` multiple times on the same host.

In addition, this makes the REST API opt-in via `docker compose run tenzir-api`. This does need to expose the port to the outside world, and there was little reason to always enable it as it is rarely used.

No changelog entry as this is a developer-facing change only.