### PR TITLE
Implement `if … else` expressions and short-circuiting for `and` / `or`

### DIFF
--- a/changelog/next/bug-fixes/5085--and-or-short-circuit.md
+++ b/changelog/next/bug-fixes/5085--and-or-short-circuit.md
@@ -1,0 +1,3 @@
+The binary operators `and` and `or` no longer evaluate their right-hand side
+when not necessary. For example, `where this.has("foo") and foo == 42` no longer
+emits a warning when `foo` does not exist.

--- a/changelog/next/bug-fixes/5085--and-or-short-circuit.md
+++ b/changelog/next/bug-fixes/5085--and-or-short-circuit.md
@@ -1,3 +1,3 @@
-The binary operators `and` and `or` no longer evaluate their right-hand side
-when not necessary. For example, `where this.has("foo") and foo == 42` no longer
-emits a warning when `foo` does not exist.
+The binary operators `and` and `or` now skip evaluating their right-hand side
+when not necessary. For example, `where this.has("foo") and foo == 42` now
+avoids emitting a warning when `foo` does not exist.

--- a/changelog/next/features/5085--inline-if-else.md
+++ b/changelog/next/features/5085--inline-if-else.md
@@ -1,0 +1,3 @@
+Tenzir now supports inline `if … else` expressions in the form `foo if pred`,
+which returns `foo` if `pred` evaluates to `true`, or `null` otherwise, and `foo
+if pred else bar`, which instead of falling back to `null` falls back to `bar`.

--- a/libtenzir/include/tenzir/multi_series.hpp
+++ b/libtenzir/include/tenzir/multi_series.hpp
@@ -102,6 +102,11 @@ public:
     parts_.push_back(std::move(s));
   }
 
+  auto append(multi_series s) -> void {
+    parts_.insert(parts_.end(), std::make_move_iterator(s.parts_.begin()),
+                  std::make_move_iterator(s.parts_.end()));
+  }
+
   // What to do on join conflict in `to_series`
   enum class to_series_strategy {
     // Fail the join

--- a/libtenzir/include/tenzir/tql2/ast.hpp
+++ b/libtenzir/include/tenzir/tql2/ast.hpp
@@ -349,7 +349,7 @@ struct unpack {
 };
 
 TENZIR_ENUM(binary_op, add, sub, mul, div, eq, neq, gt, geq, lt, leq, and_, or_,
-            in);
+            in, if_, else_);
 
 struct binary_expr {
   binary_expr() = default;

--- a/libtenzir/src/tql2/ast.cpp
+++ b/libtenzir/src/tql2/ast.cpp
@@ -172,7 +172,8 @@ auto to_operand(const ast::expression& x) -> std::optional<operand> {
     });
 }
 
-auto to_duration_comparable(const ast::expression& e) -> std::optional<operand> {
+auto to_duration_comparable(const ast::expression& e)
+  -> std::optional<operand> {
   if (auto field = to_field_extractor(e)) {
     return std::move(field).value();
   }
@@ -260,6 +261,8 @@ auto split_legacy_expression(const ast::expression& x)
           case ast::binary_op::sub:
           case ast::binary_op::mul:
           case ast::binary_op::div:
+          case ast::binary_op::if_:
+          case ast::binary_op::else_:
             return {};
           case ast::binary_op::eq:
             return relational_operator::equal;

--- a/libtenzir/src/tql2/eval_binary.cpp
+++ b/libtenzir/src/tql2/eval_binary.cpp
@@ -610,7 +610,6 @@ struct EvalBinOp<ast::binary_op::in, L, list_type> {
   }
 };
 
-// TODO rename to left/right
 template <ast::binary_op Op>
 auto eval_op(evaluator& self, const ast::binary_expr& x) -> multi_series {
   TENZIR_ASSERT(x.op.inner == Op);

--- a/libtenzir/src/tql2/eval_binary.cpp
+++ b/libtenzir/src/tql2/eval_binary.cpp
@@ -720,9 +720,7 @@ auto eval_and_or(evaluator& self, const ast::binary_expr& x) -> multi_series {
       range_offset = i;
       range_current = not range_current;
     }
-    if (range_offset != length) {
-      append_until(length);
-    }
+    append_until(length);
     TENZIR_ASSERT(result.length() == length);
     return result;
   });
