### PR TITLE
Change how signed ints are rendered in logs

### DIFF
--- a/changelog/next/bug-fixes/5037--fluent-bit-signed-int.md
+++ b/changelog/next/bug-fixes/5037--fluent-bit-signed-int.md
@@ -1,0 +1,3 @@
+We fixed a bug in the `from_fluent_bit` and `to_fluent_bit` operators that
+caused positive integer options to be forwarded with a leading `+`. For example,
+`options={port: 9200}` forwarded the option `port=+9200` to Fluent Bit.

--- a/libtenzir/include/tenzir/concept/printable/tenzir/data.hpp
+++ b/libtenzir/include/tenzir/concept/printable/tenzir/data.hpp
@@ -35,11 +35,6 @@ struct data_printer : printer_base<data_printer> {
       [&](const auto& x) {
         return make_printer<std::decay_t<decltype(x)>>{}(out, x);
       },
-      [&](int64_t x) {
-        // Force a sign to be printed even for positive integers.
-        out = fmt::format_to(out, "{:+}", x);
-        return true;
-      },
       [&](const std::string& x) {
         static auto escaper = detail::make_extra_print_escaper("\"");
         static auto p = '"' << printers::escape(escaper) << '"';

--- a/libtenzir/include/tenzir/concept/printable/tenzir/view.hpp
+++ b/libtenzir/include/tenzir/concept/printable/tenzir/view.hpp
@@ -54,10 +54,6 @@ struct data_view_printer : printer_base<data_view_printer> {
       [&](const auto& x) {
         return make_printer<std::decay_t<decltype(x)>>{}(out, x);
       },
-      [&](view<int64_t> x) {
-        out = fmt::format_to(out, "{:+}", x);
-        return true;
-      },
       [&](const view<std::string>& x) {
         return string_view_printer{}(out, x);
       },

--- a/libtenzir/test/cast.cpp
+++ b/libtenzir/test/cast.cpp
@@ -312,7 +312,7 @@ TEST(positive int64_t to string) {
   auto out = tenzir::cast_value(tenzir::int64_type{}, int64_t{5},
                                 tenzir::string_type{});
   REQUIRE(out);
-  CHECK_EQUAL(*out, "+5");
+  CHECK_EQUAL(*out, "5");
 }
 
 TEST(negative int64_t to string) {
@@ -416,7 +416,7 @@ TEST(list to string) {
                                 tenzir::list{int64_t{1}, int64_t{-1}},
                                 tenzir::string_type{});
   REQUIRE(out);
-  CHECK_EQUAL(*out, "[+1, -1]");
+  CHECK_EQUAL(*out, "[1, -1]");
 }
 
 TEST(record to string) {
@@ -428,7 +428,7 @@ TEST(record to string) {
     tenzir::record{{"int", int64_t{100}}, {"str", "strr"}},
     tenzir::string_type{});
   REQUIRE(out);
-  CHECK_EQUAL(*out, R"(<int: +100, str: "strr">)");
+  CHECK_EQUAL(*out, R"(<int: 100, str: "strr">)");
 }
 
 TEST(string to time) {
@@ -620,7 +620,7 @@ TEST(cast value type erased) {
   auto out
     = tenzir::cast_value(type, tenzir::data{int64_t{2}}, tenzir::string_type{});
   REQUIRE(out);
-  CHECK_EQUAL(*out, "+2");
+  CHECK_EQUAL(*out, "2");
 }
 
 TEST(cast value type erased 2) {
@@ -708,10 +708,10 @@ TEST(cast int64_t array to a string builder) {
     views.push_back(val);
   }
   REQUIRE_EQUAL(views.size(), 4u);
-  CHECK_EQUAL(materialize(views[0]), "+1");
-  CHECK_EQUAL(materialize(views[1]), "+2");
+  CHECK_EQUAL(materialize(views[0]), "1");
+  CHECK_EQUAL(materialize(views[1]), "2");
   CHECK_EQUAL(materialize(views[2]), caf::none);
-  CHECK_EQUAL(materialize(views[3]), "+3");
+  CHECK_EQUAL(materialize(views[3]), "3");
 }
 
 TEST(casting builder with no compatible types results in an error) {

--- a/libtenzir/test/printable.cpp
+++ b/libtenzir/test/printable.cpp
@@ -333,13 +333,13 @@ TEST(data) {
   data c{uint64_t{23}};
   CHECK_TO_STRING(c, "23");
   data i{int64_t{42}};
-  CHECK_TO_STRING(i, "+42");
+  CHECK_TO_STRING(i, "42");
   data s{std::string{"foobar"}};
   CHECK_TO_STRING(s, "\"foobar\"");
   data d{duration{512}};
   CHECK_TO_STRING(d, "512ns");
   data v{list{r, b, c, i, s, d}};
-  CHECK_TO_STRING(v, "[12.21, true, 23, +42, \"foobar\", 512ns]");
+  CHECK_TO_STRING(v, "[12.21, true, 23, 42, \"foobar\", 512ns]");
 }
 
 // -- std::chrono types -------------------------------------------------------


### PR DESCRIPTION
This removes the leading plus for positive signed integers in `tenzir::data` when rendered as a string.

This came up as part of a bug search in the `from_fluent_bit` and `to_fluent_bit` operators, where `options={port: 9200}` got forwarded as `port=+9200` to Fluent Bit, and was then just ignored because of that pesky little plus character.

The reason for why this leading plus existed is long gone: `vast export ascii <predicate>` hasn't been a thing in years, and that relied on our internal data printer (and parser) for rendering, introducing a need to distinguish between signed and unsigned integers.