### PR TITLE
Fix a stack-use-after-move in `save_tcp`

### DIFF
--- a/changelog/next/bug-fixes/5103--save-tcp.md
+++ b/changelog/next/bug-fixes/5103--save-tcp.md
@@ -1,0 +1,3 @@
+The `save_tcp` operator no longer panics or crashes on startup when it cannot
+connect to the provided hostname and port, and instead produces a helpful error
+message.


### PR DESCRIPTION
It's not save to issue a request from instantiate from the legacy saver API and using exec-node state in the corresponding response hnadler.

This rewrites `save_tcp` with the operator API, which as a byproduct fixes this problem, as we can now properly yield control to the exec node after issuing the request.