### PR TITLE
Fix edge case when parsing nullable lists with type conflicts

### DIFF
--- a/changelog/next/bug-fixes/5134--edge-case-when-parsing-nullable-lists.md
+++ b/changelog/next/bug-fixes/5134--edge-case-when-parsing-nullable-lists.md
@@ -1,0 +1,2 @@
+Parsing of nullable lists with type conflicts could previously lead to an error
+under very rare circumstances. This now works as expected.

--- a/libtenzir/builtins/contexts/bloom_filter.cpp
+++ b/libtenzir/builtins/contexts/bloom_filter.cpp
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include <tenzir/arrow_table_slice.hpp>
+#include <tenzir/arrow_utils.hpp>
 #include <tenzir/concept/parseable/numeric.hpp>
 #include <tenzir/concept/parseable/tenzir/expression.hpp>
 #include <tenzir/concept/parseable/to.hpp>
@@ -151,7 +152,7 @@ public:
     }
     auto [key_type, key_array] = key_column->get(slice);
     auto context_array = std::static_pointer_cast<arrow::Array>(
-      to_record_batch(slice)->ToStructArray().ValueOrDie());
+      check(to_record_batch(slice)->ToStructArray()));
     auto key_values = values(key_type, *key_array);
     auto key_values_list = list{};
     auto context_values = values(slice.schema(), *context_array);

--- a/libtenzir/builtins/contexts/lookup_table.cpp
+++ b/libtenzir/builtins/contexts/lookup_table.cpp
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include <tenzir/arrow_table_slice.hpp>
+#include <tenzir/arrow_utils.hpp>
 #include <tenzir/concept/parseable/numeric/bool.hpp>
 #include <tenzir/concept/parseable/tenzir/data.hpp>
 #include <tenzir/concept/parseable/tenzir/expression.hpp>
@@ -508,7 +509,7 @@ public:
       };
     }
     auto context_array = std::static_pointer_cast<arrow::Array>(
-      to_record_batch(slice)->ToStructArray().ValueOrDie());
+      check(to_record_batch(slice)->ToStructArray()));
     auto context_values = values(slice.schema(), *context_array);
     auto key_it = key_values.begin();
     auto context_it = context_values.begin();

--- a/libtenzir/builtins/formats/lines.cpp
+++ b/libtenzir/builtins/formats/lines.cpp
@@ -9,6 +9,7 @@
 #include "tenzir/defaults.hpp"
 
 #include <tenzir/argument_parser.hpp>
+#include <tenzir/arrow_utils.hpp>
 #include <tenzir/detail/assert.hpp>
 #include <tenzir/detail/base64.hpp>
 #include <tenzir/series_builder.hpp>
@@ -191,8 +192,7 @@ public:
         auto resolved_slice = flatten(resolve_enumerations(slice)).slice;
         auto input_schema = resolved_slice.schema();
         const auto& input_type = as<record_type>(input_schema);
