### PR TITLE
Add a function to check existence of configured CA bundles

### DIFF
--- a/libtenzir/include/tenzir/curl.hpp
+++ b/libtenzir/include/tenzir/curl.hpp
@@ -11,6 +11,7 @@
 #include "tenzir/fwd.hpp"
 
 #include "tenzir/data.hpp"
+#include "tenzir/diagnostics.hpp"
 #include "tenzir/generator.hpp"
 
 #include <caf/error.hpp>
@@ -296,6 +297,9 @@ public:
   template <info what>
   auto get() -> std::pair<code, typename info_type<what>::type>;
 
+  template <info what>
+  auto get_checked() -> typename info_type<what>::type;
+
   /// Sets an option to NULL / nullptr.
   auto unset(CURLoption option) -> code;
 
@@ -344,6 +348,9 @@ public:
 
   /// `curl_easy_reset`
   auto reset() -> void;
+
+  /// Checks that the
+  auto validate_cacert(diagnostic_handler& dh) -> bool;
 
 private:
   struct curl_deleter {
@@ -435,6 +442,13 @@ auto easy::get() -> std::pair<code, info_type_t<what>> {
   auto res = info_type_t<what>{};
   auto c = curl_easy_getinfo(easy_.get(), curl_info, &res);
   return {static_cast<code>(c), res};
+}
+
+template <easy::info what>
+auto easy::get_checked() -> info_type_t<what> {
+  auto [code, result] = get<what>();
+  check(code);
+  return result;
 }
 
 /// @relates easy

--- a/libtenzir/src/curl.cpp
+++ b/libtenzir/src/curl.cpp
@@ -8,6 +8,7 @@
 
 #include "tenzir/curl.hpp"
 
+#include "tenzir/arrow_utils.hpp"
 #include "tenzir/chunk.hpp"
 #include "tenzir/concept/parseable/numeric.hpp"
 #include "tenzir/concept/printable/tenzir/data.hpp"
@@ -426,6 +427,21 @@ auto set(easy& handle, chunk_ptr chunk) -> caf::error {
     return buffer.size();
   };
   return to_error(handle.set(on_read));
+}
+
+auto easy::validate_cacert(diagnostic_handler& dh) -> bool {
+  auto cainfo = get_checked<info::cainfo>();
+  if (cainfo) {
+    if (!std::filesystem::exists(cainfo)) {
+      diagnostic::error("the configured CA certificate bundle does not exist")
+        .note("configured location: {}", cainfo)
+        .emit(dh);
+      return false;
+    }
+    return true;
+  }
+  diagnostic::error("no CA certificate file configured").emit(dh);
+  return false;
 }
 
 } // namespace tenzir::curl


### PR DESCRIPTION
We discussed (with @IyeOnline ) that it would probably make more sense to extract all the TLS-related operator argument logic into a common component, so that we don't have to reproduce the same logic in every operator.

So the PR for now only contains the checking for a single operator.