### PR TITLE
Drop tests for EOL ubuntu releases

### DIFF
--- a/.github/workflows/installer.yaml
+++ b/.github/workflows/installer.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [ubuntu-22.04, ubuntu-latest]
+        image: [ubuntu-22.04, ubuntu-24.04]
         tag: ["latest", "main"]
     runs-on: ${{ matrix.image }}
     env:
@@ -41,8 +41,8 @@ jobs:
         image:
           [
             "ubuntu:22.04",
-            "ubuntu:23.04",
-            "ubuntu:23.10",
+            "ubuntu:24.04",
+            "ubuntu:24.10",
             "debian:11",
             "debian:12",
           ]


### PR DESCRIPTION
Should fix the nightly installer CI test.