### PR TITLE
Enable automatic connections in CAF's middleman

### DIFF
--- a/libtenzir/src/default_configuration.cpp
+++ b/libtenzir/src/default_configuration.cpp
@@ -22,6 +22,8 @@ default_configuration::default_configuration() {
   set("caf.logger.console.excluded-components",
       caf::make_config_value_list("caf", "caf_flow"));
   set("caf.middleman.connection-timeout", caf::timespan{120s});
+  set("caf.middleman.enable-automatic-connections", true);
+  set("caf.middleman.app-identifiers", caf::make_config_value_list("tenzir"));
 }
 
 } // namespace tenzir


### PR DESCRIPTION
The `caf.middleman.enable-automatic-connections` option causes remote actors to attempt to form a mesh to avoid tunneling. For our upcoming execution node rewrite, setting this option makes the initial setup a lot easier as it allows us to spawn execution nodes centrally instead of having each execution node spawn the following execution node.

Additionally, this changes away from the default app identifier `generic-caf-app` to `tenzir`. App identifiers need to match when connecting to a remote actor.

This change is not user-observable with the current execution model, but will become very relevant once we support spanning pipelines across many nodes.