### PR TITLE
Limit resource usage for demo nodes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -523,7 +523,8 @@ ENTRYPOINT ["tenzir-node"]
 FROM tenzir-node-ce AS tenzir-demo
 
 COPY /scripts/install-demo-node-package.tql /tmp/install-demo-node-package.tql
-ENV TENZIR_START__COMMANDS="exec --file /tmp/install-demo-node-package.tql" \
+ENV TENZIR_CACHE__CAPACITY="64Mi" \
+    TENZIR_START__COMMANDS="exec --file /tmp/install-demo-node-package.tql" \
     TENZIR_TQL2="true"
 
 # -- tenzir-node -----------------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -524,6 +524,7 @@ FROM tenzir-node-ce AS tenzir-demo
 
 COPY /scripts/install-demo-node-package.tql /tmp/install-demo-node-package.tql
 ENV TENZIR_CACHE__CAPACITY="64Mi" \
+    TENZIR_DEMAND__MAX_BATCHES=3 \
     TENZIR_START__COMMANDS="exec --file /tmp/install-demo-node-package.tql" \
     TENZIR_TQL2="true"
 


### PR DESCRIPTION
This should make our demo nodes run a bit smoother at the cost of making pipelines on them a bit slower.