### PR TITLE
Fix panic in `head 0 | write_json arrays_of_objects=true`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,6 +14,7 @@ Checks: >
   -cppcoreguidelines-avoid-non-const-global-variables,
   -cppcoreguidelines-avoid-reference-coroutine-parameters,
   -cppcoreguidelines-macro-usage,
+  -cppcoreguidelines-pro-type-bounds-pointer-arithmetic,
   -cppcoreguidelines-pro-type-reinterpret-cast,
   -cppcoreguidelines-pro-type-static-cast-downcast,
   -cppcoreguidelines-pro-type-union-access,

--- a/changelog/next/features/5115--empty-arrays-of-objects.md
+++ b/changelog/next/features/5115--empty-arrays-of-objects.md
@@ -1,0 +1,2 @@
+`write_json arrays_of_objects=true` now works correctly with an empty input,
+returning an empty JSON array instead of running into a panic.


### PR DESCRIPTION
This fixes a panic in `write_json arrays_of_objects=true` when its input is empty. This now correctly prints an empty JSON array.