### PR TITLE
Manually fix up the plugin sources

### DIFF
--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -1,5 +1,5 @@
 {
-  "hash": "sha256-Anwsvzrj9WXIw80qhrBwN1li1i72kGVn97kifTJOrA4=",
+  "hash": "sha256-4V7mQD/cJCjtU+evvHwJAs06t7pfUgDbsRgYsdvQXAs=",
   "name": "tenzir-plugins.tar.gz",
-  "url": "https://github.com/tenzir/tenzir-plugins/archive/d99ef378d0d4844e1809944b8af6056d1c93f185.tar.gz"
+  "url": "https://github.com/tenzir/tenzir-plugins/archive/a9eaa60d900df88bb8f3edafcf0218abecc6fa9e.tar.gz"
 }


### PR DESCRIPTION
CI is broken on main as the CI job that updates the source.json file failed for some reason we have yet to investigate. This fixes it up manually.