### PR TITLE
Fix `tls` option of `to_splunk`

### DIFF
--- a/changelog/next/bug-fixes/5027--to-splunk-tls.md
+++ b/changelog/next/bug-fixes/5027--to-splunk-tls.md
@@ -1,0 +1,2 @@
+Using the `tls` option of the `to_splunk` operator no longer directly emits an
+error.

--- a/libtenzir/include/tenzir/curl.hpp
+++ b/libtenzir/include/tenzir/curl.hpp
@@ -440,6 +440,10 @@ auto easy::get() -> std::pair<code, info_type_t<what>> {
 /// @relates easy
 auto to_string(easy::code code) -> std::string_view;
 
+inline void check(curl::easy::code ec) {
+  TENZIR_ASSERT(ec == curl::easy::code::ok, to_string(ec));
+}
+
 /// @relates easy
 auto to_error(easy::code code) -> caf::error;
 

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -2,7 +2,8 @@
   "name": "tenzir-plugins",
   "url": "git@github.com:tenzir/tenzir-plugins",
   "ref": "main",
-  "rev": "628be801a3624d6b2ac0c83720bed5c07412e5af",
+  "rev": "a48cb30bc809c637bdc7ec64e61edb0330241871",
   "submodules": true,
-  "shallow": true
+  "shallow": true,
+  "allRefs": true
 }


### PR DESCRIPTION
We previously asserted that setting the option _fails_. This makes it so that we assert that it _succeeds_.

Also moves a bunch of side-effects out of `TENZIR_ASSERT`.