### PR TITLE
Fix compilation error handling inside `if`

### DIFF
--- a/changelog/next/bug-fixes/5011--error-inside-if.md
+++ b/changelog/next/bug-fixes/5011--error-inside-if.md
@@ -1,0 +1,2 @@
+A compilation error within an `if` statement no longer causes pipelines to
+crash.


### PR DESCRIPTION
We previously assumed that the creation of the operator underlying the `if` statement cannot fail. However, this is not true at the moment (for example, there can be a conflict when one operator is local and the other is remote). This PR ensures that we handle the error properly. It also propagates the location of the `if` keyword such that this info can be used in diagnostics.