### PR TITLE
Respect `--color` option in default implicit events sink

### DIFF
--- a/changelog/next/bug-fixes/5007--color-auto.md
+++ b/changelog/next/bug-fixes/5007--color-auto.md
@@ -1,0 +1,4 @@
+The implicit events sink of the `tenzir` binary now respects the
+`--color=[always|never|auto]` option and the `NO_COLOR` environment variable.
+Previously, color usage was only determined based on whether `stdout` had a TTY
+attached.

--- a/libtenzir/include/tenzir/exec_pipeline.hpp
+++ b/libtenzir/include/tenzir/exec_pipeline.hpp
@@ -12,13 +12,17 @@
 
 namespace tenzir {
 
+constexpr inline auto make_default_implicit_events_sink(bool color)
+  -> std::string {
+  return color ? R"(write_tql color=true | save_file "-")"
+               : R"(write_tql | save_file "-")";
+}
+
 struct exec_config {
   std::string implicit_bytes_source = R"(load_file "-")";
   std::string implicit_events_source = R"(load_file "-" | read_json)";
   std::string implicit_bytes_sink = R"(save_file "-")";
-  std::string implicit_events_sink
-    = isatty(STDOUT_FILENO) ? R"(write_tql color=true | save_file "-")"
-                            : R"(write_tql | save_file "-")";
+  std::string implicit_events_sink = make_default_implicit_events_sink(false);
   bool dump_tokens = false;
   bool dump_ast = false;
   bool dump_pipeline = false;


### PR DESCRIPTION
This change makes it so that the default implicit events sink properly respects the `--color=[always|never|auto]` command-line option of the `tenzir` binary and the [`NO_COLOR`](https://no-color.org) env variable.