### PR TITLE
Normalize pushed-up predicates in `subscribe`

### DIFF
--- a/changelog/next/bug-fixes/5014--subscribe-predicate-pushdown.md
+++ b/changelog/next/bug-fixes/5014--subscribe-predicate-pushdown.md
@@ -1,0 +1,3 @@
+We fixed an optimization bug that caused pipelines of the form `subscribe
+<topic> | where <value> in <field>` to evaluate the predicate `<field> in
+<value>` instead, returning incorrect results from the pipeline.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "6b018b565a4e53c32c33b01fa8b6cc8cfe204940",
+  "rev": "0c0d1b986abd20ba17282714ba7723f34b1f4dc0",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
This fixes a bug where pipelines of the form `subscribe <topic> | where <value> in <field>` had missing results. This happened because the `subscribe` operator did not normalize the pushed-up predicate from `where`, causing `<field> in <value>` to be evaluated instead.