### PR TITLE
Remove unused `tenzir.node-id`  option

### DIFF
--- a/libtenzir/include/tenzir/node.hpp
+++ b/libtenzir/include/tenzir/node.hpp
@@ -34,12 +34,12 @@ struct node_state {
     -> const handler_and_endpoint&;
 
   /// The REST endpoint handlers for this node. Spawned on demand.
-  std::unordered_map<std::string, handler_and_endpoint> rest_handlers = {};
+  std::unordered_map<std::string, handler_and_endpoint> rest_handlers;
 
   // -- actor facade -----------------------------------------------------------
 
   /// The name of the NODE actor.
-  constexpr static inline auto name = "node";
+  constexpr static auto name = "node";
 
   /// A pointer to the NODE actor handle.
   node_actor::pointer self = {};
@@ -47,26 +47,26 @@ struct node_state {
   // -- member types -----------------------------------------------------------
 
   /// Stores the base directory for persistent state.
-  std::filesystem::path dir = {};
+  std::filesystem::path dir;
 
   /// The component registry.
   component_registry registry = {};
 
   /// The list of component plugin actors in the order that they were spawned.
-  std::vector<std::string> ordered_components = {};
+  std::vector<std::string> ordered_components;
 
   /// Components that are still alive for lifetime-tracking.
-  std::set<std::pair<caf::actor_addr, std::string>> alive_components = {};
+  std::set<std::pair<caf::actor_addr, std::string>> alive_components;
 
   /// Map from component actor address to name for better error messages. Never
   /// cleared.
-  std::unordered_map<caf::actor_addr, std::string> component_names = {};
+  std::unordered_map<caf::actor_addr, std::string> component_names;
 
   /// Counters for multi-instance components.
-  std::unordered_map<std::string, uint64_t> label_counters = {};
+  std::unordered_map<std::string, uint64_t> label_counters;
 
   /// Builder for API metrics.
-  std::unordered_map<std::string, series_builder> api_metrics_builders = {};
+  std::unordered_map<std::string, series_builder> api_metrics_builders;
 
   /// Startup timestamp.
   time start_time = time::clock::now();
@@ -76,14 +76,13 @@ struct node_state {
 
   /// Weak handles to remotely spawned and monitored exec ndoes for cleanup on
   /// node shutdown.
-  std::unordered_set<caf::actor_addr> monitored_exec_nodes = {};
+  std::unordered_set<caf::actor_addr> monitored_exec_nodes;
 };
 
 /// Spawns a node.
 /// @param self The actor handle
-/// @param name The unique name of the node.
 /// @param dir The directory where to store persistent state.
-node_actor::behavior_type node(node_actor::stateful_pointer<node_state> self,
-                               std::string name, std::filesystem::path dir);
+node_actor::behavior_type
+node(node_actor::stateful_pointer<node_state> self, std::filesystem::path dir);
 
 } // namespace tenzir

--- a/libtenzir/include/tenzir/spawn_node.hpp
+++ b/libtenzir/include/tenzir/spawn_node.hpp
@@ -11,7 +11,6 @@
 #include "tenzir/fwd.hpp"
 
 #include "tenzir/actors.hpp"
-#include "tenzir/data.hpp"
 #include "tenzir/scope_linked.hpp"
 
 namespace tenzir {
@@ -20,6 +19,7 @@ namespace tenzir {
 /// `self` should be equipped to handle (atom::signal, int)
 /// messages to orchestrate a graceful termination if it runs
 /// a receive-while/until loop after this call.
-caf::expected<scope_linked<node_actor>> spawn_node(caf::scoped_actor& self);
+auto spawn_node(caf::scoped_actor& self)
+  -> caf::expected<scope_linked<node_actor>>;
 
 } // namespace tenzir

--- a/libtenzir/src/spawn_node.cpp
+++ b/libtenzir/src/spawn_node.cpp
@@ -8,13 +8,10 @@
 
 #include "tenzir/spawn_node.hpp"
 
-#include "tenzir/concept/parseable/tenzir/time.hpp"
-#include "tenzir/concept/parseable/to.hpp"
 #include "tenzir/defaults.hpp"
 #include "tenzir/detail/pid_file.hpp"
 #include "tenzir/logger.hpp"
 #include "tenzir/node.hpp"
-#include "tenzir/plugin.hpp"
 #include "tenzir/scope_linked.hpp"
 
 #include <caf/actor_registry.hpp>
@@ -26,15 +23,14 @@
 #include <string>
 #include <system_error>
 #include <unistd.h>
-#include <vector>
 
 namespace tenzir {
 
-caf::expected<scope_linked<node_actor>> spawn_node(caf::scoped_actor& self) {
+auto spawn_node(caf::scoped_actor& self)
+  -> caf::expected<scope_linked<node_actor>> {
   using namespace std::string_literals;
   const auto& opts = content(self->system().config());
   // Fetch values from config.
-  auto id = get_or(opts, "tenzir.node-id", defaults::node_id.data());
   auto db_dir
     = get_or(opts, "tenzir.state-directory", defaults::state_directory.data());
   std::error_code err{};
@@ -81,8 +77,10 @@ caf::expected<scope_linked<node_actor>> spawn_node(caf::scoped_actor& self) {
   self->mail(atom::subscribe_v).send(signal_reflector);
   // Wipe the contents of the old cache directory.
   {
-    auto cache_directory = get_if<std::string>(&opts, "tenzir.cache-directory");
-    if (cache_directory && std::filesystem::exists(*cache_directory)) {
+    const auto* cache_directory
+      = get_if<std::string>(&opts, "tenzir.cache-directory");
+    if (cache_directory != nullptr
+        && std::filesystem::exists(*cache_directory)) {
       for (auto const& item :
            std::filesystem::directory_iterator{*cache_directory}) {
         std::filesystem::remove_all(item.path(), err);
@@ -94,9 +92,7 @@ caf::expected<scope_linked<node_actor>> spawn_node(caf::scoped_actor& self) {
     }
   }
   // Spawn the node.
-  TENZIR_DEBUG("{} spawns local node: {}", __func__, id);
-  // Pointer to the root command to node.
-  auto actor = self->spawn(node, id, abs_dir);
+  auto actor = self->spawn(node, abs_dir);
   actor->attach_functor(
     [=, pid_file = std::move(pid_file),
      &system = self->system()](const caf::error&) -> caf::result<void> {

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -162,9 +162,6 @@ tenzir:
   # connector plugin.
   disable-plugins: []
 
-  # The unique ID of this node.
-  node-id: "node"
-
   # Forbid unsafe location overrides for pipelines with the 'local' and 'remote'
   # keywords, e.g., remotely reading from a file.
   no-location-overrides: false


### PR DESCRIPTION
This removes the `tenzir.node-id` option that was dead code, and additionally addresses all clang-tidy warnings in all node-related files.

I didn't bother adding a changelog entry as this option was never documented in the first place outside of the example config file, and as far as I can tell it's been dead code for years.