### PR TITLE
Document CAF's OpenSSL options

### DIFF
--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -428,3 +428,25 @@ caf:
 
       # List of excluded actors from run-time metrics.
       excludes: []
+
+  # Configure using OpenSSL for node-to-node connections.
+  # NOTE: Use the tenzir.endpoint variable to configure the endpoint.
+  openssl:
+
+    # Path to the PEM-formatted certificate file.
+    certificate:
+
+    # Path to the private key file for this node.
+    key:
+
+    # Passphrase to decrypt the private key.
+    passphrase:
+
+    # Path to an OpenSSL-style directory of trusted certificates.
+    capath:
+
+    # Path to a file of concatenated PEM-formatted certificates.
+    cafile:
+
+    # Colon-separated list of OpenSSL cipher strings to use.
+    cipher-list:


### PR DESCRIPTION
This was still remaining from the CAF 1.x migration efforts. The added documentation is the bare-minimum we should have documented. I tested the options locally, but did not bother writing a test for them.

- Fixes tenzir/issues#2381