### PR TITLE
Switch to nix2container for nix built docker images

### DIFF
--- a/.github/workflows/nix.nu
+++ b/.github/workflows/nix.nu
@@ -102,14 +102,12 @@ def push_images [
   let repo_name = ($name | str replace "-static" "")
   let node_repo_name = ($repo_name | str replace "tenzir" "tenzir-node")
   let tag_suffix = if ($name | str contains "-static") {"-slim"} else {""}
-  nix --accept-flake-config run $".#stream-($image_name)-image" ...($env.extra_options | split row " ") | zstd -fo tenzir.tar.zst
-  nix --accept-flake-config run $".#stream-($node_image_name)-image" ...($env.extra_options | split row " ") | zstd -fo tenzir-node.tar.zst
   for reg in $image_registries {
     for repo in [$repo_name $node_repo_name] {
       for tag in $container_tags {
         let dest = $"docker://($reg)/tenzir/($repo):($tag)($tag_suffix)"
         print $"::notice pushing ($dest)"
-        skopeo copy $"docker-archive:./($repo).tar.zst" $dest
+        nix --accept-flake-config run $".#($name).asImage.($repo).copyTo" ...($env.extra_options | split row " ")  -- $dest
       }
     }
   }

--- a/flake.lock
+++ b/flake.lock
@@ -98,6 +98,29 @@
         "type": "github"
       }
     },
+    "nix2container": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1742501024,
+        "narHash": "sha256-4G0RaAkRQY8Oty0WjoDfIkEAkX7PckUqUGjAQrxhDiA=",
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "rev": "e6315c8307edf2938ae24df0e28b47ca865121de",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlewo",
+        "repo": "nix2container",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1736192377,
@@ -131,6 +154,7 @@
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "isReleaseBuild": "isReleaseBuild",
+        "nix2container": "nix2container",
         "nixpkgs": "nixpkgs",
         "sbomnix": "sbomnix"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,9 @@
   inputs.flake-compat.url = "github:edolstra/flake-compat";
   inputs.flake-compat.flake = false;
   inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.nix2container.url = "github:nlewo/nix2container";
+  inputs.nix2container.inputs.flake-utils.follows = "flake-utils";
+  inputs.nix2container.inputs.nixpkgs.follows = "nixpkgs";
   inputs.sbomnix.url = "github:tiiuae/sbomnix";
   inputs.sbomnix.inputs.nixpkgs.follows = "nixpkgs";
 
@@ -36,38 +39,6 @@
       system: let
         overlay = import ./nix/overlay.nix {inherit inputs;};
         pkgs = nixpkgs.legacyPackages."${system}".appendOverlays [overlay];