@@ -775,9 +773,7 @@ auto eval_if(evaluator& self, const ast::binary_expr& x) -> multi_series {
       range_offset = i;
       range_current = not range_current;
     }
-    if (range_offset != length) {
-      append_until(length);
-    }
+    append_until(length);
     TENZIR_ASSERT(result.length() == length);
     return result;
   });
@@ -818,9 +814,7 @@ auto eval_else(evaluator& self, const ast::binary_expr& x) -> multi_series {
       range_offset = i;
       range_current = not range_current;
     }
-    if (range_offset != length) {
-      append_until(length);
-    }
+    append_until(length);
     TENZIR_ASSERT(result.length() == length);
     return result;
   });

--- a/libtenzir/src/tql2/eval_impl.cpp
+++ b/libtenzir/src/tql2/eval_impl.cpp
@@ -425,13 +425,19 @@ auto evaluator::eval(const ast::expression& x) -> multi_series {
 }
 
 auto evaluator::input_or_throw(into_location location) -> const table_slice& {
-  if (not input_) {
-    diagnostic::error("expected a constant expression")
-      .primary(location)
-      .emit(ctx_);
-    throw failure::promise();
-  }
-  return *input_;
+  return input_.match(
+    [&](const table_slice* input) -> const table_slice& {
+      if (not input) {
+        diagnostic::error("expected a constant expression")
+          .primary(location)
+          .emit(ctx_);
+        throw failure::promise();
+      }
+      return *input;
+    },
+    [](const table_slice& input) -> const table_slice& {
+      return input;
+    });
 }
 
 namespace {

--- a/libtenzir/src/tql2/parser.cpp
+++ b/libtenzir/src/tql2/parser.cpp
@@ -32,9 +32,9 @@ auto precedence(unary_op x) -> int {
   switch (x) {
     case pos:
     case neg:
-      return 7;
+      return 9;
     case not_:
-      return 3;
+      return 5;
   };
   TENZIR_UNREACHABLE();
 }
@@ -44,10 +44,10 @@ auto precedence(binary_op x) -> int {
   switch (x) {
     case mul:
     case div:
-      return 6;
+      return 8;
     case add:
     case sub:
-      return 5;
+      return 7;
     case gt:
     case geq:
     case lt:
@@ -55,10 +55,14 @@ auto precedence(binary_op x) -> int {
     case eq:
     case neq:
     case in:
-      return 4;
+      return 6;
     case and_:
-      return 2;
+      return 4;
     case or_:
+      return 3;
+    case if_:
+      return 2;
+    case else_:
       return 1;
   }
   TENZIR_UNREACHABLE();
@@ -790,8 +794,8 @@ public:
     }
   }
 
-  auto parse_function_call(std::optional<ast::expression> subject,
-                           entity fn) -> function_call {
+  auto parse_function_call(std::optional<ast::expression> subject, entity fn)
+    -> function_call {
     expect(tk::lpar);
     auto scope = ignore_newlines(true);
     auto args = std::vector<ast::expression>{};
@@ -854,6 +858,8 @@ public:
     X(and_, and_);
     X(or_, or_);
     X(in, in);
+    X(if_, if_);
+    X(else_, else_);
 #undef X
     return std::nullopt;
   }

--- a/tenzir/bats/data/reference/expression/test_list_construction/step_00.ref
+++ b/tenzir/bats/data/reference/expression/test_list_construction/step_00.ref
@@ -110,26 +110,3 @@ warning: type clash in list, using `null` instead
 16 |   x14: [[{x: 123}], [{x: "abc"}]],
    |                     ~~~~~~~~~~~~ 
    |
-
-warning: type clash in list, using `null` instead
-  --> /dev/stdin:14:13
-   |
-14 |   x12: [{}, []],
-   |             ~~ 
-   |
-   = note: expected `record` but got `list`
-
-warning: type clash in list, using `null` instead
-  --> /dev/stdin:15:14
-   |
-15 |   x13: [123, "abc"],
-   |              ~~~~~ 
-   |
-   = note: expected `int64` but got `string`
-
-warning: type clash in list, using `null` instead
-  --> /dev/stdin:16:21
-   |
-16 |   x14: [[{x: 123}], [{x: "abc"}]],
-   |                     ~~~~~~~~~~~~ 
-   |

--- a/tenzir/tests/exec/binop/and.tql
+++ b/tenzir/tests/exec/binop/and.tql
@@ -1,0 +1,11 @@
+from {
+  "false_and_false": false and false,
+  "false_and_null": false and null,
+  "false_and_true": false and true,
+  "null_and_false": null and false,
+  "null_and_null": null and null,
+  "null_and_true": null and true,
+  "true_and_false": true and false,
+  "true_and_null": true and null,
+  "true_and_true": true and true,
+}

--- a/tenzir/tests/exec/binop/and.txt
+++ b/tenzir/tests/exec/binop/and.txt
@@ -1,0 +1,11 @@
+{
+  false_and_false: false,
+  false_and_null: false,
+  false_and_true: false,
+  null_and_false: false,
+  null_and_null: null,
+  null_and_true: null,
+  true_and_false: false,
+  true_and_null: null,
+  true_and_true: true,
+}

--- a/tenzir/tests/exec/binop/else.tql
+++ b/tenzir/tests/exec/binop/else.tql
@@ -1,5 +1,5 @@
 from {
-  "true_else_true": false else false,
+  "false_else_false": false else false,
   "false_else_null": false else null,
   "false_else_true": false else true,
   "null_else_false": null else false,

--- a/tenzir/tests/exec/binop/else.tql
+++ b/tenzir/tests/exec/binop/else.tql
@@ -1,0 +1,11 @@
+from {
+  "true_else_true": false else false,
+  "false_else_null": false else null,
+  "false_else_true": false else true,
+  "null_else_false": null else false,
+  "null_else_null": null else null,
+  "null_else_true": null else true,
+  "true_else_false": true else false,
+  "true_else_null": true else null,
+  "true_else_true": true else true,
+}

--- a/tenzir/tests/exec/binop/else.txt
+++ b/tenzir/tests/exec/binop/else.txt
@@ -1,5 +1,5 @@
 {
-  true_else_true: true,
+  false_else_false: false,
   false_else_null: false,
   false_else_true: false,
   null_else_false: false,
@@ -7,4 +7,5 @@
   null_else_true: true,
   true_else_false: true,
   true_else_null: true,
+  true_else_true: true,
 }

--- a/tenzir/tests/exec/binop/else.txt
+++ b/tenzir/tests/exec/binop/else.txt
@@ -1,0 +1,10 @@
+{
+  true_else_true: true,
+  false_else_null: false,
+  false_else_true: false,
+  null_else_false: false,
+  null_else_null: null,
+  null_else_true: true,
+  true_else_false: true,
+  true_else_null: true,
+}

--- a/tenzir/tests/exec/binop/if.tql
+++ b/tenzir/tests/exec/binop/if.tql
@@ -1,5 +1,5 @@
 from {
-  "true_if_true": false if false,
+  "false_if_false": false if false,
   "false_if_null": false if null,
   "false_if_true": false if true,
   "null_if_false": null if false,

--- a/tenzir/tests/exec/binop/if.tql
+++ b/tenzir/tests/exec/binop/if.tql
@@ -1,0 +1,11 @@
+from {
+  "true_if_true": false if false,
+  "false_if_null": false if null,
+  "false_if_true": false if true,
+  "null_if_false": null if false,
+  "null_if_null": null if null,
+  "null_if_true": null if true,
+  "true_if_false": true if false,
+  "true_if_null": true if null,
+  "true_if_true": true if true,
+}

--- a/tenzir/tests/exec/binop/if.txt
+++ b/tenzir/tests/exec/binop/if.txt
@@ -1,0 +1,30 @@
+{
+  true_if_true: true,
+  false_if_null: null,
+  false_if_true: false,
+  null_if_false: null,
+  null_if_null: null,
+  null_if_true: null,
+  true_if_false: null,
+  true_if_null: null,
+}
+warning: expected `bool`, but got `null`
+ --> exec/binop/if.tql:3:29
+  |
+3 |   "false_if_null": false if null,
+  |                             ~~~~ 
+  |
+
+warning: expected `bool`, but got `null`
+ --> exec/binop/if.tql:6:27
+  |
+6 |   "null_if_null": null if null,
+  |                           ~~~~ 
+  |
+
+warning: expected `bool`, but got `null`
+ --> exec/binop/if.tql:9:27
+  |
+9 |   "true_if_null": true if null,
+  |                           ~~~~ 
+  |

--- a/tenzir/tests/exec/binop/if.txt
+++ b/tenzir/tests/exec/binop/if.txt
@@ -1,5 +1,5 @@
 {
-  true_if_true: true,
+  false_if_false: null,
   false_if_null: null,
   false_if_true: false,
   null_if_false: null,
@@ -7,6 +7,7 @@
   null_if_true: null,
   true_if_false: null,
   true_if_null: null,
+  true_if_true: true,
 }
 warning: expected `bool`, but got `null`
  --> exec/binop/if.tql:3:29

--- a/tenzir/tests/exec/binop/or.tql
+++ b/tenzir/tests/exec/binop/or.tql
@@ -1,0 +1,11 @@
+from {
+  "false_or_false": false or false,
+  "false_or_null": false or null,
+  "false_or_true": false or true,
+  "null_or_false": null or false,
+  "null_or_null": null or null,
+  "null_or_true": null or true,
+  "true_or_false": true or false,
+  "true_or_null": true or null,
+  "true_or_true": true or true,
+}

--- a/tenzir/tests/exec/binop/or.txt
+++ b/tenzir/tests/exec/binop/or.txt
@@ -1,0 +1,11 @@
+{
+  false_or_false: false,
+  false_or_null: null,
+  false_or_true: true,
+  null_or_false: null,
+  null_or_null: null,
+  null_or_true: true,
+  true_or_false: true,
+  true_or_null: true,
+  true_or_true: true,
+}

--- a/web/docs/tql2/language/expressions.md
+++ b/web/docs/tql2/language/expressions.md
@@ -346,7 +346,7 @@ precedence, ordered from highest to lowest.
 | `not`                                  |
 | `and`                                  | left                           |
 | `or`                                   | left                           |
-| `if`                                   | left                           |
+| `if`                                   | right                          |
 | `else`                                 | left                           |
 
 ## Constant Expressions

--- a/web/docs/tql2/language/expressions.md
+++ b/web/docs/tql2/language/expressions.md
@@ -70,6 +70,7 @@ append `.<name>` to an expression that returns a record.
 from { my_field: 42, top_level: { nested: 0 } }
 my_field = top_level.nested
 ```
+
 ```tql
 { my_field: 0, top_level: { nested: 0 } }
 ```
@@ -108,11 +109,11 @@ The numeric types `int64`, `uint64`, and `double` support all arithmetic
 operations. If the types of the left- and right-hand side differ, the return
 type will be the one capable of holding the most values.
 
-Operation | Result
-|:---|:---
-`int64` + `int64` | `int64`
-`int64` + `uint64` | `int64`
-`int64` + `double` | `double`
+| Operation          | Result   |
+| :----------------- | :------- |
+| `int64` + `int64`  | `int64`  |
+| `int64` + `uint64` | `int64`  |
+| `int64` + `double` | `double` |
 
 The same applies to the other arithmetic operators: `-`, `*`, and `/`.
 
@@ -124,15 +125,15 @@ produces `null`.
 
 The `time` and `duration` types support specific operations:
 
-Operation | Result
-|:---|:---
-`time + duration` | `time`
-`time - duration` | `time`
-`time - time` | `duration`
-`duration + duration` | `duration`
-`duration / duration` | `double`
-`duration * number` | `duration`
-`duration / number` | `duration`
+| Operation             | Result     |
+| :-------------------- | :--------- |
+| `time + duration`     | `time`     |
+| `time - duration`     | `time`     |
+| `time - time`         | `duration` |
+| `duration + duration` | `duration` |
+| `duration / duration` | `double`   |
+| `duration * number`   | `duration` |
+| `duration / number`   | `duration` |
 
 ### String Operations
 
@@ -141,6 +142,7 @@ Concatenate strings using the `+` operator:
 ```tql
 result = "Hello " + "World!"
 ```
+
 ```tql
 { result: "Hello World!" }
 ```
@@ -151,6 +153,7 @@ Check if a string contains a substring using `in`:
 a = "World" in "Hello World"
 b = "Planet" in "Hello World"
 ```
+
 ```tql
 { a: true, b: false }
 ```
@@ -182,9 +185,9 @@ where timestamp > now() - 1d and severity == "alert"
 
 Use the `in` operator to check if a value is within a list or range.
 
-* `T in list<T>` checks if a list contains a value.
-* `ip in subnet` checks if an IP is in a given subnet.
-* `subnet in subnet` checks if one subnet is a subset of another.
+- `T in list<T>` checks if a list contains a value.
+- `ip in subnet` checks if an IP is in a given subnet.
+- `subnet in subnet` checks if one subnet is a subset of another.
 
 To negate, use `not (Value in Range)` or `Value not in Range`.
 
@@ -199,6 +202,7 @@ element.
 let $my_list = ["Hello", "World"]
 result = my_list[0]
 ```
+
 ```tql
 { result: "Hello" }
 ```
@@ -212,6 +216,7 @@ spaces or depends on a runtime value, use an indexing expression:
 let $answers = { "the ultimate question": 42 }
 result = $answers["the ultimate question"]
 ```
+
 ```tql
 { result: 42 }
 ```
@@ -221,6 +226,7 @@ let $severity_to_level = { "ERROR": 1, "WARNING": 2, "INFO": 3 }
 from { severity: "ERROR" }
 level = $severity_to_level[severity]
 ```
+
 ```tql
 {
   severity: "ERROR",
@@ -252,6 +258,7 @@ unique, and later values overwrite earlier ones.
 ```tql title="Lifting nested fields"
 from { nested: { severity: 4, type: "source" } }
 ```
+
 ```tql
 {
   nested: { severity: 4, type: "source" },
@@ -293,18 +300,22 @@ let $pi = 3
 from { radius = 1 }
 area = radius * radius * pi
 ```
+
 ```tql
 { radius: 1, area: 3 }
 ```
 
-## `if` Expression
-
-:::note
-This functionality is not implemented yet.
-:::
+## `if` and `else` Expressions
 
 The `if` keyword can also be used in an expression context, e.g.,
-`if foo == 42 { "yes" } else { "no" }`.
+`"yes" if foo == 42 else "no"`.
+
+The `else` keyword may be omitted, returning `null` instead if the predicate is
+false, e.g., `"yes" if foo == 42`.
+
+The `else` keyword may also be used standalone to provide a fallback value,
+e.g., `foo else "fallback"` returns `"fallback"` if `foo == null`, and returns
+`foo` otherwise.
 
 ## `match` Expression
 
@@ -323,18 +334,20 @@ Expressions like `1 - 2 * 3 + 4` follow precedence and associativity rules. The
 expression evaluates as `(1 - (2 * 3)) + 4`. The following table lists
 precedence, ordered from highest to lowest.
 
-Expression          | Associativity
---------------------|--------------
-method call         |
-field access        |
-`[]`-indexing       |
-unary `+`, `-`      |
-`*`, `/`            | left
-binary `+`, `-`     | left
-`==`, `!=`, `>`, `<`, `>=`, `<=`, `in` | left (will be changed to none)
-`not`               |
-`and`               | left
-`or`                | left
+| Expression                             | Associativity                  |
+| -------------------------------------- | ------------------------------ |
+| method call                            |
+| field access                           |
+| `[]`-indexing                          |
+| unary `+`, `-`                         |
+| `*`, `/`                               | left                           |
+| binary `+`, `-`                        | left                           |
+| `==`, `!=`, `>`, `<`, `>=`, `<=`, `in` | left (will be changed to none) |
+| `not`                                  |
+| `and`                                  | left                           |
+| `or`                                   | left                           |
+| `if`                                   | left                           |
+| `else`                                 | left                           |
 
 ## Constant Expressions
 

--- a/web/docs/tql2/operators/metrics.md
+++ b/web/docs/tql2/operators/metrics.md
@@ -20,6 +20,7 @@ tenzir:
   retention:
     metrics: 7d
 ```
+
 :::
 
 ### `name: string (optional)`
@@ -394,6 +395,19 @@ TCP connection.
 
 ## Examples
 
+### Sort pipelines by total ingress in bytes
+
+```tql
+metrics "pipeline"
+summarize pipeline_id, ingress=sum(ingress.bytes if not ingress.internal)
+sort -ingress
+```
+
+```tql
+{pipeline_id: "demo-node/m57-suricata", ingress: 59327586}
+{pipeline_id: "demo-node/m57-zeek", ingress: 43291764}
+```
+
 ### Show the CPU usage over the last hour
 
 ```tql
@@ -434,7 +448,8 @@ metrics "operator"
 where timestamp > now() - 1week
 where source and not hidden
 timestamp = floor(timestamp, 1day)
-summarize timestamp, bytes=sum(output.approx_bytes)```
+summarize timestamp, bytes=sum(output.approx_bytes)
+```
 
 ```tql
 {timestamp: 2023-11-08T00:00:00.000000, bytes: 79927223}


### PR DESCRIPTION
This PR implements `if` and `else` expressions. They work just like the short-hand form in Python.

The rules are very simple:
- `value if true` => `value`
- `value if false` => `null`
- `value if null` => `null` and warning
- `value else fallback` => `value`
- `null else fallback` => `null`

These can be combined:
- `value if true else fallback` => `value`
- `value if false else fallback` => `fallback`
- `value if null else fallback` => `fallback` and warning

This is pretty useful. For example, `if … else` combines nicely with the new `metrics "pipeline"`:

```
metrics "pipeline"
summarize (
  pipeline_id,
  ingress=sum(ingress.bytes / ingress.duration.count_seconds() if not ingress.internal else 0.0),
  from_node=sum(ingress.bytes / ingress.duration.count_seconds() if ingress.internal else 0.0),
  egress=sum(egress.bytes / egress.duration.count_seconds() if not egress.internal else 0.0),
  to_node=sum(egress.bytes / egress.duration.count_seconds() if egress.internal else 0.0),
)
```

This returns an overview of the ingress and egress of all pipelines, but additionally separates out node-internal ingress and egress. The latter was not easily possible before.

Note that `else` can also be used standalone, and is effectively a superior version of the `otherwise` function. That is, `foo.otherwise(bar)` is now better written as `foo else bar`. We may want to consider deprecating `otherwise`, or potentially even introducing a `??` operator as an alias for `else`. This needs further discussion.

While implementing `if … else`, I stumbled upon the lack of short-circuiting for `and` and `or` expressions. Previously, `where this.has("foo") and foo == 42` could warn that `foo` did not exist. That no longer happens.