### PR TITLE
Ignore additional fields in package config

### DIFF
--- a/changelog/next/bug-fixes/5031--package-ignore-additional-fields.md
+++ b/changelog/next/bug-fixes/5031--package-ignore-additional-fields.md
@@ -1,0 +1,2 @@
+Installing packages no longer fails when packages contain additional fields, and
+instead warns about the unexpected fields.


### PR DESCRIPTION
We're looking to adding more fields to packages, in particular a `categories` field for categorization. While testing the changes from tenzir/library#69 I noticed that installation of packages fails for additional fields instead of warning and ignoring them.