### PR TITLE
Allow assigning ids for pipelines manually

### DIFF
--- a/changelog/next/features/5026--manual-pipeline-id.md
+++ b/changelog/next/features/5026--manual-pipeline-id.md
@@ -1,0 +1,2 @@
+The `/pipeline/create` and `/pipeline/launch` endpoints now accept an optional
+`id` parameter for assigning the pipeline's ID manually.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "d934501cf60785883d58764c262b0edaa7e6dd79",
+  "rev": "3feed8da30635d7d96ce529650eeb50c6f02fe48",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }

--- a/web/openapi/openapi.yaml
+++ b/web/openapi/openapi.yaml
@@ -27,6 +27,10 @@ components:
       required:
         - definition
       properties:
+        id:
+          type: string
+          example: 08446737-da9b-4787-8599-97d85c48c3bb
+          description: The id of the pipeline to be updated. If not provided, a random id will be generated.
         definition:
           type: string
           example: export | where foo | publish /bar


### PR DESCRIPTION
The web is a lossy place. If a request from the Tenzir Platform to deploy a pipeline does not get a response, we ideally want to retry it—but that could potentially have bad side effects like deploying a pipeline twice if sending the same request again can create a different state than the one we wanted to have. Ultimately, the platform cannot know if the node received a request when it did not get a response.

This changes the `/pipeline/create` and `/pipeline/launch` endpoints to optionally accept a new `id` parameter for manually assigning a pipeline id. That's far from a perfect fix as duplicate requests will still get responded to with an error, but it's the best we can do for now without majorly revisiting the code behind the `/pipeline` API.
