### PR TITLE
Experiment with a trailing `?` for field access

### DIFF
--- a/changelog/next/features/5128--trailing-questionmark.md
+++ b/changelog/next/features/5128--trailing-questionmark.md
@@ -1,0 +1,8 @@
+The `.?field` operator for field access with suppressed warnings is now
+deprecated in favor of `.field?`. We added the `.?` operator just recently, and
+it quickly gained a lot of popularity. However, suppressing warnings in
+top-level fields required writing `this.?field`, which is a mouthful. Now, with
+the trailing questionmark, this is just `field?` instead. Additionally, the
+trailing `?` operator works for index-based access, e.g., `field[index]?`. The
+`.?` operator will be removed in the near future. We're sorry for the
+inconvenience.

--- a/libtenzir/include/tenzir/tql2/tokens.hpp
+++ b/libtenzir/include/tenzir/tql2/tokens.hpp
@@ -27,8 +27,8 @@ TENZIR_ENUM(
   // literals
   scalar, true_, false_, null, raw_string, string, ip, subnet, datetime,
   // punctuation
-  dot, dot_question_mark, plus, minus, slash, star, equal_equal, bang_equal,
-  less, less_equal, greater, greater_equal, at, equal, comma, colon,
+  dot, dot_question_mark, question_mark, plus, minus, slash, star, equal_equal,
+  bang_equal, less, less_equal, greater, greater_equal, at, equal, comma, colon,
   single_quote, fat_arrow, pipe, dot_dot_dot, colon_colon,
   // parenthesis
   lpar, rpar, lbrace, rbrace, lbracket, rbracket,

--- a/libtenzir/src/tql2/eval_impl.cpp
+++ b/libtenzir/src/tql2/eval_impl.cpp
@@ -173,8 +173,7 @@ auto evaluator::eval(const ast::field_access& x) -> multi_series {
     if (auto null = l.as<null_type>()) {
       if (not x.suppress_warnings()) {
         diagnostic::warning("tried to access field of `null`")
-          .primary(x.left)
-          .secondary(x.dot, "use the `.?` operator to suppress this warning")
+          .primary(x.name, "use `?` to suppress this warning")
           .emit(ctx_);
       }
       return std::move(*null);
@@ -193,8 +192,7 @@ auto evaluator::eval(const ast::field_access& x) -> multi_series {
         auto has_null = s.null_count() != 0;
         if (has_null and not x.suppress_warnings()) {
           diagnostic::warning("tried to access field of `null`")
-            .primary(x.name)
-            .secondary(x.dot, "use the `.?` operator to suppress this warning")
+            .primary(x.name, "use `?` to suppress this warning")
             .emit(ctx_);
           return series{field.type, check(s.GetFlattenedField(i))};
         }
@@ -203,8 +201,7 @@ auto evaluator::eval(const ast::field_access& x) -> multi_series {
     }
     if (not x.suppress_warnings()) {
       diagnostic::warning("record does not have this field")
-        .primary(x.name)
-        .secondary(x.dot, "use the `.?` operator to suppress this warning")
+        .primary(x.name, "use `?` to suppress this warning")
         .emit(ctx_);
     }
     return null();
@@ -232,17 +229,19 @@ auto evaluator::eval(const ast::this_& x) -> multi_series {
 }
 
 auto evaluator::eval(const ast::root_field& x) -> multi_series {
-  auto& input = input_or_throw(x);
-  auto& rec_ty = as<record_type>(input.schema());
+  const auto& input = input_or_throw(x);
+  const auto& rec_ty = as<record_type>(input.schema());
   for (auto [i, field] : detail::enumerate<int>(rec_ty.fields())) {
-    if (field.name == x.ident.name) {
+    if (field.name == x.id.name) {
       // TODO: Is this correct?
       return series{field.type, to_record_batch(input)->column(i)};
     }
   }
-  diagnostic::warning("field `{}` not found", x.ident.name)
-    .primary(x.ident)
-    .emit(ctx_);
+  if (not x.has_question_mark) {
+    diagnostic::warning("field `{}` not found", x.id.name)
+      .primary(x.id, "use `?` to suppress this warning")
+      .emit(ctx_);
+  }
   return null();
 }
 
@@ -255,7 +254,7 @@ auto evaluator::eval(const ast::index_expr& x) -> multi_series {
       return eval(ast::field_access{
         x.expr,
         location::unknown,
-        x.suppress_warnings,
+        x.has_question_mark,
         ast::identifier{*string, constant->source},
       });
     }
@@ -263,27 +262,36 @@ auto evaluator::eval(const ast::index_expr& x) -> multi_series {
   return map_series(
     eval(x.expr), eval(x.index),
     [&](series value, const series& index) -> multi_series {
+      const auto add_suppress_hint = [&](auto dh) {
+        if (x.rbracket != location::unknown) {
+          dh = std::move(dh).hint("use `[…]?` to suppress this warning");
+        }
+        return dh;
+      };
       TENZIR_ASSERT(value.length() == index.length());
       if (auto null = value.as<null_type>()) {
-        if (not x.suppress_warnings) {
+        if (not x.has_question_mark) {
           diagnostic::warning("tried to access field of `null`")
-            .primary(x.expr)
+            .primary(x.expr, "is null")
+            .compose(add_suppress_hint)
             .emit(ctx_);
         }
         return std::move(*null);
       }
       if (auto null = index.as<null_type>()) {
-        diagnostic::warning("cannot use `null` as index")
-          .primary(x.index)
-          .emit(ctx_);
+        if (not x.has_question_mark) {
+          diagnostic::warning("cannot use `null` as index")
+            .primary(x.index, "is null")
+            .compose(add_suppress_hint)
+            .emit(ctx_);
+        }
         return std::move(*null);
       }
       if (auto str = index.as<string_type>()) {
         auto* ty = try_as<record_type>(value.type);
         if (not ty) {
           diagnostic::warning("cannot access field of non-record type")
-            .primary(x.index)
-            .secondary(x.expr, "type `{}`", value.type.kind())
+            .primary(x.expr, "has type `{}`", value.type.kind())
             .emit(ctx_);
           return null();
         }
@@ -325,9 +333,10 @@ auto evaluator::eval(const ast::index_expr& x) -> multi_series {
             b.data(v);
           } else {
             if (std::ranges::find(not_found, name) == not_found.end()) {
-              if (not x.suppress_warnings) {
+              if (not x.has_question_mark) {
                 diagnostic::warning("record does not have field `{}`", name)
-                  .primary(x.index)
+                  .primary(x.index, "does not exist")
+                  .compose(add_suppress_hint)
                   .emit(ctx_);
               }
               not_found.emplace_back(name);
@@ -335,14 +344,16 @@ auto evaluator::eval(const ast::index_expr& x) -> multi_series {
             b.null();
           }
         }
-        if (warn_null_record and not x.suppress_warnings) {
+        if (warn_null_record and not x.has_question_mark) {
           diagnostic::warning("tried to access field of `null`")
             .primary(x.expr)
+            .compose(add_suppress_hint)
             .emit(ctx_);
         }
-        if (warn_null_index) {
+        if (warn_null_index and not x.has_question_mark) {
           diagnostic::warning("cannot use `null` as index")
-            .primary(x.index)
+            .primary(x.index, "is null")
+            .compose(add_suppress_hint)
             .emit(ctx_);
         }
         result.push_back(b.finish_assert_one_array());
@@ -395,24 +406,26 @@ auto evaluator::eval(const ast::index_expr& x) -> multi_series {
             group_offset = i;
           }
           add(group_offset, number->length());
-          if (warn_null_index and not x.suppress_warnings) {
+          if (warn_null_index and not x.has_question_mark) {
             diagnostic::warning("cannot use `null` as index")
-              .primary(x.index)
+              .primary(x.index, "is null")
+              .compose(add_suppress_hint)
               .emit(ctx_);
           }
-          if (warn_index_out_of_bounds and not x.suppress_warnings) {
+          if (warn_index_out_of_bounds and not x.has_question_mark) {
             diagnostic::warning("index out of bounds")
-              .primary(x.index)
+              .primary(x.index, "is out of bounds")
+              .compose(add_suppress_hint)
               .emit(ctx_);
           }
           return result;
         }
         auto list = value.as<list_type>();
         if (not list) {
-          if (not is<null_type>(value.type) or not x.suppress_warnings) {
-            diagnostic::warning("cannot index into `{}` with `{}`",
-                                value.type.kind(), index.type.kind())
-              .primary(x.index)
+          if (not is<null_type>(value.type) or not x.has_question_mark) {
+            diagnostic::warning("expected `record` or `list`")
+              .primary(x.expr, "has type `{}`", value.type.kind())
+              .compose(add_suppress_hint)
               .emit(ctx_);
           }
           return null();
@@ -450,19 +463,22 @@ auto evaluator::eval(const ast::index_expr& x) -> multi_series {
           check(
             append_array_slice(*b, value_type, *list_values, value_index, 1));
         }
-        if (out_of_bounds and not x.suppress_warnings) {
+        if (out_of_bounds and not x.has_question_mark) {
           diagnostic::warning("list index out of bounds")
-            .primary(x.index)
+            .primary(x.index, "is out of bounds")
+            .compose(add_suppress_hint)
             .emit(ctx_);
         }
-        if (list_null and not x.suppress_warnings) {
+        if (list_null and not x.has_question_mark) {
           diagnostic::warning("cannot index into `null`")
-            .primary(x.expr)
+            .primary(x.expr, "is null")
+            .compose(add_suppress_hint)
             .emit(ctx_);
         }
-        if (number_null) {
+        if (number_null and not x.has_question_mark) {
           diagnostic::warning("cannot use `null` as index")
-            .primary(x.index)
+            .primary(x.index, "is null")
+            .compose(add_suppress_hint)
             .emit(ctx_);
         }
         return series{value_type, finish(*b)};

--- a/libtenzir/src/tql2/exec.cpp
+++ b/libtenzir/src/tql2/exec.cpp
@@ -72,7 +72,7 @@ public:
   }
 
   void emit_not_found(const ast::dollar_var& var) {
-    diagnostic::error("variable `{}` was not declared", var.ident.name)
+    diagnostic::error("variable `{}` was not declared", var.id.name)
       .primary(var)
       .emit(ctx_);
     failure_ = failure::promise();

--- a/libtenzir/src/tql2/set.cpp
+++ b/libtenzir/src/tql2/set.cpp
@@ -429,7 +429,7 @@ auto drop(const table_slice& slice, const std::vector<ast::field_path>& fields,
           err.reason,
           [&](const resolve_error::field_not_found&) {
             diagnostic::warning("field `{}` not found", err.ident.name)
-              .primary(err.ident)
+              .primary(err.ident, "use `?` to suppress this warning")
               .emit(dh);
           },
           [&](const resolve_error::field_not_found_no_error&) {},

--- a/libtenzir/src/tql2/tokens.cpp
+++ b/libtenzir/src/tql2/tokens.cpp
@@ -94,6 +94,7 @@ auto tokenize_permissive(std::string_view content) -> std::vector<token> {
     | X("...", dot_dot_dot)
     | X(".?", dot_question_mark)
     | X(".", dot)
+    | X("?", question_mark)
     | X("(", lpar)
     | X(")", rpar)
     | X("{", lbrace)
@@ -230,6 +231,7 @@ auto describe(token_kind k) -> std::string_view {
     X(or_, "`or`");
     X(pipe, "`|`");
     X(plus, "`+`");
+    X(question_mark, "`?`");
     X(raw_string, "raw string");
     X(rbrace, "`}`");
     X(rbracket, "`]`");

--- a/libtenzir/test/variant_traits.cpp
+++ b/libtenzir/test/variant_traits.cpp
@@ -196,11 +196,11 @@ TEST(expression) {
     ast::root_field{ast::identifier{"test", location::unknown}}};
   REQUIRE(try_as<ast::root_field>(&expr));
   REQUIRE(not try_as<ast::this_>(&expr));
-  as<ast::root_field>(expr).ident.name = "okay";
+  as<ast::root_field>(expr).id.name = "okay";
   match(
     std::move(expr),
     [](ast::root_field&& x) {
-      REQUIRE(x.ident.name == "okay");
+      REQUIRE(x.id.name == "okay");
     },
     [](auto&&) {
       FAIL("unreachable");

--- a/tenzir/bats/data/reference/expression/test_list_indexing/step_00.ref
+++ b/tenzir/bats/data/reference/expression/test_list_indexing/step_00.ref
@@ -4,12 +4,14 @@ warning: list index out of bounds
  --> /dev/stdin:4:7
   |
 4 | c = a[2]
-  |       ~ 
+  |       ~ is out of bounds
   |
+  = hint: use `[…]?` to suppress this warning
 
 warning: list index out of bounds
  --> /dev/stdin:6:7
   |
 6 | e = a[-3]
-  |       ~~ 
+  |       ~~ is out of bounds
   |
+  = hint: use `[…]?` to suppress this warning

--- a/tenzir/bats/data/reference/expression/test_record_indexing/step_00.ref
+++ b/tenzir/bats/data/reference/expression/test_record_indexing/step_00.ref
@@ -8,33 +8,36 @@ warning: field `y` not found
  --> <input>:1:19
   |
 1 | read_json | z = x[y]
-  |                   ~ 
+  |                   ~ use `?` to suppress this warning
   |
 
 warning: cannot use `null` as index
  --> <input>:1:19
   |
 1 | read_json | z = x[y]
-  |                   ~ 
+  |                   ~ is null
   |
+  = hint: use `[…]?` to suppress this warning
 
 warning: record does not have field `x`
  --> <input>:1:19
   |
 1 | read_json | z = x[y]
-  |                   ~ 
+  |                   ~ does not exist
   |
+  = hint: use `[…]?` to suppress this warning
 
 warning: field `x` not found
  --> <input>:1:17
   |
 1 | read_json | z = x[y]
-  |                 ~ 
+  |                 ~ use `?` to suppress this warning
   |
 
 warning: tried to access field of `null`
  --> <input>:1:17
   |
 1 | read_json | z = x[y]
-  |                 ~ 
+  |                 ~ is null
   |
+  = hint: use `[…]?` to suppress this warning

--- a/tenzir/bats/data/reference/functions/test_otherwise/step_00.ref
+++ b/tenzir/bats/data/reference/functions/test_otherwise/step_00.ref
@@ -8,12 +8,12 @@ warning: field `x` not found
  --> <input>:1:17
   |
 1 | read_json | z = x.otherwise(y)
-  |                 ~ 
+  |                 ~ use `?` to suppress this warning
   |
 
 warning: field `y` not found
  --> <input>:1:29
   |
 1 | read_json | z = x.otherwise(y)
-  |                             ~ 
+  |                             ~ use `?` to suppress this warning
   |

--- a/tenzir/bats/data/reference/functions/test_otherwise/step_01.ref
+++ b/tenzir/bats/data/reference/functions/test_otherwise/step_01.ref
@@ -5,5 +5,5 @@ warning: field `x` not found
  --> <input>:1:21
   |
 1 | from {},{},{} | z = x.otherwise(-1)
-  |                     ~ 
+  |                     ~ use `?` to suppress this warning
   |

--- a/tenzir/bats/data/reference/functions/test_otherwise/step_03.ref
+++ b/tenzir/bats/data/reference/functions/test_otherwise/step_03.ref
@@ -5,5 +5,5 @@ warning: field `x` not found
  --> <input>:1:24
   |
 1 | from {},{x:1},{} | z = x.otherwise(-1)
-  |                        ~ 
+  |                        ~ use `?` to suppress this warning
   |

--- a/tenzir/bats/data/reference/functions/test_otherwise/step_04.ref
+++ b/tenzir/bats/data/reference/functions/test_otherwise/step_04.ref
@@ -5,5 +5,5 @@ warning: field `x` not found
  --> <input>:1:27
   |
 1 | from {x:1},{},{x:2} | z = x.otherwise(-1)
-  |                           ~ 
+  |                           ~ use `?` to suppress this warning
   |

--- a/tenzir/bats/data/reference/pipelines_local/test_deduplicate_operator/step_02.ref
+++ b/tenzir/bats/data/reference/pipelines_local/test_deduplicate_operator/step_02.ref
@@ -4,5 +4,5 @@ warning: field `value` not found
  --> <input>:1:13
   |
 1 | deduplicate value, limit=1
-  |             ~~~~~ 
+  |             ~~~~~ use `?` to suppress this warning
   |

--- a/tenzir/bats/data/reference/pipelines_local/test_deduplicate_operator/step_03.ref
+++ b/tenzir/bats/data/reference/pipelines_local/test_deduplicate_operator/step_03.ref
@@ -14,25 +14,19 @@ warning: record does not have this field
  --> <input>:1:17
   |
 1 | deduplicate foo.bar, limit=1
-  |                 ~~~ 
-  ⋮
-1 | deduplicate foo.bar, limit=1
-  |                - use the `.?` operator to suppress this warning
+  |                 ~~~ use `?` to suppress this warning
   |
 
 warning: field `foo` not found
  --> <input>:1:13
   |
 1 | deduplicate foo.bar, limit=1
-  |             ~~~ 
+  |             ~~~ use `?` to suppress this warning
   |
 
 warning: tried to access field of `null`
- --> <input>:1:13
+ --> <input>:1:17
   |
 1 | deduplicate foo.bar, limit=1
-  |             ~~~ 
-  ⋮
-1 | deduplicate foo.bar, limit=1
-  |                - use the `.?` operator to suppress this warning
+  |                 ~~~ use `?` to suppress this warning
   |

--- a/tenzir/bats/data/reference/pipelines_local/test_deduplicate_operator/step_04.ref
+++ b/tenzir/bats/data/reference/pipelines_local/test_deduplicate_operator/step_04.ref
@@ -4,5 +4,5 @@ warning: field `a` not found
  --> <input>:1:17
   |
 1 | deduplicate {a: a, b: b}, limit=1
-  |                 ~ 
+  |                 ~ use `?` to suppress this warning
   |

--- a/tenzir/tests/ast/control_flow.txt
+++ b/tenzir/tests/ast/control_flow.txt
@@ -13,7 +13,10 @@
   if_stmt {
     if_kw: 2..4,
     condition: binary_expr {
-      left: root_field `b` @ 5..6,
+      left: root_field {
+        id: `b` @ 5..6,
+        has_question_mark: false
+      },
       op: "eq" @ 7..9,
       right: constant int64 42 @ 10..12
     },
@@ -26,7 +29,10 @@
           ref: unresolved
         },
         args: [
-          root_field `d` @ 19..20
+          root_field {
+            id: `d` @ 19..20,
+            has_question_mark: false
+          }
         ]
       },
       invocation {
@@ -39,7 +45,10 @@
         args: [
           assignment {
             left: field_path {
-              expr: root_field `f` @ 25..26,
+              expr: root_field {
+                id: `f` @ 25..26,
+                has_question_mark: false
+              },
               has_this: false,
               path: [
                 {
@@ -49,7 +58,10 @@
               ]
             },
             equals: 26..27,
-            right: root_field `g` @ 27..28
+            right: root_field {
+              id: `g` @ 27..28,
+              has_question_mark: false
+            }
           }
         ]
       }
@@ -68,7 +80,10 @@
   },
   if_stmt {
     if_kw: 33..35,
-    condition: root_field `i` @ 36..37,
+    condition: root_field {
+      id: `i` @ 36..37,
+      has_question_mark: false
+    },
     then: [
       
     ],
@@ -92,7 +107,10 @@
   },
   match_stmt {
     begin: 51..56,
-    expr: root_field `k` @ 57..58,
+    expr: root_field {
+      id: `k` @ 57..58,
+      has_question_mark: false
+    },
     arms: [
       
     ],
@@ -100,7 +118,10 @@
   },
   match_stmt {
     begin: 62..67,
-    expr: root_field `k` @ 68..69,
+    expr: root_field {
+      id: `k` @ 68..69,
+      has_question_mark: false
+    },
     arms: [
       {
         filter: [
@@ -125,7 +146,10 @@
   },
   match_stmt {
     begin: 91..96,
-    expr: root_field `k` @ 97..98,
+    expr: root_field {
+      id: `k` @ 97..98,
+      has_question_mark: false
+    },
     arms: [
       {
         filter: [
@@ -158,7 +182,10 @@
               ref: unresolved
             },
             args: [
-              root_field `bar` @ 144..147
+              root_field {
+                id: `bar` @ 144..147,
+                has_question_mark: false
+              }
             ]
           },
           invocation {
@@ -169,7 +196,10 @@
               ref: unresolved
             },
             args: [
-              root_field `bar` @ 156..159
+              root_field {
+                id: `bar` @ 156..159,
+                has_question_mark: false
+              }
             ]
           }
         ]

--- a/tenzir/tests/ast/functions.txt
+++ b/tenzir/tests/ast/functions.txt
@@ -1,7 +1,10 @@
 [
   assignment {
     left: field_path {
-      expr: root_field `a` @ 0..1,
+      expr: root_field {
+        id: `a` @ 0..1,
+        has_question_mark: false
+      },
       has_this: false,
       path: [
         {
@@ -27,7 +30,10 @@
   },
   assignment {
     left: field_path {
-      expr: root_field `a` @ 8..9,
+      expr: root_field {
+        id: `a` @ 8..9,
+        has_question_mark: false
+      },
       has_this: false,
       path: [
         {
@@ -45,7 +51,10 @@
         ref: unresolved
       },
       args: [
-        root_field `c` @ 14..15
+        root_field {
+          id: `c` @ 14..15,
+          has_question_mark: false
+        }
       ],
       rpar: 15..16,
       method: false
@@ -53,7 +62,10 @@
   },
   assignment {
     left: field_path {
-      expr: root_field `a` @ 17..18,
+      expr: root_field {
+        id: `a` @ 17..18,
+        has_question_mark: false
+      },
       has_this: false,
       path: [
         {
@@ -73,7 +85,10 @@
       args: [
         assignment {
           left: field_path {
-            expr: root_field `c` @ 23..24,
+            expr: root_field {
+              id: `c` @ 23..24,
+              has_question_mark: false
+            },
             has_this: false,
             path: [
               {
@@ -83,7 +98,10 @@
             ]
           },
           equals: 24..25,
-          right: root_field `d` @ 25..26
+          right: root_field {
+            id: `d` @ 25..26,
+            has_question_mark: false
+          }
         }
       ],
       rpar: 26..27,
@@ -92,7 +110,10 @@
   },
   assignment {
     left: field_path {
-      expr: root_field `a` @ 28..29,
+      expr: root_field {
+        id: `a` @ 28..29,
+        has_question_mark: false
+      },
       has_this: false,
       path: [
         {
@@ -110,10 +131,16 @@
         ref: unresolved
       },
       args: [
-        root_field `c` @ 34..35,
+        root_field {
+          id: `c` @ 34..35,
+          has_question_mark: false
+        },
         assignment {
           left: field_path {
-            expr: root_field `d` @ 37..38,
+            expr: root_field {
+              id: `d` @ 37..38,
+              has_question_mark: false
+            },
             has_this: false,
             path: [
               {
@@ -123,7 +150,10 @@
             ]
           },
           equals: 38..39,
-          right: root_field `e` @ 39..40
+          right: root_field {
+            id: `e` @ 39..40,
+            has_question_mark: false
+          }
         }
       ],
       rpar: 40..41,
@@ -132,7 +162,10 @@
   },
   assignment {
     left: field_path {
-      expr: root_field `a` @ 42..43,
+      expr: root_field {
+        id: `a` @ 42..43,
+        has_question_mark: false
+      },
       has_this: false,
       path: [
         {
@@ -152,7 +185,10 @@
       args: [
         assignment {
           left: field_path {
-            expr: root_field `c` @ 48..49,
+            expr: root_field {
+              id: `c` @ 48..49,
+              has_question_mark: false
+            },
             has_this: false,
             path: [
               {
@@ -162,12 +198,21 @@
             ]
           },
           equals: 49..50,
-          right: root_field `d` @ 50..51
+          right: root_field {
+            id: `d` @ 50..51,
+            has_question_mark: false
+          }
         },
-        root_field `e` @ 53..54,
+        root_field {
+          id: `e` @ 53..54,
+          has_question_mark: false
+        },
         assignment {
           left: field_path {
-            expr: root_field `g` @ 56..57,
+            expr: root_field {
+              id: `g` @ 56..57,
+              has_question_mark: false
+            },
             has_this: false,
             path: [
               {
@@ -177,9 +222,15 @@
             ]
           },
           equals: 57..58,
-          right: root_field `h` @ 58..59
+          right: root_field {
+            id: `h` @ 58..59,
+            has_question_mark: false
+          }
         },
-        root_field `i` @ 61..62
+        root_field {
+          id: `i` @ 61..62,
+          has_question_mark: false
+        }
       ],
       rpar: 63..64,
       method: false
@@ -201,7 +252,10 @@
           ref: unresolved
         },
         args: [
-          root_field `a` @ 69..70
+          root_field {
+            id: `a` @ 69..70,
+            has_question_mark: false
+          }
         ],
         rpar: 73..74,
         method: true
@@ -224,8 +278,14 @@
           ref: unresolved
         },
         args: [
-          root_field `a` @ 79..80,
-          root_field `c` @ 83..84
+          root_field {
+            id: `a` @ 79..80,
+            has_question_mark: false
+          },
+          root_field {
+            id: `c` @ 83..84,
+            has_question_mark: false
+          }
         ],
         rpar: 84..85,
         method: true
@@ -248,10 +308,16 @@
           ref: unresolved
         },
         args: [
-          root_field `a` @ 90..91,
+          root_field {
+            id: `a` @ 90..91,
+            has_question_mark: false
+          },
           assignment {
             left: field_path {
-              expr: root_field `c` @ 94..95,
+              expr: root_field {
+                id: `c` @ 94..95,
+                has_question_mark: false
+              },
               has_this: false,
               path: [
                 {
@@ -261,7 +327,10 @@
               ]
             },
             equals: 95..96,
-            right: root_field `d` @ 96..97
+            right: root_field {
+              id: `d` @ 96..97,
+              has_question_mark: false
+            }
           }
         ],
         rpar: 97..98,
@@ -285,11 +354,20 @@
           ref: unresolved
         },
         args: [
-          root_field `a` @ 103..104,
-          root_field `c` @ 107..108,
+          root_field {
+            id: `a` @ 103..104,
+            has_question_mark: false
+          },
+          root_field {
+            id: `c` @ 107..108,
+            has_question_mark: false
+          },
           assignment {
             left: field_path {
-              expr: root_field `d` @ 110..111,
+              expr: root_field {
+                id: `d` @ 110..111,
+                has_question_mark: false
+              },
               has_this: false,
               path: [
                 {
@@ -299,7 +377,10 @@
               ]
             },
             equals: 111..112,
-            right: root_field `e` @ 112..113
+            right: root_field {
+              id: `e` @ 112..113,
+              has_question_mark: false
+            }
           }
         ],
         rpar: 113..114,
@@ -323,10 +404,16 @@
           ref: unresolved
         },
         args: [
-          root_field `a` @ 119..120,
+          root_field {
+            id: `a` @ 119..120,
+            has_question_mark: false
+          },
           assignment {
             left: field_path {
-              expr: root_field `c` @ 123..124,
+              expr: root_field {
+                id: `c` @ 123..124,
+                has_question_mark: false
+              },
               has_this: false,
               path: [
                 {
@@ -336,12 +423,21 @@
               ]
             },
             equals: 124..125,
-            right: root_field `d` @ 125..126
+            right: root_field {
+              id: `d` @ 125..126,
+              has_question_mark: false
+            }
           },
-          root_field `e` @ 128..129,
+          root_field {
+            id: `e` @ 128..129,
+            has_question_mark: false
+          },
           assignment {
             left: field_path {
-              expr: root_field `g` @ 131..132,
+              expr: root_field {
+                id: `g` @ 131..132,
+                has_question_mark: false
+              },
               has_this: false,
               path: [
                 {
@@ -351,9 +447,15 @@
               ]
             },
             equals: 132..133,
-            right: root_field `h` @ 133..134
+            right: root_field {
+              id: `h` @ 133..134,
+              has_question_mark: false
+            }
           },
-          root_field `i` @ 136..137
+          root_field {
+            id: `i` @ 136..137,
+            has_question_mark: false
+          }
         ],
         rpar: 138..139,
         method: true

--- a/tenzir/tests/ast/multiline_operators.txt
+++ b/tenzir/tests/ast/multiline_operators.txt
@@ -7,10 +7,22 @@
       ref: unresolved
     },
     args: [
-      root_field `b` @ 2..3,
-      root_field `c` @ 7..8,
-      root_field `d` @ 12..13,
-      root_field `e` @ 15..16
+      root_field {
+        id: `b` @ 2..3,
+        has_question_mark: false
+      },
+      root_field {
+        id: `c` @ 7..8,
+        has_question_mark: false
+      },
+      root_field {
+        id: `d` @ 12..13,
+        has_question_mark: false
+      },
+      root_field {
+        id: `e` @ 15..16,
+        has_question_mark: false
+      }
     ]
   },
   invocation {
@@ -21,7 +33,10 @@
       ref: unresolved
     },
     args: [
-      root_field `g` @ 19..20
+      root_field {
+        id: `g` @ 19..20,
+        has_question_mark: false
+      }
     ]
   },
   invocation {
@@ -32,9 +47,18 @@
       ref: unresolved
     },
     args: [
-      root_field `i` @ 27..28,
-      root_field `j` @ 32..33,
-      root_field `k` @ 38..39
+      root_field {
+        id: `i` @ 27..28,
+        has_question_mark: false
+      },
+      root_field {
+        id: `j` @ 32..33,
+        has_question_mark: false
+      },
+      root_field {
+        id: `k` @ 38..39,
+        has_question_mark: false
+      }
     ]
   },
   invocation {
@@ -46,9 +70,15 @@
     },
     args: [
       binary_expr {
-        left: root_field `m` @ 42..43,
+        left: root_field {
+          id: `m` @ 42..43,
+          has_question_mark: false
+        },
         op: "add" @ 44..45,
-        right: root_field `n` @ 48..49
+        right: root_field {
+          id: `n` @ 48..49,
+          has_question_mark: false
+        }
       }
     ]
   }

--- a/tenzir/tests/ast/ocsf_example.txt
+++ b/tenzir/tests/ast/ocsf_example.txt
@@ -1,7 +1,10 @@
 [
   assignment {
     left: field_path {
-      expr: root_field `activity_name` @ 0..13,
+      expr: root_field {
+        id: `activity_name` @ 0..13,
+        has_question_mark: false
+      },
       has_this: false,
       path: [
         {
@@ -15,7 +18,10 @@
   },
   assignment {
     left: field_path {
-      expr: root_field `activity_id` @ 25..36,
+      expr: root_field {
+        id: `activity_id` @ 25..36,
+        has_question_mark: false
+      },
       has_this: false,
       path: [
         {
@@ -30,7 +36,10 @@
   assignment {
     left: field_path {
       expr: field_access {
-        left: root_field `actor` @ 41..46,
+        left: root_field {
+          id: `actor` @ 41..46,
+          has_question_mark: false
+        },
         dot: 46..47,
         has_question_mark: false,
         name: `process` @ 47..54
@@ -58,7 +67,10 @@
             items: [
               field {
                 name: `path` @ 73..77,
-                expr: root_field `path` @ 79..83
+                expr: root_field {
+                  id: `path` @ 79..83,
+                  has_question_mark: false
+                }
               },
               field {
                 name: `parent_folder` @ 89..102,
@@ -74,7 +86,10 @@
                   args: [
                     field_access {
                       left: field_access {
-                        left: root_field `src` @ 122..125,
+                        left: root_field {
+                          id: `src` @ 122..125,
+                          has_question_mark: false
+                        },
                         dot: 125..126,
                         has_question_mark: false,
                         name: `event_data` @ 126..136
@@ -102,7 +117,10 @@
                   args: [
                     field_access {
                       left: field_access {
-                        left: root_field `src` @ 182..185,
+                        left: root_field {
+                          id: `src` @ 182..185,
+                          has_question_mark: false
+                        },
                         dot: 185..186,
                         has_question_mark: false,
                         name: `event_data` @ 186..196
@@ -140,7 +158,10 @@
             args: [
               field_access {
                 left: field_access {
-                  left: root_field `src` @ 266..269,
+                  left: root_field {
+                    id: `src` @ 266..269,
+                    has_question_mark: false
+                  },
                   dot: 269..270,
                   has_question_mark: false,
                   name: `event_data` @ 270..280
@@ -168,7 +189,10 @@
     args: [
       field_access {
         left: field_access {
-          left: root_field `src` @ 306..309,
+          left: root_field {
+            id: `src` @ 306..309,
+            has_question_mark: false
+          },
           dot: 309..310,
           has_question_mark: false,
           name: `event_data` @ 310..320
@@ -179,7 +203,10 @@
       },
       field_access {
         left: field_access {
-          left: root_field `src` @ 334..337,
+          left: root_field {
+            id: `src` @ 334..337,
+            has_question_mark: false
+          },
           dot: 337..338,
           has_question_mark: false,
           name: `event_data` @ 338..348
@@ -193,7 +220,10 @@
   assignment {
     left: field_path {
       expr: field_access {
-        left: root_field `actor` @ 365..370,
+        left: root_field {
+          id: `actor` @ 365..370,
+          has_question_mark: false
+        },
         dot: 370..371,
         has_question_mark: false,
         name: `user` @ 371..375
@@ -226,7 +256,10 @@
           name: `domain` @ 439..445,
           expr: field_access {
             left: field_access {
-              left: root_field `src` @ 447..450,
+              left: root_field {
+                id: `src` @ 447..450,
+                has_question_mark: false
+              },
               dot: 450..451,
               has_question_mark: false,
               name: `user` @ 451..455
@@ -240,7 +273,10 @@
           name: `name` @ 466..470,
           expr: field_access {
             left: field_access {
-              left: root_field `src` @ 472..475,
+              left: root_field {
+                id: `src` @ 472..475,
+                has_question_mark: false
+              },
               dot: 475..476,
               has_question_mark: false,
               name: `user` @ 476..480
@@ -254,7 +290,10 @@
           name: `uid` @ 489..492,
           expr: field_access {
             left: field_access {
-              left: root_field `src` @ 494..497,
+              left: root_field {
+                id: `src` @ 494..497,
+                has_question_mark: false
+              },
               dot: 497..498,
               has_question_mark: false,
               name: `user` @ 498..502
@@ -278,7 +317,10 @@
     args: [
       field_access {
         left: field_access {
-          left: root_field `src` @ 522..525,
+          left: root_field {
+            id: `src` @ 522..525,
+            has_question_mark: false
+          },
           dot: 525..526,
           has_question_mark: false,
           name: `user` @ 526..530
@@ -289,7 +331,10 @@
       },
       field_access {
         left: field_access {
-          left: root_field `src` @ 539..542,
+          left: root_field {
+            id: `src` @ 539..542,
+            has_question_mark: false
+          },
           dot: 542..543,
           has_question_mark: false,
           name: `user` @ 543..547
@@ -300,7 +345,10 @@
       },
       field_access {
         left: field_access {
-          left: root_field `src` @ 554..557,
+          left: root_field {
+            id: `src` @ 554..557,
+            has_question_mark: false
+          },
           dot: 557..558,
           has_question_mark: false,
           name: `user` @ 558..562
@@ -313,7 +361,10 @@
   },
   assignment {
     left: field_path {
-      expr: root_field `category_name` @ 574..587,
+      expr: root_field {
+        id: `category_name` @ 574..587,
+        has_question_mark: false
+      },
       has_this: false,
       path: [
         {
@@ -327,7 +378,10 @@
   },
   assignment {
     left: field_path {
-      expr: root_field `category_uid` @ 608..620,
+      expr: root_field {
+        id: `category_uid` @ 608..620,
+        has_question_mark: false
+      },
       has_this: false,
       path: [
         {
@@ -346,7 +400,10 @@
         ref: unresolved
       },
       args: [
-        root_field `category_name` @ 642..655
+        root_field {
+          id: `category_name` @ 642..655,
+          has_question_mark: false
+        }
       ],
       rpar: 655..656,
       method: false
@@ -354,7 +411,10 @@
   },
   assignment {
     left: field_path {
-      expr: root_field `class_name` @ 657..667,
+      expr: root_field {
+        id: `class_name` @ 657..667,
+        has_question_mark: false
+      },
       has_this: false,
       path: [
         {
@@ -368,7 +428,10 @@
   },
   assignment {
     left: field_path {
-      expr: root_field `class_uid` @ 689..698,
+      expr: root_field {
+        id: `class_uid` @ 689..698,
+        has_question_mark: false
+      },
       has_this: false,
       path: [
         {
@@ -387,7 +450,10 @@
         ref: unresolved
       },
       args: [
-        root_field `class_name` @ 717..727
+        root_field {
+          id: `class_name` @ 717..727,
+          has_question_mark: false
+        }
       ],
       rpar: 727..728,
       method: false
@@ -395,7 +461,10 @@
   },
   assignment {
     left: field_path {
-      expr: root_field `device` @ 729..735,
+      expr: root_field {
+        id: `device` @ 729..735,
+        has_question_mark: false
+      },
       has_this: false,
       path: [
         {
@@ -411,7 +480,10 @@
         field {
           name: `hostname` @ 742..750,
           expr: field_access {
-            left: root_field `src` @ 752..755,
+            left: root_field {
+              id: `src` @ 752..755,
+              has_question_mark: false
+            },
             dot: 755..756,
             has_question_mark: false,
             name: `computer_name` @ 756..769
@@ -459,7 +531,10 @@
     },
     args: [
       field_access {
-        left: root_field `src` @ 888..891,
+        left: root_field {
+          id: `src` @ 888..891,
+          has_question_mark: false
+        },
         dot: 891..892,
         has_question_mark: false,
         name: `computer_name` @ 892..905
@@ -468,7 +543,10 @@
   },
   assignment {
     left: field_path {
-      expr: root_field `message` @ 906..913,
+      expr: root_field {
+        id: `message` @ 906..913,
+        has_question_mark: false
+      },
       has_this: false,
       path: [
         {
@@ -482,7 +560,10 @@
   },
   assignment {
     left: field_path {
-      expr: root_field `metadata` @ 950..958,
+      expr: root_field {
+        id: `metadata` @ 950..958,
+        has_question_mark: false
+      },
       has_this: false,
       path: [
         {
@@ -499,7 +580,10 @@
           name: `original_time` @ 965..978,
           expr: field_access {
             left: field_access {
-              left: root_field `src` @ 980..983,
+              left: root_field {
+                id: `src` @ 980..983,
+                has_question_mark: false
+              },
               dot: 983..984,
               has_question_mark: false,
               name: `event_data` @ 984..994
@@ -552,7 +636,10 @@
         field {
           name: `uid` @ 1153..1156,
           expr: field_access {
-            left: root_field `src` @ 1158..1161,
+            left: root_field {
+              id: `src` @ 1158..1161,
+              has_question_mark: false
+            },
             dot: 1161..1162,
             has_question_mark: false,
             name: `record_id` @ 1162..1171
@@ -576,7 +663,10 @@
     args: [
       field_access {
         left: field_access {
-          left: root_field `src` @ 1200..1203,
+          left: root_field {
+            id: `src` @ 1200..1203,
+            has_question_mark: false
+          },
           dot: 1203..1204,
           has_question_mark: false,
           name: `event_data` @ 1204..1214
@@ -586,7 +676,10 @@
         name: `UtcTime` @ 1215..1222
       },
       field_access {
-        left: root_field `src` @ 1224..1227,
+        left: root_field {
+          id: `src` @ 1224..1227,
+          has_question_mark: false
+        },
         dot: 1227..1228,
         has_question_mark: false,
         name: `record_id` @ 1228..1237
@@ -595,7 +688,10 @@
   },
   assignment {
     left: field_path {
-      expr: root_field `process` @ 1238..1245,
+      expr: root_field {
+        id: `process` @ 1238..1245,
+        has_question_mark: false
+      },
       has_this: false,
       path: [
         {
@@ -612,7 +708,10 @@
           name: `cmd_line` @ 1252..1260,
           expr: field_access {
             left: field_access {
-              left: root_field `src` @ 1262..1265,
+              left: root_field {
+                id: `src` @ 1262..1265,
+                has_question_mark: false
+              },
               dot: 1265..1266,
               has_question_mark: false,
               name: `event_data` @ 1266..1276
@@ -631,7 +730,10 @@
                 name: `path` @ 1304..1308,
                 expr: field_access {
                   left: field_access {
-                    left: root_field `src` @ 1310..1313,
+                    left: root_field {
+                      id: `src` @ 1310..1313,
+                      has_question_mark: false
+                    },
                     dot: 1313..1314,
                     has_question_mark: false,
                     name: `event_data` @ 1314..1324
@@ -655,7 +757,10 @@
                   args: [
                     field_access {
                       left: field_access {
-                        left: root_field `src` @ 1369..1372,
+                        left: root_field {
+                          id: `src` @ 1369..1372,
+                          has_question_mark: false
+                        },
                         dot: 1372..1373,
                         has_question_mark: false,
                         name: `event_data` @ 1373..1383
@@ -683,7 +788,10 @@
                   args: [
                     field_access {
                       left: field_access {
-                        left: root_field `src` @ 1423..1426,
+                        left: root_field {
+                          id: `src` @ 1423..1426,
+                          has_question_mark: false
+                        },
                         dot: 1426..1427,
                         has_question_mark: false,
                         name: `event_data` @ 1427..1437
@@ -721,7 +829,10 @@
             args: [
               field_access {
                 left: field_access {
-                  left: root_field `src` @ 1501..1504,
+                  left: root_field {
+                    id: `src` @ 1501..1504,
+                    has_question_mark: false
+                  },
                   dot: 1504..1505,
                   has_question_mark: false,
                   name: `event_data` @ 1505..1515
@@ -749,7 +860,10 @@
     args: [
       field_access {
         left: field_access {
-          left: root_field `src` @ 1535..1538,
+          left: root_field {
+            id: `src` @ 1535..1538,
+            has_question_mark: false
+          },
           dot: 1538..1539,
           has_question_mark: false,
           name: `event_data` @ 1539..1549
@@ -760,7 +874,10 @@
       },
       field_access {
         left: field_access {
-          left: root_field `src` @ 1563..1566,
+          left: root_field {
+            id: `src` @ 1563..1566,
+            has_question_mark: false
+          },
           dot: 1566..1567,
           has_question_mark: false,
           name: `event_data` @ 1567..1577
@@ -771,7 +888,10 @@
       },
       field_access {
         left: field_access {
-          left: root_field `src` @ 1585..1588,
+          left: root_field {
+            id: `src` @ 1585..1588,
+            has_question_mark: false
+          },
           dot: 1588..1589,
           has_question_mark: false,
           name: `event_data` @ 1589..1599
@@ -784,7 +904,10 @@
   },
   assignment {
     left: field_path {
-      expr: root_field `severity` @ 1610..1618,
+      expr: root_field {
+        id: `severity` @ 1610..1618,
+        has_question_mark: false
+      },
       has_this: false,
       path: [
         {
@@ -798,7 +921,10 @@
   },
   assignment {
     left: field_path {
-      expr: root_field `severity_id` @ 1637..1648,
+      expr: root_field {
+        id: `severity_id` @ 1637..1648,
+        has_question_mark: false
+      },
       has_this: false,
       path: [
         {
@@ -812,7 +938,10 @@
   },
   assignment {
     left: field_path {
-      expr: root_field `status` @ 1653..1659,
+      expr: root_field {
+        id: `status` @ 1653..1659,
+        has_question_mark: false
+      },
       has_this: false,
       path: [
         {
@@ -826,7 +955,10 @@
   },
   assignment {
     left: field_path {
-      expr: root_field `status_id` @ 1672..1681,
+      expr: root_field {
+        id: `status_id` @ 1672..1681,
+        has_question_mark: false
+      },
       has_this: false,
       path: [
         {
@@ -840,7 +972,10 @@
   },
   assignment {
     left: field_path {
-      expr: root_field `time` @ 1686..1690,
+      expr: root_field {
+        id: `time` @ 1686..1690,
+        has_question_mark: false
+      },
       has_this: false,
       path: [
         {
@@ -876,7 +1011,10 @@
                 },
                 args: [
                   field_access {
-                    left: root_field `metadata` @ 1704..1712,
+                    left: root_field {
+                      id: `metadata` @ 1704..1712,
+                      has_question_mark: false
+                    },
                     dot: 1712..1713,
                     has_question_mark: false,
                     name: `original_time` @ 1713..1726
@@ -899,7 +1037,10 @@
   },
   assignment {
     left: field_path {
-      expr: root_field `type_name` @ 1748..1757,
+      expr: root_field {
+        id: `type_name` @ 1748..1757,
+        has_question_mark: false
+      },
       has_this: false,
       path: [
         {
@@ -913,7 +1054,10 @@
   },
   assignment {
     left: field_path {
-      expr: root_field `type_uid` @ 1787..1795,
+      expr: root_field {
+        id: `type_uid` @ 1787..1795,
+        has_question_mark: false
+      },
       has_this: false,
       path: [
         {
@@ -927,7 +1071,10 @@
   },
   assignment {
     left: field_path {
-      expr: root_field `unmapped` @ 1805..1813,
+      expr: root_field {
+        id: `unmapped` @ 1805..1813,
+        has_question_mark: false
+      },
       has_this: false,
       path: [
         {
@@ -937,7 +1084,10 @@
       ]
     },
     equals: 1814..1815,
-    right: root_field `src` @ 1816..1819
+    right: root_field {
+      id: `src` @ 1816..1819,
+      has_question_mark: false
+    }
   },
   invocation {
     op: {
@@ -947,7 +1097,10 @@
       ref: unresolved
     },
     args: [
-      root_field `src` @ 1825..1828
+      root_field {
+        id: `src` @ 1825..1828,
+        has_question_mark: false
+      }
     ]
   }
 ]

--- a/tenzir/tests/ast/operator_parenthesis_continuation.txt
+++ b/tenzir/tests/ast/operator_parenthesis_continuation.txt
@@ -8,9 +8,15 @@
     },
     args: [
       binary_expr {
-        left: root_field `x` @ 7..8,
+        left: root_field {
+          id: `x` @ 7..8,
+          has_question_mark: false
+        },
         op: "or_" @ 9..11,
-        right: root_field `y` @ 12..13
+        right: root_field {
+          id: `y` @ 12..13,
+          has_question_mark: false
+        }
       }
     ]
   },
@@ -24,12 +30,21 @@
     args: [
       binary_expr {
         left: binary_expr {
-          left: root_field `x` @ 22..23,
+          left: root_field {
+            id: `x` @ 22..23,
+            has_question_mark: false
+          },
           op: "or_" @ 24..26,
-          right: root_field `y` @ 27..28
+          right: root_field {
+            id: `y` @ 27..28,
+            has_question_mark: false
+          }
         },
         op: "and_" @ 30..33,
-        right: root_field `z` @ 34..35
+        right: root_field {
+          id: `z` @ 34..35,
+          has_question_mark: false
+        }
       }
     ]
   },

--- a/tenzir/tests/ast/precedence.txt
+++ b/tenzir/tests/ast/precedence.txt
@@ -1,7 +1,10 @@
 [
   assignment {
     left: field_path {
-      expr: root_field `foo` @ 0..3,
+      expr: root_field {
+        id: `foo` @ 0..3,
+        has_question_mark: false
+      },
       has_this: false,
       path: [
         {
@@ -50,7 +53,10 @@
         left: binary_expr {
           left: unary_expr {
             op: "neg" @ 43..44,
-            expr: root_field `foo` @ 44..47
+            expr: root_field {
+              id: `foo` @ 44..47,
+              has_question_mark: false
+            }
           },
           op: "add" @ 48..49,
           right: unary_expr {
@@ -60,7 +66,10 @@
         },
         op: "and_" @ 56..59,
         right: binary_expr {
-          left: root_field `bar` @ 60..63,
+          left: root_field {
+            id: `bar` @ 60..63,
+            has_question_mark: false
+          },
           op: "eq" @ 64..66,
           right: constant int64 42 @ 67..69
         }

--- a/tenzir/tests/ast/simple.txt
+++ b/tenzir/tests/ast/simple.txt
@@ -12,7 +12,10 @@
   },
   assignment {
     left: field_path {
-      expr: root_field `foo` @ 7..10,
+      expr: root_field {
+        id: `foo` @ 7..10,
+        has_question_mark: false
+      },
       has_this: false,
       path: [
         {
@@ -34,7 +37,10 @@
     args: [
       assignment {
         left: field_path {
-          expr: root_field `bar` @ 20..23,
+          expr: root_field {
+            id: `bar` @ 20..23,
+            has_question_mark: false
+          },
           has_this: false,
           path: [
             {
@@ -56,10 +62,16 @@
       ref: unresolved
     },
     args: [
-      root_field `bar` @ 33..36,
+      root_field {
+        id: `bar` @ 33..36,
+        has_question_mark: false
+      },
       assignment {
         left: field_path {
-          expr: root_field `baz` @ 38..41,
+          expr: root_field {
+            id: `baz` @ 38..41,
+            has_question_mark: false
+          },
           has_this: false,
           path: [
             {
@@ -69,9 +81,15 @@
           ]
         },
         equals: 41..42,
-        right: root_field `qux` @ 42..45
+        right: root_field {
+          id: `qux` @ 42..45,
+          has_question_mark: false
+        }
       },
-      root_field `quux` @ 47..51
+      root_field {
+        id: `quux` @ 47..51,
+        has_question_mark: false
+      }
     ]
   },
   invocation {

--- a/tenzir/tests/ast/using_pipes.txt
+++ b/tenzir/tests/ast/using_pipes.txt
@@ -12,7 +12,10 @@
   },
   assignment {
     left: field_path {
-      expr: root_field `foo` @ 9..12,
+      expr: root_field {
+        id: `foo` @ 9..12,
+        has_question_mark: false
+      },
       has_this: false,
       path: [
         {
@@ -34,7 +37,10 @@
     args: [
       assignment {
         left: field_path {
-          expr: root_field `bar` @ 24..27,
+          expr: root_field {
+            id: `bar` @ 24..27,
+            has_question_mark: false
+          },
           has_this: false,
           path: [
             {
@@ -56,10 +62,16 @@
       ref: unresolved
     },
     args: [
-      root_field `bar` @ 39..42,
+      root_field {
+        id: `bar` @ 39..42,
+        has_question_mark: false
+      },
       assignment {
         left: field_path {
-          expr: root_field `baz` @ 44..47,
+          expr: root_field {
+            id: `baz` @ 44..47,
+            has_question_mark: false
+          },
           has_this: false,
           path: [
             {
@@ -69,9 +81,15 @@
           ]
         },
         equals: 47..48,
-        right: root_field `qux` @ 48..51
+        right: root_field {
+          id: `qux` @ 48..51,
+          has_question_mark: false
+        }
       },
-      root_field `quux` @ 53..57
+      root_field {
+        id: `quux` @ 53..57,
+        has_question_mark: false
+      }
     ]
   },
   invocation {

--- a/tenzir/tests/exec/access/list.txt
+++ b/tenzir/tests/exec/access/list.txt
@@ -58,25 +58,26 @@
   get_field: null,
   get_field_lenient: null,
 }
+warning: leading `.?` is deprecated; use a trailing `?` instead
+  --> exec/access/list.tql:19:25
+   |
+19 |   get_field_lenient = xs.?foo,
+   |                         ~~ 
+   |
+
 warning: cannot use `null` as index
   --> exec/access/list.tql:12:19
    |
 12 |   index_null = xs[null],
-   |                   ~~~~ 
+   |                   ~~~~ is null
    |
+   = hint: use `[…]?` to suppress this warning
 
 warning: cannot use `null` as index
   --> exec/access/list.tql:13:21
    |
 13 |   get_null = xs.get(null),
-   |                     ~~~~ 
-   |
-
-warning: cannot use `null` as index
-  --> exec/access/list.tql:14:30
-   |
-14 |   get_null_fallback = xs.get(null, -1),
-   |                              ~~~~ 
+   |                     ~~~~ is null
    |
 
 warning: cannot access field of non-record type
@@ -133,83 +134,86 @@ warning: list index out of bounds
  --> exec/access/list.tql:9:20
   |
 9 |   index_first = xs[0],
-  |                    ~ 
+  |                    ~ is out of bounds
   |
+  = hint: use `[…]?` to suppress this warning
 
 warning: list index out of bounds
   --> exec/access/list.tql:10:22
    |
 10 |   get_first = xs.get(0),
-   |                      ~ 
+   |                      ~ is out of bounds
    |
 
 warning: tried to access field of `null`
  --> exec/access/list.tql:9:17
   |
 9 |   index_first = xs[0],
-  |                 ~~ 
+  |                 ~~ is null
   |
+  = hint: use `[…]?` to suppress this warning
 
 warning: tried to access field of `null`
   --> exec/access/list.tql:10:15
    |
 10 |   get_first = xs.get(0),
-   |               ~~ 
+   |               ~~ is null
    |
 
 warning: tried to access field of `null`
   --> exec/access/list.tql:12:16
    |
 12 |   index_null = xs[null],
-   |                ~~ 
+   |                ~~ is null
    |
+   = hint: use `[…]?` to suppress this warning
 
 warning: tried to access field of `null`
   --> exec/access/list.tql:13:14
    |
 13 |   get_null = xs.get(null),
-   |              ~~ 
+   |              ~~ is null
    |
 
 warning: tried to access field of `null`
-  --> exec/access/list.tql:15:15
+  --> exec/access/list.tql:15:18
    |
 15 |   index_str = xs["foo"],
-   |               ~~ 
+   |                  ~~~~~ use `?` to suppress this warning
+   |
 
 warning: tried to access field of `null`
-  --> exec/access/list.tql:16:13
+  --> exec/access/list.tql:16:20
    |
 16 |   get_str = xs.get("foo"),
-   |             ~~ 
+   |                    ~~~~~ use `?` to suppress this warning
+   |
 
 warning: tried to access field of `null`
-  --> exec/access/list.tql:18:15
+  --> exec/access/list.tql:18:18
    |
 18 |   get_field = xs.foo,
-   |               ~~ 
-   ⋮
-18 |   get_field = xs.foo,
-   |                 - use the `.?` operator to suppress this warning
+   |                  ~~~ use `?` to suppress this warning
    |
 
-warning: cannot index into `string` with `int64`
- --> exec/access/list.tql:9:20
+warning: expected `record` or `list`
+ --> exec/access/list.tql:9:17
   |
 9 |   index_first = xs[0],
-  |                    ~ 
+  |                 ~~ has type `string`
   |
+  = hint: use `[…]?` to suppress this warning
 
-warning: cannot index into `string` with `int64`
-  --> exec/access/list.tql:10:22
+warning: expected `record` or `list`
+  --> exec/access/list.tql:10:15
    |
 10 |   get_first = xs.get(0),
-   |                      ~ 
+   |               ~~ has type `string`
    |
 
-warning: cannot index into `string` with `int64`
-  --> exec/access/list.tql:11:31
+warning: expected `record` or `list`
+  --> exec/access/list.tql:11:24
    |
 11 |   get_first_fallback = xs.get(0, -1),
-   |                               ~ 
+   |                        ~~ has type `string`
    |

--- a/tenzir/tests/exec/access/record.txt
+++ b/tenzir/tests/exec/access/record.txt
@@ -56,132 +56,135 @@
   get_field: null,
   get_field_lenient: null,
 }
+warning: leading `.?` is deprecated; use a trailing `?` instead
+  --> exec/access/record.tql:19:25
+   |
+19 |   get_field_lenient = xs.?foo,
+   |                         ~~ 
+   |
+
 warning: cannot use `null` as index
   --> exec/access/record.tql:12:19
    |
 12 |   index_null = xs[null],
-   |                   ~~~~ 
+   |                   ~~~~ is null
    |
+   = hint: use `[…]?` to suppress this warning
 
 warning: cannot use `null` as index
   --> exec/access/record.tql:13:21
    |
 13 |   get_null = xs.get(null),
-   |                     ~~~~ 
-   |
-
-warning: cannot use `null` as index
-  --> exec/access/record.tql:14:30
-   |
-14 |   get_null_fallback = xs.get(null, -1),
-   |                              ~~~~ 
+   |                     ~~~~ is null
    |
 
 warning: index out of bounds
  --> exec/access/record.tql:9:20
   |
 9 |   index_first = xs[0],
-  |                    ~ 
+  |                    ~ is out of bounds
   |
+  = hint: use `[…]?` to suppress this warning
 
 warning: index out of bounds
   --> exec/access/record.tql:10:22
    |
 10 |   get_first = xs.get(0),
-   |                      ~ 
+   |                      ~ is out of bounds
    |
 
 warning: record does not have this field
   --> exec/access/record.tql:15:18
    |
 15 |   index_str = xs["foo"],
-   |                  ~~~~~ 
+   |                  ~~~~~ use `?` to suppress this warning
+   |
 
 warning: record does not have this field
   --> exec/access/record.tql:16:20
    |
 16 |   get_str = xs.get("foo"),
-   |                    ~~~~~ 
+   |                    ~~~~~ use `?` to suppress this warning
+   |
 
 warning: record does not have this field
   --> exec/access/record.tql:18:18
    |
 18 |   get_field = xs.foo,
-   |                  ~~~ 
-   ⋮
-18 |   get_field = xs.foo,
-   |                 - use the `.?` operator to suppress this warning
+   |                  ~~~ use `?` to suppress this warning
    |
 
 warning: tried to access field of `null`
  --> exec/access/record.tql:9:17
   |
 9 |   index_first = xs[0],
-  |                 ~~ 
+  |                 ~~ is null
   |
+  = hint: use `[…]?` to suppress this warning
 
 warning: tried to access field of `null`
   --> exec/access/record.tql:10:15
    |
 10 |   get_first = xs.get(0),
-   |               ~~ 
+   |               ~~ is null
    |
 
 warning: tried to access field of `null`
   --> exec/access/record.tql:12:16
    |
 12 |   index_null = xs[null],
-   |                ~~ 
+   |                ~~ is null
    |
+   = hint: use `[…]?` to suppress this warning
 
 warning: tried to access field of `null`
   --> exec/access/record.tql:13:14
    |
 13 |   get_null = xs.get(null),
-   |              ~~ 
+   |              ~~ is null
    |
 
 warning: tried to access field of `null`
-  --> exec/access/record.tql:15:15
+  --> exec/access/record.tql:15:18
    |
 15 |   index_str = xs["foo"],
-   |               ~~ 
+   |                  ~~~~~ use `?` to suppress this warning
+   |
 
 warning: tried to access field of `null`
-  --> exec/access/record.tql:16:13
+  --> exec/access/record.tql:16:20
    |
 16 |   get_str = xs.get("foo"),
-   |             ~~ 
+   |                    ~~~~~ use `?` to suppress this warning
+   |
 
 warning: tried to access field of `null`
-  --> exec/access/record.tql:18:15
+  --> exec/access/record.tql:18:18
    |
 18 |   get_field = xs.foo,
-   |               ~~ 
-   ⋮
-18 |   get_field = xs.foo,
-   |                 - use the `.?` operator to suppress this warning
+   |                  ~~~ use `?` to suppress this warning
    |
 
-warning: cannot index into `string` with `int64`
- --> exec/access/record.tql:9:20
+warning: expected `record` or `list`
+ --> exec/access/record.tql:9:17
   |
 9 |   index_first = xs[0],
-  |                    ~ 
+  |                 ~~ has type `string`
   |
+  = hint: use `[…]?` to suppress this warning
 
-warning: cannot index into `string` with `int64`
-  --> exec/access/record.tql:10:22
+warning: expected `record` or `list`
+  --> exec/access/record.tql:10:15
    |
 10 |   get_first = xs.get(0),
-   |                      ~ 
+   |               ~~ has type `string`
    |
 
-warning: cannot index into `string` with `int64`
-  --> exec/access/record.tql:11:31
+warning: expected `record` or `list`
+  --> exec/access/record.tql:11:24
    |
 11 |   get_first_fallback = xs.get(0, -1),
-   |                               ~ 
+   |                        ~~ has type `string`
    |
 
 warning: cannot access field of non-record type

--- a/tenzir/tests/exec/chart/fill.txt
+++ b/tenzir/tests/exec/chart/fill.txt
@@ -38,5 +38,5 @@ warning: field `y` not found
  --> exec/chart/fill.tql:2:23
   |
 2 | chart_area x=x, y=sum(y), resolution=2s, x_min=0s, x_max=15s, fill=0s
-  |                       ~ 
+  |                       ~ use `?` to suppress this warning
   |

--- a/tenzir/tests/finalize/export_where.txt
+++ b/tenzir/tests/finalize/export_where.txt
@@ -32,8 +32,14 @@
     }
   },
   where_exec binary_expr {
-    left: root_field `bar` @ 26..29,
+    left: root_field {
+      id: `bar` @ 26..29,
+      has_question_mark: false
+    },
     op: "eq" @ 30..32,
-    right: root_field `baz` @ 33..36
+    right: root_field {
+      id: `baz` @ 33..36,
+      has_question_mark: false
+    }
   }
 ]

--- a/tenzir/tests/instantiation/every.diff
+++ b/tenzir/tests/instantiation/every.diff
@@ -34,7 +34,10 @@
            where_ir {
              self: 150..155,
              predicate: binary_expr {
-               left: root_field `time` @ 156..160,
+               left: root_field {
+                 id: `time` @ 156..160,
+                 has_question_mark: false
+               },
                op: "lt" @ 161..162,
                right: dollar_var `$ts` -> 1 @ 163..166
              }

--- a/tenzir/tests/instantiation/if.diff
+++ b/tenzir/tests/instantiation/if.diff
@@ -47,14 +47,20 @@
              self: 53..58,
              predicate: binary_expr {
                left: binary_expr {
-                 left: root_field `foo` @ 59..62,
+                 left: root_field {
+                   id: `foo` @ 59..62,
+                   has_question_mark: false
+                 },
                  op: "eq" @ 63..65,
 -                right: dollar_var `$foo` -> 1 @ 66..70
 +                right: constant int64 1 @ 66..70
                },
                op: "and_" @ 71..74,
                right: binary_expr {
-                 left: root_field `bar` @ 75..78,
+                 left: root_field {
+                   id: `bar` @ 75..78,
+                   has_question_mark: false
+                 },
                  op: "eq" @ 79..81,
 -                right: dollar_var `$bar` -> 2 @ 82..86
 +                right: constant int64 2 @ 82..86
@@ -79,14 +85,20 @@
                self: 113..118,
                predicate: binary_expr {
                  left: binary_expr {
-                   left: root_field `foo` @ 119..122,
+                   left: root_field {
+                     id: `foo` @ 119..122,
+                     has_question_mark: false
+                   },
                    op: "eq" @ 123..125,
 -                  right: dollar_var `$foo` -> 1 @ 126..130
 +                  right: constant int64 1 @ 126..130
                  },
                  op: "and_" @ 131..134,
                  right: binary_expr {
-                   left: root_field `bar` @ 135..138,
+                   left: root_field {
+                     id: `bar` @ 135..138,
+                     has_question_mark: false
+                   },
                    op: "eq" @ 139..141,
 -                  right: dollar_var `$bar` -> 3 @ 142..146
 +                  right: constant int64 3 @ 142..146

--- a/tenzir/tests/instantiation/let.diff
+++ b/tenzir/tests/instantiation/let.diff
@@ -28,7 +28,10 @@
      where_ir {
        self: 75..80,
        predicate: binary_expr {
-         left: root_field `foo` @ 81..84,
+         left: root_field {
+           id: `foo` @ 81..84,
+           has_question_mark: false
+         },
          op: "eq" @ 85..87,
 -        right: dollar_var `$foo` -> 1 @ 88..92
 +        right: constant int64 42 @ 88..92

--- a/tenzir/tests/instantiation/let_now.diff
+++ b/tenzir/tests/instantiation/let_now.diff
@@ -44,7 +44,10 @@
      where_ir {
        self: 39..44,
        predicate: binary_expr {
-         left: root_field `foo` @ 45..48,
+         left: root_field {
+           id: `foo` @ 45..48,
+           has_question_mark: false
+         },
          op: "eq" @ 49..51,
 -        right: dollar_var `$foo` -> 1 @ 52..56
 +        right: constant bool false @ 52..56

--- a/tenzir/tests/ir/group.txt
+++ b/tenzir/tests/ir/group.txt
@@ -8,7 +8,10 @@
   ],
   operators: [
     group_ir {
-      over: root_field `count` @ 20..25,
+      over: root_field {
+        id: `count` @ 20..25,
+        has_question_mark: false
+      },
       pipe: {
         lets: [
           

--- a/tenzir/tests/oldir/else_const_pred.txt
+++ b/tenzir/tests/oldir/else_const_pred.txt
@@ -12,7 +12,10 @@
     assignments: [
       {
         left: field_path {
-          expr: root_field `foo` @ 40..43,
+          expr: root_field {
+            id: `foo` @ 40..43,
+            has_question_mark: false
+          },
           has_this: false,
           path: [
             {

--- a/tenzir/tests/oldir/else_discard.txt
+++ b/tenzir/tests/oldir/else_discard.txt
@@ -10,7 +10,10 @@
   ],
   where_assert_operator {
     expression: binary_expr {
-      left: root_field `foo` @ 11..14,
+      left: root_field {
+        id: `foo` @ 11..14,
+        has_question_mark: false
+      },
       op: "eq" @ 15..17,
       right: constant int64 1 @ 18..19
     },
@@ -20,7 +23,10 @@
     assignments: [
       {
         left: field_path {
-          expr: root_field `foo` @ 28..31,
+          expr: root_field {
+            id: `foo` @ 28..31,
+            has_question_mark: false
+          },
           has_this: false,
           path: [
             {

--- a/tenzir/tests/oldir/if_const_pred.txt
+++ b/tenzir/tests/oldir/if_const_pred.txt
@@ -12,7 +12,10 @@
     assignments: [
       {
         left: field_path {
-          expr: root_field `foo` @ 20..23,
+          expr: root_field {
+            id: `foo` @ 20..23,
+            has_question_mark: false
+          },
           has_this: false,
           path: [
             {

--- a/tenzir/tests/oldir/if_discard.txt
+++ b/tenzir/tests/oldir/if_discard.txt
@@ -12,7 +12,10 @@
     expression: unary_expr {
       op: "not_" @ 0..0,
       expr: binary_expr {
-        left: root_field `foo` @ 11..14,
+        left: root_field {
+          id: `foo` @ 11..14,
+          has_question_mark: false
+        },
         op: "eq" @ 15..17,
         right: constant int64 1 @ 18..19
       }
@@ -23,7 +26,10 @@
     assignments: [
       {
         left: field_path {
-          expr: root_field `foo` @ 47..50,
+          expr: root_field {
+            id: `foo` @ 47..50,
+            has_question_mark: false
+          },
           has_this: false,
           path: [
             {

--- a/tenzir/tests/opt/export_where.diff
+++ b/tenzir/tests/opt/export_where.diff
@@ -44,7 +44,10 @@
 -    where_ir {
 -      self: 22..27,
 -      predicate: binary_expr {
--        left: root_field `foo` @ 28..31,
+-        left: root_field {
+-          id: `foo` @ 28..31,
+-          has_question_mark: false
+-        },
 -        op: "eq" @ 32..34,
 -        right: constant int64 42 @ 35..39
 -      }

--- a/tenzir/tests/opt/export_where_now.diff
+++ b/tenzir/tests/opt/export_where_now.diff
@@ -44,7 +44,10 @@
 -    where_ir {
 -      self: 336..341,
 -      predicate: binary_expr {
--        left: root_field `bar` @ 342..345,
+-        left: root_field {
+-          id: `bar` @ 342..345,
+-          has_question_mark: false
+-        },
 -        op: "eq" @ 346..348,
 -        right: constant bool true @ 349..353
 -      }

--- a/web/docs/tql2/language/expressions.md
+++ b/web/docs/tql2/language/expressions.md
@@ -80,14 +80,14 @@ my_field = top_level.nested
 {my_field: 0, top_level: {nested: 0}}
 ```
 
-To avoid a warning when the nested field does not exist, use `.?<name>`.
+To avoid a warning when the nested field does not exist, use `<name>?`.
 
 ```tql
 from (
   {foo: 1},
   {bar: 2},
 )
-select foo = this.?foo
+select foo = foo?
 ```
 
 ```tql
@@ -294,20 +294,18 @@ level = $severity_to_level[severity]
 }
 ```
 
-To suppress warnings when the record field is missing, use the
-[`get`](../functions/get.md) function with a fallback value:
+To suppress warnings when the record field is missing, use the `?` operator:
 
 ```tql
 from {foo: 1, bar: 2}
-result = this.get("baz", "default")
+result = baz?
 ```
 
 ```tql
-{result: "default"}
+{result: null}
 ```
 
-Both indexing expressions and the `get` function support numeric indices to
-access record fields:
+Indexing expressions support numeric indices to access record fields:
 
 ```tql title="Accessing a field by index"
 from {foo: "Hello", bar: "World"}


### PR DESCRIPTION
Now that we're working more with suppressed warnings in field accesses, I wanted to experiment with a trailing `?` instead of using a separate `.?` operator for field access:
- `this.?foo` is now `foo?`
- `foo.?bar` is now `foo.bar?`
- `foo.get(bar, null)` is now `foo[bar]?`

Just opening this for comments; not sure if we want to go forward with this. This came up because of the recent work on the `move` keyword, where moving top-level fields becomes a lot more readable with `move foo?` instead of `move this.?foo`.