### PR TITLE
Do not ignore the `tenzir.zstd-compression-level` option

### DIFF
--- a/changelog/next/bug-fixes/5183--zstd-compression-level.md
+++ b/changelog/next/bug-fixes/5183--zstd-compression-level.md
@@ -1,0 +1,4 @@
+The `tenzir.zstd-compression-level` option now works again as advertised for
+setting the Zstd compression level for the partitions written by the `import`
+operator. For the past few releases, newly written partitions unconditionally
+used the default compression level.


### PR DESCRIPTION
Support for this was apparently silently dropped at some point in the past, and nobody ever noticed. The option is documented in the example configuration file, and this makes it work again.