### PR TITLE
Fix splitting logic for heterogeneous evaluation

### DIFF
--- a/changelog/next/bug-fixes/5043--heterogeneous-evaluation-fix.md
+++ b/changelog/next/bug-fixes/5043--heterogeneous-evaluation-fix.md
@@ -1,0 +1,2 @@
+Expressions that have varying output types for the same input types (mostly the
+`parse_*` family of functions) no longer trigger an assertion on certain inputs.

--- a/libtenzir/src/multi_series.cpp
+++ b/libtenzir/src/multi_series.cpp
@@ -35,11 +35,12 @@ auto split_multi_series(std::span<const multi_series> input,
     auto shortest_length = std::numeric_limits<int64_t>::max();
     for (auto i = size_t{0}; i < input.size(); ++i) {
       auto [part, start] = positions[i];
-      if (part >= input[i].parts().size()) {
+      TENZIR_ASSERT(part <= input[i].parts().size());
+      if (part == input[i].parts().size()) {
         // We assert that everything else is done as well.
         for (auto j = size_t{0}; j < input.size(); ++j) {
           std::tie(part, start) = positions[j];
-          TENZIR_ASSERT(part == input[i].parts().size());
+          TENZIR_ASSERT(part == input[j].parts().size());
           TENZIR_ASSERT(start == 0);
         }
         co_return;
@@ -52,7 +53,7 @@ auto split_multi_series(std::span<const multi_series> input,
     // Split everything to the shortest length.
     for (auto i = size_t{0}; i < input.size(); ++i) {
       auto& [part, start] = positions[i];
-      output[i] = input[i].part(part).slice(start, shortest_length);
+      output[i] = input[i].part(part).slice(start, start + shortest_length);
       // Adjust the position.
       auto length = input[i].part(part).length() - start;
       if (length > shortest_length) {

--- a/libtenzir/src/tql2/eval_impl.cpp
+++ b/libtenzir/src/tql2/eval_impl.cpp
@@ -32,6 +32,7 @@ auto evaluator::eval(const ast::record& x) -> multi_series {
       })));
   }
   return map_series(arrays, [&](std::span<series> arrays) {
+    auto length = arrays.empty() ? length_ : arrays.front().length();
     auto fields = detail::stable_map<std::string, series>{};
     for (auto [array, item] : detail::zip_equal(arrays, x.items)) {
       match(
@@ -42,13 +43,17 @@ auto evaluator::eval(const ast::record& x) -> multi_series {
         [&](const ast::spread& spread) {
           auto records = array.as<record_type>();
           if (not records) {
-            diagnostic::warning("expected record, got {}", array.type.kind())
-              .primary(spread.expr)
-              .emit(ctx_);
+            if (array.type.kind().is_not<null_type>()) {
+              diagnostic::warning("expected record, got {}", array.type.kind())
+                .primary(spread.expr)
+                .emit(ctx_);
+            }
             return;
           }
+          // TODO: We could also make sure that record-nulls do not create any
+          // fields. This will create an additional splitting point.
           for (auto [i, field_array] :
-               detail::enumerate(records->array->fields())) {
+               detail::enumerate(check(records->array->Flatten()))) {
             auto field = records->type.field(i);
             fields[field.name] = series{field.type, field_array};
           }
@@ -66,7 +71,7 @@ auto evaluator::eval(const ast::record& x) -> multi_series {
     auto new_type
       = type{record_type{std::vector(field_types.begin(), field_types.end())}};
     auto result
-      = make_struct_array(length_, nullptr,
+      = make_struct_array(length, nullptr,
                           std::vector(field_names.begin(), field_names.end()),
                           std::vector(field_arrays.begin(), field_arrays.end()),
                           as<record_type>(new_type));


### PR DESCRIPTION
Tenzir's evaluator mostly deals with batches of uniformly typed data. However, some functions can return different types depending on the actual value of the input – for example, `parse_json`. Thus, there is some segmentation logic which deals with heterogeneous types and allows the rest of the evaluator to assume uniform types. This PR fixes a few issues within that code, and also contains a drive-by fix for the evaluation of record expressions.