### PR TITLE
Always rebatch in `set`

### DIFF
--- a/libtenzir/src/tql2/set.cpp
+++ b/libtenzir/src/tql2/set.cpp
@@ -517,9 +517,8 @@ auto set_operator::operator()(generator<table_slice> input,
     if (order_ != event_order::ordered) {
       std::ranges::stable_sort(results, std::ranges::less{},
                                &table_slice::schema);
-      results = rebatch_events(std::move(results));
     }
-    for (auto& result : results) {
+    for (auto& result : rebatch_events(std::move(results))) {
       co_yield std::move(result);
     }
   }


### PR DESCRIPTION
Consider this pipeline:

```
from {}
repeat 1k
batch
label = "head" if random().round() == 1 else "tails"
measure
select events
write_lines
```

After this change, this reliably prints `1000`. Before, it would print a series of numbers adding up to `1000`, as the recently added rebatching in the `set` operator only took place when the operator was allowed to reorder events.