### PR TITLE
Enable `to_gogle_cloud_logging` for the Nix builds

### DIFF
--- a/changelog/next/bug-fixes/5154--google-logging-nix.md
+++ b/changelog/next/bug-fixes/5154--google-logging-nix.md
@@ -1,0 +1,2 @@
+The `to_google_cloud_logging` operator was not available in static binary builds
+due to an oversight. This is now fixed.

--- a/nix/tenzir/plugins/names.nix
+++ b/nix/tenzir/plugins/names.nix
@@ -8,6 +8,7 @@
   "snowflake"
   "to_asl"
   "to_splunk"
+  "to_google_cloud_logging"
   "to_google_secops"
   "vast"
 ]


### PR DESCRIPTION
Whoops 🙈