### PR TITLE
Check for spdlog setup before using TENZIR_ERROR

### DIFF
--- a/libtenzir/include/tenzir/detail/logger.hpp
+++ b/libtenzir/include/tenzir/detail/logger.hpp
@@ -37,6 +37,9 @@ void shutdown_spdlog() noexcept;
 /// Get a spdlog::logger handel
 std::shared_ptr<spdlog::logger>& logger();
 
+/// Checks if spdlog is already setup by checking `logger()->name()`
+auto is_spdlog_setup() noexcept -> bool;
+
 template <class T>
 auto pretty_type_name(const T&) {
   return caf::detail::pretty_type_name(typeid(std::remove_pointer_t<T>));

--- a/libtenzir/src/logger.cpp
+++ b/libtenzir/src/logger.cpp
@@ -107,7 +107,7 @@ namespace detail {
 
 bool setup_spdlog(bool is_server, const tenzir::invocation& cmd_invocation,
                   const caf::settings& cfg_file) try {
-  if (tenzir::detail::logger()->name() != "/dev/null") {
+  if (is_spdlog_setup()) {
     TENZIR_ERROR("Log already up");
     return false;
   }
@@ -299,6 +299,10 @@ std::shared_ptr<spdlog::logger>& logger() {
     = spdlog::async_factory::template create<spdlog::sinks::null_sink_mt>(
       "/dev/null");
   return tenzir_logger;
+}
+
+auto is_spdlog_setup() noexcept -> bool {
+  return logger()->name() != "/dev/null";
 }
 
 } // namespace detail

--- a/tenzir/tenzir.cpp
+++ b/tenzir/tenzir.cpp
@@ -356,7 +356,7 @@ auto main(int argc, char** argv) -> int try {
 } catch (tenzir::panic_exception& e) {
   auto diagnostic = to_diagnostic(e);
   const auto is_server = is_server_from_app_path(argv[0]);
-  if (not is_server) {
+  if (not is_server or not tenzir::detail::is_spdlog_setup()) {
     auto dh = make_diagnostic_printer(
       std::nullopt, tenzir::color_diagnostics::yes, std::cerr);
     dh->emit(std::move(diagnostic));


### PR DESCRIPTION
The global exception handler on `main` made the assumption that no TENZIR_ASSERT would happen before spdlog was properly setup and used `TENZIR_ERROR`. This could cause an internal error in spdlog when trying to emit the terminal error.

Exploring the code, there may be some spots where we call `TENZIR_ERROR` directly before `create_log_context` is called in `main`, but those seem to never happen...

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made in the pull request description in a way that
   is consumable by everyone, not just developers who know the context of the
   change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://docs.tenzir.com/next/contribute/changelog
3. Provide instructions for the reviewer.
4. Remove this comment so it doesn't show up in the merge commit.
-->
