### PR TITLE
Avoid 'unknown config option' warning for TLS-related platform settings

### DIFF
--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "867c398a4fd4b2acd526f77e0d63536739c1106c",
+  "rev": "94a33beeaedd6c7a04051e2b00363942f0c0eed2",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
Starting a node with a custom CA cert for the platform would always result in a warning message 

```
ignoring unknown config field .cacert
```

even though the config field is, in fact, known.