-        auto array
-          = to_record_batch(resolved_slice)->ToStructArray().ValueOrDie();
+        auto array = check(to_record_batch(resolved_slice)->ToStructArray());
         for (const auto& row : values(input_type, *array)) {
           TENZIR_ASSERT(row);
           const auto ok = printer.print_values(out_iter, *row);

--- a/libtenzir/builtins/formats/pcap.cpp
+++ b/libtenzir/builtins/formats/pcap.cpp
@@ -9,6 +9,7 @@
 
 #include <tenzir/argument_parser.hpp>
 #include <tenzir/arrow_table_slice.hpp>
+#include <tenzir/arrow_utils.hpp>
 #include <tenzir/detail/byteswap.hpp>
 #include <tenzir/error.hpp>
 #include <tenzir/logger.hpp>
@@ -308,7 +309,7 @@ auto make_file_header(const table_slice& slice) -> std::optional<file_header> {
   }
   auto result = file_header{};
   const auto& input_record = as<record_type>(slice.schema());
-  auto array = to_record_batch(slice)->ToStructArray().ValueOrDie();
+  auto array = check(to_record_batch(slice)->ToStructArray());
   auto xs = values(input_record, *array);
   auto begin = xs.begin();
   if (begin == xs.end() || *begin == std::nullopt) {
@@ -495,8 +496,7 @@ public:
         const auto& input_record = as<record_type>(slice.schema());
         if (slice.schema().name() == "pcap.packet") {
           auto resolved_slice = resolve_enumerations(slice);
-          auto array
-            = to_record_batch(resolved_slice)->ToStructArray().ValueOrDie();
+          auto array = check(to_record_batch(resolved_slice)->ToStructArray());
           for (const auto& row : values(input_record, *array)) {
             TENZIR_ASSERT(row);
             if (auto diag = process_packet_row(*row)) {

--- a/libtenzir/builtins/formats/xsv.cpp
+++ b/libtenzir/builtins/formats/xsv.cpp
@@ -772,8 +772,7 @@ public:
         auto resolved_slice = flatten(resolve_enumerations(slice)).slice;
         auto input_schema = resolved_slice.schema();
         auto slice_type = as<record_type>(input_schema);
-        auto array
-          = to_record_batch(resolved_slice)->ToStructArray().ValueOrDie();
+        auto array = check(to_record_batch(resolved_slice)->ToStructArray());
         for (const auto& row : values3(*array)) {
           TENZIR_ASSERT(row);
           if (first && not args.no_header) {

--- a/libtenzir/builtins/formats/yaml.cpp
+++ b/libtenzir/builtins/formats/yaml.cpp
@@ -269,8 +269,7 @@ public:
         }
         auto input_type = as<record_type>(slice.schema());
         auto resolved_slice = resolve_enumerations(slice);
-        auto array
-          = to_record_batch(resolved_slice)->ToStructArray().ValueOrDie();
+        auto array = check(to_record_batch(resolved_slice)->ToStructArray());
         auto out = std::make_unique<YAML::Emitter>();
         out->SetOutputCharset(YAML::EscapeNonAscii); // restrict to ASCII output
         out->SetNullFormat(YAML::LowerNull);

--- a/libtenzir/builtins/formats/zeek_tsv.cpp
+++ b/libtenzir/builtins/formats/zeek_tsv.cpp
@@ -823,8 +823,7 @@ public:
       auto resolved_slice = flatten(resolve_enumerations(slice)).slice;
       auto input_schema = resolved_slice.schema();
       auto input_type = as<record_type>(input_schema);
-      auto array
-        = to_record_batch(resolved_slice)->ToStructArray().ValueOrDie();
+      auto array = check(to_record_batch(resolved_slice)->ToStructArray());
       auto first = true;
       auto is_first_schema = not * last_schema;
       auto did_schema_change = *last_schema != input_schema;

--- a/libtenzir/builtins/functions/hash.cpp
+++ b/libtenzir/builtins/functions/hash.cpp
@@ -107,7 +107,7 @@ public:
             config_.out,
             string_type{},
           },
-          hashes_builder->Finish().ValueOrDie(),
+          finish(*hashes_builder),
         },
       };
     };

--- a/libtenzir/builtins/operators/chart.cpp
+++ b/libtenzir/builtins/operators/chart.cpp
@@ -267,7 +267,7 @@ private:
       return false;
     }
     const auto& record_schema = *record_schema_ptr;
-    auto struct_array = to_record_batch(slice)->ToStructArray().ValueOrDie();
+    auto struct_array = check(to_record_batch(slice)->ToStructArray());
     for (const auto& item : cfg_) {
       const auto count = item.count_fields(record_schema);
       if (item.req == requirement::none) {
@@ -300,7 +300,7 @@ private:
       return std::nullopt;
     }
     const auto& record_schema = *record_schema_ptr;
-    auto struct_array = to_record_batch(slice)->ToStructArray().ValueOrDie();
+    auto struct_array = check(to_record_batch(slice)->ToStructArray());
     std::vector<type::attribute_view> result{};
     for (const auto& item : cfg_) {
       const auto count = item.count_fields(record_schema);

--- a/libtenzir/builtins/operators/deduplicate.cpp
+++ b/libtenzir/builtins/operators/deduplicate.cpp
@@ -8,6 +8,7 @@
 
 #include <tenzir/argument_parser.hpp>
 #include <tenzir/arrow_table_slice.hpp>
+#include <tenzir/arrow_utils.hpp>
 #include <tenzir/collect.hpp>
 #include <tenzir/concept/parseable/tenzir/pipeline.hpp>
 #include <tenzir/null_bitmap.hpp>
@@ -159,7 +160,7 @@ public:
         co_yield table_slice{projected_batch, projected_type};
         continue;
       }
-      auto elements = projected_batch->ToStructArray().ValueOrDie();
+      auto elements = check(projected_batch->ToStructArray());
       TENZIR_ASSERT(elements);
       for (auto&& new_slice :
            deduplicate(matches, row_number, slice, projected_type, *elements)) {
@@ -444,7 +445,7 @@ auto deduplicate_operator::cached_projection::make(
         }
         using field_type = struct record_type::field;
         result.emplace_back(field_type{missing_field, type{null_type{}}},
-                            builder->Finish().ValueOrDie());
+                            finish(*builder));
       }
       return result;
     };

