### PR TITLE
Hardcode the fluent-bit page size to 24576

### DIFF
--- a/changelog/next/bug-fixes/5084--fix-fluent-bit-stacks.md
+++ b/changelog/next/bug-fixes/5084--fix-fluent-bit-stacks.md
@@ -1,0 +1,2 @@
+The `from_fluent_bit` and `to_fluent_bit` operators no longer crash when trying
+to handle very large payloads.

--- a/nix/fluent-bit/default.nix
+++ b/nix/fluent-bit/default.nix
@@ -117,6 +117,7 @@ stdenv.mkDerivation rec {
       "-DFLB_RELEASE=ON"
       "-DFLB_DEBUG=OFF"
       "-DFLB_PREFER_SYSTEM_LIBS=Yes"
+      "-DFLB_CORO_STACK_SIZE=24576"
     ]
     ++ lib.optionals stdenv.cc.isClang [
       # FLB_SECURITY causes bad linker options for Clang to be set.


### PR DESCRIPTION
This is larger then the page size of all currently supported platforms, with apple silicon being the biggest at 16K.

The specific value 24576 is coming from the fluent-bit configuration docs, claiming it to be the default value. The code must have gone out of sync from the docs, so we now set it explicitly.

This change fixes a segfault when the fluent-bit engine is rebatching large-ish events in its internal format. For example

    plugins
    repeat 1000
    to_fluent_bit "http", fluent_bit_options={
        host: "localhost",
        format: "json_lines"
    }

would reliably crash before this change.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made in the pull request description in a way that
   is consumable by everyone, not just developers who know the context of the
   change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://docs.tenzir.com/next/contribute/changelog
3. Provide instructions for the reviewer.
4. Remove this comment so it doesn't show up in the merge commit.
-->
