### PR TITLE
Make `seconds()` and friends no-ops on durations

### DIFF
--- a/libtenzir/builtins/functions/duration.cpp
+++ b/libtenzir/builtins/functions/duration.cpp
@@ -108,7 +108,7 @@ public:
             check(b->AppendNulls(arg.length()));
           },
           [&](const duration_type& t) {
-            diagnostic::warning("casting to `duration` has no effect")
+            diagnostic::warning("interpreting as `{}` has no effect", name())
               .primary(expr, "already has type `duration`")
               .hint("use `count_{}` to extract the number of {}", name(),
                     name())

--- a/libtenzir/builtins/functions/duration.cpp
+++ b/libtenzir/builtins/functions/duration.cpp
@@ -107,6 +107,16 @@ public:
           [&](const null_type&) {
             check(b->AppendNulls(arg.length()));
           },
+          [&](const duration_type& t) {
+            diagnostic::warning("casting to `duration` has no effect")
+              .primary(expr, "already has type `duration`")
+              .hint("use `count_{}` to extract the number of {}", name(),
+                    name())
+              .emit(ctx);
+            check(append_array_slice(
+              *b, t, as<type_to_arrow_array_t<duration_type>>(*arg.array), 0,
+              arg.length()));
+          },
           [&]<class U>(const U&)
             requires concepts::one_of<U, int64_type, uint64_type, double_type>
           {


### PR DESCRIPTION
Additionally, this emits a helpful warning that the user was likely looking for `count_seconds()` and friends, or did not need to call the function in the first place.