--- a/libtenzir/builtins/operators/enumerate.cpp
+++ b/libtenzir/builtins/operators/enumerate.cpp
@@ -71,7 +71,7 @@ public:
       }
       offset += n;
       // Replace first column with a pair of (RID, first).
-      auto rid_array = builder->Finish().ValueOrDie();
+      auto rid_array = finish(*builder);
       return {
         {{field_, rid_type}, rid_array},
         {field, array},

--- a/libtenzir/builtins/operators/from_opensearch.cpp
+++ b/libtenzir/builtins/operators/from_opensearch.cpp
@@ -174,8 +174,7 @@ auto decompress_payload(const http::request& r, diagnostic_handler& dh)
   const auto codec = arrow::util::Codec::Create(
     compression_type.ValueUnsafe(), arrow::util::kUseDefaultCompressionLevel);
   TENZIR_ASSERT(codec.ok());
-  const auto decompressor
-    = codec.ValueUnsafe()->MakeDecompressor().ValueOrDie();
+  const auto decompressor = check(codec.ValueUnsafe()->MakeDecompressor());
   auto written = size_t{};
   auto read = size_t{};
   while (read != r.payload().size_bytes()) {

--- a/libtenzir/builtins/operators/http.cpp
+++ b/libtenzir/builtins/operators/http.cpp
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "tenzir/argument_parser2.hpp"
+#include "tenzir/arrow_utils.hpp"
 #include "tenzir/plugin.hpp"
 #include "tenzir/series_builder.hpp"
 
@@ -219,8 +220,7 @@ auto try_decompress_payload(const http::request& r, diagnostic_handler& dh)
   const auto codec = arrow::util::Codec::Create(
     compression_type.ValueUnsafe(), arrow::util::kUseDefaultCompressionLevel);
   TENZIR_ASSERT(codec.ok());
-  const auto decompressor
-    = codec.ValueUnsafe()->MakeDecompressor().ValueOrDie();
+  const auto decompressor = check(codec.ValueUnsafe()->MakeDecompressor());
   auto written = size_t{};
   auto read = size_t{};
   while (read != r.payload().size_bytes()) {

--- a/libtenzir/builtins/operators/parse.cpp
+++ b/libtenzir/builtins/operators/parse.cpp
@@ -8,6 +8,7 @@
 
 #include <tenzir/argument_parser.hpp>
 #include <tenzir/arrow_table_slice.hpp>
+#include <tenzir/arrow_utils.hpp>
 #include <tenzir/collect.hpp>
 #include <tenzir/operator_control_plane.hpp>
 #include <tenzir/plugin.hpp>
@@ -107,8 +108,7 @@ public:
         co_return;
       }
       TENZIR_ASSERT(total == string_array->length());
-      const auto children
-        = batch->ToStructArray().ValueOrDie()->Flatten().ValueOrDie();
+      const auto children = check(check(batch->ToStructArray())->Flatten());
       auto next = int64_t{0};
       for (auto& [result_ty, result] : results) {
         auto sub = subslice(slice, next, next + result->length());

--- a/libtenzir/builtins/operators/print.cpp
+++ b/libtenzir/builtins/operators/print.cpp
@@ -10,6 +10,7 @@
 
 #include "tenzir/argument_parser.hpp"
 #include "tenzir/arrow_table_slice.hpp"
+#include "tenzir/arrow_utils.hpp"
 #include "tenzir/collect.hpp"
 #include "tenzir/detail/assert.hpp"
 #include "tenzir/generator.hpp"
@@ -115,7 +116,7 @@ public:
         };
         auto rb = arrow::RecordBatch::Make(
           field.type.to_arrow_schema(), array->length(),
-          static_cast<const arrow::StructArray&>(*array).Flatten().ValueOrDie());
+          check(static_cast<const arrow::StructArray&>(*array).Flatten()));
         auto slice = table_slice{rb, field.type};
         auto builder = series_builder{type{string_type{}}};
         for (size_t i = 0; i < slice.rows(); i++) {

--- a/libtenzir/builtins/operators/pseudonymize.cpp
+++ b/libtenzir/builtins/operators/pseudonymize.cpp
@@ -74,7 +74,7 @@ public:
         }
         TENZIR_ASSERT(append_status.ok(), append_status.ToString().c_str());
       }
