### PR TITLE
docs: fix logo dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 <a target="_blank" href="https://docs.tenzir.com">
 <p align="center">
-<img src="./web/static/img/tenzir-white.svg#gh-dark-mode-only" width="60%" alt="Tenzir">
-<img src="./web/static/img/tenzir-black.svg#gh-light-mode-only" width="60%" alt="Tenzir">
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="./web/static/img/tenzir-white.svg">
+  <source media="(prefers-color-scheme: light)" srcset="./web/static/img/tenzir-black.svg">
+  <img alt="Tenzir" src="./web/static/img/tenzir-white.svg">
+</picture>
 </p>
 </a>
 


### PR DESCRIPTION
This PR fixes the automatic dark mode functionality of the Tenzir logo in README.md.

Previously this was implemented using [anchor tags](https://github.blog/changelog/2021-11-24-specify-theme-context-for-images-in-markdown/) however this doesn't work anymore. It now uses a picture tag and two sources for dark and light mode respectively.

I recommend applying this fix to all Tenzir repositories. There's also a global GitHub-wide issue with spaces being replaced by linked underscores, see GitHub community board for more information.

_See also:_
- [Changing README.md image display conditional to GitHub light-mode / dark-mode](https://stackoverflow.com/a/70200610)
- [[BUG] Badges in README files show underlined spaces](https://github.com/orgs/community/discussions/154640)