### PR TITLE
Fix darwin-static release builds

### DIFF
--- a/nix/tenzir/default.nix
+++ b/nix/tenzir/default.nix
@@ -245,13 +245,13 @@
           ++ extraCmakeFlags;
 
         # TODO: Omit this for "tagged release" builds.
-        preConfigure = if isReleaseBuild then ''
+        preConfigure = (if isReleaseBuild then ''
           cmakeFlagsArray+=("-DTENZIR_VERSION_BUILD_METADATA=")
         ''
         else ''
           version_build_metadata=$(basename $out | cut -d'-' -f 1)
           cmakeFlagsArray+=("-DTENZIR_VERSION_BUILD_METADATA=N$version_build_metadata")
-        ''
+        '')
         # TODO: Fix LTO on darwin by passing these commands by their original
         # executable names "llvm-ar" and "llvm-ranlib". Should work with
         # `readlink -f $AR` to find the correct ones.


### PR DESCRIPTION
A previous refactoring of the Tenzir Nix packaging introduced a precedence error. `+` binds stronger than `else` in nixlang.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made in the pull request description in a way that
   is consumable by everyone, not just developers who know the context of the
   change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://docs.tenzir.com/next/contribute/changelog
3. Provide instructions for the reviewer.
4. Remove this comment so it doesn't show up in the merge commit.
-->
