### PR TITLE
Fix hang in `cache` when creating an empty cache

### DIFF
--- a/changelog/next/bug-fixes/5042--cache-fix.md
+++ b/changelog/next/bug-fixes/5042--cache-fix.md
@@ -1,0 +1,3 @@
+The `cache` operator no longer hangs indefinitely when creating a new cache from
+a pipeline that returned zero events. For example, the pipeline `from {} | head
+0 | cache "whoops"` never exited before this fix.

--- a/libtenzir/builtins/operators/cache.cpp
+++ b/libtenzir/builtins/operators/cache.cpp
@@ -44,6 +44,8 @@ struct cache_update {
 
 struct cache_actor_traits {
   using signatures = caf::type_list<
+    // Make the cache actor monitor the sender.
+    auto(atom::announce)->caf::result<void>,
     // Check if the cache already has a writer.
     auto(atom::write, atom::ok)->caf::result<bool>,
     // Write events into the cache.
@@ -81,8 +83,17 @@ public:
       .subscribe(std::move(update_producer));
   }
 
+  ~cache() noexcept {
+    for (auto& [_, reader] : readers_) {
+      reader.rp.deliver({});
+    }
+  }
+
   auto make_behavior() -> cache_actor::behavior_type {
     return {
+      [this](atom::announce) -> caf::result<void> {
+        return announce();
+      },
       [this](atom::write, atom::ok) -> caf::result<bool> {
         return write_ok();
       },
@@ -115,15 +126,9 @@ private:
     });
   }
 
-  auto write_ok() -> caf::result<bool> {
-    return writer_;
-  }
-
-  auto write(table_slice events) -> caf::result<bool> {
-    TENZIR_ASSERT(events.rows() > 0);
-    const auto sender = self_->current_sender();
-    TENZIR_ASSERT(sender);
+  auto announce() -> caf::result<void> {
     if (not writer_) {
+      const auto sender = self_->current_sender();
       writer_ = sender->address();
       self_->monitor(sender, [this](const caf::error& err) {
         TENZIR_ASSERT(not done_);
@@ -142,7 +147,20 @@ private:
         }
       });
       set_write_timeout();
-    } else if (writer_ != sender->address()) {
+    }
+    return {};
+  }
+
+  auto write_ok() -> caf::result<bool> {
+    return writer_;
+  }
+
+  auto write(table_slice events) -> caf::result<bool> {
+    TENZIR_ASSERT(writer_);
+    TENZIR_ASSERT(events.rows() > 0);
+    const auto sender = self_->current_sender();
+    TENZIR_ASSERT(sender);
+    if (writer_ != sender->address()) {
       return false;
     }
     auto exceeded_capacity = false;
@@ -469,6 +487,21 @@ public:
       }
       co_yield {};
     }
+    ctrl.set_waiting(true);
+    ctrl.self()
+      .mail(atom::announce_v)
+      .request(cache, caf::infinite)
+      .then(
+        [&]() {
+          ctrl.set_waiting(false);
+        },
+        [&](caf::error& err) {
+          diagnostic::error(err)
+            .note("failed to announce write-cache operator to cache")
+            .primary(id_.source)
+            .emit(ctrl.diagnostics());
+        });
+    co_yield {};
     // Now, all we need to do is send our inputs to the cache batch by batch.
     for (auto&& events : input) {
       if (events.rows() == 0) {


### PR DESCRIPTION
This fixes an infinite hang in `<source> | head 0 | cache "<id>"`, which successfully created the cache, but then failed to shut it down. This happened because the pipeline writing into the cache lazily registered itself at the cache upon writing the first batch of events. The fix was to simply register beforehand.