### PR TITLE
Avoid idle wakeups in `load_tcp`

### DIFF
--- a/.github/workflows/analysis.yaml
+++ b/.github/workflows/analysis.yaml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   code-coverage:
     name: Code Coverage
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: debian:bookworm-20230227-slim
     strategy:
       fail-fast: false

--- a/.github/workflows/bump-plugins-submodule.yaml
+++ b/.github/workflows/bump-plugins-submodule.yaml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   bump-plugins-submodule:
     name: Bump the plugins submodule if necessary
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Configure ssh-agent
         uses: webfactory/ssh-agent@v0.9.0

--- a/.github/workflows/docker-manual.yaml
+++ b/.github/workflows/docker-manual.yaml
@@ -25,7 +25,7 @@ on:
 jobs:
   configure:
     name: Configure Inputs
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       docker-config: ${{ steps.docker.outputs.docker-config }}
     steps:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         build:
-          - runner: ubuntu-20.04
+          - runner: ubuntu-latest
             arch: linux/amd64
             tag: amd64
           - runner: ubicloud-standard-4-arm
@@ -128,7 +128,7 @@ jobs:
 
   push-manifest:
     name: Push Manifest
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs:
       - build
     steps:

--- a/.github/workflows/installer.yaml
+++ b/.github/workflows/installer.yaml
@@ -2,7 +2,7 @@ name: Tenzir Installer
 on:
   workflow_dispatch:
   schedule:
-    - cron: '20 2 * * *'  # everyday at 2:20
+    - cron: "20 2 * * *" # everyday at 2:20
 
 # IMPORTANT NOTE: The distros that are tested here were chosen to maximize test
 # coverage of the installer script. That doesn't imply that we commit to support
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [ubuntu-20.04, ubuntu-22.04]
+        image: [ubuntu-22.04, ubuntu-latest]
         tag: ["latest", "main"]
     runs-on: ${{ matrix.image }}
     env:
@@ -38,7 +38,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: ["ubuntu:22.04", "ubuntu:23.04", "ubuntu:23.10", "debian:11", "debian:12"]
+        image:
+          [
+            "ubuntu:22.04",
+            "ubuntu:23.04",
+            "ubuntu:23.10",
+            "debian:11",
+            "debian:12",
+          ]
         tag: ["latest", "main"]
     container:
       image: ${{ matrix.image }}
@@ -55,7 +62,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: ["fedora:37", "fedora:38", "fedora:39", "amazonlinux:2", "amazonlinux:2023"]
+        image:
+          [
+            "fedora:37",
+            "fedora:38",
+            "fedora:39",
+            "amazonlinux:2",
+            "amazonlinux:2023",
+          ]
         tag: ["latest", "main"]
     container:
       image: ${{ matrix.image }}

--- a/.github/workflows/nix-manual.yaml
+++ b/.github/workflows/nix-manual.yaml
@@ -25,7 +25,7 @@ on:
 jobs:
   configure:
     name: Configure Inputs
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       nix-matrix: ${{ steps.nix.outputs.nix-matrix }}
     steps:

--- a/.github/workflows/tenzir.yaml
+++ b/.github/workflows/tenzir.yaml
@@ -57,7 +57,7 @@ permissions:
 jobs:
   configure:
     name: Configure
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       version-matrix: ${{ steps.configure.outputs.version-matrix }}
       build-version: ${{ steps.configure.outputs.build-version }}
@@ -321,7 +321,7 @@ jobs:
     needs:
       - configure
     if: github.event_name != 'workflow_dispatch'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -377,7 +377,7 @@ jobs:
     needs:
       - configure
     if: ${{ needs.configure.outputs.run-changelog == 'true' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: debian:bookworm-slim
     steps:
       - name: Install git
@@ -410,7 +410,7 @@ jobs:
       - changelog
     if: ${{ needs.configure.outputs.run-docs == 'true' }}
     name: Documentation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -462,7 +462,7 @@ jobs:
       - configure
     if: needs.configure.outputs.run-docker-tenzir == 'true'
     name: OpenAPI Spec
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: 1
     steps:
@@ -498,7 +498,7 @@ jobs:
       matrix:
         regression-tests: ${{ fromJson(needs.configure.outputs.version-matrix) }}
     name: Regression Tests (${{ matrix.regression-tests.version }})
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: 1
     steps:
@@ -784,7 +784,7 @@ jobs:
       - configure
     if: ${{ needs.configure.outputs.run-python-package == 'true' }}
     name: Python Package
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       DEBIAN_FRONTEND: noninteractive
     steps:

--- a/.github/workflows/update-sbom.yaml
+++ b/.github/workflows/update-sbom.yaml
@@ -1,6 +1,5 @@
 name: Update SBOM
-on:
-  workflow_dispatch
+on: workflow_dispatch
 
 permissions:
   pull-requests: write
@@ -8,7 +7,7 @@ permissions:
 jobs:
   sbom:
     name: Generate SBOM
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Install Nix
         uses: cachix/install-nix-action@v30
@@ -26,8 +25,7 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
       - name: Regenerate SBOM
-        run:
-          nix run .#generate-sbom
+        run: nix run .#generate-sbom
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:

--- a/.github/workflows/upload-cache-artifact.yaml
+++ b/.github/workflows/upload-cache-artifact.yaml
@@ -3,19 +3,19 @@ on:
   workflow_dispatch:
     inputs:
       path:
-        description: 'Must match the path value passed to actions/cache/save'
+        description: "Must match the path value passed to actions/cache/save"
         type: string
         required: true
         default: /tmp/ccache
       key:
-        description: 'Must match the key value passed to actions/cache/save'
+        description: "Must match the key value passed to actions/cache/save"
         type: string
         required: true
 
 jobs:
   upload:
     name: Copy Cache Entry to GCS
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Fetch Cache Entry
         uses: actions/cache/restore@v4

--- a/changelog/next/bug-fixes/5035--load-tcp-v20.md
+++ b/changelog/next/bug-fixes/5035--load-tcp-v20.md
@@ -1,0 +1,4 @@
+We fixed a bug that caused unnecessary idle wakeups in the `load_tcp` operator,
+throwing off scheduling of pipelines using it. Under rare circumstances, this
+could also lead to partially duplicated output of the operator's nested
+pipeline.


### PR DESCRIPTION
This fixes two bugs in `load_tcp`:
1. The operator forwarded empty batches, which causes unnecessary wakeups.
2. When the TCP connection was slower than the following pipeline, the operator both buffered the batches and forwarded them immediately, potentially duplicating the batches. This did not only produce broken data, but also made (1) a much worse problem.