### PR TITLE
Fix a crash in `{parse,read}_grok` for invalid patterns

### DIFF
--- a/changelog/v4.29.0/bug-fixes/5018.md
+++ b/changelog/v4.29.0/bug-fixes/5018.md
@@ -1,0 +1,2 @@
+The `read_grok` operator and `parse_grok` functions no longer crash when
+providing an invalid Grok expression.


### PR DESCRIPTION
This fixes a crash in `parse_grok` and `read_grok` for invalid patterns. The crash only happened with TQL2, where it is not safe to throw a diagnostic instead of emitting it through a diagnostic handler.

Note that the fix I've applied here is pretty lazy, and just catches the thrown diagnostic. A better solution would be not to throw diagnotics when resolvin patterns.