### PR TITLE
Fix passing string params to `{from,to}_fluent_bit`

### DIFF
--- a/changelog/next/bug-fixes/5053--fluent-bit-strings.md
+++ b/changelog/next/bug-fixes/5053--fluent-bit-strings.md
@@ -1,0 +1,3 @@
+We fixed a regression introduced in v4.29.2 that caused strings passed as
+options to the `from_fluent_bit` and `to_fluent_bit` operators to incorrectly be
+surrounded by double quotes.

--- a/changelog/next/bug-fixes/5053--fluent-bit-strings.md
+++ b/changelog/next/bug-fixes/5053--fluent-bit-strings.md
@@ -1,3 +1,6 @@
-We fixed a regression introduced in v4.29.2 that caused strings passed as
-options to the `from_fluent_bit` and `to_fluent_bit` operators to incorrectly be
-surrounded by double quotes.
+We fixed a regression that caused strings passed as options to the
+`from_fluent_bit` and `to_fluent_bit` operators to incorrectly be surrounded by
+double quotes.
+
+`to_fluent_bit` incorrectly reported zero bytes being pushed to the Fluent Bit
+engine as an error. This no longer happens.

--- a/plugins/fluent-bit/include/fluent-bit/fluent-bit_operator.hpp
+++ b/plugins/fluent-bit/include/fluent-bit/fluent-bit_operator.hpp
@@ -229,6 +229,12 @@ inline auto to_property_map(const std::optional<tenzir::record>& rec)
     return res;
   }
   for (const auto& [key, value] : *rec) {
+    // Avoid double quotes around strings.
+    if (const auto* str = try_as<std::string>(&value)) {
+      const auto [it, inserted] = res.try_emplace(key, *str);
+      TENZIR_ASSERT(inserted);
+      continue;
+    }
     const auto [it, inserted] = res.try_emplace(key, fmt::format("{}", value));
     TENZIR_ASSERT(inserted);
   }

--- a/plugins/fluent-bit/include/fluent-bit/fluent-bit_operator.hpp
+++ b/plugins/fluent-bit/include/fluent-bit/fluent-bit_operator.hpp
@@ -395,7 +395,7 @@ public:
   auto push(std::string_view data) -> bool {
     TENZIR_ASSERT(ctx_ != nullptr);
     TENZIR_ASSERT(ffd_ >= 0);
-    return flb_lib_push(ctx_, ffd_, data.data(), data.size()) != 0;
+    return flb_lib_push(ctx_, ffd_, data.data(), data.size()) != FLB_LIB_ERROR;
   }
 
 private:
@@ -804,6 +804,7 @@ public:
       auto array
         = to_record_batch(resolved_slice)->ToStructArray().ValueOrDie();
       auto it = std::back_inserter(event);
+      auto failed = false;
       for (const auto& row : values3(*array)) {
         TENZIR_ASSERT(row);
         auto printer = json_printer{{
@@ -813,10 +814,14 @@ public:
         TENZIR_ASSERT(ok);
         // Wrap JSON object in the 2-element JSON array that Fluent Bit expects.
         auto message = fmt::format("[{}, {}]", flb_time_now(), event);
-        if (engine->push(message)) {
-          TENZIR_ERROR("failed to push data into Fluent Bit engine");
+        if (not engine->push(message)) {
+          failed = true;
         }
         event.clear();
+      }
+      if (failed) {
+        diagnostic::warning("failed to push data into Fluent Bit Engine")
+          .emit(ctrl.diagnostics());
       }
       co_yield {};
     }


### PR DESCRIPTION
This fixes a recently added regression that causes strings to be forwarded with double quotes. A user reported this via Discord.