### PR TITLE
Add 'libcap2-bin' as runtime dependency to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -316,6 +316,7 @@ RUN apt-get update && \
       libboost-stacktrace1.81 \
       libc++1 \
       libc++abi1 \
+      libcap2-bin \
       libflatbuffers2 \
       libfmt9 \
       libgrpc++1.51 \


### PR DESCRIPTION
This allows the usage of the 'capsh' binary in our docker compose setups. The capsh binary in turn is currently the easiest way to manipulate ambient capabilities from the command line, which are required to allow the tenzir node to e.g. bind to privileged ports in host networking mode.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made in the pull request description in a way that
   is consumable by everyone, not just developers who know the context of the
   change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://docs.tenzir.com/next/contribute/changelog
3. Provide instructions for the reviewer.
4. Remove this comment so it doesn't show up in the merge commit.
-->
