### PR TITLE
Add a `split_at_regex` option to `read_lines`

### DIFF
--- a/changelog/next/features/5123--read_lines-split-regex.md
+++ b/changelog/next/features/5123--read_lines-split-regex.md
@@ -1,0 +1,2 @@
+We added a `split_regex` option to allow the use of regular expressions to
+split events with the `read_lines` operator.

--- a/libtenzir/builtins/formats/lines.cpp
+++ b/libtenzir/builtins/formats/lines.cpp
@@ -13,6 +13,7 @@
 #include <tenzir/detail/base64.hpp>
 #include <tenzir/series_builder.hpp>
 #include <tenzir/split_nulls.hpp>
+#include <tenzir/split_at_regex.hpp>
 #include <tenzir/to_lines.hpp>
 #include <tenzir/tql/parser.hpp>
 #include <tenzir/tql2/plugin.hpp>
@@ -26,12 +27,14 @@ namespace {
 struct parser_args {
   std::optional<location> skip_empty;
   std::optional<location> null;
+  std::optional<located<std::string>> split_at_regex;
 
   template <class Inspector>
   friend auto inspect(Inspector& f, parser_args& x) -> bool {
     return f.object(x)
       .pretty_name("parser_args")
-      .fields(f.field("skip_empty", x.skip_empty), f.field("null", x.null));
+      .fields(f.field("skip_empty", x.skip_empty), f.field("null", x.null),
+              f.field("split_at_regex", x.split_at_regex));
   }
 };
 
@@ -50,7 +53,8 @@ public:
   instantiate(generator<chunk_ptr> input, operator_control_plane& ctrl) const
     -> std::optional<generator<table_slice>> override {
     auto make = [](auto& ctrl, generator<chunk_ptr> input, bool skip_empty,
-                   bool nulls) -> generator<table_slice> {
+                   bool nulls, std::optional<located<std::string>> split_at_regex)
+      -> generator<table_slice> {
       TENZIR_UNUSED(ctrl);
       auto builder = series_builder{type{
         "tenzir.line",
@@ -59,7 +63,17 @@ public:
         },
       }};
       auto last_finish = std::chrono::steady_clock::now();
-      auto cutter = nulls ? split_nulls : to_lines;
+      auto cutter
+        = [&]() -> std::function<generator<std::optional<std::string_view>>(
+                  generator<chunk_ptr>)> {
+        if (nulls) {
+          return split_nulls;
+        }
+        if (split_at_regex) {
+          return tenzir::split_at_regex(split_at_regex->inner);
+        }
+        return to_lines;
+      }();
       for (auto line : cutter(std::move(input))) {
         if (not line) {
           co_yield {};
@@ -82,7 +96,8 @@ public:
         co_yield builder.finish_assert_one_slice();
       }
     };
-    return make(ctrl, std::move(input), !!args_.skip_empty, !!args_.null);
+    return make(ctrl, std::move(input), ! ! args_.skip_empty, ! ! args_.null,
+                args_.split_at_regex);
   }
 
   friend auto inspect(auto& f, lines_parser& x) -> bool {
@@ -262,8 +277,17 @@ class read_lines final
     argument_parser2::operator_(name())
       .named("skip_empty", args.skip_empty)
       .named("split_at_null", args.null)
+      .named("split_at_regex", args.split_at_regex)
       .parse(inv, ctx)
       .ignore();
+    if (args.split_at_regex && args.null) {
+      diagnostic::error(
+        "cannot use `split_at_regex` and `split_at_null` at the same time")
+        .primary(*args.split_at_regex)
+        .primary(*args.null)
+        .emit(ctx);
+      return failure::promise();
+    }
     return std::make_unique<parser_adapter<lines_parser>>(
       lines_parser{std::move(args)});
   }

--- a/libtenzir/include/tenzir/split_at_regex.hpp
+++ b/libtenzir/include/tenzir/split_at_regex.hpp
@@ -1,0 +1,75 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2025 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "tenzir/chunk.hpp"
+#include "tenzir/generator.hpp"
+
+#include <boost/regex.hpp>
+
+#include <optional>
+#include <string_view>
+
+namespace tenzir {
+
+inline auto split_at_regex(std::string_view separator) {
+  auto expr = boost::regex{separator.data(), separator.size(),
+                           boost::regex_constants::no_except
+                             | boost::regex_constants::optimize};
+  return [exp = std::move(expr)](generator<chunk_ptr> input) mutable
+           -> generator<std::optional<std::string_view>> {
+    auto expr = std::move(exp); // NOLINT
+    auto buffer = std::string{};
+    auto consumed = true;
+    boost::match_results<std::string::const_iterator> what;
+    for (auto&& chunk : input) {
+      if (not chunk or chunk->size() == 0) {
+        co_yield std::nullopt;
+        continue;
+      }
+      buffer.append(reinterpret_cast<const char*>(chunk->data()), chunk->size());
+      const auto first = buffer.cbegin();
+      auto current = first;
+      auto begin = current + (consumed ? 0 : 1);
+      while (begin <= buffer.end()
+             and boost::regex_search(begin, buffer.cend(), what, expr)) {
+        // Don't yield when we reached the end as a longer match could be found
+        // with the subsequent characters at the beginning of the next chunk.
+        if (buffer.cend() == what[0].second) {
+          break;
+        }
+        co_yield std::string_view{current, what[0].first};
+        // Move forward by at least one position in case the search did not
+        // consume any characters.
+        consumed = what[0].second > current;
+        current = what[0].second;
+        begin = what[0].second + (consumed ? 0 : 1);
+      }
+      buffer = buffer.substr(current - first);
+      co_yield std::nullopt;
+    }
+    if (! buffer.empty()) {
+      auto current = buffer.cbegin();
+      auto begin = current + (consumed ? 0 : 1);
+      while (begin <= buffer.end()
+             and boost::regex_search(begin, buffer.cend(), what, expr)) {
+        auto event = std::string_view{current, what[0].first};
+        co_yield event;
+        consumed = what[0].second > current;
+        current = what[0].second;
+        begin = what[0].second + (consumed ? 0 : 1);
+      }
+      if (buffer.cend() != current) {
+        co_yield std::string_view{current, buffer.cend()};
+      }
+    }
+  };
+}
+
+} // namespace tenzir

--- a/tenzir/tests/exec/operators/read_lines/split_at_regex.tql
+++ b/tenzir/tests/exec/operators/read_lines/split_at_regex.tql
@@ -1,0 +1,5 @@
+from {
+  line: "<123>foo=bar <456>foo=baz x=y <999>x=z"
+}
+write_lines
+read_lines split_at_regex=" (?=<)"

--- a/tenzir/tests/exec/operators/read_lines/split_at_regex.txt
+++ b/tenzir/tests/exec/operators/read_lines/split_at_regex.txt
@@ -1,0 +1,9 @@
+{
+  line: "<123>foo=bar",
+}
+{
+  line: "<456>foo=baz x=y",
+}
+{
+  line: "<999>x=z\n",
+}

--- a/web/docs/tql2/operators/read_lines.md
+++ b/web/docs/tql2/operators/read_lines.md
@@ -3,7 +3,7 @@
 Parses an incoming bytes stream into events.
 
 ```tql
-read_lines [skip_empty=bool, split_at_null=bool]
+read_lines [skip_empty=bool, split_at_null=bool, split_at_regex=string]
 ```
 
 ## Description
@@ -25,6 +25,11 @@ Ignores empty lines in the input.
 
 Use null byte (`\0`) as the delimiter instead of newline characters.
 
+### `split_at_regex = string (optional)`
+
+Use the specified regex as the delimiter instead of newline characters.
+The regex flavor is Perl compatible and documented [here](https://www.boost.org/doc/libs/1_88_0/libs/regex/doc/html/boost_regex/syntax/perl_syntax.html).
+
 ## Examples
 
 ### Reads lines from a file
@@ -33,4 +38,12 @@ Use null byte (`\0`) as the delimiter instead of newline characters.
 load_file "events.log"
 read_lines
 is_error = line.starts_with("error:")
+```
+
+### Split Syslog-like events without newline terminators from a TCP input
+
+```tql
+load_tcp "0.0.0.0:514"
+read_lines split_at_regex="(?=<[0-9]+>)"
+this = line.parse_syslog()
 ```


### PR DESCRIPTION
This change enhances the `read_lines` operator with a `split_at_regex=<regex>` option. This is handy for input bytestreams that do not contain newlines or NULL bytes as a delimiter.

```
echo -n '<123>foo=bar <456>foo=baz x=y <999>x=z' | \
 tenzir '
   read_lines split_at_regex=" (?=<)"
   message = line.parse_grok("<%{NONNEGINT:priority}>%{GREEDYDATA:kv_payload}")
 '
```