### PR TITLE
Delay catalog lookups until catalog is ready

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,6 +3,7 @@ Checks: >
   *,
   -abseil-*,
   -altera-*,
+  -boost-*,
   -bugprone-lambda-function-name,
   -bugprone-easily-swappable-parameters,
   -bugprone-switch-missing-default-case,

--- a/changelog/next/bug-fixes/5156--catalog-delay.md
+++ b/changelog/next/bug-fixes/5156--catalog-delay.md
@@ -1,3 +1,3 @@
 The `export`, `metrics`, `diagnostics` and `partitions` operators returned an
-empty result when used before the node had successfully loaded its persistd
+empty result when used before the node had successfully loaded its persisted
 data. They now wait correctly.

--- a/changelog/next/bug-fixes/5156--catalog-delay.md
+++ b/changelog/next/bug-fixes/5156--catalog-delay.md
@@ -1,0 +1,3 @@
+The `export`, `metrics`, `diagnostics` and `partitions` operators returned an
+empty result when used before the node had successfully loaded its persistd
+data. They now wait correctly.

--- a/libtenzir/include/tenzir/actors.hpp
+++ b/libtenzir/include/tenzir/actors.hpp
@@ -136,12 +136,8 @@ using partition_creation_listener_actor = typed_actor_fwd<
 
 /// The CATALOG actor interface.
 using catalog_actor = typed_actor_fwd<
-  // Reinitialize the catalog from a set of partition synopses. Used at
-  // startup, so the map is expected to be huge and we use a shared_ptr
-  // to be sure it's not accidentally copied.
-  auto(atom::merge,
-       std::shared_ptr<std::unordered_map<uuid, partition_synopsis_ptr>>)
-    ->caf::result<atom::ok>,
+  // Reinitialize the catalog from a set of partition synopses.
+  auto(atom::start, std::vector<partition_synopsis_pair>)->caf::result<atom::ok>,
   // Merge a set of partition synopses.
   auto(atom::merge, std::vector<partition_synopsis_pair>)->caf::result<atom::ok>,
   // Get *ALL* partition synopses stored in the catalog, optionally filtered


### PR DESCRIPTION
This fixes the `export`, `metrics`, `diagnostics` and `partitions` operators when used on startup before the catalog loaded its state. The operators now correctly wait until the catalog has initialized instead of returning no results.