### PR TITLE
Temporarily bring back TQL1 `save amqp` for testing

### DIFF
--- a/libtenzir/include/tenzir/tql2/plugin.hpp
+++ b/libtenzir/include/tenzir/tql2/plugin.hpp
@@ -269,6 +269,116 @@ private:
   Parser parser_;
 };
 
+template <class Loader, detail::string_literal NameOverride = "">
+class loader_adapter final : public crtp_operator<loader_adapter<Loader>> {
+public:
+  loader_adapter() = default;
+
+  explicit loader_adapter(Loader loader) : loader_{std::move(loader)} {
+  }
+
+  auto name() const -> std::string override {
+    return fmt::format("load_{}", NameOverride.str().empty()
+                                    ? Loader{}.name()
+                                    : NameOverride.str());
+  }
+
+  auto operator()(operator_control_plane& ctrl) const -> generator<chunk_ptr> {
+    co_yield {};
+    auto gen = loader_.instantiate(ctrl);
+    if (not gen) {
+      diagnostic::error("failed to instantiate `{}`", name())
+        .emit(ctrl.diagnostics());
+      co_return;
+    }
+    for (auto&& chunk : *gen) {
+      co_yield std::move(chunk);
+    }
+  }
+
+  auto detached() const -> bool override {
+    return true;
+  }
+
+  auto location() const -> operator_location override {
+    return operator_location::local;
+  }
+
+  auto internal() const -> bool override {
+    return loader_.internal();
+  }
+
+  auto optimize(expression const&, event_order) const
+    -> optimize_result override {
+    return do_not_optimize(*this);
+  }
+
+  friend auto inspect(auto& f, loader_adapter& x) -> bool {
+    return f.apply(x.loader_);
+  }
+
+private:
+  Loader loader_;
+};
+
+// Essentially the tql1 save operator
+template <class Saver, detail::string_literal NameOverride = "">
+class saver_adapter final : public crtp_operator<saver_adapter<Saver>> {
+public:
+  saver_adapter() = default;
+
+  explicit saver_adapter(Saver saver) : saver_{std::move(saver)} {
+  }
+
+  auto name() const -> std::string override {
+    return fmt::format("save_{}", NameOverride.str().empty()
+                                    ? Saver{}.name()
+                                    : NameOverride.str());
+  }
+
+  auto
+  operator()(generator<chunk_ptr> input, operator_control_plane& ctrl) const
+    -> generator<std::monostate> {
+    co_yield {};
+    // TODO: Extend API to allow schema-less make_saver().
+    auto new_saver = Saver{saver_}.instantiate(ctrl, std::nullopt);
+    if (!new_saver) {
+      diagnostic::error(new_saver.error())
+        .note("failed to instantiate `{}`", name())
+        .emit(ctrl.diagnostics());
+      co_return;
+    }
+    for (auto&& x : input) {
+      (*new_saver)(std::move(x));
+      co_yield {};
+    }
+  }
+
+  auto detached() const -> bool override {
+    return true;
+  }
+
+  auto location() const -> operator_location override {
+    return operator_location::local;
+  }
+
+  auto optimize(expression const&, event_order) const
+    -> optimize_result override {
+    return do_not_optimize(*this);
+  }
+
+  auto internal() const -> bool override {
+    return saver_.internal();
+  }
+
+  friend auto inspect(auto& f, saver_adapter& x) -> bool {
+    return f.apply(x.saver_);
+  }
+
+private:
+  Saver saver_;
+};
+
 // Essentially the tql1 write operator
 template <class Writer, detail::string_literal NameOverride = "">
 class writer_adapter final : public crtp_operator<writer_adapter<Writer>> {

--- a/plugins/amqp/src/plugin.cpp
+++ b/plugins/amqp/src/plugin.cpp
@@ -6,25 +6,127 @@
 // SPDX-FileCopyrightText: (c) 2023 The Tenzir Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+#include <tenzir/argument_parser.hpp>
+#include <tenzir/chunk.hpp>
+#include <tenzir/concept/parseable/tenzir/kvp.hpp>
+#include <tenzir/config.hpp>
+#include <tenzir/data.hpp>
+#include <tenzir/detail/weak_run_delayed.hpp>
 #include <tenzir/plugin.hpp>
+
+#include <caf/expected.hpp>
+
+#include "operator.hpp"
+
+#if __has_include(<rabbitmq-c/amqp.h>)
+#  include <rabbitmq-c/amqp.h>
+#  include <rabbitmq-c/ssl_socket.h>
+#  include <rabbitmq-c/tcp_socket.h>
+#else
+#  include <amqp.h>
+#  include <amqp_ssl_socket.h>
+#  include <amqp_tcp_socket.h>
+#endif
+
+using namespace std::chrono_literals;
 
 namespace tenzir::plugins::amqp {
 
 namespace {
 
-class registrar final : public plugin {
+class plugin final : public virtual loader_plugin<rabbitmq_loader>,
+                     public virtual saver_plugin<rabbitmq_saver> {
 public:
-  auto initialize(const record&, const record&) -> caf::error override {
+  auto initialize(const record& config,
+                  const record& /* global_config */) -> caf::error override {
+    config_ = config;
     return caf::none;
+  }
+
+  auto parse_loader(parser_interface& p) const
+    -> std::unique_ptr<plugin_loader> override {
+    auto [args, config] = parse_args<loader_args>(p);
+    return std::make_unique<rabbitmq_loader>(std::move(args),
+                                             std::move(config));
+  }
+
+  auto parse_saver(parser_interface& p) const
+    -> std::unique_ptr<plugin_saver> override {
+    auto [args, config] = parse_args<saver_args>(p);
+    return std::make_unique<rabbitmq_saver>(std::move(args), std::move(config));
+  }
+
+  template <class Args>
+  auto parse_args(parser_interface& p) const -> std::pair<Args, record> {
+    auto parser = argument_parser{
+      name(), fmt::format("https://docs.tenzir.com/connectors/{}", name())};
+    auto args = Args{};
+    parser.add("-c,--channel", args.channel, "<channel>");
+    parser.add("-e,--exchange", args.exchange, "<exchange>");
+    parser.add("-r,--routing_key", args.routing_key, "<key>");
+    parser.add("-X,--set", args.options, "<key=value>,...");
+    if constexpr (std::is_same_v<Args, loader_args>) {
+      parser.add("-q,--queue", args.queue, "<queue>");
+      parser.add("--passive", args.passive);
+      parser.add("--durable", args.durable);
+      parser.add("--exclusive", args.exclusive);
+      parser.add("--no-auto-delete", args.no_auto_delete);
+      parser.add("--no-local", args.no_local);
+      parser.add("--ack", args.ack);
+    } else if constexpr (std::is_same_v<Args, saver_args>) {
+      parser.add("--mandatory", args.mandatory);
+      parser.add("--immediate", args.immediate);
+    }
+    parser.add(args.url, "<url>");
+    parser.parse(p);
+    auto config = config_;
+    if (args.url) {
+      if (auto cfg = parse_url(config_, args.url->inner)) {
+        config = std::move(*cfg);
+      } else {
+        diagnostic::error("failed to parse AMQP URL")
+          .primary(args.url->source)
+          .hint("URL must adhere to the following format")
+          .hint("amqp://[USERNAME[:PASSWORD]\\@]HOSTNAME[:PORT]/[VHOST]")
+          .throw_();
+      }
+    }
+    if (args.options) {
+      std::vector<std::pair<std::string, std::string>> kvps;
+      if (not parsers::kvp_list(args.options->inner, kvps)) {
+        diagnostic::error("invalid list of key=value pairs")
+          .primary(args.options->source)
+          .throw_();
+      }
+      // For all string keys, we don't attempt automatic conversion.
+      auto strings = std::set<std::string>{"hostname", "vhost", "sasl_method",
+                                           "username", "password"};
+      for (auto& [key, value] : kvps) {
+        if (strings.contains(key)) {
+          config[key] = std::move(value);
+        } else if (auto x = from_yaml(value)) {
+          config[key] = std::move(*x);
+        } else {
+          diagnostic::error("failed to parse value in key-value pair")
+            .primary(args.options->source)
+            .note("value: {}", value)
+            .throw_();
+        }
+      }
+    }
+    return {std::move(args), std::move(config)};
   }
 
   auto name() const -> std::string override {
     return "amqp";
   }
+
+private:
+  record config_;
 };
 
 } // namespace
 
 } // namespace tenzir::plugins::amqp
 
-TENZIR_REGISTER_PLUGIN(tenzir::plugins::amqp::registrar)
+TENZIR_REGISTER_PLUGIN(tenzir::plugins::amqp::plugin)


### PR DESCRIPTION
This temporarily brings back TQL1 `save amqp` for testing.

This PR should never be merged.