### PR TITLE
Fix healthcheck in docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
       - tenzir-lib:/var/lib/tenzir/
       - tenzir-log:/var/log/tenzir/
     healthcheck:
-      test: tenzir --connection-timeout=30s --connection-retry-delay=1s 'api /ping'
+      test: tenzir --connection-timeout=30s --connection-retry-delay=1s 'api "/ping"'
       interval: 30s
       retries: 1
 


### PR DESCRIPTION
This fixes the missing double-quotes in the `healthcheck` section of the `docker-compose.yaml` file, that utilized the `api` TQL command:

```
$ tenzir --connection-timeout=30s --connection-retry-delay=1s 'api /ping'
error: expected expression, got `/`
 --> <input>:1:5
  |
1 | api /ping
  |     ^ got `/`
  |
```

Now it works fine:
```
$ tenzir --connection-timeout=30s --connection-retry-delay=1s 'api "/ping"'
{
  version: "5.0.0",
}
```