### PR TITLE
Make UDO resolution order-independent

### DIFF
--- a/changelog/next/bug-fixes/5029--udo-resolution.md
+++ b/changelog/next/bug-fixes/5029--udo-resolution.md
@@ -1,0 +1,4 @@
+The resolution of user-defined operator aliases in the `tenzir.operators`
+section is no longer order-dependent. Previously, an operator `foo` may have
+depended on an operator `bar`, but not the other way around. This limitation no
+longer exists.


### PR DESCRIPTION
A user reported that their user-defined operators failed to resolve entities. Usually, this error is supposed to only occur when users define circular dependencies in their user-defined operators, which they clearly did not.

I found this as a minimal reproduction:

```yaml
tenzir:
  operators:
    a: |
      b
    b: |
      pass
```

What was curious was that this worked if I switched the names of the two user-defined operators:

```yaml
tenzir:
  operators:
    a: |
      pass
    b: |
      a
```

Digging a bit deeper, it looked like we did the entity resolution in lexicographical order, as that is what we got from parsing the configuration file. That approach is obviously broken: Whether a user-defined operator is usable from another one should not depend on the names of the operators.

To fix this, I changed the resolution algorithm to work in multiple passes. We simply iterate over the available user-defined oeprators as often as we need, and if in an iteration we cannot resolve a single operator we now fail. To make this possible, I needed to add one indirection for diagnostics. When the entity resolution works I forward them immediately, and if it fails I hold them back and only emit them when I couldn't resolve a single one in an iteration.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made in the pull request description in a way that
   is consumable by everyone, not just developers who know the context of the
   change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://docs.tenzir.com/next/contribute/changelog
3. Provide instructions for the reviewer.
4. Remove this comment so it doesn't show up in the merge commit.
-->
