### PR TITLE
Add CAP_NET_BIND_SERVICE capability to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -374,7 +374,8 @@ COPY --from=zmq-plugin --chown=tenzir:tenzir /plugin/zmq /
 
 FROM tenzir-de AS tenzir-node-de
 
-ENTRYPOINT ["tenzir-node"]
+USER root:root
+ENTRYPOINT ["capsh", "--caps=cap_net_bind_service,cap_setuid,cap_setgid=+eip", "--user=tenzir", "--addamb=cap_net_bind_service", "--", "-c", "/opt/tenzir/bin/tenzir-node"]
 
 # -- third-party-plugins -------------------------------------------------------------------
 
@@ -517,7 +518,8 @@ FROM tenzir-ce-${TARGETARCH} AS tenzir-ce
 
 FROM tenzir-ce AS tenzir-node-ce
 
-ENTRYPOINT ["tenzir-node"]
+USER root:root
+ENTRYPOINT ["capsh", "--caps=cap_net_bind_service,cap_setuid,cap_setgid=+eip", "--user=tenzir", "--addamb=cap_net_bind_service", "--", "-c", "/opt/tenzir/bin/tenzir-node"]
 
 # -- tenzir-demo --------------------------------------------------------------
 


### PR DESCRIPTION
Use `capsh` to give the node the `net_bind_service` capability by default.

This is relevant in combination with docker host networking, to enable the node to listen on privileged ports.