### PR TITLE
Allow values to be `null` when charting

### DIFF
--- a/changelog/next/changes/5009--chart-null.md
+++ b/changelog/next/changes/5009--chart-null.md
@@ -1,0 +1,2 @@
+The `chart_area`, `chart_bar`, and `chart_pie` operators no longer reject
+null-values. Previously, gaps in charts were only supported for `chart_line`.

--- a/tenzir/tests/exec/chart/null_break.tql
+++ b/tenzir/tests/exec/chart/null_break.tql
@@ -1,2 +1,2 @@
 from {x: 10s, y: 2}, {x: 21.3s, y: 1}, {x: 100d, y: 100}
-chart_line x=x, y=sum(y), resolution=5s, x_min=0s, x_max=1min
+chart_area x=x, y=sum(y), resolution=5s, x_min=0s, x_max=1min

--- a/tenzir/tests/exec/chart/resolution.tql
+++ b/tenzir/tests/exec/chart/resolution.tql
@@ -1,2 +1,2 @@
 from {a: 2025-01-02T00:00:00Z, b: 22}, {a: 2025-01-02T00:30:00Z, b: 42}, {a: 2025-01-02T01:00:00Z, b: 32}
-chart_line x=a, y=sum(b), x_min=2025-01-01T23:50:00Z, x_max=2025-01-02T00:50:00Z, resolution=1h
+chart_bar x=a, y=sum(b), x_min=2025-01-01T23:50:00Z, x_max=2025-01-02T00:50:00Z, resolution=1h


### PR DESCRIPTION
Additionally, this now fills gaps for all chart types.