### PR TITLE
Fix panic catching in `main()`

### DIFF
--- a/libtenzir/include/tenzir/detail/scope_guard.hpp
+++ b/libtenzir/include/tenzir/detail/scope_guard.hpp
@@ -38,8 +38,13 @@ public:
   }
 
   ~scope_guard() noexcept {
+    trigger();
+  }
+
+  void trigger() noexcept {
     if (enabled_) {
       fun_();
+      enabled_ = false;
     }
   }
 


### PR DESCRIPTION
We recently added exception catching for panics, but did not account for a `std::thread` that was not joined on unwind. This PR makes it so that we join the thread on unwind instead, preventing a `std::terminate`. There is no changelog because the panic machinery is only visible for bugs anyway.