-      auto new_array = builder->Finish().ValueOrDie();
+      auto new_array = finish(*builder);
       return {
         {field, new_array},
       };

--- a/libtenzir/builtins/operators/python.cpp
+++ b/libtenzir/builtins/operators/python.cpp
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include <tenzir/argument_parser.hpp>
+#include <tenzir/arrow_utils.hpp>
 #include <tenzir/as_bytes.hpp>
 #include <tenzir/chunk.hpp>
 #include <tenzir/concept/parseable/string/quoted_string.hpp>
@@ -409,10 +410,9 @@ public:
         }
         auto original_schema_name = slice.schema().name();
         auto batch = to_record_batch(slice);
-        auto stream = arrow::io::BufferOutputStream::Create().ValueOrDie();
-        auto writer = arrow::ipc::MakeStreamWriter(
-                        stream, slice.schema().to_arrow_schema())
-                        .ValueOrDie();
+        auto stream = check(arrow::io::BufferOutputStream::Create());
+        auto writer = check(arrow::ipc::MakeStreamWriter(
+          stream, slice.schema().to_arrow_schema()));
         if (! writer->WriteRecordBatch(*batch).ok()) {
           diagnostic::error("failed to convert input batch to Arrow format")
             .note(

--- a/libtenzir/builtins/operators/serve.cpp
+++ b/libtenzir/builtins/operators/serve.cpp
@@ -749,8 +749,7 @@ struct serve_handler_state {
       seen_types.insert(slice.schema());
       auto resolved_slice = resolve_enumerations(slice);
       auto type = as<record_type>(resolved_slice.schema());
-      auto array
-        = to_record_batch(resolved_slice)->ToStructArray().ValueOrDie();
+      auto array = check(to_record_batch(resolved_slice)->ToStructArray());
       for (const auto& row : values(type, *array)) {
         if (first) {
           out_iter = fmt::format_to(out_iter, "{{");

--- a/libtenzir/builtins/operators/sort.cpp
+++ b/libtenzir/builtins/operators/sort.cpp
@@ -126,7 +126,7 @@ public:
     // at the start, and uses std::upper_bound to find the entry in the cache
     // using the offset table.
     const auto chunked_key
-      = arrow::ChunkedArray::Make(std::move(sort_keys_)).ValueOrDie();
+      = check(arrow::ChunkedArray::Make(std::move(sort_keys_)));
     const auto indices
       = arrow::compute::SortIndices(*chunked_key, sort_options_);
     if (not indices.ok()) {

--- a/libtenzir/builtins/operators/summarize.cpp
+++ b/libtenzir/builtins/operators/summarize.cpp
@@ -253,9 +253,9 @@ struct binding {
       if (column) {
         auto array = column->offset.get(batch);
         if (config.time_resolution && is<time_type>(column->type)) {
-          array = arrow::compute::FloorTemporal(
-                    array, make_round_temporal_options(*config.time_resolution))
-                    .ValueOrDie()
+          array = check(arrow::compute::FloorTemporal(
+                          array,
+                          make_round_temporal_options(*config.time_resolution)))
                     .make_array();
         }
         result.emplace_back(std::move(array));

--- a/libtenzir/include/tenzir/cast.hpp
+++ b/libtenzir/include/tenzir/cast.hpp
@@ -266,10 +266,9 @@ struct cast_helper<list_type, list_type> {
     const auto offsets = from_array->offsets();
     const auto cast_values = cast_helper<type, type>::cast(
       from_type.value_type(), from_array->values(), to_type.value_type());
-    return type_to_arrow_array_t<list_type>::FromArrays(
-             *offsets, *cast_values, arrow::default_memory_pool(),
-             from_array->null_bitmap(), from_array->null_count())
-      .ValueOrDie();
+    return check(type_to_arrow_array_t<list_type>::FromArrays(
+      *offsets, *cast_values, arrow::default_memory_pool(),
+      from_array->null_bitmap(), from_array->null_count()));
   }
 
   template <class InputType>
@@ -395,10 +394,8 @@ struct cast_helper<record_type, record_type> {
         const auto index = from_type.resolve_key(key);
         if (!index) {
           // The field does not exist, so we insert a bunch of nulls.
-          children.push_back(
-            arrow::MakeArrayOfNull(to_field.type.to_arrow_type(),
-                                   from_array->length())
-              .ValueOrDie());
+          children.push_back(check(arrow::MakeArrayOfNull(
+            to_field.type.to_arrow_type(), from_array->length())));
           continue;
         }
         // The field exists, so we can insert the casted column.
@@ -406,8 +403,7 @@ struct cast_helper<record_type, record_type> {
           from_type.field(*index).type, index->get(*from_array),
           to_field.type));
       }
-      return type_to_arrow_array_t<record_type>::Make(children, fields)
-        .ValueOrDie();
+      return check(type_to_arrow_array_t<record_type>::Make(children, fields));
     };
     return impl(impl, to_type, "");
   }

--- a/libtenzir/include/tenzir/series.hpp
+++ b/libtenzir/include/tenzir/series.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "tenzir/arrow_table_slice.hpp"
+#include "tenzir/arrow_utils.hpp"
 #include "tenzir/offset.hpp"
 #include "tenzir/type.hpp"
 
@@ -33,13 +34,13 @@ struct basic_series {
   explicit basic_series(const table_slice& slice)
     requires(std::same_as<Type, type>)
     : type{slice.schema()},
-      array{to_record_batch(slice)->ToStructArray().ValueOrDie()} {
+      array{check(to_record_batch(slice)->ToStructArray())} {
   }
 
   explicit basic_series(const table_slice& slice)
     requires(std::same_as<Type, record_type>)
     : type{as<record_type>(slice.schema())},
-      array{to_record_batch(slice)->ToStructArray().ValueOrDie()} {
+      array{check(to_record_batch(slice)->ToStructArray())} {
   }
 
   basic_series(table_slice slice, offset idx)
@@ -86,7 +87,7 @@ struct basic_series {
     (void)b->AppendNulls(length);
     return {std::move(ty),
             std::static_pointer_cast<type_to_arrow_array_t<Other>>(
-              b->Finish().ValueOrDie())};
+              check(b->Finish()))};
   }
 
   template <class Inspector>

--- a/libtenzir/src/arrow_table_slice.cpp
+++ b/libtenzir/src/arrow_table_slice.cpp
@@ -350,7 +350,7 @@ transform_columns(type schema,
           = as<arrow::StructArray>(*layer.arrays[index.back()]);
         auto nested_layer = unpacked_layer{
           .fields = {},
-          .arrays = nested_array.Flatten().ValueOrDie(),
+          .arrays = check(nested_array.Flatten()),
         };
         nested_layer.fields.reserve(nested_layer.arrays.size());
         for (auto&& [name, type] :
@@ -388,7 +388,7 @@ transform_columns(type schema,
   const auto sentinel = transformations.end();
   auto layer = unpacked_layer{
     .fields = {},
-    .arrays = struct_array->Flatten().ValueOrDie(),
+    .arrays = check(struct_array->Flatten()),
   };
   const auto num_columns
     = detail::narrow_cast<size_t>(struct_array->num_fields());
@@ -424,7 +424,7 @@ transform_columns(type schema,
     // function does not really allow this, as it can change the behavior for
     // nulls.
     new_struct_array
-      = arrow::StructArray::Make(layer.arrays, arrow_fields).ValueOrDie();
+      = check(arrow::StructArray::Make(layer.arrays, arrow_fields));
   }
 #if TENZIR_ENABLE_ASSERTIONS
   auto validate_status = new_struct_array->Validate();
@@ -449,7 +449,7 @@ transform_columns(const table_slice& slice,
     return slice;
   }
   auto input_batch = to_record_batch(slice);
-  auto input_struct_array = input_batch->ToStructArray().ValueOrDie();
+  auto input_struct_array = check(input_batch->ToStructArray());
   auto [output_schema, output_struct_array] = transform_columns(
     slice.schema(), input_struct_array, std::move(transformations));
   if (!output_schema) {
@@ -519,7 +519,7 @@ select_columns(type schema, const std::shared_ptr<arrow::RecordBatch>& batch,
           = as<arrow::StructArray>(*layer.arrays[index.back()]);
         auto nested_layer = unpacked_layer{
           .fields = {},
-          .arrays = nested_array.Flatten().ValueOrDie(),
+          .arrays = check(nested_array.Flatten()),
         };
         nested_layer.fields.reserve(nested_layer.arrays.size());
         for (auto&& [name, type] :

--- a/libtenzir/src/cast.cpp
+++ b/libtenzir/src/cast.cpp
@@ -20,7 +20,7 @@ auto cast(table_slice from_slice, const type& to_schema) noexcept
   if (from_slice.schema() == to_schema)
     return from_slice;
   const auto from_batch = to_record_batch(from_slice);
-  const auto from_struct_array = from_batch->ToStructArray().ValueOrDie();
+  const auto from_struct_array = check(from_batch->ToStructArray());
   const auto to_struct_array
     = detail::cast_helper<record_type, record_type>::cast(
       as<record_type>(from_slice.schema()), from_struct_array,

--- a/libtenzir/src/chunk.cpp
+++ b/libtenzir/src/chunk.cpp
@@ -8,6 +8,7 @@
 
 #include "tenzir/chunk.hpp"
 
+#include "tenzir/arrow_utils.hpp"
 #include "tenzir/detail/legacy_deserialize.hpp"
 #include "tenzir/detail/posix.hpp"
 #include "tenzir/detail/tracepoint.hpp"
@@ -281,12 +282,9 @@ chunk::mmap(const std::filesystem::path& filename, size_type size,
 caf::expected<chunk_ptr> chunk::compress(view_type bytes) noexcept {
   // Creating the codec cannot fail; we test that it works in Tenzir's main
   // function to catch this early.
-  auto codec
-    = arrow::util::Codec::Create(
-        arrow::Compression::ZSTD,
-        arrow::util::Codec::DefaultCompressionLevel(arrow::Compression::ZSTD)
-          .ValueOrDie())
-        .ValueOrDie();
+  auto codec = check(arrow::util::Codec::Create(
+    arrow::Compression::ZSTD, check(arrow::util::Codec::DefaultCompressionLevel(
+                                arrow::Compression::ZSTD))));
   const auto bytes_size = detail::narrow_cast<int64_t>(bytes.size());
   const auto* bytes_data = reinterpret_cast<const uint8_t*>(bytes.data());
   const auto max_length = codec->MaxCompressedLen(bytes_size, bytes_data);
@@ -307,12 +305,9 @@ caf::expected<chunk_ptr>
 chunk::decompress(view_type bytes, size_t decompressed_size) noexcept {
   // Creating the codec cannot fail; we test that it works in Tenzir's main
   // function to catch this early.
-  auto codec
-    = arrow::util::Codec::Create(
-        arrow::Compression::ZSTD,
-        arrow::util::Codec::DefaultCompressionLevel(arrow::Compression::ZSTD)
-          .ValueOrDie())
-        .ValueOrDie();
+  auto codec = check(arrow::util::Codec::Create(
+    arrow::Compression::ZSTD, check(arrow::util::Codec::DefaultCompressionLevel(
+                                arrow::Compression::ZSTD))));
   const auto bytes_size = detail::narrow_cast<int64_t>(bytes.size());
   const auto* bytes_data = reinterpret_cast<const uint8_t*>(bytes.data());
   auto buffer = std::vector<uint8_t>{};

--- a/libtenzir/src/plugin.cpp
+++ b/libtenzir/src/plugin.cpp
@@ -546,8 +546,8 @@ auto plugin_parser::parse_strings(std::shared_ptr<arrow::StringArray> input,
     TENZIR_ASSERT(null_builder->AppendNull().ok());
     auto null_array = std::shared_ptr<arrow::StructArray>{};
     TENZIR_ASSERT(null_builder->Finish(&null_array).ok());
-    auto null_batch = arrow::RecordBatch::Make(
-      last.schema().to_arrow_schema(), 1, null_array->Flatten().ValueOrDie());
+    auto null_batch = arrow::RecordBatch::Make(last.schema().to_arrow_schema(),
+                                               1, check(null_array->Flatten()));
     last
       = concatenate({std::move(last), table_slice{null_batch, last.schema()}});
   };
@@ -591,7 +591,7 @@ auto plugin_parser::parse_strings(std::shared_ptr<arrow::StringArray> input,
   result.reserve(output.size());
   for (auto&& slice : output) {
     result.emplace_back(slice.schema(),
-                        to_record_batch(slice)->ToStructArray().ValueOrDie());
+                        check(to_record_batch(slice)->ToStructArray()));
   }
   return result;
 }

--- a/libtenzir/src/series_builder.cpp
+++ b/libtenzir/src/series_builder.cpp
@@ -673,6 +673,7 @@ public:
     // correctly even if we write a null.
     auto ending_offset = result_offsets->Value(count);
     if (result_offsets->IsNull(count)) {
+      TENZIR_WARN("YO");
       check(offsets_.Reserve(result_offsets->length()));
       check(offsets_.AppendArraySlice(*result_offsets->data(), 0,
                                       result_offsets->length() - 1));

--- a/libtenzir/src/tql2/eval_impl.cpp
+++ b/libtenzir/src/tql2/eval_impl.cpp
@@ -227,8 +227,7 @@ auto evaluator::eval(const ast::function_call& x) -> multi_series {
 
 auto evaluator::eval(const ast::this_& x) -> multi_series {
   auto& input = input_or_throw(x);
-  return series{input.schema(),
-                to_record_batch(input)->ToStructArray().ValueOrDie()};
+  return series{input.schema(), check(to_record_batch(input)->ToStructArray())};
 }
 
 auto evaluator::eval(const ast::root_field& x) -> multi_series {

--- a/libtenzir/src/tql2/set.cpp
+++ b/libtenzir/src/tql2/set.cpp
@@ -75,7 +75,7 @@ auto assign(std::span<const ast::identifier> left, series right, series input,
     if (array.null_count() == 0) {
       return array.fields();
     }
-    return array.Flatten().ValueOrDie();
+    return check(array.Flatten());
   });
   auto index = std::optional<size_t>{};
   for (auto [i, field] : detail::enumerate(new_ty_fields)) {

--- a/libtenzir/test/arrow_extension_types.cpp
+++ b/libtenzir/test/arrow_extension_types.cpp
@@ -6,6 +6,7 @@
 // SPDX-FileCopyrightText: (c) 2022 The Tenzir Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+#include "tenzir/arrow_utils.hpp"
 #include "tenzir/detail/overload.hpp"
 #include "tenzir/test/test.hpp"
 #include "tenzir/type.hpp"
@@ -53,13 +54,13 @@ template <class Builder, class T = typename Builder::value_type>
 std::shared_ptr<arrow::Array> make_arrow_array(std::vector<T> xs) {
   Builder b{};
   CHECK(b.AppendValues(xs).ok());
-  return b.Finish().ValueOrDie();
+  return check(b.Finish());
 }
 
 std::shared_ptr<arrow::Array> make_ip_array() {
   arrow::FixedSizeBinaryBuilder b{arrow::fixed_size_binary(16)};
   return std::make_shared<ip_type::array_type>(
-    std::make_shared<ip_type::arrow_type>(), b.Finish().ValueOrDie());
+    std::make_shared<ip_type::arrow_type>(), check(b.Finish()));
 }
 
 // Returns a visitor that checks whether the expected concrete types are the

--- a/libtenzir/test/cast.cpp
+++ b/libtenzir/test/cast.cpp
@@ -695,13 +695,11 @@ TEST(cast int64_t array to a string builder) {
   status = int_builder->Append(2);
   status = int_builder->AppendNull();
   status = int_builder->Append(3);
-  auto array
-    = std::static_pointer_cast<tenzir::type_to_arrow_array_t<tenzir::int64_type>>(
-      int_builder->Finish().ValueOrDie());
+  auto array = tenzir::finish(*int_builder);
   auto out = tenzir::cast_to_builder(tenzir::int64_type{}, *array,
                                      tenzir::string_type{});
   REQUIRE(out);
-  auto arr = (*out)->Finish().ValueOrDie();
+  auto arr = tenzir::check((*out)->Finish());
   auto vals = tenzir::values(tenzir::type{tenzir::string_type{}}, *arr);
   std::vector<tenzir::data_view> views;
   for (const auto& val : vals) {
@@ -720,7 +718,7 @@ TEST(casting builder with no compatible types results in an error) {
   auto status = int_builder->Append(1);
   auto array
     = std::static_pointer_cast<tenzir::type_to_arrow_array_t<tenzir::int64_type>>(
-      int_builder->Finish().ValueOrDie());
+      tenzir::check(int_builder->Finish()));
   auto out = tenzir::cast_to_builder(tenzir::int64_type{}, *array,
                                      tenzir::list_type{tenzir::string_type{}});
   CHECK(not out);
@@ -735,11 +733,11 @@ TEST(
   status = int_builder->Append(3);
   auto array
     = std::static_pointer_cast<tenzir::type_to_arrow_array_t<tenzir::int64_type>>(
-      int_builder->Finish().ValueOrDie());
+      tenzir::check(int_builder->Finish()));
   auto out = tenzir::cast_to_builder(tenzir::int64_type{}, *array,
                                      tenzir::uint64_type{});
   REQUIRE(out);
-  auto arr = (*out)->Finish().ValueOrDie();
+  auto arr = tenzir::check((*out)->Finish());
   auto vals = tenzir::values(tenzir::type{tenzir::uint64_type{}}, *arr);
   std::vector<tenzir::data_view> views;
   for (const auto& val : vals) {
@@ -757,7 +755,7 @@ TEST(casting int64_t array to uint64_t builder fails due to negative value) {
   auto status = int_builder->Append(-1);
   auto array
     = std::static_pointer_cast<tenzir::type_to_arrow_array_t<tenzir::int64_type>>(
-      int_builder->Finish().ValueOrDie());
+      tenzir::check(int_builder->Finish()));
   auto out = tenzir::cast_to_builder(tenzir::int64_type{}, *array,
                                      tenzir::uint64_type{});
   CHECK(not out);

--- a/plugins/fluent-bit/include/fluent-bit/fluent-bit_operator.hpp
+++ b/plugins/fluent-bit/include/fluent-bit/fluent-bit_operator.hpp
@@ -810,8 +810,7 @@ public:
       }
       // Print table slice as JSON.
       auto resolved_slice = resolve_enumerations(slice);
-      auto array
-        = to_record_batch(resolved_slice)->ToStructArray().ValueOrDie();
+      auto array = check(to_record_batch(resolved_slice)->ToStructArray());
       auto failed = false;
       for (const auto& row : values3(*array)) {
         auto it = std::back_inserter(event);


### PR DESCRIPTION
This fixes a rare edge case where a series of lists was partially finished and the last list happened to be `null`.

It also replaces the remaining usages of `.ValueOrDie()` in the series builder with `check(…)`, which means we now just terminate the pipeline instead of the whole node.

## Review notes

The first commit contains the actual change in behavior.