### PR TITLE
Introduce lambda functions

### DIFF
--- a/libtenzir/builtins/functions/numeric.cpp
+++ b/libtenzir/builtins/functions/numeric.cpp
@@ -6,6 +6,9 @@
 // SPDX-FileCopyrightText: (c) 2024 The Tenzir Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+#include "tenzir/tql2/ast.hpp"
+#include "tenzir/tql2/set.hpp"
+
 #include <tenzir/arrow_time_utils.hpp>
 #include <tenzir/arrow_utils.hpp>
 #include <tenzir/concept/parseable/tenzir/si.hpp>
@@ -118,17 +121,38 @@ public:
 
 class count_instance final : public aggregation_instance {
 public:
-  explicit count_instance(std::optional<ast::expression> expr)
-    : expr_{std::move(expr)} {
+  explicit count_instance(std::optional<ast::expression> expr,
+                          std::optional<ast::lambda_expr> lambda)
+    : expr_{std::move(expr)}, lambda_{std::move(lambda)} {
+    if (lambda_) {
+      lambda_->right = lambda_->right_or(located{false, location::unknown});
+    }
   }
 
   void update(const table_slice& input, session ctx) override {
-    if (not expr_) {
-      count_ += detail::narrow<int64_t>(input.rows());
+    const auto subject
+      = expr_ ? eval(*expr_, input, ctx) : multi_series{series{input}};
+    if (not lambda_) {
+      for (const auto& part : subject) {
+        count_ += part.array->length() - part.array->null_count();
+      }
       return;
     }
-    auto arg = eval(*expr_, input, ctx);
-    count_ += arg.length() - arg.null_count();
+    for (const auto& pred : eval(*lambda_, subject, ctx)) {
+      const auto typed_pred = pred.as<bool_type>();
+      if (not typed_pred) {
+        diagnostic::warning("expected `bool`, got `{}`", pred.type.kind())
+          .primary(lambda_->right)
+          .emit(ctx);
+        continue;
+      }
+      if (typed_pred->array->null_count() > 0) {
+        diagnostic::warning("expected `bool`, got `null`")
+          .primary(lambda_->right)
+          .emit(ctx);
+      }
+      count_ += typed_pred->array->true_count();
+    }
   }
 
   auto get() const -> data override {
@@ -159,6 +183,7 @@ public:
 
 private:
   std::optional<ast::expression> expr_;
+  std::optional<ast::lambda_expr> lambda_;
   int64_t count_ = 0;
 };
 
@@ -174,7 +199,25 @@ public:
     TRY(argument_parser2::function("count")
           .positional("x", expr, "any")
           .parse(inv, ctx));
-    return std::make_unique<count_instance>(std::move(expr));
+    return std::make_unique<count_instance>(std::move(expr), std::nullopt);
+  }
+};
+
+class count_where final : public aggregation_plugin {
+public:
+  auto name() const -> std::string override {
+    return "tql2.count_where";
+  }
+
+  auto make_aggregation(invocation inv, session ctx) const
+    -> failure_or<std::unique_ptr<aggregation_instance>> override {
+    auto expr = ast::expression{};
+    auto lambda = ast::lambda_expr{};
+    TRY(argument_parser2::function("count_where")
+          .positional("x", expr, "any")
+          .positional("lambda", lambda, "lambda")
+          .parse(inv, ctx));
+    return std::make_unique<count_instance>(std::move(expr), std::move(lambda));
   }
 };
 
@@ -229,7 +272,8 @@ public:
           // Silently ignore nulls, like we do above.
         },
         [&](const auto&) {
-          diagnostic::warning("expected `int`, `uint`, `double` or `duration`, "
+          diagnostic::warning("expected `int`, `uint`, `double` or "
+                              "`duration`, "
                               "got `{}`",
                               arg.type.kind())
             .primary(expr_)
@@ -398,5 +442,6 @@ public:
 TENZIR_REGISTER_PLUGIN(tenzir::plugins::numeric::sqrt)
 TENZIR_REGISTER_PLUGIN(tenzir::plugins::numeric::random)
 TENZIR_REGISTER_PLUGIN(tenzir::plugins::numeric::count)
+TENZIR_REGISTER_PLUGIN(tenzir::plugins::numeric::count_where)
 TENZIR_REGISTER_PLUGIN(tenzir::plugins::numeric::quantile)
 TENZIR_REGISTER_PLUGIN(tenzir::plugins::numeric::median)

--- a/libtenzir/builtins/operators/where_map.cpp
+++ b/libtenzir/builtins/operators/where_map.cpp
@@ -134,7 +134,7 @@ public:
     parser.add(expr, "<expr>");
     parser.parse(p);
     auto normalized_and_validated = normalize_and_validate(expr.inner);
-    if (!normalized_and_validated) {
+    if (! normalized_and_validated) {
       diagnostic::error("invalid expression")
         .primary(expr.source)
         .docs("https://tenzir.com/language/expressions")
@@ -248,18 +248,54 @@ private:
 
 struct arguments {
   ast::expression field;
-  ast::field_path capture;
-  ast::expression expr;
+  ast::lambda_expr lambda;
+
+  static auto parse(const std::string& name,
+                    const function_plugin::invocation& inv, session ctx)
+    -> failure_or<arguments> {
+    auto dh = collecting_diagnostic_handler{};
+    auto sp = session_provider::make(dh);
+    auto args = arguments{};
+    if (argument_parser2::function(name)
+          .positional("list", args.field, "list")
+          .positional("lambda", args.lambda, "lambda")
+          .parse(inv, sp.as_session())) {
+      std::move(dh).forward_to(ctx);
+      return args;
+    }
+    auto diags = std::exchange(dh, {}).collect();
+    auto expr = ast::expression{};
+    if (argument_parser2::function(name)
+          .positional("list", args.field, "list")
+          .positional("x", expr, "any")
+          .positional("expr", args.lambda.right, "any")
+          .parse(inv, sp.as_session())) {
+      diagnostic::warning("deprecated; please use a lambda expression instead")
+        .primary(expr.get_location().combine(args.lambda.right))
+        .hint("instead of `x, y`, provide `x => y`")
+        .emit(ctx);
+      std::move(dh).forward_to(ctx);
+      auto* field = try_as<ast::root_field>(expr);
+      if (not field or field->has_question_mark) {
+        diagnostic::error("expected identifier").primary(expr).emit(ctx);
+        return failure::promise();
+      }
+      return args;
+    }
+    for (auto& diag : diags) {
+      ctx.dh().emit(std::move(diag));
+    }
+    return args;
+  }
 };
 
 auto make_where_function(function_plugin::invocation inv, session ctx)
   -> failure_or<function_ptr> {
-  auto args = arguments{};
-  TRY(argument_parser2::function("where")
-        .positional("list", args.field, "list")
-        .positional("capture", args.capture)
-        .positional("expression", args.expr, "any")
-        .parse(inv, ctx));
+  TRY(auto args, arguments::parse("where", inv, ctx));
+  // TODO: The implementation of `map` predates lambdas, so right now it handles
+  // nulls in the input list by itself. The implementation would probably be
+  // simpler if it used this:
+  // args.lambda.right = args.lambda.right_or(located{false, location::unknown});
   return function_use::make([args = std::move(args)](
                               function_plugin::evaluator eval, session ctx) {
     return map_series(eval(args.field), [&](series field) -> multi_series {
@@ -284,16 +320,7 @@ auto make_where_function(function_plugin::invocation inv, session ctx)
       if (list_values.length() == 0) {
         return field;
       }
-      // TODO: The name here is somewhat arbitrary. It could be accessed if
-      // `@name` where to be used inside the inner expression.
-      const auto empty_type = type{"where", record_type{}};
-      auto slice = table_slice{
-        arrow::RecordBatch::Make(empty_type.to_arrow_schema(),
-                                 list_values.length(), arrow::ArrayVector{}),
-        empty_type,
-      };
-      slice = assign(args.capture, list_values, slice, ctx);
-      auto ms = tenzir::eval(args.expr, slice, ctx);
+      auto ms = tenzir::eval(args.lambda, list_values, ctx);
       TENZIR_ASSERT(not ms.parts().empty());
       auto result = std::vector<series>{};
       auto offset = int64_t{0};
@@ -313,7 +340,7 @@ auto make_where_function(function_plugin::invocation inv, session ctx)
         if (not predicate) {
           diagnostic::warning("expected `bool`, but got `{}`",
                               values.type.kind())
-            .primary(args.expr)
+            .primary(args.lambda.right)
             .emit(ctx);
           result.push_back(series::null(field.type, field.length()));
           continue;
@@ -412,12 +439,11 @@ struct where_result_part {
 
 auto make_map_function(function_plugin::invocation inv, session ctx)
   -> failure_or<function_ptr> {
-  auto args = arguments{};
-  TRY(argument_parser2::function("map")
-        .positional("list", args.field, "list")
-        .positional("capture", args.capture)
-        .positional("expression", args.expr, "any")
-        .parse(inv, ctx));
+  TRY(auto args, arguments::parse("map", inv, ctx));
+  // TODO: The implementation of `map` predates lambdas, so right now it handles
+  // nulls in the input list by itself. The implementation would probably be
+  // simpler if it used this:
+  // args.lambda.right = args.lambda.right_or_null();
   return function_use::make([args = std::move(args)](
                               function_plugin::evaluator eval, session ctx) {
     return map_series(eval(args.field), [&](series field) -> multi_series {
@@ -442,16 +468,7 @@ auto make_map_function(function_plugin::invocation inv, session ctx)
       if (list_values.length() == 0) {
         return field;
       }
-      // TODO: The name here is somewhat arbitrary. It could be accessed if
-      // `@name` where to be used inside the inner expression.
-      const auto empty_type = type{"map", record_type{}};
-      auto slice = table_slice{
-        arrow::RecordBatch::Make(empty_type.to_arrow_schema(),
-                                 list_values.length(), arrow::ArrayVector{}),
-        empty_type,
-      };
-      slice = assign(args.capture, list_values, slice, ctx);
-      auto ms = tenzir::eval(args.expr, slice, ctx);
+      auto ms = tenzir::eval(args.lambda, list_values, ctx);
       TENZIR_ASSERT(not ms.parts().empty());
       // If there were no conflicts in the result, we are in the happy case
       // Here we just need to take that slice and re-join it with the offsets
@@ -658,8 +675,8 @@ auto make_map_function(function_plugin::invocation inv, session ctx)
                                merged_series.type.kind());
           }
           diagnostic::warning(
-            "`expr` must evaluate to compatible types within the same list")
-            .primary(args.expr, primary)
+            "lambda must evaluate to compatible types within the same list")
+            .primary(args.lambda.right, primary)
             .note(note)
             .emit(ctx);
         }

--- a/libtenzir/include/tenzir/argument_parser2.hpp
+++ b/libtenzir/include/tenzir/argument_parser2.hpp
@@ -26,10 +26,10 @@ using argument_parser_data_types
   = detail::tl_map_t<detail::tl_filter_not_type_t<data::types, pattern>,
                      as_located>;
 
-using argument_parser_full_types
-  = detail::tl_concat_t<argument_parser_data_types,
-                        detail::type_list<located<pipeline>, ast::expression,
-                                          ast::field_path, located<data>>>;
+using argument_parser_full_types = detail::tl_concat_t<
+  argument_parser_data_types,
+  detail::type_list<located<pipeline>, ast::expression, ast::field_path,
+                    ast::lambda_expr, located<data>>>;
 
 using argument_parser_bare_types
   = detail::tl_map_t<detail::tl_filter_t<argument_parser_full_types, is_located>,
@@ -70,8 +70,8 @@ public:
 
   /// Adds a required positional argument.
   template <argument_parser_type T>
-  auto positional(std::string name, T& x,
-                  std::string type = maybe_default<T>) -> argument_parser2&;
+  auto positional(std::string name, T& x, std::string type = maybe_default<T>)
+    -> argument_parser2&;
 
   /// Adds an optional positional argument.
   template <argument_parser_type T>
@@ -82,8 +82,8 @@ public:
 
   /// Adds a required named argument.
   template <argument_parser_type T>
-  auto named(std::string name, T& x,
-             std::string type = maybe_default<T>) -> argument_parser2&;
+  auto named(std::string name, T& x, std::string type = maybe_default<T>)
+    -> argument_parser2&;
 
   /// Adds an optional named argument. Use this is "Not Given" is a case you
   /// need to handle.
@@ -94,24 +94,25 @@ public:
   /// Adds an optional named argument. Use this if you have an object with a
   /// default value.
   template <argument_parser_type T>
-  auto named_optional(std::string name, T& x,
-                      std::string type = maybe_default<T>) -> argument_parser2&;
+  auto
+  named_optional(std::string name, T& x, std::string type = maybe_default<T>)
+    -> argument_parser2&;
 
   /// Adds an optional named argument.
   auto named(std::string name, std::optional<location>& x,
              std::string type = "") -> argument_parser2&;
 
   /// Adds an optional named argument.
-  auto
-  named(std::string name, bool& x, std::string type = "") -> argument_parser2&;
+  auto named(std::string name, bool& x, std::string type = "")
+    -> argument_parser2&;
 
   // ------------------------------------------------------------------------
 
-  auto parse(const operator_factory_plugin::invocation& inv,
-             session ctx) -> failure_or<void>;
+  auto parse(const operator_factory_plugin::invocation& inv, session ctx)
+    -> failure_or<void>;
   auto parse(const ast::function_call& call, session ctx) -> failure_or<void>;
-  auto parse(const function_plugin::invocation& inv,
-             session ctx) -> failure_or<void>;
+  auto parse(const function_plugin::invocation& inv, session ctx)
+    -> failure_or<void>;
   auto parse(const ast::entity& self, std::span<ast::expression const> args,
              session ctx) -> failure_or<void>;
 

--- a/libtenzir/include/tenzir/fwd.hpp
+++ b/libtenzir/include/tenzir/fwd.hpp
@@ -420,6 +420,7 @@ struct identifier;
 struct if_stmt;
 struct index_expr;
 struct invocation;
+struct lambda_expr;
 struct let_stmt;
 struct list;
 struct match_stmt;

--- a/libtenzir/include/tenzir/tql2/eval.hpp
+++ b/libtenzir/include/tenzir/tql2/eval.hpp
@@ -31,6 +31,9 @@ auto const_eval(const ast::expression& expr, diagnostic_handler& dh)
 auto try_const_eval(const ast::expression& expr, diagnostic_handler& dh)
   -> std::optional<data>;
 
+auto eval(const ast::lambda_expr& lambda, const multi_series& input,
+          diagnostic_handler& dh) -> multi_series;
+
 struct resolve_error {
   struct field_not_found {};
   struct field_not_found_no_error {};

--- a/libtenzir/src/argument_parser2.cpp
+++ b/libtenzir/src/argument_parser2.cpp
@@ -12,6 +12,7 @@
 #include "tenzir/detail/enumerate.hpp"
 #include "tenzir/detail/similarity.hpp"
 #include "tenzir/detail/type_traits.hpp"
+#include "tenzir/tql2/ast.hpp"
 #include "tenzir/tql2/eval.hpp"
 #include "tenzir/tql2/exec.hpp"
 
@@ -143,6 +144,14 @@ auto argument_parser2::parse(const ast::entity& self,
         }
         set(std::move(*sel));
       },
+      [&](setter<ast::lambda_expr>& set) {
+        const auto* lambda = try_as<ast::lambda_expr>(expr);
+        if (not lambda) {
+          emit(diagnostic::error("expected a lambda").primary(expr));
+          return;
+        }
+        set(*lambda);
+      },
       [&](setter<located<pipeline>>& set) {
         auto pipe_expr = std::get_if<ast::pipeline_expr>(&*expr.kind);
         if (not pipe_expr) {
@@ -249,6 +258,14 @@ auto argument_parser2::parse(const ast::entity& self,
             }
             set(std::move(*sel));
           },
+          [&](setter<ast::lambda_expr>& set) {
+            auto* lambda = try_as<ast::lambda_expr>(expr);
+            if (not lambda) {
+              emit(diagnostic::error("expected a lambda").primary(expr));
+              return;
+            }
+            set(std::move(*lambda));
+          },
           [&](setter<located<pipeline>>& set) {
             auto pipe_expr = std::get_if<ast::pipeline_expr>(&*expr.kind);
             if (not pipe_expr) {
@@ -326,6 +343,9 @@ auto argument_parser2::usage() const -> std::string {
       [](const setter<ast::field_path>&) -> std::string {
         // TODO: `field` is not 100% accurate, but we use it in the docs.
         return "field";
+      },
+      [](const setter<ast::lambda_expr>&) -> std::string {
+        return "lambda";
       },
       [](const setter<located<pipeline>>&) -> std::string {
         return "{ … }";

--- a/libtenzir/src/tql2/eval.cpp
+++ b/libtenzir/src/tql2/eval.cpp
@@ -109,4 +109,32 @@ auto try_const_eval(const ast::expression& expr, diagnostic_handler& dh)
   return {};
 }
 
+auto eval(const ast::lambda_expr& lambda, const multi_series& input,
+          diagnostic_handler& dh) -> multi_series {
+  auto result = multi_series{};
+  for (const auto& part : input) {
+    if (part.length() == 0) {
+      continue;
+    }
+    // TODO: This is rather expensive; instead of evaluating the lambda on a
+    // newly created table slice, we should much rather support them in the
+    // evaluator directly.
+    auto schema = type{
+      "lambda",
+      record_type{
+        {lambda.left.name, part.type},
+      },
+    };
+    auto arrow_schema = arrow::schema({{lambda.left.name, part.array->type()}},
+                                      schema.make_arrow_metadata());
+    auto slice = table_slice{
+      arrow::RecordBatch::Make(std::move(arrow_schema), input.length(),
+                               arrow::ArrayVector{part.array}),
+      std::move(schema),
+    };
+    result.append(eval(lambda.right, slice, dh));
+  }
+  return result;
+}
+
 } // namespace tenzir

--- a/libtenzir/src/tql2/parser.cpp
+++ b/libtenzir/src/tql2/parser.cpp
@@ -376,6 +376,16 @@ public:
           continue;
         }
       }
+      if (auto arrow = accept(tk::fat_arrow)) {
+        auto* left = try_as<ast::root_field>(expr);
+        if (not left or left->has_question_mark) {
+          diagnostic::error("expected identifier").primary(expr).throw_();
+        }
+        auto right = parse_expression();
+        expr
+          = lambda_expr{std::move(left->id), arrow.location, std::move(right)};
+        continue;
+      }
       auto negate = std::optional<location>{};
       if (silent_peek(tk::not_) and silent_peek_n(tk::in, 1)
           and precedence(binary_op::in) >= min_prec) {
@@ -499,7 +509,6 @@ public:
     if (accept(tk::lpar)) {
       auto scope = ignore_newlines(true);
       auto result = parse_expression();
-      expect(tk::rpar);
       return result;
     }
     if (auto constant = accept_constant()) {

--- a/libtenzir/src/tql2/set.cpp
+++ b/libtenzir/src/tql2/set.cpp
@@ -336,10 +336,6 @@ namespace {
 struct move_resolver final : ast::visitor<move_resolver> {
   std::vector<ast::field_path> out;
 
-  auto visit(ast::assignment& x) -> void {
-    enter(x);
-  }
-
   auto visit(ast::expression& x) -> void {
     if (auto* unary = try_as<ast::unary_expr>(x)) {
       if (unary->op.inner == ast::unary_op::move) {
@@ -352,18 +348,9 @@ struct move_resolver final : ast::visitor<move_resolver> {
     enter(x);
   }
 
-  auto visit(ast::function_call& x) -> void {
-    // TODO: The `map` and `where` functions abuse the expressions they take
-    // as arguments as a poor-mans lambda expression. We don't recurse
-    // further when we encounter them here, but that's at best a stopgap.
-    // Ideally, there'd be proper lambda support in the language itself.
-    if (x.fn.path.size() == 1) {
-      const auto& name = x.fn.path.front().name;
-      if (name == "map" or name == "where") {
-        return;
-      }
-    }
-    enter(x);
+  auto visit(ast::lambda_expr&) -> void {
+    // Expressions inside lambda arguments do not necessarily refer to the
+    // top-level event. We cannot resolve the move keyword inside of them.
   }
 
   auto visit(auto& x) -> void {


### PR DESCRIPTION
This adds lambda functions to TQL, used as arguments for the `map` and `where` functions, and additionally for the newly added `count_where` aggregation function.

I'm opening this PR to discuss the feature before I follow up on it—as of now this is an hour of hacking on it over the weekend, and nothing more. There's a fair amount of work to be done on this before we could merge it.