### PR TITLE
Check array validity before iterating

### DIFF
--- a/changelog/next/bug-fixes/5100--check-json-array-validity.md
+++ b/changelog/next/bug-fixes/5100--check-json-array-validity.md
@@ -1,0 +1,2 @@
+The `parse_json` function no longer crashes in case it encounters invalid
+arrays.

--- a/libtenzir/include/tenzir/json_parser.hpp
+++ b/libtenzir/include/tenzir/json_parser.hpp
@@ -118,8 +118,7 @@ public:
       case simdjson::ondemand::json_type::string:
         return parse_string(val, builder);
       case simdjson::ondemand::json_type::array: {
-        const auto success = parse_array(val.get_array().value_unsafe(),
-                                         builder.list(), depth + 1);
+        const auto success = parse_array(val, builder.list(), depth + 1);
         return success ? result::success : result::failure_with_write;
       }
       case simdjson::ondemand::json_type::object: {
@@ -205,8 +204,13 @@ private:
     return result::success;
   }
 
-  [[nodiscard]] auto parse_array(auto&& arr, auto builder, size_t depth)
+  [[nodiscard]] auto parse_array(auto&& val, auto builder, size_t depth)
     -> bool {
+    auto arr = val.get_array();
+    if (arr.error()) {
+      report_parse_err(val, "an array");
+      return false;
+    }
     auto written_once = false;
     for (auto element : arr) {
       if (element.error()) {


### PR DESCRIPTION
An oversight in the JSON parser caused it to try to enter incomplete arrays, causing segfaults with inputs as simple as
```
tenzir --tql2 'from {} | x = "[ ".parse_json()'
```
The change here adds the missing check.