### PR TITLE
Allow unary operators to be used like function calls

### DIFF
--- a/changelog/next/features/5170--unary-op-fn.md
+++ b/changelog/next/features/5170--unary-op-fn.md
@@ -1,0 +1,3 @@
+Unary operators like `move` or `not` may now be used like function calls. For
+example, instead of using `(move x).frobnify()`, TQL now also supports
+`move(x).frobnify()` or `x.move().frobnify()`.

--- a/web/docs/tql2/language/expressions.md
+++ b/web/docs/tql2/language/expressions.md
@@ -146,8 +146,9 @@ may allow defining custom metadata fields.
 
 ## Unary Expression
 
-Use the unary operators `+`, `-`, and `not`. The `+` and `-` operators expect a
-number or duration, while `not` expects a boolean value.
+Use the unary operators `+`, `-`, `not`, and `move`. The `+` and `-` operators
+expect a number or duration, `not` expects a boolean value, and `move` expects a
+field.
 
 ## Binary Expression
 


### PR DESCRIPTION
This makes `move x`, `move(x)`, and `x.move()` all equivalent.

This originated from a discussion with a customer, who tried using `move(x).frobnify()` instead of `(move x).frobnify()` or `frobnify(move x)`.