### PR TITLE
Remove 20k element limits from `data_builder`

### DIFF
--- a/changelog/next/bug-fixes/5091--data-builder-limit.md
+++ b/changelog/next/bug-fixes/5091--data-builder-limit.md
@@ -1,0 +1,2 @@
+We removed the limit of 20,000 elements in lists and records for `read_*`
+operators and `parse_*` functions.

--- a/libtenzir/include/tenzir/data_builder.hpp
+++ b/libtenzir/include/tenzir/data_builder.hpp
@@ -303,8 +303,12 @@ private:
   ///             to ensure that field types actually match it.
   auto append_to_signature(signature_type& sig, class data_builder& rb,
                            const tenzir::record_type* seed) -> void;
+
   /// @brief marks all fields in the record as dead.
   auto clear() -> void;
+
+  /// @brief reduces the number of elements to the limit
+  auto prune() -> void;
 
   // Record entry. This contains a string for the key and a field.
   // Its defined out of line because node_object cannot be defined at this point.
@@ -399,8 +403,12 @@ private:
   ///             to ensure that field types actually match it.
   auto append_to_signature(signature_type& sig, class data_builder& rb,
                            const tenzir::list_type* seed) -> void;
+
   /// @brief marks the list and all its contents as dead, resetting its size to 0
   auto clear() -> void;
+
+  /// @brief reduces the number of elements to the limit
+  auto prune() -> void;
 
   // gets all alive nodes, i.e. all nodes with indices in `[0, first_dead_idx_)`
   auto alive_elements() -> std::span<node_object>;
@@ -516,6 +524,12 @@ private:
 struct node_record::entry_type {
   std::string key;
   node_object value;
+
+  /// This must exist for the `data_.resize()` call, but is guaranteed by the
+  /// surrounding logic to never be called.
+  entry_type() {
+    TENZIR_UNREACHABLE();
+  }
 
   entry_type(std::string_view name) : key{name} {
   }


### PR DESCRIPTION
These arbitrary limits were put there during development to prevent unbounded memory consumption and retention by the `data_builder`, as its internal structure would be kept around (for both optimization and batching reasons) for the entirety of a pipeline.

With this change, the limit is gone, and instead the memory is released after every event, if it exceeded the size limit.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made in the pull request description in a way that
   is consumable by everyone, not just developers who know the context of the
   change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://docs.tenzir.com/next/contribute/changelog
3. Provide instructions for the reviewer.
4. Remove this comment so it doesn't show up in the merge commit.
-->
