### PR TITLE
Fix bug that caused `read_zeek_tsv` to produce invalid fields

### DIFF
--- a/changelog/next/bug-fixes/5052--zeek-tsv.md
+++ b/changelog/next/bug-fixes/5052--zeek-tsv.md
@@ -1,0 +1,2 @@
+The `read_zeek_tsv` operator sometimes produced an invalid field with the name
+`\0` for types without a schema specified. This no longer happens.

--- a/libtenzir/builtins/formats/zeek_tsv.cpp
+++ b/libtenzir/builtins/formats/zeek_tsv.cpp
@@ -662,13 +662,13 @@ auto parser_impl(generator<std::optional<std::string_view>> lines,
         const auto make_unset_parser = [&, field]() {
           return ignore(parsers::str{document.unset_field}
                         >> &(parsers::chr{document.separator} | parsers::eoi))
-            .then([&]() {
+            .then([&, field]() {
               document.event->field(field).null();
               return true;
             });
         };
         const auto make_empty_parser
-          = [&]<concrete_type Type>(const Type& type) {
+          = [&, field]<concrete_type Type>(const Type& type) {
               return ignore(parsers::str{document.empty_field} >> &(
                               parsers::chr{document.separator} | parsers::eoi))
                 .then([&, field]() {


### PR DESCRIPTION
This fixes the following pipeline:

```
from "https://storage.googleapis.com/tenzir-datasets/M57/zeek-all.log.zst" {
  decompress_zstd
  read_zeek_tsv
}
where @name == "zeek.analyzer"
```

This returned one additional field with the name `\0`, which failed UTF8 validation, causing nodes to be disconnected from the platform when running this pipeline in the Explorer.
