### PR TITLE
Do not refuse startup when `pid.lock` is invalid

### DIFF
--- a/changelog/next/bug-fixes/5164--pid-file-empty.md
+++ b/changelog/next/bug-fixes/5164--pid-file-empty.md
@@ -1,0 +1,2 @@
+The node no longer refuses to start when its last shutdown happened in the brief
+period on startup after its PID file was created and before it was flushed.

--- a/libtenzir/include/tenzir/detail/pid_file.hpp
+++ b/libtenzir/include/tenzir/detail/pid_file.hpp
@@ -18,6 +18,6 @@ namespace tenzir::detail {
 /// @param filename The path to the PID file.
 /// @returns `none` if acquiring succeeded and an error on failure.
 /// @relates release_pid_file
-caf::error acquire_pid_file(const std::filesystem::path& filename);
+auto acquire_pid_file(const std::filesystem::path& filename) -> caf::error;
 
 } // namespace tenzir::detail

--- a/libtenzir/src/detail/pid_file.cpp
+++ b/libtenzir/src/detail/pid_file.cpp
@@ -12,14 +12,12 @@
 #include "tenzir/concept/parseable/to.hpp"
 #include "tenzir/detail/assert.hpp"
 #include "tenzir/detail/load_contents.hpp"
-#include "tenzir/detail/posix.hpp"
 #include "tenzir/error.hpp"
 #include "tenzir/logger.hpp"
 
 #include <sys/file.h>
 
 #include <fcntl.h>
-#include <string_view>
 #include <system_error>
 #include <unistd.h>
 
@@ -29,10 +27,10 @@ namespace tenzir::detail {
 
 namespace {
 
-bool pid_belongs_to_tenzir(pid_t pid) {
+auto pid_belongs_to_tenzir(pid_t pid) -> bool {
   const auto proc_pid_path = fmt::format("/proc/{}/status", pid);
   const auto proc_pid_contents = detail::load_contents(proc_pid_path);
-  if (!proc_pid_contents) {
+  if (not proc_pid_contents) {
     TENZIR_DEBUG("failed to read {}: {}", proc_pid_path,
                  proc_pid_contents.error());
     return false;
@@ -48,43 +46,46 @@ bool pid_belongs_to_tenzir(pid_t pid) {
 
 #endif // TENZIR_LINUX
 
-caf::error acquire_pid_file(const std::filesystem::path& filename) {
+auto acquire_pid_file(const std::filesystem::path& filename) -> caf::error {
   auto pid = ::getpid();
   std::error_code err{};
   // Check if the db directory is owned by an existing Tenzir process.
   const auto exists = std::filesystem::exists(filename, err);
-  if (err)
+  if (err) {
     TENZIR_WARN("failed to check if the state directory {} exists: {}",
                 filename, err.message());
+  }
   if (exists) {
     // Attempt to read file to display an actionable error message.
     auto contents = detail::load_contents(filename);
-    if (!contents)
+    if (not contents) {
       return contents.error();
-    auto other_pid = to<int32_t>(*contents);
-    if (!other_pid)
-      return caf::make_error(ec::parse_error,
-                             "unable to parse pid_file:", *contents);
+    }
+    // If we fail to parse the file contents, we silently treat it as an invalid
+    // PID.
+    const auto other_pid = to<int32_t>(*contents).value_or(-1);
     // Safeguard in case the pid_file already belongs to this process.
-    if (*other_pid == pid)
+    if (other_pid == pid) {
       return caf::none;
+    }
     // Safeguard in case the pid_file contains a PID of a non-Tenzir process.
-    if (::getpgid(*other_pid) >= 0) {
+    if (::getpgid(other_pid) >= 0) {
 #if TENZIR_LINUX
       // In deployments with containers it's rather likely that the PID in the
       // PID file belongs to a different, non-Tenzir process after a crash,
       // because after a restart of the container the PID may be assigned to
       // another process. If it does, we ignore the PID in the PID file and
       // don't stop execution.
-      const auto ignore_pid = !pid_belongs_to_tenzir(*other_pid);
+      const auto ignore_pid = not pid_belongs_to_tenzir(other_pid);
 #else
       const auto ignore_pid = false;
 #endif
-      if (!ignore_pid)
+      if (not ignore_pid) {
         return caf::make_error(ec::filesystem_error,
                                fmt::format("PID file found: {}, terminate "
                                            "process {}",
                                            filename, *contents));
+      }
       TENZIR_DEBUG(
         "ignores conflicting PID file because contained PID does not "
         "belong to a Tenzir process");
@@ -95,11 +96,12 @@ caf::error acquire_pid_file(const std::filesystem::path& filename) {
   }
   // Open the file.
   auto fd = ::open(filename.c_str(), O_WRONLY | O_CREAT, 0600);
-  if (fd < 0)
+  if (fd < 0) {
     return caf::make_error(ec::filesystem_error,
                            fmt::format("failed in open(2) with filename {} : "
                                        "{}",
                                        filename, strerror(errno)));
+  }
   // Lock the file handle.
   if (::flock(fd, LOCK_EX | LOCK_NB) < 0) {
     ::close(fd);
@@ -108,7 +110,7 @@ caf::error acquire_pid_file(const std::filesystem::path& filename) {
   }
   // Write the PID in human readable form into the file.
   auto pid_string = std::to_string(pid);
-  TENZIR_ASSERT(!pid_string.empty());
+  TENZIR_ASSERT(not pid_string.empty());
   if (::write(fd, pid_string.data(), pid_string.size()) < 0) {
     ::close(fd);
     return caf::make_error(ec::filesystem_error,


### PR DESCRIPTION
During my many tests of for tenzir/tenzir#5163, I sometimes stopped the node after the `pid.lock` file was created but before it was written to, causing it to be empty. Afterwards, my node always refused to start up again until I manually deleted the `pid.lock` file.

This change makes it so that we warn the user about the incorrect shutdown, but still start up, overriding the file.