### PR TITLE
Fix mismatch in type metadata after assignments

### DIFF
--- a/changelog/next/bug-fixes/5033--arrow-metadata-mismatch.md
+++ b/changelog/next/bug-fixes/5033--arrow-metadata-mismatch.md
@@ -1,0 +1,3 @@
+We fixed a bug that caused a loss of type names for nested fields in
+assignments, causing field metadata in `write_feather` and `write_parquet` to be
+missing.

--- a/libtenzir/include/tenzir/arrow_table_slice.hpp
+++ b/libtenzir/include/tenzir/arrow_table_slice.hpp
@@ -412,12 +412,13 @@ auto make_struct_array(int64_t length,
 auto make_struct_array(int64_t length,
                        std::shared_ptr<arrow::Buffer> null_bitmap,
                        std::vector<std::string> field_names,
-                       const arrow::ArrayVector& field_arrays)
+                       const arrow::ArrayVector& field_arrays,
+                       const record_type& rt)
   -> std::shared_ptr<arrow::StructArray>;
 auto make_struct_array(
   int64_t length, std::shared_ptr<arrow::Buffer> null_bitmap,
-  std::vector<std::pair<std::string, std::shared_ptr<arrow::Array>>> fields)
-  -> std::shared_ptr<arrow::StructArray>;
+  std::vector<std::pair<std::string, std::shared_ptr<arrow::Array>>> fields,
+  const record_type& rt) -> std::shared_ptr<arrow::StructArray>;
 
 // -- template machinery -------------------------------------------------------
 

--- a/libtenzir/include/tenzir/type.hpp
+++ b/libtenzir/include/tenzir/type.hpp
@@ -322,6 +322,11 @@ public:
   /// @pre `is<record_type>(*this)`
   [[nodiscard]] std::shared_ptr<arrow::Schema> to_arrow_schema() const noexcept;
 
+  /// Creates Arrow metadata from the type. Returns `nullptr` if the type has no
+  /// metadata.
+  [[nodiscard]] auto make_arrow_metadata() const
+    -> std::shared_ptr<arrow::KeyValueMetadata>;
+
   /// Creates an Arrow ArrayBuilder from the type.
   [[nodiscard]] std::shared_ptr<arrow::ArrayBuilder>
   make_arrow_builder(arrow::MemoryPool* pool) const noexcept;

--- a/libtenzir/src/arrow_table_slice.cpp
+++ b/libtenzir/src/arrow_table_slice.cpp
@@ -9,6 +9,7 @@
 #include "tenzir/arrow_table_slice.hpp"
 
 #include "tenzir/arrow_utils.hpp"
+#include "tenzir/collect.hpp"
 #include "tenzir/config.hpp"
 #include "tenzir/detail/narrow.hpp"
 #include "tenzir/detail/overload.hpp"
