### PR TITLE
Make field access faster

### DIFF
--- a/libtenzir/include/tenzir/type.hpp
+++ b/libtenzir/include/tenzir/type.hpp
@@ -1347,6 +1347,10 @@ public:
   [[nodiscard]] generator<offset>
   resolve_type_extractor(std::string_view type_extractor) const noexcept;
 
+  /// Resolved a field name.
+  [[nodiscard]] std::optional<size_t>
+  resolve_field(std::string_view field) const noexcept;
+
   /// Checks whether a field name is contained in the record.
   [[nodiscard]] bool has_field(std::string_view field) const noexcept;
 

--- a/libtenzir/src/tql2/eval.cpp
+++ b/libtenzir/src/tql2/eval.cpp
@@ -47,27 +47,21 @@ auto resolve(const ast::field_path& sel, type ty)
         resolve_error::field_of_non_record{ty},
       };
     }
-    auto found = false;
-    for (const auto& [idx, field] : detail::enumerate(rty->fields())) {
-      if (field.name == segment.id.name) {
-        found = true;
-        result.push_back(idx);
-        ty = field.type;
-        break;
-      }
+    if (auto idx = rty->resolve_field(segment.id.name)) {
+      result.push_back(*idx);
+      ty = rty->field(*idx).type;
+      continue;
     }
-    if (not found) {
-      if (segment.has_question_mark) {
-        return resolve_error{
-          segment.id,
-          resolve_error::field_not_found_no_error{},
-        };
-      }
+    if (segment.has_question_mark) {
       return resolve_error{
         segment.id,
-        resolve_error::field_not_found{},
+        resolve_error::field_not_found_no_error{},
       };
     }
+    return resolve_error{
+      segment.id,
+      resolve_error::field_not_found{},
+    };
   }
   return result;
 }

--- a/libtenzir/src/type.cpp
+++ b/libtenzir/src/type.cpp
@@ -3144,15 +3144,22 @@ generator<offset> record_type::resolve_type_extractor(
   }
 }
 
-bool record_type::has_field(std::string_view field) const noexcept {
+std::optional<size_t>
+record_type::resolve_field(std::string_view field) const noexcept {
   const auto* record = table().type_as_record_type();
   TENZIR_ASSERT(record);
+  size_t index = 0;
   for (const auto* rf : *record->fields()) {
     if (rf->name()->string_view() == field) {
-      return true;
+      return index;
     }
+    ++index;
   }
-  return false;
+  return {};
+}
+
+bool record_type::has_field(std::string_view field) const noexcept {
+  return resolve_field(field).has_value();
 }
 
 std::string_view record_type::key(size_t index) const& noexcept {


### PR DESCRIPTION
This avoids calls to the rather expensive `record_type::fields()` function in favor of doing a direct field lookup.