### PR TITLE
Fix some minor things in docs and remove leftover debug log

### DIFF
--- a/libtenzir/src/series_builder.cpp
+++ b/libtenzir/src/series_builder.cpp
@@ -673,7 +673,6 @@ public:
     // correctly even if we write a null.
     auto ending_offset = result_offsets->Value(count);
     if (result_offsets->IsNull(count)) {
-      TENZIR_WARN("YO");
       check(offsets_.Reserve(result_offsets->length()));
       check(offsets_.AppendArraySlice(*result_offsets->data(), 0,
                                       result_offsets->length() - 1));

--- a/web/docs/tql2/functions.md
+++ b/web/docs/tql2/functions.md
@@ -67,7 +67,7 @@ but often resort to the method style when it is more idiomatic.
 
 | Function                      | Description                         | Example                                    |
 | :---------------------------- | :---------------------------------- | :----------------------------------------- |
-| [`get`](functions/get.md)     | Accesses a field of a record        | `record.get("field with spaces", default)` |
+| [`get`](functions/get.md)     | Accesses a field of a record        | `record.get("field", default)`             |
 | [`has`](functions/has.md)     | Checks whether a record has a field | `record.has("field")`                      |
 | [`merge`](functions/merge.md) | Merges two records                  | `merge(foo, bar)`                          |
 | [`sort`](functions/sort.md)   | Sorts a record by field names       | `xs.sort()`                                |
@@ -146,10 +146,10 @@ but often resort to the method style when it is more idiomatic.
 | [`parse_csv`](functions/parse_csv.mdx)       | Parses a string as CSV                   | `string.parse_csv(header=["a","b"])`               |
 | [`parse_grok`](functions/parse_grok.mdx)     | Parses a string following a grok pattern | `string.parse_grok("%{IP:client} …")`              |
 | [`parse_json`](functions/parse_json.mdx)     | Parses a string as a JSON value          | `string.parse_json()`                              |
-| [`parse_kv`](functions/parse_kv.mdx)         | Parses a string as Key-Value paris       | `string.parse_kv()`                                |
+| [`parse_kv`](functions/parse_kv.mdx)         | Parses a string as key-value pairs       | `string.parse_kv()`                                |
 | [`parse_leef`](functions/parse_leef.mdx)     | Parses a string as a LEEF message        | `string.parse_leef()`                              |
 | [`parse_ssv`](functions/parse_ssv.mdx)       | Parses a string as SSV                   | `string.parse_ssv(header=["a","b"])`               |
-| [`parse_syslog`](functions/parse_syslog.mdx) | Parses a string as a Syslog message      | `string.parse_syslog()`                            |
+| [`parse_syslog`](functions/parse_syslog.mdx) | Parses a string as a syslog message      | `string.parse_syslog()`                            |
 | [`parse_tsv`](functions/parse_tsv.mdx)       | Parses a string as TSV                   | `string.parse_tsv(header=["a","b"])`               |
 | [`parse_xsv`](functions/parse_xsv.mdx)       | Parses a string as XSV                   | `string.parse_xsv(",", ";", "", header=["a","b"])` |
 | [`parse_yaml`](functions/parse_yaml.mdx)     | Parses a string as YAML                  | `string.parse_yaml()`                              |
@@ -279,7 +279,7 @@ This is hidden because there is an issue with the timezone DB.
 | Function                          | Description                                    | Example            |
 | :-------------------------------- | :--------------------------------------------- | :----------------- |
 | [`type_id`](functions/type_id.md) | Retrieves the type id of an expression         | `type_id(1 + 3.2)` |
-| [`type_of`](functions/type_id.md) | Retrieves the type definition of an expression | `type_id(this)`    |
+| [`type_of`](functions/type_of.md) | Retrieves the type definition of an expression | `type_of(this)`    |
 
 ### Conversion
 
@@ -307,4 +307,4 @@ This is hidden because there is an issue with the timezone DB.
 | :------------------------------ | :---------------------------- | :--------------- |
 | [`config`](functions/config.md) | Reads the configuration file  | `config()`       |
 | [`env`](functions/env.md)       | Reads an environment variable | `env("PATH")`    |
-| [`secret`](functions/secret.md) | Reads a secret from a store   | `secret("PATH")` |
+| [`secret`](functions/secret.md) | Reads a secret from a store   | `secret("KEY")`  |

--- a/web/docs/tql2/functions/parse_kv.mdx
+++ b/web/docs/tql2/functions/parse_kv.mdx
@@ -2,7 +2,7 @@ import CommonOptions from './_common_parsing_options.mdx';
 
 # parse_kv
 
-Parses a string as Key-Value pairs.
+Parses a string as key-value pairs.
 
 ```tql
 parse_kv(input:string, [field_split=string, value_split=string, quotes=string,
@@ -12,7 +12,7 @@ parse_kv(input:string, [field_split=string, value_split=string, quotes=string,
 
 ## Description
 
-The `parse_kv` function parses a string as Key-Value pairs.
+The `parse_kv` function parses a string as key-value pairs.
 
 The string is first split into fields according to `field_split`. This
 can be a regular expression. For example, the input `foo: bar, baz: 42` can be

--- a/web/docs/tql2/operators.md
+++ b/web/docs/tql2/operators.md
@@ -162,13 +162,13 @@ Tenzir comes with a wide range of built-in pipeline operators.
 | [`write_csv`](./operators/write_csv.md)           | Writes events as CSV                           | `write_csv`      |
 | [`write_feather`](./operators/write_feather.md)   | Writes events as Feather                       | `write_feather`  |
 | [`write_json`](./operators/write_json.md)         | Writes events as JSON                          | `write_json`     |
-| [`write_kv`](./operators/write_kv.md)             | Writes events as Key-Value pairs               | `write_kv`       |
+| [`write_kv`](./operators/write_kv.md)             | Writes events as key-value pairs               | `write_kv`       |
 | [`write_ndjson`](./operators/write_ndjson.md)     | Writes events as Newline-Delimited JSON        | `write_ndjson`   |
 | [`write_lines`](./operators/write_lines.md)       | Writes events as lines                         | `write_lines`    |
 | [`write_parquet`](./operators/write_parquet.md)   | Writes events as Parquet                       | `write_parquet`  |
 | [`write_pcap`](./operators/write_pcap.md)         | Writes events as PCAP                          | `write_pcap`     |
 | [`write_ssv`](./operators/write_ssv.md)           | Writes events as SSV                           | `write_ssv`      |
-| [`write_syslog`](./operators/write_syslog.md)     | Writes events as RFC 5424 Syslog messages      | `write_syslog`   |
+| [`write_syslog`](./operators/write_syslog.md)     | Writes events as RFC 5424 syslog messages      | `write_syslog`   |
 | [`write_tsv`](./operators/write_tsv.md)           | Writes events as TSV                           | `write_tsv`      |
 | [`write_tql`](./operators/write_tql.md)           | Writes events as TQL objects                   | `write_tql`      |
 | [`write_xsv`](./operators/write_xsv.md)           | Writes events as XSV                           | `write_xsv`      |
@@ -246,18 +246,18 @@ Tenzir comes with a wide range of built-in pipeline operators.
 
 ## Encode & Decode
 
-| Operator                                                | Description                               | Example                   |
-| :------------------------------------------------------ | :---------------------------------------- | :------------------------ |
-| [`compress_brotli`](./operators/compress_brotli.md)     | Compresses bytes using Brotli compression | `compress_zstd, level=10` |
-| [`compress_bz2`](./operators/compress_bz2.md)           | Compresses bytes using Bzip compression   | `compress_bz2, level=9`   |
-| [`compress_gzip`](./operators/compress_gzip.md)         | Compresses bytes using Gzip compression   | `compress_gzip, level=8`  |
-| [`compress_lz4`](./operators/compress_lz4.md)           | Compresses bytes using lz4 compression    | `compress_lz4, level=7`   |
-| [`compress_zstd`](./operators/compress_zstd.md)         | Compresses bytes using Gzip compression   | `compress_zstd, level=6`  |
-| [`decompress_brotli`](./operators/decompress_brotli.md) | Decompresses Brotli compressed bytes      | `decompress_zstd`         |
-| [`decompress_bz2`](./operators/decompress_bz2.md)       | Decompresses Bzip2 compressed bytes       | `decompress_bz2`          |
-| [`decompress_gzip`](./operators/decompress_gzip.md)     | Decompresses Gzip compressed bytes        | `decompress_gzip`         |
-| [`decompress_lz4`](./operators/decompress_lz4.md)       | Decompresses lz4 compressed bytes         | `decompress_lz4`          |
-| [`decompress_zstd`](./operators/decompress_zstd.md)     | Decompresses Zstd compressed bytes        | `decompress_zstd`         |
+| Operator                                                | Description                               | Example                     |
+| :------------------------------------------------------ | :---------------------------------------- | :-------------------------- |
+| [`compress_brotli`](./operators/compress_brotli.md)     | Compresses bytes using Brotli compression | `compress_brotli, level=10` |
+| [`compress_bz2`](./operators/compress_bz2.md)           | Compresses bytes using bzip compression   | `compress_bz2, level=9`     |
+| [`compress_gzip`](./operators/compress_gzip.md)         | Compresses bytes using gzip compression   | `compress_gzip, level=8`    |
+| [`compress_lz4`](./operators/compress_lz4.md)           | Compresses bytes using lz4 compression    | `compress_lz4, level=7`     |
+| [`compress_zstd`](./operators/compress_zstd.md)         | Compresses bytes using zstd compression   | `compress_zstd, level=6`    |
+| [`decompress_brotli`](./operators/decompress_brotli.md) | Decompresses Brotli compressed bytes      | `decompress_brotli`         |
+| [`decompress_bz2`](./operators/decompress_bz2.md)       | Decompresses bzip2 compressed bytes       | `decompress_bz2`            |
+| [`decompress_gzip`](./operators/decompress_gzip.md)     | Decompresses gzip compressed bytes        | `decompress_gzip`           |
+| [`decompress_lz4`](./operators/decompress_lz4.md)       | Decompresses lz4 compressed bytes         | `decompress_lz4`            |
+| [`decompress_zstd`](./operators/decompress_zstd.md)     | Decompresses zstd compressed bytes        | `decompress_zstd`           |
 
 ## Pipelines
 


### PR DESCRIPTION
This PR fixes a few mistakes in the docs, such as `type_id` instead of `type_of` and bad links due to copy-paste.

It also contains some minor changes like aligning the capitalization of "syslog", "key-value pairs" and "zstd".

Finally, I removed a leftover debug logging statement that somehow ended up being merged into main.