@@ -606,12 +607,16 @@ auto make_struct_array(int64_t length,
 auto make_struct_array(int64_t length,
                        std::shared_ptr<arrow::Buffer> null_bitmap,
                        std::vector<std::string> field_names,
-                       const arrow::ArrayVector& field_arrays)
+                       const arrow::ArrayVector& field_arrays,
+                       const record_type& rt)
   -> std::shared_ptr<arrow::StructArray> {
   auto field_types = arrow::FieldVector{};
-  for (auto [name, array] : detail::zip(field_names, field_arrays)) {
+  const auto rt_fields = collect(rt.fields());
+  for (const auto& [name, array, rt_field] :
+       detail::zip(field_names, field_arrays, rt_fields)) {
     field_types.push_back(
-      std::make_shared<arrow::Field>(std::move(name), array->type()));
+      std::make_shared<arrow::Field>(std::move(name), array->type(), true,
+                                     rt_field.type.make_arrow_metadata()));
   }
   return make_struct_array(length, std::move(null_bitmap), field_types,
                            field_arrays);
@@ -619,15 +624,17 @@ auto make_struct_array(int64_t length,
 
 auto make_struct_array(
   int64_t length, std::shared_ptr<arrow::Buffer> null_bitmap,
-  std::vector<std::pair<std::string, std::shared_ptr<arrow::Array>>> fields)
-  -> std::shared_ptr<arrow::StructArray> {
+  std::vector<std::pair<std::string, std::shared_ptr<arrow::Array>>> fields,
+  const record_type& rt) -> std::shared_ptr<arrow::StructArray> {
   auto field_types = arrow::FieldVector{};
   field_types.reserve(fields.size());
   auto field_arrays = std::vector<std::shared_ptr<arrow::Array>>{};
   field_arrays.reserve(fields.size());
-  for (auto& field : fields) {
+  auto rt_fields = collect(rt.fields());
+  for (const auto& [field, rt_field] : detail::zip(fields, rt_fields)) {
     field_types.push_back(
-      std::make_shared<arrow::Field>(field.first, field.second->type()));
+      std::make_shared<arrow::Field>(field.first, field.second->type(), true,
+                                     rt_field.type.make_arrow_metadata()));
     field_arrays.push_back(std::move(field.second));
   }
   return make_struct_array(length, std::move(null_bitmap), field_types,

--- a/libtenzir/src/table_slice.cpp
+++ b/libtenzir/src/table_slice.cpp
@@ -1254,13 +1254,15 @@ auto realize(unflatten_entry&& entry) -> std::shared_ptr<arrow::Array> {
 }
 
 auto realize(unflatten_record&& record) -> std::shared_ptr<arrow::StructArray> {
-  auto names = std::vector<std::string>{};
+  auto fields = std::vector<std::shared_ptr<arrow::Field>>{};
   auto arrays = std::vector<std::shared_ptr<arrow::Array>>{};
   for (auto& [name, entry] : record.fields) {
-    names.emplace_back(name);
-    arrays.push_back(realize(std::move(entry)));
+    auto array = realize(std::move(entry));
+    fields.push_back(
+      std::make_shared<arrow::Field>(std::string{name}, array->type()));
+    arrays.push_back(std::move(array));
   }
-  return make_struct_array(record.length, record.null_bitmap, std::move(names),
+  return make_struct_array(record.length, record.null_bitmap, std::move(fields),
                            arrays);
 }
 

--- a/libtenzir/src/tql2/eval_impl.cpp
+++ b/libtenzir/src/tql2/eval_impl.cpp
@@ -63,11 +63,15 @@ auto evaluator::eval(const ast::record& x) -> multi_series {
     auto field_types = fields | std::views::transform([](auto& x) {
                          return record_type::field_view{x.first, x.second.type};
                        });
-    auto result = make_struct_array(
-      length_, nullptr, std::vector(field_names.begin(), field_names.end()),
-      std::vector(field_arrays.begin(), field_arrays.end()));
+    auto new_type
+      = type{record_type{std::vector(field_types.begin(), field_types.end())}};
+    auto result
+      = make_struct_array(length_, nullptr,
+                          std::vector(field_names.begin(), field_names.end()),
+                          std::vector(field_arrays.begin(), field_arrays.end()),
+                          as<record_type>(new_type));
     return series{
-      type{record_type{std::vector(field_types.begin(), field_types.end())}},
+      std::move(new_type),
       std::move(result),
     };
   });


### PR DESCRIPTION
This fixes a crash in Debug builds (via `TENZIR_ASSERT_EXPENSIVE`) in the pipeline `from {} | x = this`, or, more generally speaking, any pipeline that involves an assignment on a field which has metadata.

The expensive assertion that fired here compared that Tenzir's and Arrow's metadata on Tenzir's types and Arrow's fields and schemas matches exactly. A performance optimization made in Tenzir Node v4.28 introduced this bug that under some circumstances caused a mismatch between the two.

The impact of this bug is luckily only small. Events persisted with `write_feather`, `write_parquet`, or `import` restore the metadata from Arrow when read. This implies a loss of metadata for nested fields with metadata persisted since the release of v4.28, but luckily the data is not in a broken state on disk.

- Fixes https://github.com/tenzir/issues/issues/2868