-        stream-image = {
-          entrypoint,
-          name,
-          pkg,
-          tag ? "latest",
-        }: {
-          type = "app";
-          program = "${pkgs.dockerTools.streamLayeredImage {
-            inherit name tag;
-            contents = [
-              pkg pkgs.bash pkgs.python3
-            ];
-            config = let
-              tenzir-dir = "/var/lib/tenzir";
-            in {
-              Entrypoint = ["/bin/${entrypoint}"];
-              CMD = ["--help"];
-              Env = [
-                # When changing these, make sure to also update the
-                # corresponding entries in the Dockerfile.
-                "TENZIR_STATE_DIRECTORY=${tenzir-dir}"
-                "TENZIR_CACHE_DIRECTORY=/var/cache/tenzir"
-                "TENZIR_LOG_FILE=/var/log/tenzir/server.log"
-                "TENZIR_ENDPOINT=0.0.0.0"
-              ];
-              WorkingDir = "${tenzir-dir}";
-              Volumes = {
-                "${tenzir-dir}" = {};
-              };
-            };
-          }}";
-        };
       in {
         packages =
           flake-utils.lib.flattenTree {
@@ -88,50 +59,6 @@
         apps.tenzir-static = flake-utils.lib.mkApp {
           drv =
             self.packages.${system}.tenzir-static;
-        };
-        apps.stream-tenzir-de-image = stream-image {
-          entrypoint = "tenzir";
-          name = "tenzir/tenzir-de";
-          pkg = self.packages.${system}.tenzir-de;
-        };
-        apps.stream-tenzir-node-de-image = stream-image {
-          entrypoint = "tenzir-node";
-          name = "tenzir/tenzir-de";
-          pkg = self.packages.${system}.tenzir-de;
-        };
-        apps.stream-tenzir-de-slim-image = stream-image {
-          entrypoint = "tenzir";
-          name = "tenzir/tenzir-de-slim";
-          pkg = self.packages.${system}.tenzir-de-static;
-          tag = "latest-slim";
-        };
-        apps.stream-tenzir-node-de-slim-image = stream-image {
-          entrypoint = "tenzir-node";
-          name = "tenzir/tenzir-de-slim";
-          pkg = self.packages.${system}.tenzir-de-static;
-          tag = "latest-slim";
-        };
-        apps.stream-tenzir-image = stream-image {
-          entrypoint = "tenzir";
-          name = "tenzir/tenzir";
-          pkg = self.packages.${system}.tenzir;
-        };
-        apps.stream-tenzir-node-image = stream-image {
-          entrypoint = "tenzir-node";
-          name = "tenzir/tenzir";
-          pkg = self.packages.${system}.tenzir;
-        };
-        apps.stream-tenzir-slim-image = stream-image {
-          entrypoint = "tenzir";
-          name = "tenzir/tenzir-slim";
-          pkg = self.packages.${system}.tenzir-static;
-          tag = "latest-slim";
-        };
-        apps.stream-tenzir-node-slim-image = stream-image {
-          entrypoint = "tenzir-node";
-          name = "tenzir/tenzir-slim";
-          pkg = self.packages.${system}.tenzir-static;
-          tag = "latest-slim";
         };
         apps.default = self.apps.${system}.tenzir-static;
         # Run with `nix run .#generate-sbom`, output is created in sbom/.

--- a/flake.nix
+++ b/flake.nix
@@ -104,7 +104,7 @@
         };
         # Legacy aliases for backwards compatibility.
         devShell = import ./shell.nix {inherit pkgs;};
-        formatter = pkgs.alejandra;
+        formatter = pkgs.nixfmt-rfc-style;
         hydraJobs =
           {packages = self.packages.${system};}
           // (

--- a/libtenzir/CMakeLists.txt
+++ b/libtenzir/CMakeLists.txt
@@ -230,6 +230,9 @@ dependency_summary("OpenSSL" OpenSSL::SSL "Dependencies")
 
 # Link against yaml-cpp.
 find_package(yaml-cpp 0.6.2 REQUIRED)
+# We need to resolve this in find_packge(Tenzir) for because the
+# libtenzir_builtins target needs to be installed for plugins.
+# See the comment above `install(TARGETS` for details.
 string(APPEND TENZIR_FIND_DEPENDENCY_LIST
        "\nfind_package(yaml-cpp 0.6.2 REQUIRED)")
 if (yaml-cpp_VERSION VERSION_GREATER_EQUAL 0.8)

--- a/libtenzir/src/detail/installdirs_relocatable.cpp.in
+++ b/libtenzir/src/detail/installdirs_relocatable.cpp.in
@@ -6,8 +6,10 @@
 // SPDX-FileCopyrightText: (c) 2021 The Tenzir Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#include "tenzir/detail/assert.hpp"
 #include "tenzir/detail/installdirs.hpp"
+
+#include "tenzir/detail/assert.hpp"
+#include "tenzir/detail/env.hpp"
 #include "tenzir/detail/process.hpp"
 #include "tenzir/detail/string.hpp"
 
@@ -26,6 +28,9 @@ std::filesystem::path install_libdir() {
 /// directories for multi-config generators.
 std::pair<std::filesystem::path, std::filesystem::path>
 install_prefix_and_suffix() {
+  if (auto runtime_prefix = detail::getenv("TENZIR_RUNTIME_PREFIX")) {
+    return {*runtime_prefix, {}};
+  }
   auto prefix_from_libdir = [](const auto& libdir) {
     auto err = std::error_code{};
     auto prefix = libdir / "@TENZIR_LIBDIR_TO_PREFIX@";

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -309,14 +309,12 @@ in {
   unchecked = {
     tenzir-de = final.callPackage ./tenzir {
       inherit stdenv;
-      pname = "tenzir-de";
       isReleaseBuild = inputs.isReleaseBuild.value;
     };
     # Policy: The suffix-less `tenzir' packages come with a few closed source
     # plugins.
     tenzir = let
       pkg = final.unchecked.tenzir-de.override {
-        pname = "tenzir";
       };
     in
       pkg.withPlugins (ps: [

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -9,6 +9,7 @@
     then package
     else package.overrideAttrs f;
 in {
+  nix2container = inputs.nix2container.packages.x86_64-linux;
   musl = overrideAttrsIf isStatic prev.musl (orig: {
     patches = (orig.patches or []) ++ [
       (prev.buildPackages.fetchpatch {

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -314,7 +314,12 @@ in {
     # Policy: The suffix-less `tenzir' packages come with a few closed source
     # plugins.
     tenzir = let
+      tenzir-plugins-source =
+        if builtins.pathExists ./../contrib/tenzir-plugins/README.md
+          then ./../contrib/tenzir-plugins
+          else prev.callPackage ./tenzir/plugins/source.nix {};
       pkg = final.unchecked.tenzir-de.override {
+        inherit tenzir-plugins-source;
       };
     in
       pkg.withPlugins (ps: [

--- a/nix/tenzir/default.nix
+++ b/nix/tenzir/default.nix
@@ -4,7 +4,6 @@
     lib,
     stdenv,
     callPackage,
-    pname,
     tenzir-source,
     cmake,
     ninja,
@@ -98,7 +97,8 @@
         ]);
   in
     stdenv.mkDerivation (finalAttrs: ({
-        inherit pname version;
+        inherit version;
+        pname = "tenzir";
         src = tenzir-source;
 
         postUnpack = ''
@@ -177,7 +177,6 @@
           [
             "-DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON"
             "-DCAF_ROOT_DIR=${caf}"
-            "-DTENZIR_EDITION_NAME=${lib.toUpper pname}"
             "-DTENZIR_ENABLE_RELOCATABLE_INSTALLATIONS=ON"
             "-DTENZIR_ENABLE_JEMALLOC=${lib.boolToString isMusl}"
             "-DTENZIR_ENABLE_MANPAGES=OFF"

--- a/nix/tenzir/default.nix
+++ b/nix/tenzir/default.nix
@@ -132,12 +132,9 @@
           clickhouse-cpp
           fast-float
           fluent-bit
-          google-cloud-cpp
-          grpc
           libpcap
           libunwind
           libyamlcpp
-          protobuf
           rabbitmq-c
           rdkafka
           cppzmq
@@ -158,7 +155,10 @@
           caf
           curl
           flatbuffers
+          google-cloud-cpp
+          grpc
           libmaxminddb
+          protobuf
           re2
           robin-map
           simdjson

--- a/nix/tenzir/default.nix
+++ b/nix/tenzir/default.nix
@@ -332,6 +332,13 @@
               symlinkJoin {
                 inherit (self) passthru meta pname version name;
                 paths = [ self ] ++ actualPlugins;
+                nativeBuildInputs = [ makeBinaryWrapper ];
+                postBuild = ''
+                  rm $out/bin/tenzir
+                  makeWrapper ${self}/bin/tenzir $out/bin/tenzir \
+                    --inherit-argv0 \
+                    --set-default TENZIR_RUNTIME_PREFIX $out
+                '';
               };
         };
 

--- a/nix/tenzir/default.nix
+++ b/nix/tenzir/default.nix
@@ -44,6 +44,8 @@
     restinio,
     llhttp,
     pfs,
+    # Defaults to null because it is omitted for the developer edition build.
+    tenzir-plugins-source ? null,
     extraPlugins ? [],
     symlinkJoin,
     extraCmakeFlags ? [],
@@ -320,7 +322,7 @@
         passthru = {
           plugins = bundledPlugins ++ extraPlugins;
           withPlugins = selection: let
-            allPlugins = callPackage ./plugins {tenzir = self;};
+            allPlugins = callPackage ./plugins {tenzir = self; inherit tenzir-plugins-source; };
             actualPlugins = selection allPlugins;
           in
             if isStatic

--- a/nix/tenzir/default.nix
+++ b/nix/tenzir/default.nix
@@ -199,7 +199,6 @@
           fluent-bit
           libpcap
           libunwind
-          libyamlcpp
           rabbitmq-c
           rdkafka
           cppzmq
@@ -223,6 +222,7 @@
           google-cloud-cpp
           grpc
           libmaxminddb
+          libyamlcpp
           protobuf
           re2
           robin-map

--- a/nix/tenzir/image.nix
+++ b/nix/tenzir/image.nix
@@ -1,0 +1,102 @@
+{
+  lib,
+  nix2container,
+  runCommand,
+  bashInteractive,
+  coreutils,
+  libcap,
+  isStatic,
+}:
+{ pkg, plugins }:
+
+let
+  tag = "latest" + lib.optionalString isStatic "-slim";
+
+  # Nest all layers so that prior layers are dependencies of later layers.
+  # This way, we should avoid redundant dependencies.
+  foldImageLayers =
+    let
+      mergeToLayer =
+        priorLayers: component:
+        assert builtins.isList priorLayers;
+        assert builtins.isAttrs component;
+        let
+          layer = nix2container.nix2container.buildLayer (
+            component
+            // {
+              layers = priorLayers;
+            }
+          );
+        in
+        priorLayers ++ [ layer ];
+    in
+    layers: lib.foldl mergeToLayer [ ] layers;
+
+  tmp = {
+    copyToRoot =
+      runCommand "tmp-dir"
+        {
+          outputHash = "sha256-AVwrjJdGCmzJ8JlT6x69JkHlFlRvOJ4hcqNt10YNoAU=";
+          outputHashAlgo = "sha256";
+          outputHashMode = "recursive";
+          preferLocalBuild = true;
+        }
+        ''
+          mkdir -p $out/tmp
+        '';
+    perms = [
+      {
+        path = "/tmp";
+        regex = ".*";
+        mode = "a=rwxt";
+      }
+    ];
+  };
+
+  extraTools = [
+    bashInteractive
+    coreutils
+    libcap
+  ];
+
+  layerDefs = [
+    tmp
+    { deps = extraTools; }
+    { deps = [ pkg ]; }
+  ] ++ builtins.map (pluginLayer: { deps = pluginLayer; }) plugins;
+
+  layers = foldImageLayers layerDefs;
+
+  buildTenzirImage =
+    {
+      name,
+      entrypoint ? [ "tenzir" ],
+    }:
+    nix2container.nix2container.buildImage {
+      inherit name layers tag;
+      config = {
+        Env = [
+          (
+            let
+              path = lib.makeBinPath (extraTools ++ [ pkg ]);
+            in
+            "PATH=${path}"
+          )
+          "TENZIR_PLUGIN_DIRS=${
+            lib.concatMapStringsSep "," (x: "${lib.getLib x}/lib/tenzir/plugins") (builtins.concatLists plugins)
+          }"
+        ];
+        Entrypoint = entrypoint;
+      };
+    };
+
+in
+{
+  tenzir = buildTenzirImage {
+    name = "tenzir/tenzir";
+  };
+  tenzir-node = buildTenzirImage {
+    name = "tenzir/tenzir-node";
+    entrypoint = [ "tenzir-node" ];
+  };
+}

--- a/nix/tenzir/plugins/default.nix
+++ b/nix/tenzir/plugins/default.nix
@@ -1,21 +1,15 @@
 {
   lib,
   callPackage,
-  runCommand,
   tenzir,
+  tenzir-plugins-source ? callPackage ./source.nix {},
   ...
 }: let
-  source = builtins.fromJSON (builtins.readFile ./source.json);
-  tenzir-plugins-tarball = import <nix/fetchurl.nix> source;
-  tenzir-plugins = runCommand "tenzir-plugins-source" {} ''
-    mkdir -p $out
-    tar --strip-components=1 -C $out -xf ${tenzir-plugins-tarball}
-  '';
   versions = import ./names.nix;
   f = name:
     callPackage ./generic.nix {
       name = "tenzir-plugin-${name}";
-      src = "${tenzir-plugins}/${name}";
+      src = "${tenzir-plugins-source}/${name}";
       inherit tenzir;
     };
 in

--- a/nix/tenzir/plugins/source.nix
+++ b/nix/tenzir/plugins/source.nix
@@ -1,0 +1,11 @@
+{
+  runCommand,
+  ...
+}: let
+  source = builtins.fromJSON (builtins.readFile ./source.json);
+  tenzir-plugins-tarball = import <nix/fetchurl.nix> source;
+in
+  runCommand "tenzir-plugins-source" {} ''
+    mkdir -p $out
+    tar --strip-components=1 -C $out -xf ${tenzir-plugins-tarball}
+  ''

--- a/shell.nix
+++ b/shell.nix
@@ -13,6 +13,7 @@ in
           pkgs.clang-tools
           pkgs.cmake-format
           pkgs.gdb
+          pkgs.nixfmt-rfc-style
           pkgs.speeve
           pkgs.shfmt
           pkgs.poetry

--- a/tenzir/bats/tests/vast_server.bats
+++ b/tenzir/bats/tests/vast_server.bats
@@ -189,7 +189,7 @@ teardown() {
   TENZIR_EXAMPLE_YAML="$(dirname "$BATS_TEST_DIRNAME")/../../tenzir.yaml.example"
 
   check tenzir "from file ${TENZIR_EXAMPLE_YAML} read yaml | put plugins=tenzir.plugins, commands=tenzir.start.commands"
-  TENZIR_LEGACY=false check tenzir 'from config() | drop tenzir.cacert, tenzir["cache-directory"], tenzir["state-directory"], tenzir.endpoint | write_yaml'
+  TENZIR_LEGACY=false check tenzir 'from config() | drop tenzir.cacert?, tenzir["cache-directory"]?, tenzir["runtime-prefix"]?, tenzir["state-directory"]?, tenzir.endpoint | write_yaml'
   check tenzir "from file ${INPUTSDIR}/zeek/zeek.json read zeek-json | head 5 | write yaml"
   check tenzir 'plugins | where name == "yaml" | repeat 10 | write yaml | read yaml'
 }


### PR DESCRIPTION
This makes the nix-built non-slim docker image functionally equivalent with the Debian Trixie Dockerfile based image.

You can test it with
```
nix run .#tenzir.asImage.tenzir.copyToDockerDaemon
docker run tenzir/tenzir 'plugins | where kind == "dynamic" | this = {name: name} | write_lines'
```