### PR TITLE
Support building against Boost 1.88+

### DIFF
--- a/libtenzir/builtins/functions/misc.cpp
+++ b/libtenzir/builtins/functions/misc.cpp
@@ -13,7 +13,11 @@
 #include <tenzir/tql2/eval.hpp>
 #include <tenzir/tql2/plugin.hpp>
 
-#include <boost/process/environment.hpp>
+#if __has_include(<boost/process/v1/environment.hpp>)
+#  include <boost/process/v1/environment.hpp>
+#else
+#  include <boost/process/environment.hpp>
+#endif
 
 #include <ranges>
 

--- a/libtenzir/include/tenzir/detail/preserved_fds.hpp
+++ b/libtenzir/include/tenzir/detail/preserved_fds.hpp
@@ -20,8 +20,8 @@
 
 namespace tenzir::detail {
 
-struct preserved_fds : boost::process::detail::handler,
-                       boost::process::detail::uses_handles {
+struct preserved_fds : boost::process::v1::detail::handler,
+                       boost::process::v1::detail::uses_handles {
   std::vector<int> fds;
   preserved_fds(std::vector<int> pfds);
 


### PR DESCRIPTION
Boost.Process v2 is now officially the default Boost.Process, so now we need to spell out all the old includes and explicitly use `boost::process::v1` instead of just `boost::process`.