### PR TITLE
Make schema definitions represent the type system exactly

### DIFF
--- a/changelog/next/features/5062--type-of.md
+++ b/changelog/next/features/5062--type-of.md
@@ -1,0 +1,9 @@
+We introduced a new `type_of(x: any) -> record` function that returns the exact
+type definition of a TQL expression. For example, `this = type_of(this)`
+replaces an event with its schema's definition.
+
+The `/serve` endpoint gained a new option `schema`, which can be set to `legacy`
+(default), `exact`, or `never`. The `legacy` option causes the schema definition
+to be rendered in a simplified way, which is the current default. The `exact`
+option causes the schema definitions to be rendered exactly without omitting any
+information. Set the option to `never` to omit schema definitions entirely.

--- a/libtenzir/builtins/functions/misc.cpp
+++ b/libtenzir/builtins/functions/misc.cpp
@@ -54,7 +54,7 @@ public:
 class type_of final : public function_plugin {
 public:
   auto name() const -> std::string override {
-    return "tql2.type_of";
+    return "type_of";
   }
 
   auto make_function(invocation inv, session ctx) const
@@ -66,7 +66,6 @@ public:
     return function_use::make(
       [expr = std::move(expr)](evaluator eval, session ctx) -> multi_series {
         TENZIR_UNUSED(ctx);
-        auto value = eval(expr);
         return map_series(eval(expr), [](auto&& x) {
           auto builder = series_builder{};
           auto definition = x.type.to_definition();

--- a/libtenzir/builtins/functions/misc.cpp
+++ b/libtenzir/builtins/functions/misc.cpp
@@ -6,11 +6,10 @@
 // SPDX-FileCopyrightText: (c) 2024 The Tenzir Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#include "tenzir/series_builder.hpp"
-
 #include <tenzir/arrow_utils.hpp>
 #include <tenzir/detail/heterogeneous_string_hash.hpp>
 #include <tenzir/detail/zip_iterator.hpp>
+#include <tenzir/series_builder.hpp>
 #include <tenzir/tql2/plugin.hpp>
 
 #include <boost/process/environment.hpp>

--- a/libtenzir/builtins/operators/serve.cpp
+++ b/libtenzir/builtins/operators/serve.cpp
@@ -119,6 +119,11 @@ constexpr auto SPEC_V0 = R"_(
                 example: "200ms"
                 default: "5s"
                 description: The maximum amount of time spent on the request. Hitting the timeout is not an error. The timeout must not be greater than 10 seconds.
+              schema:
+                type: string
+                example: "exact"
+                default: "legacy"
+                description: The output format in which schemas are represented. Must be one of "legacy", "exact", or "never". Use "exact" to switch to a type representation matching Tenzir's type system exactly, and "never" to omit schema schema definitions from the output entirely.
     responses:
       200:
         description: Success.
@@ -233,9 +238,12 @@ struct request_limits {
   duration timeout = defaults::api::serve::timeout;
 };
 
+TENZIR_ENUM(schema, legacy, exact, never);
+
 struct serve_request {
   std::string serve_id = {};
   std::string continuation_token = {};
+  enum schema schema = schema::legacy;
   request_limits limits = {};
 };
 
@@ -692,12 +700,32 @@ struct serve_handler_state {
       }
       result.limits.timeout = **timeout;
     }
+    auto schema = try_get<std::string>(params, "schema");
+    if (not schema) {
+      auto detail_msg
+        = fmt::format("{}; got params {}", schema.error(), params);
+      auto detail
+        = caf::make_error(ec::invalid_argument, std::move(detail_msg));
+      return parse_error{.message = "failed to read schema parameter",
+                         .detail = std::move(detail)};
+    }
+    if (*schema) {
+      auto opt = from_string<enum schema>(**schema);
+      if (not opt) {
+        return parse_error{
+          .message = "invalid schema parameter",
+          .detail = caf::make_error(ec::invalid_argument,
+                                    fmt::format("got `{}`", **schema))};
+      }
+      result.schema = *opt;
+    }
     return result;
   }
 
   static auto create_response(const std::string& next_continuation_token,
                               const std::vector<table_slice>& results,
-                              serve_state state) -> std::string {
+                              serve_state state, enum schema schema)
+    -> std::string {
     auto printer = json_printer{{
       .indentation = 0,
       .oneline = true,
@@ -712,13 +740,13 @@ struct serve_handler_state {
               R"({{"next_continuation_token":"{}","state":"{}","events":[)",
               next_continuation_token, state);
     auto out_iter = std::back_inserter(result);
-    auto seen_schemas = std::unordered_set<type>{};
+    auto seen_types = std::unordered_set<type>{};
     bool first = true;
     for (const auto& slice : results) {
       if (slice.rows() == 0) {
         continue;
       }
-      seen_schemas.insert(slice.schema());
+      seen_types.insert(slice.schema());
       auto resolved_slice = resolve_enumerations(slice);
       auto type = as<record_type>(resolved_slice.schema());
       auto array
@@ -737,13 +765,21 @@ struct serve_handler_state {
         TENZIR_ASSERT(ok);
       }
     }
+    if (schema == schema::never) {
+      if (not seen_types.empty()) {
+        *out_iter++ = '}';
+      }
+      *out_iter++ = ']';
+      *out_iter++ = '}';
+      return result;
+    }
     // Write schemas
-    if (seen_schemas.empty()) {
+    if (seen_types.empty()) {
       out_iter = fmt::format_to(out_iter, R"(],"schemas":[]}}{})", '\n');
       return result;
     }
     out_iter = fmt::format_to(out_iter, R"(}}],"schemas":[)");
-    for (bool first = true; const auto& schema : seen_schemas) {
+    for (bool first = true; const auto& type : seen_types) {
       if (first) {
         out_iter = fmt::format_to(out_iter, "{{");
       } else {
@@ -751,11 +787,13 @@ struct serve_handler_state {
       }
       first = false;
       out_iter = fmt::format_to(out_iter, R"("schema_id":"{}","definition":)",
-                                schema.make_fingerprint());
-      const auto ok = printer.print(out_iter, schema.to_definition());
+                                type.make_fingerprint());
+      const auto ok = printer.print(out_iter, schema == schema::legacy
+                                                ? type.to_legacy_definition()
+                                                : type.to_definition());
       TENZIR_ASSERT(ok);
     }
-    out_iter = fmt::format_to(out_iter, R"(}}]}}{})", '\n');
+    out_iter = fmt::format_to(out_iter, R"(}}]}})");
     return result;
   }
 
@@ -781,15 +819,17 @@ struct serve_handler_state {
              request.limits.max_events)
       .request(serve_manager, caf::infinite)
       .then(
-        [rp](const std::tuple<std::string, std::vector<table_slice>>&
-               result) mutable {
+        [rp, schema = request.schema](
+          const std::tuple<std::string, std::vector<table_slice>>&
+            result) mutable {
           const auto& [continuation_token, results] = result;
-          rp.deliver(rest_response::from_json_string(create_response(
-            continuation_token, results,
-            continuation_token.empty() ? serve_state::completed
-                                       : serve_state::running)));
+          rp.deliver(rest_response::from_json_string(
+            create_response(continuation_token, results,
+                            continuation_token.empty() ? serve_state::completed
+                                                       : serve_state::running,
+                            schema)));
         },
-        [rp](const caf::error& err) mutable {
+        [rp, schema = request.schema](const caf::error& err) mutable {
           if (err == caf::exit_reason::user_shutdown
               or err.context().match_elements<diagnostic>()) {
             // The pipeline has either shut down naturally or we got an error
@@ -800,7 +840,8 @@ struct serve_handler_state {
             rp.deliver(rest_response::from_json_string(create_response(
               {}, {},
               err == caf::exit_reason::user_shutdown ? serve_state::completed
-                                                     : serve_state::failed)));
+                                                     : serve_state::failed,
+              schema)));
             return;
           }
           rp.deliver(rest_response::make_error(400, fmt::to_string(err), {}));
@@ -863,7 +904,7 @@ public:
             .emit(ctrl.diagnostics());
         });
     co_yield {};
-    //  Forward events to the SERVE MANAGER.
+    // Forward events to the SERVE MANAGER.
     for (auto&& slice : input) {
       if (slice.rows() == 0) {
         co_yield {};
@@ -1018,6 +1059,7 @@ public:
           {"max_events", uint64_type{}},
           {"min_events", uint64_type{}},
           {"timeout", duration_type{}},
+          {"schema", string_type{}},
         },
         .version = api_version::v0,
         .content_type = http_content_type::json,

--- a/libtenzir/include/tenzir/type.hpp
+++ b/libtenzir/include/tenzir/type.hpp
@@ -300,6 +300,7 @@ public:
   /// Converts the type into its type definition.
   /// @pre *this
   [[nodiscard]] auto to_definition() const noexcept -> record;
+  [[nodiscard]] auto to_legacy_definition() const noexcept -> record;
 
   /// Creates a type from an Arrow DataType, Field, or Schema.
   [[nodiscard]] static type from_arrow(const arrow::DataType& other) noexcept;

--- a/libtenzir/include/tenzir/type.hpp
+++ b/libtenzir/include/tenzir/type.hpp
@@ -300,7 +300,9 @@ public:
   /// Converts the type into its type definition.
   /// @pre *this
   [[nodiscard]] auto to_definition() const noexcept -> record;
-  [[nodiscard]] auto to_legacy_definition() const noexcept -> record;
+  [[nodiscard]] auto
+  to_legacy_definition(std::optional<std::string> field_name = {},
+                       offset parent_path = {}) const noexcept -> record;
 
   /// Creates a type from an Arrow DataType, Field, or Schema.
   [[nodiscard]] static type from_arrow(const arrow::DataType& other) noexcept;

--- a/libtenzir/include/tenzir/type.hpp
+++ b/libtenzir/include/tenzir/type.hpp
@@ -299,9 +299,7 @@ public:
 
   /// Converts the type into its type definition.
   /// @pre *this
-  [[nodiscard]] auto to_definition(std::optional<std::string> field_name = {},
-                                   offset parent_path = {}) const noexcept
-    -> record;
+  [[nodiscard]] auto to_definition() const noexcept -> record;
 
   /// Creates a type from an Arrow DataType, Field, or Schema.
   [[nodiscard]] static type from_arrow(const arrow::DataType& other) noexcept;

--- a/libtenzir/src/type.cpp
+++ b/libtenzir/src/type.cpp
@@ -747,62 +747,63 @@ data type::construct() const noexcept {
   });
 }
 
-auto type::to_definition(std::optional<std::string> field_name,
-                         offset parent_path) const noexcept -> record {
-  auto attributes = record{};
-  for (const auto& [key, value] : this->attributes()) {
-    attributes.emplace(key, value.empty() ? data{} : data{std::string{value}});
-  }
-  auto path = list{};
-  for (const auto& index : parent_path) {
-    path.push_back(data{static_cast<int64_t>(index)});
-  }
-  return match(
-    *this,
-    [&](const auto&) noexcept -> record {
-      auto result = record{};
-      result.emplace("name", field_name.value_or(std::string{name()}));
-      result.emplace("kind", std::string{to_string(kind())});
-      result.emplace("type", name().empty() ? std::string{to_string(kind())}
-                                            : std::string{name()});
-      result.emplace("attributes", std::move(attributes));
-      result.emplace("path", std::move(path));
-      result.emplace("fields", list{});
-      return result;
-    },
-    [&](const list_type& self) noexcept -> record {
-      // Recursively create the definition for the nested type, but add a -1 to
-      // it for the values. We override the type to include the list, but leave
-      // the kind as the nested value.
-      if (is<record_type>(self.value_type())) {
-        parent_path.push_back(-1);
-      }
-      auto result = self.value_type().to_definition(
-        field_name.value_or(std::string{name()}), parent_path);
-      result["kind"] = fmt::format("list<{}>", as<std::string>(result["kind"]));
-      result["type"]
-        = name().empty()
-            ? fmt::format("list<{}>", as<std::string>(result["type"]))
-            : std::string{name()};
-      return result;
-    },
-    [&](const record_type& self) noexcept -> record {
-      auto fields = list{};
-      parent_path.push_back(-1);
-      for (const auto& field : self.fields()) {
-        ++parent_path.back();
-        fields.push_back(
-          field.type.to_definition(std::string{field.name}, parent_path));
-      }
-      auto result = record{};
-      result.emplace("name", field_name.value_or(std::string{name()}));
-      result.emplace("kind", "record");
-      result.emplace("type", name().empty() ? "record" : std::string{name()});
-      result.emplace("attributes", std::move(attributes));
-      result.emplace("path", std::move(path));
-      result.emplace("fields", std::move(fields));
-      return result;
-    });
+auto type::to_definition() const noexcept -> record {
+  const auto make_attributes = [&] {
+    auto result = list{};
+    for (const auto& [key, value] : attributes()) {
+      result.push_back(record{
+        {"key", std::string{key}},
+        {"value", std::string{value}},
+      });
+    }
+    return result;
+  };
+  const auto make_state = [&] {
+    return match(
+      *this,
+      [](const enumeration_type& self) -> data {
+        auto result = list{};
+        for (const auto& field : self.fields()) {
+          result.push_back(record{
+            {"key", uint64_t{field.key}},
+            {"name", std::string{field.name}},
+          });
+        }
+        return record{
+          {"fields", std::move(result)},
+        };
+      },
+      [](const list_type& self) -> data {
+        return record{
+          {"type", self.value_type().to_definition()},
+        };
+      },
+      [](const map_type&) -> data {
+        TENZIR_UNREACHABLE();
+      },
+      [](const record_type& self) -> data {
+        auto result = list{};
+        result.reserve(self.num_fields());
+        for (const auto& field : self.fields()) {
+          result.push_back(record{
+            {"name", std::string{field.name}},
+            {"type", field.type.to_definition()},
+          });
+        }
+        return record{
+          {"fields", std::move(result)},
+        };
+      },
+      [](const basic_type auto&) -> data {
+        return {};
+      });
+  };
+  return record{
+    {"name", name().empty() ? data{} : data{std::string{name()}}},
+    {"kind", fmt::to_string(kind())},
+    {"attributes", make_attributes()},
+    {"state", make_state()},
+  };
 }
 
 type type::from_arrow(const arrow::DataType& other) noexcept {

--- a/libtenzir/src/type.cpp
+++ b/libtenzir/src/type.cpp
@@ -806,63 +806,62 @@ auto type::to_definition() const noexcept -> record {
   };
 }
 
-auto type::to_legacy_definition() const noexcept -> record {
-  const auto make_attributes = [&] {
-    auto result = list{};
-    for (const auto& [key, value] : attributes()) {
-      result.push_back(record{
-        {"key", std::string{key}},
-        {"value", std::string{value}},
-      });
-    }
-    return result;
-  };
-  const auto make_state = [&] {
-    return match(
-      *this,
-      [](const enumeration_type& self) -> data {
-        auto result = list{};
-        for (const auto& field : self.fields()) {
-          result.push_back(record{
-            {"key", uint64_t{field.key}},
-            {"name", std::string{field.name}},
-          });
-        }
-        return record{
-          {"fields", std::move(result)},
-        };
-      },
-      [](const list_type& self) -> data {
-        return record{
-          {"type", self.value_type().to_definition()},
-        };
-      },
-      [](const map_type&) -> data {
-        TENZIR_UNREACHABLE();
-      },
-      [](const record_type& self) -> data {
-        auto result = list{};
-        result.reserve(self.num_fields());
-        for (const auto& field : self.fields()) {
-          result.push_back(record{
-            {"name", std::string{field.name}},
-            {"type", field.type.to_definition()},
-          });
-        }
-        return record{
-          {"fields", std::move(result)},
-        };
-      },
-      [](const basic_type auto&) -> data {
-        return {};
-      });
-  };
-  return record{
-    {"name", name().empty() ? data{} : data{std::string{name()}}},
-    {"kind", std::string{to_string(kind())}},
-    {"attributes", make_attributes()},
-    {"state", make_state()},
-  };
+auto type::to_legacy_definition(std::optional<std::string> field_name,
+                                offset parent_path) const noexcept -> record {
+  auto attributes = record{};
+  for (const auto& [key, value] : this->attributes()) {
+    attributes.emplace(key, value.empty() ? data{} : data{std::string{value}});
+  }
+  auto path = list{};
+  for (const auto& index : parent_path) {
+    path.push_back(data{static_cast<int64_t>(index)});
+  }
+  return match(
+    *this,
+    [&](const auto&) noexcept -> record {
+      auto result = record{};
+      result.emplace("name", field_name.value_or(std::string{name()}));
+      result.emplace("kind", std::string{to_string(kind())});
+      result.emplace("type", name().empty() ? std::string{to_string(kind())}
+                                            : std::string{name()});
+      result.emplace("attributes", std::move(attributes));
+      result.emplace("path", std::move(path));
+      result.emplace("fields", list{});
+      return result;
+    },
+    [&](const list_type& self) noexcept -> record {
+      // Recursively create the definition for the nested type, but add a -1 to
+      // it for the values. We override the type to include the list, but leave
+      // the kind as the nested value.
+      if (is<record_type>(self.value_type())) {
+        parent_path.push_back(-1);
+      }
+      auto result = self.value_type().to_legacy_definition(
+        field_name.value_or(std::string{name()}), parent_path);
+      result["kind"] = fmt::format("list<{}>", as<std::string>(result["kind"]));
+      result["type"]
+        = name().empty()
+            ? fmt::format("list<{}>", as<std::string>(result["type"]))
+            : std::string{name()};
+      return result;
+    },
+    [&](const record_type& self) noexcept -> record {
+      auto fields = list{};
+      parent_path.push_back(-1);
+      for (const auto& field : self.fields()) {
+        ++parent_path.back();
+        fields.push_back(field.type.to_legacy_definition(
+          std::string{field.name}, parent_path));
+      }
+      auto result = record{};
+      result.emplace("name", field_name.value_or(std::string{name()}));
+      result.emplace("kind", "record");
+      result.emplace("type", name().empty() ? "record" : std::string{name()});
+      result.emplace("attributes", std::move(attributes));
+      result.emplace("path", std::move(path));
+      result.emplace("fields", std::move(fields));
+      return result;
+    });
 }
 
 type type::from_arrow(const arrow::DataType& other) noexcept {

--- a/libtenzir/src/type.cpp
+++ b/libtenzir/src/type.cpp
@@ -800,7 +800,7 @@ auto type::to_definition() const noexcept -> record {
   };
   return record{
     {"name", name().empty() ? data{} : data{std::string{name()}}},
-    {"kind", fmt::to_string(kind())},
+    {"kind", std::string{to_string(kind())}},
     {"attributes", make_attributes()},
     {"state", make_state()},
   };

--- a/libtenzir/src/version.cpp
+++ b/libtenzir/src/version.cpp
@@ -84,6 +84,9 @@ auto tenzir_features(const record& cfg) -> std::vector<std::string> {
     "modules",
     // The node supports the TQL2 `from` and `to` operators.
     "tql2_from",
+    // Schema definitions use the new format that represents Tenzir's type
+    // system exactly.
+    "exact_schema",
   };
   if (auto fallback = false; get_or(cfg, "tenzir.tql2", fallback)) {
     // The experimental TQL2-only mode is enabled.

--- a/web/docs/tql2/functions.md
+++ b/web/docs/tql2/functions.md
@@ -31,7 +31,7 @@ f(arg1:<type>, arg2=<type>, [arg3=type]) -> <type>
 TQL features the [uniform function call syntax
 (UFCS)](https://en.wikipedia.org/wiki/Uniform_Function_Call_Syntax), which
 allows you to interchangeably call a function with at least one argument either
-as *free function* or *method*. For example, `length(str)` and `str.length()`
+as _free function_ or _method_. For example, `length(str)` and `str.length()`
 resolve to the identical function call. The latter syntax is particularly
 suitable for function chaining, e.g., `x.f().g().h()` reads left-to-right as
 "start with `x`, apply `f()`, then `g()` and then `h()`," compared to
@@ -42,158 +42,158 @@ but often resort to the method style when it is more idiomatic.
 
 ## Aggregation
 
-Function | Description | Example
-:--------|:------------|:-------
-[`all`](functions/all.md) | Computes the conjunction (AND) of all boolean values | `all([true,true,false])`
-[`any`](functions/any.md) | Computes the disjunction (OR) of all boolean values | `any([true,false,true])`
-[`collect`](functions/collect.md) | Creates a list of all non-null values, preserving duplicates | `collect([1,2,2,3])`
-[`count`](functions/count.md) | Counts the events or non-null values | `count([1,2,null])`
-[`count_distinct`](functions/count_distinct.md) | Counts all distinct non-null values | `count_distinct([1,2,2,3])`
-[`distinct`](functions/distinct.md) | Creates a sorted list without duplicates of non-null values | `distinct([1,2,2,3])`
-[`first`](functions/first.md) | Takes the first non-null value | `first([null,2,3])`
-[`last`](functions/last.md) | Takes the last non-null value | `last([1,2,null])`
-[`max`](functions/max.md) | Computes the maximum of all values | `max([1,2,3])`
-[`mean`](functions/mean.md) | Computes the mean of all values | `mean([1,2,3])`
-[`median`](functions/median.md) | Computes the approximate median with a t-digest algorithm | `median([1,2,3,4])`
-[`min`](functions/min.md) | Computes the minimum of all values | `min([1,2,3])`
-[`mode`](functions/mode.md) | Takes the most common non-null value | `mode([1,1,2,3])`
-[`quantile`](functions/quantile.md) | Computes the specified quantile `q` of values | `quantile([1,2,3,4], q=0.5)`
-[`stddev`](functions/stddev.md) | Computes the standard deviation of all values | `stddev([1,2,3])`
-[`sum`](functions/sum.md) | Computes the sum of all values | `sum([1,2,3])`
-[`value_counts`](functions/value_counts.md) | Returns a list of values with their frequency | `value_counts([1,2,2,3])`
-[`variance`](functions/variance.md) | Computes the variance of all values | `variance([1,2,3])`
+| Function                                        | Description                                                  | Example                      |
+| :---------------------------------------------- | :----------------------------------------------------------- | :--------------------------- |
+| [`all`](functions/all.md)                       | Computes the conjunction (AND) of all boolean values         | `all([true,true,false])`     |
+| [`any`](functions/any.md)                       | Computes the disjunction (OR) of all boolean values          | `any([true,false,true])`     |
+| [`collect`](functions/collect.md)               | Creates a list of all non-null values, preserving duplicates | `collect([1,2,2,3])`         |
+| [`count`](functions/count.md)                   | Counts the events or non-null values                         | `count([1,2,null])`          |
+| [`count_distinct`](functions/count_distinct.md) | Counts all distinct non-null values                          | `count_distinct([1,2,2,3])`  |
+| [`distinct`](functions/distinct.md)             | Creates a sorted list without duplicates of non-null values  | `distinct([1,2,2,3])`        |
+| [`first`](functions/first.md)                   | Takes the first non-null value                               | `first([null,2,3])`          |
+| [`last`](functions/last.md)                     | Takes the last non-null value                                | `last([1,2,null])`           |
+| [`max`](functions/max.md)                       | Computes the maximum of all values                           | `max([1,2,3])`               |
+| [`mean`](functions/mean.md)                     | Computes the mean of all values                              | `mean([1,2,3])`              |
+| [`median`](functions/median.md)                 | Computes the approximate median with a t-digest algorithm    | `median([1,2,3,4])`          |
+| [`min`](functions/min.md)                       | Computes the minimum of all values                           | `min([1,2,3])`               |
+| [`mode`](functions/mode.md)                     | Takes the most common non-null value                         | `mode([1,1,2,3])`            |
+| [`quantile`](functions/quantile.md)             | Computes the specified quantile `q` of values                | `quantile([1,2,3,4], q=0.5)` |
+| [`stddev`](functions/stddev.md)                 | Computes the standard deviation of all values                | `stddev([1,2,3])`            |
+| [`sum`](functions/sum.md)                       | Computes the sum of all values                               | `sum([1,2,3])`               |
+| [`value_counts`](functions/value_counts.md)     | Returns a list of values with their frequency                | `value_counts([1,2,2,3])`    |
+| [`variance`](functions/variance.md)             | Computes the variance of all values                          | `variance([1,2,3])`          |
 
 ## Record
 
-Function | Description | Example
-:--------|:-------------|:-------
-[`has`](functions/has.md) | Checks whether a record has a field | `record.has("field")`
-[`merge`](functions/merge.md) | Merges two records | `merge(foo, bar)`
-[`sort`](functions/sort.md) | Sorts a record by field names | `xs.sort()`
+| Function                      | Description                         | Example               |
+| :---------------------------- | :---------------------------------- | :-------------------- |
+| [`has`](functions/has.md)     | Checks whether a record has a field | `record.has("field")` |
+| [`merge`](functions/merge.md) | Merges two records                  | `merge(foo, bar)`     |
+| [`sort`](functions/sort.md)   | Sorts a record by field names       | `xs.sort()`           |
 
 ## List
 
-Function | Description | Example
-:--------|:------------|:-------
-[`append`](functions/append.md) | Inserts an element at the back of a list | `xs.append(y)`
-[`prepend`](functions/prepend.md) | Inserts an element at the front of a list | `xs.prepend(y)`
-[`concatenate`](functions/concatenate.md) | Merges two lists | `concatenate(xs, ys)`
-[`length`](functions/length.md) | Retrieves the length of a list | `[1,2,3].length()`
-[`map`](functions/map.md) | Maps each list element to an expression | `xs.map(x, x + 3)`
-[`sort`](functions/sort.md) | Sorts a list by its values. | `xs.sort()`
-[`where`](functions/where.md) | Filters list elements based on a predicate | `xs.where(x, x > 5)`
-[`zip`](functions/zip.md) | Combines two lists into a list of pairs | `zip(xs, ys)`
+| Function                                  | Description                                | Example               |
+| :---------------------------------------- | :----------------------------------------- | :-------------------- |
+| [`append`](functions/append.md)           | Inserts an element at the back of a list   | `xs.append(y)`        |
+| [`prepend`](functions/prepend.md)         | Inserts an element at the front of a list  | `xs.prepend(y)`       |
+| [`concatenate`](functions/concatenate.md) | Merges two lists                           | `concatenate(xs, ys)` |
+| [`length`](functions/length.md)           | Retrieves the length of a list             | `[1,2,3].length()`    |
+| [`map`](functions/map.md)                 | Maps each list element to an expression    | `xs.map(x, x + 3)`    |
+| [`sort`](functions/sort.md)               | Sorts a list by its values.                | `xs.sort()`           |
+| [`where`](functions/where.md)             | Filters list elements based on a predicate | `xs.where(x, x > 5)`  |
+| [`zip`](functions/zip.md)                 | Combines two lists into a list of pairs    | `zip(xs, ys)`         |
 
 ## Subnet
 
-Function | Description | Example
-:--------|:-------------|:-------
-[`network`](functions/network.md) | Retrieves the network address of a subnet | `10.0.0.0/8.network()`
-[`type_id`](functions/type_id.md) | Retrieves the type of an expression | `type_id(1 + 3.2)`
+| Function                          | Description                               | Example                |
+| :-------------------------------- | :---------------------------------------- | :--------------------- |
+| [`network`](functions/network.md) | Retrieves the network address of a subnet | `10.0.0.0/8.network()` |
 
 ## String
 
 ### Inspection
 
-Function | Description | Example
-:--------|:-------------|:-------
-[`length_bytes`](functions/length_bytes.md) | Returns the length of a string in bytes | `"hello".length_bytes()`
-[`length_chars`](functions/length_chars.md) | Returns the length of a string in characters | `"hello".length_chars()`
-[`starts_with`](functions/starts_with.md) | Checks if a string starts with a substring | `"hello".starts_with("he")`
-[`ends_with`](functions/ends_with.md) | Checks if a string ends with a substring | `"hello".ends_with("lo")`
-[`is_alnum`](functions/is_alnum.md) | Checks if a string is alphanumeric | `"hello123".is_alnum()`
-[`is_alpha`](functions/is_alpha.md) | Checks if a string contains only letters | `"hello".is_alpha()`
-[`is_lower`](functions/is_lower.md) | Checks if a string is in lowercase | `"hello".is_lower()`
-[`is_numeric`](functions/is_numeric.md) | Checks if a string contains only numbers | `"1234".is_numeric()`
-[`is_printable`](functions/is_printable.md) | Checks if a string contains only printable characters | `"hello".is_printable()`
-[`is_title`](functions/is_title.md) | Checks if a string follows title case | `"Hello World".is_title()`
-[`is_upper`](functions/is_upper.md) | Checks if a string is in uppercase | `"HELLO".is_upper()`
-[`match_regex`](functions/match_regex.md) | Checks if a string partially matches a regular expression | `"Hi".match_regex("[Hh]i")`
-[`slice`](functions/slice.md) | Slices a string with offsets and strides | `"Hi".slice(begin=2, stride=4)`
+| Function                                    | Description                                               | Example                         |
+| :------------------------------------------ | :-------------------------------------------------------- | :------------------------------ |
+| [`length_bytes`](functions/length_bytes.md) | Returns the length of a string in bytes                   | `"hello".length_bytes()`        |
+| [`length_chars`](functions/length_chars.md) | Returns the length of a string in characters              | `"hello".length_chars()`        |
+| [`starts_with`](functions/starts_with.md)   | Checks if a string starts with a substring                | `"hello".starts_with("he")`     |
+| [`ends_with`](functions/ends_with.md)       | Checks if a string ends with a substring                  | `"hello".ends_with("lo")`       |
+| [`is_alnum`](functions/is_alnum.md)         | Checks if a string is alphanumeric                        | `"hello123".is_alnum()`         |
+| [`is_alpha`](functions/is_alpha.md)         | Checks if a string contains only letters                  | `"hello".is_alpha()`            |
+| [`is_lower`](functions/is_lower.md)         | Checks if a string is in lowercase                        | `"hello".is_lower()`            |
+| [`is_numeric`](functions/is_numeric.md)     | Checks if a string contains only numbers                  | `"1234".is_numeric()`           |
+| [`is_printable`](functions/is_printable.md) | Checks if a string contains only printable characters     | `"hello".is_printable()`        |
+| [`is_title`](functions/is_title.md)         | Checks if a string follows title case                     | `"Hello World".is_title()`      |
+| [`is_upper`](functions/is_upper.md)         | Checks if a string is in uppercase                        | `"HELLO".is_upper()`            |
+| [`match_regex`](functions/match_regex.md)   | Checks if a string partially matches a regular expression | `"Hi".match_regex("[Hh]i")`     |
+| [`slice`](functions/slice.md)               | Slices a string with offsets and strides                  | `"Hi".slice(begin=2, stride=4)` |
 
 ### Transformation
 
-Function | Description | Example
-:--------|:-------------|:-------
-[`trim`](functions/trim.md) | Trims whitespace from both ends of a string | `" hello ".trim()`
-[`trim_start`](functions/trim_start.md) | Trims whitespace from the start of a string | `" hello".trim_start()`
-[`trim_end`](functions/trim_end.md) | Trims whitespace from the end of a string | `"hello ".trim_end()`
-[`capitalize`](functions/capitalize.md) | Capitalizes the first character of a string | `"hello".capitalize()`
-[`replace`](functions/replace.md) | Replaces characters within a string | `"hello".replace("o", "a")`
-[`replace_regex`](functions/replace_regex.md) | Reverses the characters of a string | `"hello".replace("l+o", "y")`
-[`reverse`](functions/reverse.md) | Reverses the characters of a string | `"hello".reverse()`
-[`to_lower`](functions/to_lower.md) | Converts a string to lowercase | `"HELLO".to_lower()`
-[`to_title`](functions/to_title.md) | Converts a string to title case | `"hello world".to_title()`
-[`to_upper`](functions/to_upper.md) | Converts a string to uppercase | `"hello".to_upper()`
-[`split`](functions/split.md) | Splits a string into substrings | `split("a,b,c", ",")`
-[`split_regex`](functions/split_regex.md) | Splits a string into substrings with a regex | `split_regex("a1b2c", r"\d")`
-[`join`](functions/join.md) | Joins a list of strings into a single string | `join(["a", "b", "c"], ",")`
+| Function                                      | Description                                  | Example                       |
+| :-------------------------------------------- | :------------------------------------------- | :---------------------------- |
+| [`trim`](functions/trim.md)                   | Trims whitespace from both ends of a string  | `" hello ".trim()`            |
+| [`trim_start`](functions/trim_start.md)       | Trims whitespace from the start of a string  | `" hello".trim_start()`       |
+| [`trim_end`](functions/trim_end.md)           | Trims whitespace from the end of a string    | `"hello ".trim_end()`         |
+| [`capitalize`](functions/capitalize.md)       | Capitalizes the first character of a string  | `"hello".capitalize()`        |
+| [`replace`](functions/replace.md)             | Replaces characters within a string          | `"hello".replace("o", "a")`   |
+| [`replace_regex`](functions/replace_regex.md) | Reverses the characters of a string          | `"hello".replace("l+o", "y")` |
+| [`reverse`](functions/reverse.md)             | Reverses the characters of a string          | `"hello".reverse()`           |
+| [`to_lower`](functions/to_lower.md)           | Converts a string to lowercase               | `"HELLO".to_lower()`          |
+| [`to_title`](functions/to_title.md)           | Converts a string to title case              | `"hello world".to_title()`    |
+| [`to_upper`](functions/to_upper.md)           | Converts a string to uppercase               | `"hello".to_upper()`          |
+| [`split`](functions/split.md)                 | Splits a string into substrings              | `split("a,b,c", ",")`         |
+| [`split_regex`](functions/split_regex.md)     | Splits a string into substrings with a regex | `split_regex("a1b2c", r"\d")` |
+| [`join`](functions/join.md)                   | Joins a list of strings into a single string | `join(["a", "b", "c"], ",")`  |
 
 ### File Paths
 
-Function | Description | Example
-:--------|:-------------|:-------
-[`file_name`](functions/file_name.md) | Extracts the file name from a file path | `file_name("/path/to/log.json")`
-[`parent_dir`](functions/parent_dir.md) | Extracts the parent directory from a file path | `parent_dir("/path/to/log.json")`
+| Function                                | Description                                    | Example                           |
+| :-------------------------------------- | :--------------------------------------------- | :-------------------------------- |
+| [`file_name`](functions/file_name.md)   | Extracts the file name from a file path        | `file_name("/path/to/log.json")`  |
+| [`parent_dir`](functions/parent_dir.md) | Extracts the parent directory from a file path | `parent_dir("/path/to/log.json")` |
 
 ## Parsing
 
-Function | Description | Example
-:--------|:-------------|:-------
-[`parse_cef`](functions/parse_cef.mdx) | Parses a string as a CEF message  | `string.parse_cef()`
-[`parse_csv`](functions/parse_csv.mdx) | Parses a string as CSV  | `string.parse_csv(header=["a","b"])`
-[`parse_grok`](functions/parse_grok.mdx) | Parses a string following a grok pattern | `string.parse_grok("%{IP:client} …")`
-[`parse_json`](functions/parse_json.mdx) | Parses a string as a JSON value | `string.parse_json()`
-[`parse_kv`](functions/parse_kv.mdx) | Parses a string as Key-Value paris | `string.parse_kv()`
-[`parse_leef`](functions/parse_leef.mdx) | Parses a string as a LEEF message | `string.parse_leef()`
-[`parse_ssv`](functions/parse_ssv.mdx) | Parses a string as SSV  | `string.parse_ssv(header=["a","b"])`
-[`parse_syslog`](functions/parse_syslog.mdx) | Parses a string as a Syslog message  | `string.parse_syslog()`
-[`parse_tsv`](functions/parse_tsv.mdx) | Parses a string as TSV  | `string.parse_tsv(header=["a","b"])`
-[`parse_xsv`](functions/parse_xsv.mdx) | Parses a string as XSV | `string.parse_xsv(",", ";", "", header=["a","b"])`
-[`parse_yaml`](functions/parse_yaml.mdx) | Parses a string as YAML | `string.parse_yaml()`
+| Function                                     | Description                              | Example                                            |
+| :------------------------------------------- | :--------------------------------------- | :------------------------------------------------- |
+| [`parse_cef`](functions/parse_cef.mdx)       | Parses a string as a CEF message         | `string.parse_cef()`                               |
+| [`parse_csv`](functions/parse_csv.mdx)       | Parses a string as CSV                   | `string.parse_csv(header=["a","b"])`               |
+| [`parse_grok`](functions/parse_grok.mdx)     | Parses a string following a grok pattern | `string.parse_grok("%{IP:client} …")`              |
+| [`parse_json`](functions/parse_json.mdx)     | Parses a string as a JSON value          | `string.parse_json()`                              |
+| [`parse_kv`](functions/parse_kv.mdx)         | Parses a string as Key-Value paris       | `string.parse_kv()`                                |
+| [`parse_leef`](functions/parse_leef.mdx)     | Parses a string as a LEEF message        | `string.parse_leef()`                              |
+| [`parse_ssv`](functions/parse_ssv.mdx)       | Parses a string as SSV                   | `string.parse_ssv(header=["a","b"])`               |
+| [`parse_syslog`](functions/parse_syslog.mdx) | Parses a string as a Syslog message      | `string.parse_syslog()`                            |
+| [`parse_tsv`](functions/parse_tsv.mdx)       | Parses a string as TSV                   | `string.parse_tsv(header=["a","b"])`               |
+| [`parse_xsv`](functions/parse_xsv.mdx)       | Parses a string as XSV                   | `string.parse_xsv(",", ";", "", header=["a","b"])` |
+| [`parse_yaml`](functions/parse_yaml.mdx)     | Parses a string as YAML                  | `string.parse_yaml()`                              |
 
 ## Printing
 
-Function | Description | Example
-:--------|:-------------|:-------
-[`print_csv`](functions/print_csv.mdx) | Prints a record as comma separated values | `record.print_csv()`
-[`print_kv`](functions/print_kv.md) | Prints a record as Key-Value pairs | `record.print_kv()`
-[`print_json`](functions/print_json.mdx) | Prints a record as a JSON string | `record.print_json()`
-[`print_ndjson`](functions/print_ndjson.mdx) | Prints a record as NDJSON string | `record.print_ndjson()`
-[`print_ssv`](functions/print_ssv.mdx) | Prints a record as space separated values | `record.print_ssv()`
-[`print_tsv`](functions/print_tsv.mdx) | Prints a record as tab separated values | `record.print_tsv()`
-[`print_yaml`](functions/print_yaml.md) | Prints a value as a YAML document | `record.print_yaml()`
-[`print_xsv`](functions/print_xsv.md) | Prints a record as delimited separated values | `record.print_tsv()`
+| Function                                     | Description                                   | Example                 |
+| :------------------------------------------- | :-------------------------------------------- | :---------------------- |
+| [`print_csv`](functions/print_csv.mdx)       | Prints a record as comma separated values     | `record.print_csv()`    |
+| [`print_kv`](functions/print_kv.md)          | Prints a record as Key-Value pairs            | `record.print_kv()`     |
+| [`print_json`](functions/print_json.mdx)     | Prints a record as a JSON string              | `record.print_json()`   |
+| [`print_ndjson`](functions/print_ndjson.mdx) | Prints a record as NDJSON string              | `record.print_ndjson()` |
+| [`print_ssv`](functions/print_ssv.mdx)       | Prints a record as space separated values     | `record.print_ssv()`    |
+| [`print_tsv`](functions/print_tsv.mdx)       | Prints a record as tab separated values       | `record.print_tsv()`    |
+| [`print_yaml`](functions/print_yaml.md)      | Prints a value as a YAML document             | `record.print_yaml()`   |
+| [`print_xsv`](functions/print_xsv.md)        | Prints a record as delimited separated values | `record.print_tsv()`    |
 
 ## Time & Date
 
-Function | Description | Example
-:--------|:-------------|:-------
-[`as_secs`](functions/as_secs.md) | Converts a duration into seconds | `as_secs(42ms)`
-[`from_epoch`](functions/from_epoch.md) | Interprets a duration as Unix time | `from_epoch(time_ms * 1ms)`
-[`now`](functions/now.md) | Gets the current wallclock time | `now()`
-[`since_epoch`](functions/since_epoch.md) | Turns a time into a duration since the Unix epoch | `since_epoch(2021-02-24)`
-[`parse_time`](functions/parse_time.md) | Parses a timestamp following a given format | `"10/11/2012".parse_time("%d/%m/%Y")`
-[`years`](functions/years.mdx) | Converts a number to equivalent years | `years(100)`
-[`months`](functions/months.mdx) | Converts a number to equivalent months | `months(100)`
-[`weeks`](functions/weeks.mdx) | Converts a number to equivalent weeks | `weeks(100)`
-[`days`](functions/days.mdx) | Converts a number to equivalent days | `days(100)`
-[`hours`](functions/hours.mdx) | Converts a number to equivalent hours | `hours(100)`
-[`minutes`](functions/minutes.mdx) | Converts a number to equivalent minutes | `minutes(100)`
-[`seconds`](functions/seconds.mdx) | Converts a number to equivalent seconds | `seconds(100)`
-[`milliseconds`](functions/milliseconds.mdx) | Converts a number to equivalent milliseconds | `milliseconds(100)`
-[`microseconds`](functions/microseconds.mdx) | Converts a number to equivalent microseconds | `microseconds(100)`
-[`nanoseconds`](functions/nanoseconds.mdx) | Converts a number to equivalent nanoseconds | `nanoseconds(100)`
-[`count_years`](functions/count_years.mdx) | Counts the number of years in a duration | `count_years(100d)`
-[`count_months`](functions/count_months.mdx) | Counts the number of months in a duration | `count_months(100d)`
-[`count_weeks`](functions/count_weeks.mdx) | Counts the number of weeks in a duration | `count_weeks(100d)`
-[`count_days`](functions/count_days.mdx) | Counts the number of days in a duration | `count_days(100d)`
-[`count_hours`](functions/count_hours.mdx) | Counts the number of hours in a duration | `count_hours(100d)`
-[`count_minutes`](functions/count_minutes.mdx) | Counts the number of minutes in a duration | `count_minutes(100d)`
-[`count_seconds`](functions/count_seconds.mdx) | Counts the number of seconds in a duration | `count_seconds(100d)`
-[`count_milliseconds`](functions/count_milliseconds.mdx) | Counts the number of milliseconds in a duration | `count_milliseconds(100d)`
-[`count_microseconds`](functions/count_microseconds.mdx) | Counts the number of microseconds in a duration | `count_microseconds(100d)`
-[`count_nanoseconds`](functions/count_nanoseconds.mdx) | Counts the number of nanoseconds in a duration | `count_nanoseconds(100d)`
+| Function                                                 | Description                                       | Example                               |
+| :------------------------------------------------------- | :------------------------------------------------ | :------------------------------------ |
+| [`as_secs`](functions/as_secs.md)                        | Converts a duration into seconds                  | `as_secs(42ms)`                       |
+| [`from_epoch`](functions/from_epoch.md)                  | Interprets a duration as Unix time                | `from_epoch(time_ms * 1ms)`           |
+| [`now`](functions/now.md)                                | Gets the current wallclock time                   | `now()`                               |
+| [`since_epoch`](functions/since_epoch.md)                | Turns a time into a duration since the Unix epoch | `since_epoch(2021-02-24)`             |
+| [`parse_time`](functions/parse_time.md)                  | Parses a timestamp following a given format       | `"10/11/2012".parse_time("%d/%m/%Y")` |
+| [`years`](functions/years.mdx)                           | Converts a number to equivalent years             | `years(100)`                          |
+| [`months`](functions/months.mdx)                         | Converts a number to equivalent months            | `months(100)`                         |
+| [`weeks`](functions/weeks.mdx)                           | Converts a number to equivalent weeks             | `weeks(100)`                          |
+| [`days`](functions/days.mdx)                             | Converts a number to equivalent days              | `days(100)`                           |
+| [`hours`](functions/hours.mdx)                           | Converts a number to equivalent hours             | `hours(100)`                          |
+| [`minutes`](functions/minutes.mdx)                       | Converts a number to equivalent minutes           | `minutes(100)`                        |
+| [`seconds`](functions/seconds.mdx)                       | Converts a number to equivalent seconds           | `seconds(100)`                        |
+| [`milliseconds`](functions/milliseconds.mdx)             | Converts a number to equivalent milliseconds      | `milliseconds(100)`                   |
+| [`microseconds`](functions/microseconds.mdx)             | Converts a number to equivalent microseconds      | `microseconds(100)`                   |
+| [`nanoseconds`](functions/nanoseconds.mdx)               | Converts a number to equivalent nanoseconds       | `nanoseconds(100)`                    |
+| [`count_years`](functions/count_years.mdx)               | Counts the number of years in a duration          | `count_years(100d)`                   |
+| [`count_months`](functions/count_months.mdx)             | Counts the number of months in a duration         | `count_months(100d)`                  |
+| [`count_weeks`](functions/count_weeks.mdx)               | Counts the number of weeks in a duration          | `count_weeks(100d)`                   |
+| [`count_days`](functions/count_days.mdx)                 | Counts the number of days in a duration           | `count_days(100d)`                    |
+| [`count_hours`](functions/count_hours.mdx)               | Counts the number of hours in a duration          | `count_hours(100d)`                   |
+| [`count_minutes`](functions/count_minutes.mdx)           | Counts the number of minutes in a duration        | `count_minutes(100d)`                 |
+| [`count_seconds`](functions/count_seconds.mdx)           | Counts the number of seconds in a duration        | `count_seconds(100d)`                 |
+| [`count_milliseconds`](functions/count_milliseconds.mdx) | Counts the number of milliseconds in a duration   | `count_milliseconds(100d)`            |
+| [`count_microseconds`](functions/count_microseconds.mdx) | Counts the number of microseconds in a duration   | `count_microseconds(100d)`            |
+| [`count_nanoseconds`](functions/count_nanoseconds.mdx)   | Counts the number of nanoseconds in a duration    | `count_nanoseconds(100d)`             |
+
 <!--
 This is hidden because there is an issue with the timezone DB.
 [`format_time`](functions/format_time.md) | Format a timestamp following a given format | `2012-11-10.format_time("%d/%m/%Y")`
@@ -214,81 +214,82 @@ This is hidden because there is an issue with the timezone DB.
 
 ## Math
 
-Function | Description | Example
-:--------|:-------------|:-------
-[`ceil`](functions/ceil.md) | Takes the ceiling | `ceil(4.2)`, `ceil(3.2s, 1m)`
-[`floor`](functions/floor.md) | Takes the floor | `floor(4.2)`, `floor(32h, 1d)`
-[`random`](functions/random.md) | Generates a random number | `random()`
-[`round`](functions/round.md) | Rounds a value | `round(4.2)`, `round(31m, 1h)`
-[`sqrt`](functions/sqrt.md) | Calculates the square root | `sqrt(49)`
+| Function                        | Description                | Example                        |
+| :------------------------------ | :------------------------- | :----------------------------- |
+| [`ceil`](functions/ceil.md)     | Takes the ceiling          | `ceil(4.2)`, `ceil(3.2s, 1m)`  |
+| [`floor`](functions/floor.md)   | Takes the floor            | `floor(4.2)`, `floor(32h, 1d)` |
+| [`random`](functions/random.md) | Generates a random number  | `random()`                     |
+| [`round`](functions/round.md)   | Rounds a value             | `round(4.2)`, `round(31m, 1h)` |
+| [`sqrt`](functions/sqrt.md)     | Calculates the square root | `sqrt(49)`                     |
 
 ## Networking
 
-Function | Description | Example
-:--------|:-------------|:-------
-[`community_id`](functions/community_id.md) | Computes a Community ID | `community_id(src_ip=1.2.3.4, dst_ip=4.5.6.7, proto="tcp")`
-[`decapsulate`](functions/decapsulate.md) | Decapsulates PCAP packets | `decapsulate(this)`
-[`encrypt_cryptopan`](functions/encrypt_cryptopan.md) | Encrypts IPs via Crypto-PAn | `encrypt_cryptopan(1.2.3.4)`
-[`is_v4`](functions/is_v4.md) | Checks if an IP is IPv4 | `is_v4(1.2.3.4)`
-[`is_v6`](functions/is_v6.md) | Checks if an IP is IPv6 | `is_v6(::1)`
+| Function                                              | Description                 | Example                                                     |
+| :---------------------------------------------------- | :-------------------------- | :---------------------------------------------------------- |
+| [`community_id`](functions/community_id.md)           | Computes a Community ID     | `community_id(src_ip=1.2.3.4, dst_ip=4.5.6.7, proto="tcp")` |
+| [`decapsulate`](functions/decapsulate.md)             | Decapsulates PCAP packets   | `decapsulate(this)`                                         |
+| [`encrypt_cryptopan`](functions/encrypt_cryptopan.md) | Encrypts IPs via Crypto-PAn | `encrypt_cryptopan(1.2.3.4)`                                |
+| [`is_v4`](functions/is_v4.md)                         | Checks if an IP is IPv4     | `is_v4(1.2.3.4)`                                            |
+| [`is_v6`](functions/is_v6.md)                         | Checks if an IP is IPv6     | `is_v6(::1)`                                                |
 
 ## Hashing
 
-Function | Description | Example
-:--------|:-------------|:-------
-[`hash_md5`](functions/hash_md5.md) | Computes a MD5 hash digest | `hash_md5("foo")`
-[`hash_sha1`](functions/hash_sha1.md) | Computes a SHA1 hash digest | `hash_sha1("foo")`
-[`hash_sha224`](functions/hash_sha224.md) | Computes a SHA224 hash digest | `hash_sha224("foo")`
-[`hash_sha256`](functions/hash_sha256.md) | Computes a SHA256 hash digest | `hash_sha256("foo")`
-[`hash_sha384`](functions/hash_sha384.md) | Computes a SHA384 hash digest | `hash_sha384("foo")`
-[`hash_sha512`](functions/hash_sha512.md) | Computes a SHA512 hash digest | `hash_sha512("foo")`
-[`hash_xxh3`](functions/hash_xxh3.md) | Computes a XXH3 hash digest | `hash_xxh3("foo")`
+| Function                                  | Description                   | Example              |
+| :---------------------------------------- | :---------------------------- | :------------------- |
+| [`hash_md5`](functions/hash_md5.md)       | Computes a MD5 hash digest    | `hash_md5("foo")`    |
+| [`hash_sha1`](functions/hash_sha1.md)     | Computes a SHA1 hash digest   | `hash_sha1("foo")`   |
+| [`hash_sha224`](functions/hash_sha224.md) | Computes a SHA224 hash digest | `hash_sha224("foo")` |
+| [`hash_sha256`](functions/hash_sha256.md) | Computes a SHA256 hash digest | `hash_sha256("foo")` |
+| [`hash_sha384`](functions/hash_sha384.md) | Computes a SHA384 hash digest | `hash_sha384("foo")` |
+| [`hash_sha512`](functions/hash_sha512.md) | Computes a SHA512 hash digest | `hash_sha512("foo")` |
+| [`hash_xxh3`](functions/hash_xxh3.md)     | Computes a XXH3 hash digest   | `hash_xxh3("foo")`   |
 
 ## Encoding
 
-function | description | example
-:--------|:-------------|:-------
-[`encode_base64`](functions/encode_base64.md) | Encodes bytes as Base64 | `encode_base64("Tenzir")`
-[`encode_hex`](functions/encode_hex.md) | Encodes bytes as their hexadecimal representation | `encode_hex("Tenzir")`
+| function                                      | description                                       | example                   |
+| :-------------------------------------------- | :------------------------------------------------ | :------------------------ |
+| [`encode_base64`](functions/encode_base64.md) | Encodes bytes as Base64                           | `encode_base64("Tenzir")` |
+| [`encode_hex`](functions/encode_hex.md)       | Encodes bytes as their hexadecimal representation | `encode_hex("Tenzir")`    |
 
 ## Decoding
 
-function | description | example
-:--------|:-------------|:-------
-[`decode_base64`](functions/decode_base64.md) | Decodes bytes as Base64 | `decode_base64("VGVuemly")`
-[`decode_hex`](functions/decode_hex.md) | Decodes bytes from their hexadecimal representation | `decode_hex("4e6f6E6365")`
+| function                                      | description                                         | example                     |
+| :-------------------------------------------- | :-------------------------------------------------- | :-------------------------- |
+| [`decode_base64`](functions/decode_base64.md) | Decodes bytes as Base64                             | `decode_base64("VGVuemly")` |
+| [`decode_hex`](functions/decode_hex.md)       | Decodes bytes from their hexadecimal representation | `decode_hex("4e6f6E6365")`  |
 
 ## Type System
 
 ### Introspection
 
-Function | Description | Example
-:--------|:-------------|:-------
-[`type_id`](functions/type_id.md) | Retrieves the type of an expression | `type_id(1 + 3.2)`
+| Function                          | Description                                    | Example            |
+| :-------------------------------- | :--------------------------------------------- | :----------------- |
+| [`type_id`](functions/type_id.md) | Retrieves the type id of an expression         | `type_id(1 + 3.2)` |
+| [`type_of`](functions/type_id.md) | Retrieves the type definition of an expression | `type_id(this)`    |
 
 ### Conversion
 
-Function | Description | Example
-:--------|:-------------|:-------
-[`int`](functions/int.md) | Casts an expression to a signed integer | `int(-4.2)`
-[`uint`](functions/uint.md) | Casts an expression to an unsigned integer | `uint(4.2)`
-[`float`](functions/float.md) | Casts an expression to a float | `float(42)`
-[`string`](functions/string.md) | Casts an expression to string | `string(1.2.3.4)`
-[`ip`](functions/ip.md) | Casts an expression to an IP | `ip("1.2.3.4")`
-[`subnet`](functions/subnet.md) | Casts an expression to a subnet | `subnet("1.2.3.4/16")`
-[`time`](functions/time.md) | Casts an expression to a time value | `time("2020-03-15")`
-[`duration`](functions/duration.md) | Casts an expression to a duration value | `duration("1.34w")`
+| Function                            | Description                                | Example                |
+| :---------------------------------- | :----------------------------------------- | :--------------------- |
+| [`int`](functions/int.md)           | Casts an expression to a signed integer    | `int(-4.2)`            |
+| [`uint`](functions/uint.md)         | Casts an expression to an unsigned integer | `uint(4.2)`            |
+| [`float`](functions/float.md)       | Casts an expression to a float             | `float(42)`            |
+| [`string`](functions/string.md)     | Casts an expression to string              | `string(1.2.3.4)`      |
+| [`ip`](functions/ip.md)             | Casts an expression to an IP               | `ip("1.2.3.4")`        |
+| [`subnet`](functions/subnet.md)     | Casts an expression to a subnet            | `subnet("1.2.3.4/16")` |
+| [`time`](functions/time.md)         | Casts an expression to a time value        | `time("2020-03-15")`   |
+| [`duration`](functions/duration.md) | Casts an expression to a duration value    | `duration("1.34w")`    |
 
 ### Transposition
 
-Function | Description | Example
-:--------|:-------------|:-------
-[`flatten`](functions/flatten.md) | Flattens nested data | `flatten(this)`
-[`unflatten`](functions/unflatten.md) | Unflattens nested structures | `unflatten(this)`
+| Function                              | Description                  | Example           |
+| :------------------------------------ | :--------------------------- | :---------------- |
+| [`flatten`](functions/flatten.md)     | Flattens nested data         | `flatten(this)`   |
+| [`unflatten`](functions/unflatten.md) | Unflattens nested structures | `unflatten(this)` |
 
 ## Runtime
 
-Function | Description | Example
-:--------|:-------------|:-------
-[`env`](functions/env.md) | Reads an environment variable | `env("PATH")`
-[`secret`](functions/secret.md) | Reads a secret from a store | `secret("PATH")`
+| Function                        | Description                   | Example          |
+| :------------------------------ | :---------------------------- | :--------------- |
+| [`env`](functions/env.md)       | Reads an environment variable | `env("PATH")`    |
+| [`secret`](functions/secret.md) | Reads a secret from a store   | `secret("PATH")` |

--- a/web/docs/tql2/functions.md
+++ b/web/docs/tql2/functions.md
@@ -161,8 +161,8 @@ but often resort to the method style when it is more idiomatic.
 | [`print_ndjson`](functions/print_ndjson.mdx) | Prints a record as NDJSON string              | `record.print_ndjson()` |
 | [`print_ssv`](functions/print_ssv.mdx)       | Prints a record as space separated values     | `record.print_ssv()`    |
 | [`print_tsv`](functions/print_tsv.mdx)       | Prints a record as tab separated values       | `record.print_tsv()`    |
-| [`print_yaml`](functions/print_yaml.md)      | Prints a value as a YAML document             | `record.print_yaml()`   |
 | [`print_xsv`](functions/print_xsv.md)        | Prints a record as delimited separated values | `record.print_tsv()`    |
+| [`print_yaml`](functions/print_yaml.md)      | Prints a value as a YAML document             | `record.print_yaml()`   |
 
 ## Time & Date
 

--- a/web/docs/tql2/functions/type_id.md
+++ b/web/docs/tql2/functions/type_id.md
@@ -1,6 +1,6 @@
 # type_id
 
-Retrieves the type of an expression.
+Retrieves the type id of an expression.
 
 ```tql
 type_id(x:any) -> string
@@ -8,7 +8,7 @@ type_id(x:any) -> string
 
 ## Description
 
-The `type_id` function returns the type of the given value `x`.
+The `type_id` function returns the type id of the given value `x`.
 
 ## Examples
 
@@ -21,3 +21,7 @@ from {x: type_id(1 + 3.2)}
 ```tql
 {x: "41615fdb30a38aaf"}
 ```
+
+## See also
+
+[`type_of`](type_of.md)

--- a/web/docs/tql2/functions/type_of.md
+++ b/web/docs/tql2/functions/type_of.md
@@ -1,0 +1,59 @@
+# type_of
+
+Retrieves the type definition of an expression.
+
+```tql
+type_of(x:any) -> record
+```
+
+## Description
+
+The `type_of` function returns the type definition of the given value `x`.
+
+:::warning Subject to change
+This function is designed for internal use of the Tenzir Platform and its output
+format is subject to change without notice.
+:::
+
+## Examples
+
+### Retrieve the type definition of a schema
+
+```tql
+from {x: 1, y: "2"}
+this = type_of(this)
+```
+
+```tql
+{
+  name: "tenzir.from",
+  kind: "record",
+  attributes: [],
+  state: {
+    fields: [
+      {
+        name: "x",
+        type: {
+          name: null,
+          kind: "int64",
+          attributes: [],
+          state: null,
+        },
+      },
+      {
+        name: "y",
+        type: {
+          name: null,
+          kind: "string",
+          attributes: [],
+          state: null,
+        },
+      },
+    ],
+  },
+}
+```
+
+## See also
+
+[`type_id`](type_id.md)

--- a/web/openapi/openapi.yaml
+++ b/web/openapi/openapi.yaml
@@ -612,6 +612,11 @@ paths:
                   example: 200ms
                   default: 5s
                   description: The maximum amount of time spent on the request. Hitting the timeout is not an error. The timeout must not be greater than 10 seconds.
+                schema:
+                  type: string
+                  example: exact
+                  default: legacy
+                  description: The output format in which schemas are represented. Must be one of "legacy", "exact", or "never". Use "exact" to switch to a type representation matching Tenzir's type system exactly, and "never" to omit schema schema definitions from the output entirely.
       responses:
         200:
           description: Success.


### PR DESCRIPTION
The type definitions returned by `/serve` and `measure _definition=true` were tailor-made for the Explorer in the Tenzir Platform, and returned a simplified version of Tenzir's type system.

Planned changes to the Explorer require revisiting these simplifications, as the full schema definition is now required in the Tenzir Platform. To enable this in a backwards-compatible way, this PR makes three changes:
1. It introduces a new `type_of(x: any) -> record` function that returns the exact type definition of a TQL expression. For example, `this = type_of(this)` replaces an event with its exact schema definition.
2. It introduces a hidden option `_exact_definition=bool` to the `measure` operator, which always overrules the existing `_definition=bool?  option and causes the operator to return the exact schema definition in place of the schema name (or simplified definition).
3. It introduces a new option `schema: legacy|exact|never` to the `/serve` API endpoint, defaulting to `legacy`. Pass `exact` to render the exact schema definitions instead, and pass `never` to omit the schema definitions entirely.