### PR TITLE
Fix cache eviction always happening on maximally large caches

### DIFF
--- a/changelog/next/bug-fixes/5039--large-cache-eviction.md
+++ b/changelog/next/bug-fixes/5039--large-cache-eviction.md
@@ -1,0 +1,2 @@
+We fixed a bug in the `cache` operator that caused caches that were capped just
+short of the `tenzir.cache.capacity` option to still get evicted immediately.

--- a/libtenzir/builtins/operators/cache.cpp
+++ b/libtenzir/builtins/operators/cache.cpp
@@ -156,17 +156,18 @@ private:
         return false;
       }
     }
-    cache_size_ += events.rows();
-    byte_size_ += events.approx_bytes();
+    const auto approx_bytes = events.approx_bytes();
     // If a single cache exceeds the total capacity, we stop short of adding the
     // batch of events that'd make it go over the limit. This is better than
     // being evicted immediately.
-    if (byte_size_ > max_bytes_ and not exceeded_capacity) {
+    if (byte_size_ + approx_bytes > max_bytes_ and not exceeded_capacity) {
       diagnostic::warning("cache exceeded total capacity in bytes")
         .hint("consider increasing `tenzir.cache.capacity` option")
         .emit(diagnostics_);
       return false;
     }
+    cache_size_ += events.rows();
+    byte_size_ += approx_bytes;
     update_multicaster_.push(cache_update{
       .approx_bytes = byte_size_,
       .state = cache_state::open,


### PR DESCRIPTION
When a cache would grow beyond the byte size configured in `tenzir.cache.capacity`, a pipeline warning is emitted, and the cache operator no longer accepts new events. Offending events are discarded, meaning that the cache will have stopped just short of exceeding the limit.

Additionally, caches all report their sizes up to a central cache eviction service which periodically evicts older caches that cause the global limit to be exceeded.

However, currently the reported size of the a cache that "stopped just short" of exceeding the limit includes the size of the events that would've caused it to be exceeded, leading the eviction service to immediately evict the cache.

This PR makes it so the size of offending events isn't included in the size reported to the eviction service.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made in the pull request description in a way that
   is consumable by everyone, not just developers who know the context of the
   change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://docs.tenzir.com/next/contribute/changelog
3. Provide instructions for the reviewer.
4. Remove this comment so it doesn't show up in the merge commit.
-->
