### PR TITLE
Fix URL check in `to_hive`

### DIFF
--- a/changelog/next/bug-fixes/5204--to-hive.md
+++ b/changelog/next/bug-fixes/5204--to-hive.md
@@ -1,0 +1,2 @@
+The `to_hive` operator no longer incorrectly rejects URLs, which was due to a
+bug introduced by Tenzir v5.1.6.


### PR DESCRIPTION
This operator was only partially converted by #5194, such that it still tried to use the `save` operator when pre-checking the validity of the given URL.