### PR TITLE
Introduce `metrics "pipeline"`

### DIFF
--- a/changelog/next/changes/5024--pipeline-metrics.md
+++ b/changelog/next/changes/5024--pipeline-metrics.md
@@ -1,0 +1,4 @@
+`metrics "operator"` is now deprecated. Use `metrics "pipeline"` instead, which
+offers a pre-aggregated view of pipeline metrics. We plan to remove operator
+metrics in an upcoming release, as they are too expensive in large-scale
+deployments.

--- a/changelog/next/features/5024--pipeline-metrics.md
+++ b/changelog/next/features/5024--pipeline-metrics.md
@@ -1,0 +1,3 @@
+`metrics "pipeline"` provides an easy way to view the ingress and egress of
+pipelines. The new metrics show the ingress and egress of every pipeline in
+windows of ten seconds.

--- a/libtenzir/include/tenzir/diagnostics.hpp
+++ b/libtenzir/include/tenzir/diagnostics.hpp
@@ -183,8 +183,26 @@ public:
     : result_{severity, std::move(message), {}, {}} {
   }
 
-  auto compose(auto fn) && {
-    return std::move(fn)(std::move(*this));
+  /// Calls a function on the diagnostic builder. This is useful for
+  /// conditionally adding notes and annotations:
+  ///
+  ///   diagnostic::error(…)
+  ///     .compose([&](auto x) { return foo ? x.note("foo") : x; })
+  ///     .emit(ctx)
+  ///
+  /// Without this, the condition would need to be outside of the diagnostic
+  /// builder:
+  ///
+  ///   if (foo) {
+  ///     diagnostic::error(…)
+  ///       .note("foo")
+  ///       .emit(ctx);
+  ///   } else {
+  ///     diagnostic::error(…)
+  ///       .emit(ctx);
+  ///   }
+  auto compose(auto&& fn) && {
+    return std::forward<decltype(fn)>(fn)(std::move(*this));
   }
 
   // -- annotations -----------------------------------------------------------

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "be69827c5c976573ef7af326de21114ab8dec1a9",
+  "rev": "b1aa04275e7a40ff6d423c4ad5d6a2aff14f706d",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/web/docs/tql2/operators/metrics.md
+++ b/web/docs/tql2/operators/metrics.md
@@ -248,6 +248,14 @@ Contains a measurement of the available memory on the host.
 Contains input and output measurements over some amount of time for a single
 operator instantiation.
 
+:::warning Deprecation Notice
+Operator metrics are deprecated and will be removed in a future release. Use
+[pipeline metrics](#tenzirmetricspipeline) instead. While they offered great
+insight into the performance of operators, they were not as useful as pipeline
+metrics for understanding the overall performance of a pipeline, and were too
+expensive to collect and store.
+:::
+
 | Field                 | Type       | Description                                                                     |
 | :-------------------- | :--------- | :------------------------------------------------------------------------------ |
 | `pipeline_id`         | `string`   | The ID of the pipeline where the associated operator is from.                   |
@@ -275,7 +283,29 @@ The records `input` and `output` have the following schema:
 | `unit`         | `string` | The type of the elements, which is `void`, `bytes` or `events`. |
 | `elements`     | `uint64` | Number of elements that were seen during the collection period. |
 | `approx_bytes` | `uint64` | An approximation for the number of bytes transmitted.           |
-| `batches` | `uint64` | The number of batches included in this metric.                       |
+| `batches`      | `uint64` | The number of batches included in this metric.                  |
+
+### `tenzir.metrics.pipeline`
+
+Contains measurements of data flowing through pipelines, emitted once every 10
+seconds.
+
+| Field         | Type     | Description                                     |
+| :------------ | :------- | :---------------------------------------------- |
+| `timestamp`   | `time`   | The time at which this metric was recorded.     |
+| `pipeline_id` | `string` | The ID of the pipeline these metrics represent. |
+| `ingress`     | `record` | Measurement of data entering the pipeline.      |
+| `egress`      | `record` | Measurement of data exiting the pipeline.       |
+
+The records `ingress` and `egress` have the following schema:
+
+| Field      | Type       | Description                                              |
+| :--------- | :--------- | :------------------------------------------------------- |
+| `duration` | `duration` | The timespan over which this data was collected.         |
+| `events`   | `uint64`   | Number of events that passed through during this period. |
+| `bytes`    | `uint64`   | Approximate number of bytes that passed through.         |
+| `batches`  | `uint64`   | Number of batches that passed through.                   |
+| `internal` | `bool`     | True if the data flow is considered internal to Tenzir.  |
 
 ### `tenzir.metrics.platform`
 


### PR DESCRIPTION
This PR adds `metrics "pipeline"` as an easier-to-understand version of the now deprecated `metrics "operator"`.

Operator metrics were very detailed. We simply generated too many of them, causing them to take away significant compute resources. Looking at how we utilize operator metrics in the Tenzir Platform, it became clear that we just need a small subset of the information that they provided. The new pipeline metrics are exactly that subset, showing the ingress and egress of every managed pipeline pre-aggregated in windows of ten seconds.

We will remove operator metrics once we have adapated the Tenzir Platform to make use of pipeline metrics instead.