### PR TITLE
Explicitly mark whether functions are deterministic

### DIFF
--- a/libtenzir/builtins/aggregation-functions/all.cpp
+++ b/libtenzir/builtins/aggregation-functions/all.cpp
@@ -35,7 +35,7 @@ private:
     if (is<caf::none_t>(view)) {
       return;
     }
-    if (!all_) {
+    if (! all_) {
       all_ = materialize(as<view_type>(view));
     } else {
       all_ = *all_ && as<view_type>(view);
@@ -44,7 +44,7 @@ private:
 
   void add(const arrow::Array& array) override {
     const auto& bool_array = as<type_to_arrow_array_t<bool_type>>(array);
-    if (!all_) {
+    if (! all_) {
       all_ = bool_array.false_count() == 0;
     } else {
       all_ = *all_ && bool_array.false_count() == 0;
@@ -162,11 +162,11 @@ class plugin final : public virtual aggregation_function_plugin,
     return {};
   }
 
-  [[nodiscard]] std::string name() const override {
+  std::string name() const override {
     return "all";
   };
 
-  [[nodiscard]] caf::expected<std::unique_ptr<aggregation_function>>
+  caf::expected<std::unique_ptr<aggregation_function>>
   make_aggregation_function(const type& input_type) const override {
     if (is<bool_type>(input_type)) {
       return std::make_unique<all_function>(input_type);
@@ -175,6 +175,10 @@ class plugin final : public virtual aggregation_function_plugin,
                            fmt::format("all aggregation function does not "
                                        "support type {}",
                                        input_type));
+  }
+
+  auto is_deterministic() const -> bool override {
+    return true;
   }
 
   auto make_aggregation(invocation inv, session ctx) const

--- a/libtenzir/builtins/aggregation-functions/any.cpp
+++ b/libtenzir/builtins/aggregation-functions/any.cpp
@@ -35,7 +35,7 @@ private:
     if (is<caf::none_t>(view)) {
       return;
     }
-    if (!any_) {
+    if (! any_) {
       any_ = materialize(as<view_type>(view));
     } else {
       any_ = *any_ || as<view_type>(view);
@@ -44,7 +44,7 @@ private:
 
   void add(const arrow::Array& array) override {
     const auto& bool_array = as<type_to_arrow_array_t<bool_type>>(array);
-    if (!any_) {
+    if (! any_) {
       any_ = bool_array.true_count() > 0;
     } else {
       any_ = *any_ || bool_array.true_count() > 0;
@@ -162,11 +162,11 @@ class plugin : public virtual aggregation_function_plugin,
     return {};
   }
 
-  [[nodiscard]] std::string name() const override {
+  std::string name() const override {
     return "any";
   };
 
-  [[nodiscard]] caf::expected<std::unique_ptr<aggregation_function>>
+  caf::expected<std::unique_ptr<aggregation_function>>
   make_aggregation_function(const type& input_type) const override {
     if (is<bool_type>(input_type)) {
       return std::make_unique<any_function>(input_type);
@@ -175,6 +175,10 @@ class plugin : public virtual aggregation_function_plugin,
                            fmt::format("any aggregation function does not "
                                        "support type {}",
                                        input_type));
+  }
+
+  auto is_deterministic() const -> bool override {
+    return true;
   }
 
   auto make_aggregation(invocation inv, session ctx) const

--- a/libtenzir/builtins/aggregation-functions/collect.cpp
+++ b/libtenzir/builtins/aggregation-functions/collect.cpp
@@ -155,6 +155,10 @@ class plugin : public virtual aggregation_function_plugin,
     return match(input_type, f);
   }
 
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
   auto make_aggregation(invocation inv, session ctx) const
     -> failure_or<std::unique_ptr<aggregation_instance>> override {
     auto expr = ast::expression{};

--- a/libtenzir/builtins/aggregation-functions/distinct.cpp
+++ b/libtenzir/builtins/aggregation-functions/distinct.cpp
@@ -33,7 +33,7 @@ struct heterogeneous_data_hash {
   [[nodiscard]] auto
 
   operator()(const type_to_data_t<Type>& value) const -> size_t
-    requires(!std::is_same_v<view<type_to_data_t<Type>>, type_to_data_t<Type>>)
+    requires(! std::is_same_v<view<type_to_data_t<Type>>, type_to_data_t<Type>>)
   {
     return hash(make_view(value));
   }
@@ -50,7 +50,7 @@ struct heterogeneous_data_equal {
 
   [[nodiscard]] auto operator()(const type_to_data_t<Type>& lhs,
                                 view<type_to_data_t<Type>> rhs) const -> bool
-    requires(!std::is_same_v<view<type_to_data_t<Type>>, type_to_data_t<Type>>)
+    requires(! std::is_same_v<view<type_to_data_t<Type>>, type_to_data_t<Type>>)
   {
     return make_view(lhs) == rhs;
   }
@@ -75,7 +75,7 @@ private:
       return;
     }
     const auto& typed_view = as<view_type>(view);
-    if (!distinct_.contains(typed_view)) {
+    if (! distinct_.contains(typed_view)) {
       const auto [it, inserted] = distinct_.insert(materialize(typed_view));
       TENZIR_ASSERT(inserted);
     }
@@ -191,17 +191,21 @@ class plugin : public virtual aggregation_function_plugin,
     return {};
   }
 
-  [[nodiscard]] auto name() const -> std::string override {
+  auto name() const -> std::string override {
     return "distinct";
   };
 
-  [[nodiscard]] auto make_aggregation_function(const type& input_type) const
+  auto make_aggregation_function(const type& input_type) const
     -> caf::expected<std::unique_ptr<aggregation_function>> override {
     auto f = [&]<concrete_type Type>(
                const Type&) -> std::unique_ptr<aggregation_function> {
       return std::make_unique<distinct_function<Type>>(input_type);
     };
     return match(input_type, f);
+  }
+
+  auto is_deterministic() const -> bool override {
+    return true;
   }
 
   auto make_aggregation(invocation inv, session ctx) const

--- a/libtenzir/builtins/aggregation-functions/first_last.cpp
+++ b/libtenzir/builtins/aggregation-functions/first_last.cpp
@@ -108,6 +108,10 @@ public:
     return Mode == mode::first ? "first" : "last";
   };
 
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
   auto make_aggregation(invocation inv, session ctx) const
     -> failure_or<std::unique_ptr<aggregation_instance>> override {
     auto expr = ast::expression{};

--- a/libtenzir/builtins/aggregation-functions/mean.cpp
+++ b/libtenzir/builtins/aggregation-functions/mean.cpp
@@ -241,6 +241,10 @@ class plugin : public virtual aggregation_function_plugin,
     return match(input_type, f);
   }
 
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
   auto make_aggregation(invocation inv, session ctx) const
     -> failure_or<std::unique_ptr<aggregation_instance>> override {
     auto expr = ast::expression{};

--- a/libtenzir/builtins/aggregation-functions/min_max.cpp
+++ b/libtenzir/builtins/aggregation-functions/min_max.cpp
@@ -275,6 +275,10 @@ public:
     return match(input_type, f);
   }
 
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
   auto make_aggregation(invocation inv, session ctx) const
     -> failure_or<std::unique_ptr<aggregation_instance>> override {
     auto expr = ast::expression{};

--- a/libtenzir/builtins/aggregation-functions/mode_value_counts.cpp
+++ b/libtenzir/builtins/aggregation-functions/mode_value_counts.cpp
@@ -151,6 +151,10 @@ class plugin : public virtual aggregation_plugin {
     return Kind == kind::mode ? "mode" : "value_counts";
   };
 
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
   auto make_aggregation(invocation inv, session ctx) const
     -> failure_or<std::unique_ptr<aggregation_instance>> override {
     auto expr = ast::expression{};

--- a/libtenzir/builtins/aggregation-functions/once.cpp
+++ b/libtenzir/builtins/aggregation-functions/once.cpp
@@ -94,6 +94,10 @@ public:
     return "once";
   };
 
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
   auto make_aggregation(invocation inv, session ctx) const
     -> failure_or<std::unique_ptr<aggregation_instance>> override {
     auto expr = ast::expression{};

--- a/libtenzir/builtins/aggregation-functions/stddev_variance.cpp
+++ b/libtenzir/builtins/aggregation-functions/stddev_variance.cpp
@@ -259,7 +259,7 @@ class plugin : public virtual aggregation_function_plugin,
     return Mode == mode::stddev ? "stddev" : "variance";
   };
 
-  [[nodiscard]] caf::expected<std::unique_ptr<aggregation_function>>
+  caf::expected<std::unique_ptr<aggregation_function>>
   make_aggregation_function(const type& input_type) const override {
     auto f = detail::overload{
       [&](const uint64_type&)
@@ -282,6 +282,10 @@ class plugin : public virtual aggregation_function_plugin,
       },
     };
     return match(input_type, f);
+  }
+
+  auto is_deterministic() const -> bool override {
+    return true;
   }
 
   auto make_aggregation(invocation inv, session ctx) const

--- a/libtenzir/builtins/aggregation-functions/sum.cpp
+++ b/libtenzir/builtins/aggregation-functions/sum.cpp
@@ -37,7 +37,7 @@ private:
     if (is<caf::none_t>(view)) {
       return;
     }
-    if (!sum_) {
+    if (! sum_) {
       sum_ = materialize(as<view_type>(view));
     } else {
       sum_ = *sum_ + materialize(as<view_type>(view));
@@ -318,6 +318,10 @@ class plugin : public virtual aggregation_function_plugin,
 
   auto aggregation_default() const -> data override {
     return caf::none;
+  }
+
+  auto is_deterministic() const -> bool override {
+    return true;
   }
 
   auto make_aggregation(invocation inv, session ctx) const

--- a/libtenzir/builtins/formats/grok.cpp
+++ b/libtenzir/builtins/formats/grok.cpp
@@ -317,7 +317,7 @@ void pattern::resolve(const pattern_store& patterns, bool allow_recursion) {
         std::vector<std::string> items;
         auto f = name.begin();
         bool s = parser(f, name.end(), items);
-        if (!s || f != name.end()) {
+        if (! s || f != name.end()) {
           diagnostic::error("invalid replacement field")
             .note("invalid NAME")
             .hint("field: `{}`, NAME: `{}`", std::string{replacement_field},
@@ -512,7 +512,7 @@ public:
     auto record = builder.record();
     auto add_field = [&](std::string_view name, const boost::csub_match& match,
                          capture_type type) {
-      if (!match.matched) {
+      if (! match.matched) {
         if (type != capture_type::unnamed or include_unnamed_) {
           record.field(name).null();
         }
@@ -768,6 +768,10 @@ class parse_grok_plugin final : public virtual function_plugin {
 public:
   auto name() const -> std::string override {
     return "tql2.parse_grok";
+  }
+
+  auto is_deterministic() const -> bool override {
+    return true;
   }
 
   auto make_function(invocation inv, session ctx) const

--- a/libtenzir/builtins/formats/json.cpp
+++ b/libtenzir/builtins/formats/json.cpp
@@ -59,7 +59,7 @@ inline auto split_at_crlf(generator<chunk_ptr> input)
   auto buffer = std::string{};
   bool ended_on_carriage_return = false;
   for (auto&& chunk : input) {
-    if (!chunk || chunk->size() == 0) {
+    if (! chunk || chunk->size() == 0) {
       co_yield std::nullopt;
       continue;
     }
@@ -96,7 +96,7 @@ inline auto split_at_crlf(generator<chunk_ptr> input)
     buffer.append(begin, end);
     co_yield std::nullopt;
   }
-  if (!buffer.empty()) {
+  if (! buffer.empty()) {
     buffer.reserve(buffer.size() + simdjson::SIMDJSON_PADDING);
     co_yield simdjson::padded_string_view{buffer};
   }
@@ -105,7 +105,7 @@ inline auto split_at_null(generator<chunk_ptr> input)
   -> generator<std::optional<simdjson::padded_string_view>> {
   auto buffer = std::string{};
   for (auto&& chunk : input) {
-    if (!chunk || chunk->size() == 0) {
+    if (! chunk || chunk->size() == 0) {
       co_yield std::nullopt;
       continue;
     }
@@ -130,7 +130,7 @@ inline auto split_at_null(generator<chunk_ptr> input)
     buffer.append(begin, end);
     co_yield std::nullopt;
   }
-  if (!buffer.empty()) {
+  if (! buffer.empty()) {
     buffer.reserve(buffer.size() + simdjson::SIMDJSON_PADDING);
     co_yield simdjson::padded_string_view{buffer};
   }
@@ -1234,6 +1234,10 @@ public:
     return "tql2.parse_json";
   }
 
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
   auto make_function(invocation inv, session ctx) const
     -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
@@ -1398,6 +1402,10 @@ class print_json_plugin : public virtual function_plugin {
 public:
   auto name() const -> std::string override {
     return compact_ ? "print_ndjson" : "print_json";
+  }
+
+  auto is_deterministic() const -> bool override {
+    return true;
   }
 
   print_json_plugin(bool compact) : compact_{compact} {

--- a/libtenzir/builtins/formats/kv.cpp
+++ b/libtenzir/builtins/formats/kv.cpp
@@ -150,8 +150,8 @@ struct kv_args {
 
 class kv_parser;
 auto parse_loop(generator<std::optional<std::string_view>> input,
-                operator_control_plane& ctrl,
-                kv_parser parser) -> generator<table_slice>;
+                operator_control_plane& ctrl, kv_parser parser)
+  -> generator<table_slice>;
 
 class kv_parser final : public plugin_parser {
 public:
@@ -193,9 +193,9 @@ public:
     }
   }
 
-  auto
-  parse_strings(const arrow::StringArray& input,
-                diagnostic_handler& diagnostics) const -> std::vector<series> {
+  auto parse_strings(const arrow::StringArray& input,
+                     diagnostic_handler& diagnostics) const
+    -> std::vector<series> {
     auto dh = transforming_diagnostic_handler{
       diagnostics,
       [](auto diag) {
@@ -229,8 +229,8 @@ public:
 };
 
 auto parse_loop(generator<std::optional<std::string_view>> input,
-                operator_control_plane& ctrl,
-                kv_parser parser) -> generator<table_slice> {
+                operator_control_plane& ctrl, kv_parser parser)
+  -> generator<table_slice> {
   auto dh = transforming_diagnostic_handler{
     ctrl.diagnostics(),
     [](auto diag) {
@@ -401,13 +401,13 @@ public:
   write_kv_operator(kv_writer writer) : writer_{std::move(writer)} {
   }
 
-  auto
-  optimize(expression const&, event_order) const -> optimize_result override {
+  auto optimize(expression const&, event_order) const
+    -> optimize_result override {
     return do_not_optimize(*this);
   }
 
-  auto operator()(generator<table_slice> input,
-                  operator_control_plane&) const -> generator<chunk_ptr> {
+  auto operator()(generator<table_slice> input, operator_control_plane&) const
+    -> generator<chunk_ptr> {
     for (auto&& slice : input) {
       if (slice.rows() == 0) {
         co_yield {};
@@ -476,8 +476,8 @@ public:
     return "read_kv";
   }
 
-  auto
-  make(invocation inv, session ctx) const -> failure_or<operator_ptr> override {
+  auto make(invocation inv, session ctx) const
+    -> failure_or<operator_ptr> override {
     auto parser = argument_parser2::operator_(name());
     auto field_split = std::optional<located<std::string>>{
       std::in_place,
@@ -513,8 +513,8 @@ public:
     return "write_kv";
   }
 
-  auto
-  make(invocation inv, session ctx) const -> failure_or<operator_ptr> override {
+  auto make(invocation inv, session ctx) const
+    -> failure_or<operator_ptr> override {
     auto parser = argument_parser2::operator_(name());
     auto writer = kv_writer{inv.self.get_location()};
     writer.add(parser);
@@ -530,8 +530,12 @@ public:
     return "parse_kv";
   }
 
-  auto make_function(invocation inv,
-                     session ctx) const -> failure_or<function_ptr> override {
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
+  auto make_function(invocation inv, session ctx) const
+    -> failure_or<function_ptr> override {
     auto input = ast::expression{};
     auto parser = argument_parser2::function(name());
     auto field_split = std::optional<located<std::string>>{
@@ -585,8 +589,12 @@ public:
     return "print_kv";
   }
 
-  auto make_function(invocation inv,
-                     session ctx) const -> failure_or<function_ptr> override {
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
+  auto make_function(invocation inv, session ctx) const
+    -> failure_or<function_ptr> override {
     auto input = ast::expression{};
     auto parser = argument_parser2::function(name());
     auto writer = kv_writer{};

--- a/libtenzir/builtins/formats/leef.cpp
+++ b/libtenzir/builtins/formats/leef.cpp
@@ -272,7 +272,7 @@ auto parse_loop(generator<std::optional<std::string_view>> lines,
     for (auto& v : msb.yield_ready_as_table_slice()) {
       co_yield std::move(v);
     }
-    if (!line) {
+    if (! line) {
       co_yield {};
       continue;
     }
@@ -365,6 +365,10 @@ class parse_leef final : public virtual function_plugin {
 public:
   auto name() const -> std::string override {
     return "parse_leef";
+  }
+
+  auto is_deterministic() const -> bool override {
+    return true;
   }
 
   auto make_function(invocation inv, session ctx) const

--- a/libtenzir/builtins/formats/syslog.cpp
+++ b/libtenzir/builtins/formats/syslog.cpp
@@ -1098,6 +1098,10 @@ public:
     return "tql2.parse_syslog";
   }
 
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
   auto make_function(invocation inv, session ctx) const
     -> failure_or<function_ptr> override {
     auto expr = ast::expression{};

--- a/libtenzir/builtins/formats/xsv.cpp
+++ b/libtenzir/builtins/formats/xsv.cpp
@@ -70,8 +70,8 @@ struct xsv_printer_options {
     return {};
   }
 
-  static auto
-  try_parse_printer_options(parser_interface& p) -> xsv_printer_options {
+  static auto try_parse_printer_options(parser_interface& p)
+    -> xsv_printer_options {
     auto parser = argument_parser{"xsv", "https://docs.tenzir.com/formats/xsv"};
     auto field_sep_str = located<std::string>{};
     auto list_sep_str = located<std::string>{};
@@ -83,13 +83,13 @@ struct xsv_printer_options {
     parser.add(null_value, "<null-value>");
     parser.parse(p);
     auto field_sep = to_xsv_sep(field_sep_str.inner);
-    if (!field_sep) {
+    if (! field_sep) {
       diagnostic::error(field_sep.error())
         .primary(field_sep_str.source)
         .throw_();
     }
     auto list_sep = to_xsv_sep(list_sep_str.inner);
-    if (!list_sep) {
+    if (! list_sep) {
       diagnostic::error(list_sep.error()).primary(list_sep_str.source).throw_();
     }
     if (*field_sep == *list_sep) {
@@ -152,10 +152,11 @@ struct xsv_parser_options {
   }
 };
 
-auto parse_header(
-  std::string_view line, location loc, const xsv_parser_options& args,
-  const detail::quoting_escaping_policy& quoting,
-  diagnostic_handler& dh) -> failure_or<std::vector<std::string>> {
+auto parse_header(std::string_view line, location loc,
+                  const xsv_parser_options& args,
+                  const detail::quoting_escaping_policy& quoting,
+                  diagnostic_handler& dh)
+  -> failure_or<std::vector<std::string>> {
   auto fields = std::vector<std::string>{};
   auto field_text = std::string_view{};
   while (auto split = quoting.split_at_unquoted(line, args.field_separator)) {
@@ -411,7 +412,7 @@ struct xsv_printer_impl {
   auto print_header(It& out, const view3<record>& x) const noexcept -> bool {
     auto first = true;
     for (const auto& [k, _] : x) {
-      if (!first) {
+      if (! first) {
         out = fmt::format_to(out, "{}", sep);
       } else {
         first = false;
@@ -425,7 +426,7 @@ struct xsv_printer_impl {
   auto print_values(It& out, const view3<record>& x) const noexcept -> bool {
     auto first = true;
     for (const auto& [_, v] : x) {
-      if (!first) {
+      if (! first) {
         out = fmt::format_to(out, "{}", sep);
       } else {
         first = false;
@@ -442,7 +443,7 @@ struct xsv_printer_impl {
     }
 
     auto operator()(caf::none_t) noexcept -> bool {
-      if (!printer.null.empty()) {
+      if (! printer.null.empty()) {
         sequence_empty = false;
         out = std::copy(printer.null.begin(), printer.null.end(), out);
       }
@@ -518,10 +519,10 @@ struct xsv_printer_impl {
     auto operator()(const view3<list>& x) noexcept -> bool {
       sequence_empty = true;
       for (const auto& v : x) {
-        if (!sequence_empty) {
+        if (! sequence_empty) {
           out = fmt::format_to(out, "{}", printer.list_sep);
         }
-        if (!match(v, *this)) {
+        if (! match(v, *this)) {
           return false;
         }
       }
@@ -629,8 +630,8 @@ auto parse_line(std::string_view line, std::vector<std::string>& fields,
 }
 
 auto parse_loop(generator<std::optional<std::string_view>> lines,
-                operator_control_plane& ctrl,
-                xsv_parser_options args) -> generator<table_slice> {
+                operator_control_plane& ctrl, xsv_parser_options args)
+  -> generator<table_slice> {
   // Parse header.
   auto it = lines.begin();
   auto line = std::optional<std::string_view>{};
@@ -907,8 +908,8 @@ public:
   auto name() const -> std::string override {
     return "read_xsv";
   }
-  auto
-  make(invocation inv, session ctx) const -> failure_or<operator_ptr> override {
+  auto make(invocation inv, session ctx) const
+    -> failure_or<operator_ptr> override {
     auto parser = argument_parser2::operator_(name());
     auto opt_parser = xsv_common_parser_options_parser{name()};
     opt_parser.add_to_parser(parser, true, false);
@@ -929,8 +930,8 @@ public:
     return fmt::format("read_{}", Name);
   }
 
-  auto
-  make(invocation inv, session ctx) const -> failure_or<operator_ptr> override {
+  auto make(invocation inv, session ctx) const
+    -> failure_or<operator_ptr> override {
     auto parser = argument_parser2::operator_(name());
     auto opt_parser = xsv_common_parser_options_parser{
       name(),
@@ -954,8 +955,8 @@ public:
 
 class write_xsv : public operator_plugin2<writer_adapter<xsv_printer>> {
 public:
-  auto
-  make(invocation inv, session ctx) const -> failure_or<operator_ptr> override {
+  auto make(invocation inv, session ctx) const
+    -> failure_or<operator_ptr> override {
     auto args = xsv_printer_options{};
     auto parser = argument_parser2::operator_(name());
     args.add(parser);
@@ -1031,8 +1032,13 @@ class parse_xsv : public function_plugin {
   auto name() const -> std::string override {
     return "parse_xsv";
   }
-  auto make_function(invocation inv,
-                     session ctx) const -> failure_or<function_ptr> override {
+
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
+  auto make_function(invocation inv, session ctx) const
+    -> failure_or<function_ptr> override {
     auto input = ast::expression{};
     auto parser = argument_parser2::function(name());
     parser.positional("input", input, "string");
@@ -1058,8 +1064,13 @@ public:
   auto name() const -> std::string override {
     return fmt::format("parse_{}", Name);
   }
-  auto make_function(invocation inv,
-                     session ctx) const -> failure_or<function_ptr> override {
+
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
+  auto make_function(invocation inv, session ctx) const
+    -> failure_or<function_ptr> override {
     auto input = ast::expression{};
     auto parser = argument_parser2::function(name());
     parser.positional("input", input, "string");
@@ -1083,48 +1094,47 @@ public:
   }
 };
 
-auto make_xsv_printing_function(ast::expression input,
-                                xsv_printer_options opts) -> function_ptr {
-  return function_use::make(
-    [input = std::move(input),
-     opts = std::move(opts)](function_plugin::evaluator eval, session ctx) {
-      return map_series(eval(input), [&](series data) -> multi_series {
-        if (data.type.kind().is<null_type>()) {
-          return series::null(string_type{}, data.length());
+auto make_xsv_printing_function(ast::expression input, xsv_printer_options opts)
+  -> function_ptr {
+  return function_use::make([input = std::move(input), opts = std::move(opts)](
+                              function_plugin::evaluator eval, session ctx) {
+    return map_series(eval(input), [&](series data) -> multi_series {
+      if (data.type.kind().is<null_type>()) {
+        return series::null(string_type{}, data.length());
+      }
+      if (data.type.kind() != type{record_type{}}.kind()) {
+        diagnostic::warning("expected `record`, got `{}`", data.type.kind())
+          .primary(input)
+          .emit(ctx);
+        return series::null(string_type{}, data.length());
+      }
+      const auto struct_array
+        = std::dynamic_pointer_cast<arrow::StructArray>(data.array);
+      TENZIR_ASSERT(struct_array);
+      auto [flattend_type, flattend_array, _]
+        = flatten(data.type, struct_array, ".");
+      auto [resolved_type, resolved_array]
+        = resolve_enumerations(as<record_type>(flattend_type), flattend_array);
+      auto builder = type_to_arrow_builder_t<string_type>{};
+      auto printer = xsv_printer_impl{
+        opts.field_separator.inner,
+        opts.list_separator.inner,
+        opts.null_value.inner,
+      };
+      auto buffer = std::string{};
+      for (auto row : values3(*resolved_array)) {
+        if (not row) {
+          check(builder.AppendNull());
+          continue;
         }
-        if (data.type.kind() != type{record_type{}}.kind()) {
-          diagnostic::warning("expected `record`, got `{}`", data.type.kind())
-            .primary(input)
-            .emit(ctx);
-          return series::null(string_type{}, data.length());
-        }
-        const auto struct_array
-          = std::dynamic_pointer_cast<arrow::StructArray>(data.array);
-        TENZIR_ASSERT(struct_array);
-        auto [flattend_type, flattend_array, _]
-          = flatten(data.type, struct_array, ".");
-        auto [resolved_type, resolved_array] = resolve_enumerations(
-          as<record_type>(flattend_type), flattend_array);
-        auto builder = type_to_arrow_builder_t<string_type>{};
-        auto printer = xsv_printer_impl{
-          opts.field_separator.inner,
-          opts.list_separator.inner,
-          opts.null_value.inner,
-        };
-        auto buffer = std::string{};
-        for (auto row : values3(*resolved_array)) {
-          if (not row) {
-            check(builder.AppendNull());
-            continue;
-          }
-          buffer.clear();
-          auto out = std::back_inserter(buffer);
-          printer.print_values(out, *row);
-          check(builder.Append(buffer));
-        }
-        return series{string_type{}, check(builder.Finish())};
-      });
+        buffer.clear();
+        auto out = std::back_inserter(buffer);
+        printer.print_values(out, *row);
+        check(builder.Append(buffer));
+      }
+      return series{string_type{}, check(builder.Finish())};
     });
+  });
 }
 
 class print_xsv : public function_plugin {
@@ -1132,8 +1142,12 @@ class print_xsv : public function_plugin {
     return "print_xsv";
   }
 
-  auto make_function(invocation inv,
-                     session ctx) const -> failure_or<function_ptr> override {
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
+  auto make_function(invocation inv, session ctx) const
+    -> failure_or<function_ptr> override {
     auto input = ast::expression{};
     auto opts = xsv_printer_options{
       .no_header = true,
@@ -1154,8 +1168,13 @@ public:
   auto name() const -> std::string override {
     return fmt::format("print_{}", Name);
   }
-  auto make_function(invocation inv,
-                     session ctx) const -> failure_or<function_ptr> override {
+
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
+  auto make_function(invocation inv, session ctx) const
+    -> failure_or<function_ptr> override {
     auto input = ast::expression{};
     auto opts = xsv_printer_options{
       .field_separator = located{std::string{Sep}, inv.call.get_location()},

--- a/libtenzir/builtins/formats/yaml.cpp
+++ b/libtenzir/builtins/formats/yaml.cpp
@@ -50,8 +50,8 @@ auto try_as(const YAML::Node& node, auto&& guard) -> bool {
   return false;
 }
 
-auto parse_node(auto&& guard, const YAML::Node& node,
-                diagnostic_handler& diag) -> void {
+auto parse_node(auto&& guard, const YAML::Node& node, diagnostic_handler& diag)
+  -> void {
   switch (node.Type()) {
     case YAML::NodeType::Undefined: {
       diagnostic::warning("yaml parser encountered undefined field").emit(diag);
@@ -174,8 +174,8 @@ template <class View>
 auto print_node(auto& out, const View& value) -> void {
   if constexpr (std::is_same_v<View, data_view>) {
     return match(value, [&](const auto& value) {
-        return print_node(out, value);
-      });
+      return print_node(out, value);
+    });
   } else if constexpr (std::same_as<View, data_view3>) {
     return match(value, [&](const auto& value) {
       return print_node(out, value);
@@ -350,8 +350,8 @@ class yaml_plugin final : public virtual parser_plugin<yaml_parser>,
 
 class read_yaml final
   : public virtual operator_plugin2<parser_adapter<yaml_parser>> {
-  auto
-  make(invocation inv, session ctx) const -> failure_or<operator_ptr> override {
+  auto make(invocation inv, session ctx) const
+    -> failure_or<operator_ptr> override {
     auto parser = argument_parser2::operator_("read_yaml");
     auto msb_parser = multi_series_builder_argument_parser{};
     msb_parser.add_all_to_parser(parser);
@@ -373,8 +373,12 @@ public:
     return "tql2.parse_yaml";
   }
 
-  auto make_function(invocation inv,
-                     session ctx) const -> failure_or<function_ptr> override {
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
+  auto make_function(invocation inv, session ctx) const
+    -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
     // TODO: Consider adding a `many` option to expect multiple yaml values.
     auto parser = argument_parser2::function(name());
@@ -424,8 +428,8 @@ public:
 
 class write_yaml final
   : public virtual operator_plugin2<writer_adapter<yaml_printer>> {
-  auto
-  make(invocation inv, session ctx) const -> failure_or<operator_ptr> override {
+  auto make(invocation inv, session ctx) const
+    -> failure_or<operator_ptr> override {
     TRY(argument_parser2::operator_(name()).parse(inv, ctx));
     return std::make_unique<writer_adapter<yaml_printer>>(yaml_printer{});
   }
@@ -440,8 +444,12 @@ class print_yaml final : public virtual function_plugin {
     return "print_yaml";
   }
 
-  auto make_function(invocation inv,
-                     session ctx) const -> failure_or<function_ptr> override {
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
+  auto make_function(invocation inv, session ctx) const
+    -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
     auto include_document_markers = std::optional<location>{};
     auto parser = argument_parser2::function(name());

--- a/libtenzir/builtins/functions/abs.cpp
+++ b/libtenzir/builtins/functions/abs.cpp
@@ -26,6 +26,10 @@ public:
     return "abs";
   }
 
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
   auto make_function(invocation inv, session ctx) const
     -> failure_or<function_ptr> override {
     auto expr = ast::expression{};

--- a/libtenzir/builtins/functions/base64.cpp
+++ b/libtenzir/builtins/functions/base64.cpp
@@ -27,8 +27,12 @@ class plugin final : public function_plugin {
     return std::string{to_string(Mode)};
   }
 
-  auto make_function(invocation inv,
-                     session ctx) const -> failure_or<function_ptr> override {
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
+  auto make_function(invocation inv, session ctx) const
+    -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
     TRY(argument_parser2::function(name())
           .positional("value", expr, "blob|string")

--- a/libtenzir/builtins/functions/bit.cpp
+++ b/libtenzir/builtins/functions/bit.cpp
@@ -27,6 +27,10 @@ public:
     return name_;
   }
 
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
   struct impl final : public function_use {
     auto run(evaluator eval, session ctx) -> multi_series override {
       return map_series(eval(expr), [&](const series& values) -> multi_series {
@@ -75,6 +79,10 @@ class binary_fn : public virtual function_plugin {
 public:
   binary_fn(std::string name, std::string compute_fn)
     : name_{std::move(name)}, compute_fn_{std::move(compute_fn)} {
+  }
+
+  auto is_deterministic() const -> bool override {
+    return true;
   }
 
   auto name() const -> std::string override {

--- a/libtenzir/builtins/functions/ceil_round_floor.cpp
+++ b/libtenzir/builtins/functions/ceil_round_floor.cpp
@@ -28,8 +28,12 @@ public:
     return std::string{to_string(Mode)};
   }
 
-  auto make_function(invocation inv,
-                     session ctx) const -> failure_or<function_ptr> override {
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
+  auto make_function(invocation inv, session ctx) const
+    -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
     auto spec = std::optional<located<duration>>{};
     TRY(argument_parser2::function(name())

--- a/libtenzir/builtins/functions/community_id.cpp
+++ b/libtenzir/builtins/functions/community_id.cpp
@@ -33,6 +33,10 @@ public:
     return "tql2.community_id";
   }
 
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
   auto make_function(invocation inv, session ctx) const
     -> failure_or<function_ptr> override {
     auto args = arguments{};

--- a/libtenzir/builtins/functions/config.cpp
+++ b/libtenzir/builtins/functions/config.cpp
@@ -22,6 +22,10 @@ public:
     return "config";
   }
 
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
   auto initialize(const record& plugin_config, const record& global_config)
     -> caf::error override {
     TENZIR_UNUSED(plugin_config);

--- a/libtenzir/builtins/functions/cryptopan.cpp
+++ b/libtenzir/builtins/functions/cryptopan.cpp
@@ -25,8 +25,12 @@ class encrypt : public virtual function_plugin {
     return "encrypt_cryptopan";
   }
 
-  auto make_function(invocation inv,
-                     session ctx) const -> failure_or<function_ptr> override {
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
+  auto make_function(invocation inv, session ctx) const
+    -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
     auto seed = std::optional<std::string>{};
     TRY(argument_parser2::function(name())

--- a/libtenzir/builtins/functions/duration.cpp
+++ b/libtenzir/builtins/functions/duration.cpp
@@ -25,6 +25,10 @@ public:
     return "duration";
   }
 
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
   auto make_function(invocation inv, session ctx) const
     -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
@@ -88,6 +92,10 @@ public:
 
   auto name() const -> std::string override {
     return name_;
+  }
+
+  auto is_deterministic() const -> bool override {
+    return true;
   }
 
   auto make_function(invocation inv, session ctx) const
@@ -186,6 +194,10 @@ public:
 
   auto name() const -> std::string override {
     return name_;
+  }
+
+  auto is_deterministic() const -> bool override {
+    return true;
   }
 
   auto make_function(invocation inv, session ctx) const

--- a/libtenzir/builtins/functions/file_contents.cpp
+++ b/libtenzir/builtins/functions/file_contents.cpp
@@ -25,6 +25,10 @@ struct file_contents final : public function_plugin {
     return "file_contents";
   }
 
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
   auto make_function(invocation inv, session ctx) const
     -> failure_or<function_ptr> override {
     auto path = located<std::string>{};

--- a/libtenzir/builtins/functions/float.cpp
+++ b/libtenzir/builtins/functions/float.cpp
@@ -23,8 +23,12 @@ public:
     return "float";
   }
 
-  auto make_function(invocation inv,
-                     session ctx) const -> failure_or<function_ptr> override {
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
+  auto make_function(invocation inv, session ctx) const
+    -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
     TRY(argument_parser2::function(name())
           .positional("x", expr, "number|string")

--- a/libtenzir/builtins/functions/hash.cpp
+++ b/libtenzir/builtins/functions/hash.cpp
@@ -73,7 +73,7 @@ public:
     -> caf::expected<state_type> override {
     // Get the target field if it exists.
     auto column_index = schema.resolve_key_or_concept_once(config_.field);
-    if (!column_index) {
+    if (! column_index) {
       return state_type{};
     }
     auto transform_fn = [this](struct record_type::field field,
@@ -153,7 +153,7 @@ public:
     const auto options = option_set_parser{{{"salt", 's'}}};
     const auto option_parser = (required_ws_or_comment >> options);
     auto parsed_options = std::unordered_map<std::string, data>{};
-    if (!option_parser(f, l, parsed_options)) {
+    if (! option_parser(f, l, parsed_options)) {
       return {
         std::string_view{f, l},
         caf::make_error(ec::syntax_error, fmt::format("failed to parse hash "
@@ -165,7 +165,7 @@ public:
                                   >> optional_ws_or_comment
                                   >> end_of_pipeline_operator;
     auto parsed_extractors = std::vector<std::string>{};
-    if (!extractor_parser(f, l, parsed_extractors)) {
+    if (! extractor_parser(f, l, parsed_extractors)) {
       return {
         std::string_view{f, l},
         caf::make_error(ec::syntax_error, fmt::format("failed to parse hash "
@@ -179,7 +179,7 @@ public:
     config.out = parsed_extractors.front() + "_hashed";
     for (const auto& [key, value] : parsed_options) {
       auto value_str = try_as<std::string>(&value);
-      if (!value_str) {
+      if (! value_str) {
         return {
           std::string_view{f, l},
           caf::make_error(ec::syntax_error, fmt::format("invalid option value "
@@ -205,6 +205,10 @@ template <class HashAlgorithm, detail::string_literal Name>
 class fun : public virtual function_plugin {
   auto name() const -> std::string override {
     return fmt::format("hash_{}", Name);
+  }
+
+  auto is_deterministic() const -> bool override {
+    return true;
   }
 
   auto make_function(invocation inv, session ctx) const

--- a/libtenzir/builtins/functions/hex.cpp
+++ b/libtenzir/builtins/functions/hex.cpp
@@ -26,8 +26,12 @@ class plugin final : public function_plugin {
     return Mode == mode::encode ? "encode_hex" : "decode_hex";
   }
 
-  auto make_function(invocation inv,
-                     session ctx) const -> failure_or<function_ptr> override {
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
+  auto make_function(invocation inv, session ctx) const
+    -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
     TRY(argument_parser2::function(name())
           .positional("value", expr, "blob|string")

--- a/libtenzir/builtins/functions/int.cpp
+++ b/libtenzir/builtins/functions/int.cpp
@@ -28,6 +28,10 @@ public:
     return Signed ? "int" : "uint";
   }
 
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
   auto make_function(invocation inv, session ctx) const
     -> failure_or<function_ptr> override {
     auto expr = ast::expression{};

--- a/libtenzir/builtins/functions/ip.cpp
+++ b/libtenzir/builtins/functions/ip.cpp
@@ -24,6 +24,10 @@ public:
     return "tql2.ip";
   }
 
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
   auto make_function(invocation inv, session ctx) const
     -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
@@ -79,6 +83,10 @@ public:
 
   auto name() const -> std::string override {
     return v4_ ? "is_v4" : "is_v6";
+  }
+
+  auto is_deterministic() const -> bool override {
+    return true;
   }
 
   auto make_function(invocation inv, session ctx) const

--- a/libtenzir/builtins/functions/list.cpp
+++ b/libtenzir/builtins/functions/list.cpp
@@ -25,6 +25,10 @@ public:
     return "prepend";
   }
 
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
   auto make_function(invocation inv, session ctx) const
     -> failure_or<function_ptr> override {
     auto list = ast::expression{};
@@ -57,6 +61,10 @@ public:
     return "append";
   }
 
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
   auto make_function(invocation inv, session ctx) const
     -> failure_or<function_ptr> override {
     auto list = ast::expression{};
@@ -87,6 +95,10 @@ class concatenate : public virtual function_plugin {
 public:
   auto name() const -> std::string override {
     return "concatenate";
+  }
+
+  auto is_deterministic() const -> bool override {
+    return true;
   }
 
   auto make_function(invocation inv, session ctx) const
@@ -127,6 +139,10 @@ public:
 
   auto name() const -> std::string override {
     return "tql2.zip";
+  }
+
+  auto is_deterministic() const -> bool override {
+    return true;
   }
 
   auto make_function(invocation inv, session ctx) const

--- a/libtenzir/builtins/functions/misc.cpp
+++ b/libtenzir/builtins/functions/misc.cpp
@@ -32,6 +32,10 @@ public:
     return "tql2.type_id";
   }
 
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
   auto make_function(invocation inv, session ctx) const
     -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
@@ -61,6 +65,10 @@ class type_of final : public function_plugin {
 public:
   auto name() const -> std::string override {
     return "type_of";
+  }
+
+  auto is_deterministic() const -> bool override {
+    return true;
   }
 
   auto make_function(invocation inv, session ctx) const
@@ -98,6 +106,10 @@ public:
       env_.emplace(entry.get_name(), entry.to_string());
     }
     return {};
+  }
+
+  auto is_deterministic() const -> bool override {
+    return true;
   }
 
   auto make_function(invocation inv, session ctx) const
@@ -177,6 +189,10 @@ public:
     return "length";
   }
 
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
   auto make_function(invocation inv, session ctx) const
     -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
@@ -224,6 +240,10 @@ class network final : public function_plugin {
 public:
   auto name() const -> std::string override {
     return "network";
+  }
+
+  auto is_deterministic() const -> bool override {
+    return true;
   }
 
   auto make_function(invocation inv, session ctx) const
@@ -275,6 +295,10 @@ class has final : public function_plugin {
 public:
   auto name() const -> std::string override {
     return "has";
+  }
+
+  auto is_deterministic() const -> bool override {
+    return true;
   }
 
   auto make_function(invocation inv, session ctx) const
@@ -381,6 +405,10 @@ public:
     return "keys";
   }
 
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
   auto make_function(invocation inv, session ctx) const
     -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
@@ -432,6 +460,10 @@ public:
 
   auto name() const -> std::string override {
     return select_ ? "select_matching" : "drop_matching";
+  }
+
+  auto is_deterministic() const -> bool override {
+    return true;
   }
 
   auto make_function(invocation inv, session ctx) const
@@ -492,6 +524,10 @@ public:
     return "merge";
   }
 
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
   auto make_function(invocation inv, session ctx) const
     -> failure_or<function_ptr> override {
     auto record1 = ast::expression{};
@@ -525,6 +561,10 @@ class get final : public function_plugin {
 public:
   auto name() const -> std::string override {
     return "get";
+  }
+
+  auto is_deterministic() const -> bool override {
+    return true;
   }
 
   auto make_function(invocation inv, session ctx) const

--- a/libtenzir/builtins/functions/numeric.cpp
+++ b/libtenzir/builtins/functions/numeric.cpp
@@ -29,6 +29,10 @@ public:
     return "tql2.sqrt";
   }
 
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
   auto make_function(invocation inv, session ctx) const
     -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
@@ -99,6 +103,10 @@ public:
     return "tql2.random";
   }
 
+  auto is_deterministic() const -> bool override {
+    return false;
+  }
+
   auto make_function(invocation inv, session ctx) const
     -> failure_or<function_ptr> override {
     argument_parser2::function("random").parse(inv, ctx).ignore();
@@ -166,6 +174,10 @@ class count final : public aggregation_plugin {
 public:
   auto name() const -> std::string override {
     return "tql2.count";
+  }
+
+  auto is_deterministic() const -> bool final {
+    return true;
   }
 
   auto make_aggregation(invocation inv, session ctx) const
@@ -285,6 +297,10 @@ public:
     return "tql2.quantile";
   }
 
+  auto is_deterministic() const -> bool final {
+    return true;
+  }
+
   auto make_aggregation(invocation inv, session ctx) const
     -> failure_or<std::unique_ptr<aggregation_instance>> override {
     auto expr = ast::expression{};
@@ -346,6 +362,10 @@ class median final : public aggregation_plugin {
 public:
   auto name() const -> std::string override {
     return "tql2.median";
+  }
+
+  auto is_deterministic() const -> bool final {
+    return true;
   }
 
   auto make_aggregation(invocation inv, session ctx) const

--- a/libtenzir/builtins/functions/ocsf.cpp
+++ b/libtenzir/builtins/functions/ocsf.cpp
@@ -108,8 +108,8 @@ constexpr ocsf_pair class_map[]{
   {"Network Remediation Activity", 7004},
 };
 
-auto name_to_id(std::span<const ocsf_pair> lookup,
-                std::string_view key) -> std::optional<int64_t> {
+auto name_to_id(std::span<const ocsf_pair> lookup, std::string_view key)
+  -> std::optional<int64_t> {
   for (const auto& [category, id] : lookup) {
     if (key == category) {
       return id;
@@ -118,8 +118,8 @@ auto name_to_id(std::span<const ocsf_pair> lookup,
   return std::nullopt;
 }
 
-auto id_to_name(std::span<const ocsf_pair> lookup,
-                int64_t key) -> std::optional<std::string_view> {
+auto id_to_name(std::span<const ocsf_pair> lookup, int64_t key)
+  -> std::optional<std::string_view> {
   for (const auto& [category, id] : lookup) {
     if (key == id) {
       return category;
@@ -140,6 +140,10 @@ public:
     return name_;
   }
 
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
   generic_mapping_plugin(std::string name, std::string input_meta,
                          const std::span<const ocsf_pair> map,
                          std::string warning_text)
@@ -149,8 +153,8 @@ public:
       warning_text_{std::move(warning_text)} {
   }
 
-  auto make_function(invocation inv,
-                     session ctx) const -> failure_or<function_ptr> override {
+  auto make_function(invocation inv, session ctx) const
+    -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
     TRY(argument_parser2::function(name_)
           .positional("x", expr, input_meta_)

--- a/libtenzir/builtins/functions/otherwise.cpp
+++ b/libtenzir/builtins/functions/otherwise.cpp
@@ -19,6 +19,10 @@ public:
     return "otherwise";
   }
 
+  auto is_deterministic() const -> bool final {
+    return true;
+  }
+
   auto make_function(invocation inv, session ctx) const
     -> failure_or<function_ptr> override {
     auto primary = ast::expression{};

--- a/libtenzir/builtins/functions/path.cpp
+++ b/libtenzir/builtins/functions/path.cpp
@@ -19,6 +19,10 @@ public:
     return "tql2.file_name";
   }
 
+  auto is_deterministic() const -> bool final {
+    return true;
+  }
+
   auto make_function(invocation inv, session ctx) const
     -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
@@ -71,6 +75,10 @@ class parent_dir final : public function_plugin {
 public:
   auto name() const -> std::string override {
     return "tql2.parent_dir";
+  }
+
+  auto is_deterministic() const -> bool final {
+    return true;
   }
 
   auto make_function(invocation inv, session ctx) const

--- a/libtenzir/builtins/functions/secret.cpp
+++ b/libtenzir/builtins/functions/secret.cpp
@@ -23,6 +23,10 @@ public:
     return "tql2.secret";
   }
 
+  auto is_deterministic() const -> bool final {
+    return true;
+  }
+
   auto initialize(const record&, const record& global_config)
     -> caf::error override {
     const auto v

--- a/libtenzir/builtins/functions/string.cpp
+++ b/libtenzir/builtins/functions/string.cpp
@@ -35,6 +35,10 @@ public:
     return starts_with_ ? "starts_with" : "ends_with";
   }
 
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
   auto make_function(invocation inv, session ctx) const
     -> failure_or<function_ptr> override {
     auto subject_expr = ast::expression{};
@@ -89,6 +93,10 @@ class match_regex : public virtual function_plugin {
 public:
   auto name() const -> std::string override {
     return "match_regex";
+  }
+
+  auto is_deterministic() const -> bool override {
+    return true;
   }
 
   auto make_function(invocation inv, session ctx) const
@@ -151,6 +159,10 @@ public:
 
   auto name() const -> std::string override {
     return name_;
+  }
+
+  auto is_deterministic() const -> bool override {
+    return true;
   }
 
   auto make_function(invocation inv, session ctx) const
@@ -221,6 +233,10 @@ public:
     return name_;
   }
 
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
   auto function_name() const -> std::string override {
     if (name_.ends_with("()")) {
       return name_.substr(0, name_.size() - 2);
@@ -285,6 +301,10 @@ public:
 
   auto name() const -> std::string override {
     return regex_ ? "tql2.replace_regex" : "tql2.replace";
+  }
+
+  auto is_deterministic() const -> bool override {
+    return true;
   }
 
   auto make_function(invocation inv, session ctx) const
@@ -360,6 +380,10 @@ public:
     return "tql2.slice";
   }
 
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
   auto make_function(invocation inv, session ctx) const
     -> failure_or<function_ptr> override {
     auto subject_expr = ast::expression{};
@@ -425,6 +449,10 @@ class string_fn : public virtual function_plugin {
 public:
   auto name() const -> std::string override {
     return Deprecated ? "tql2.str" : "tql2.string";
+  }
+
+  auto is_deterministic() const -> bool override {
+    return true;
   }
 
   auto make_function(invocation inv, session ctx) const
@@ -510,6 +538,10 @@ public:
     return regex_ ? "tql2.split_regex" : "tql2.split";
   }
 
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
   auto make_function(invocation inv, session ctx) const
     -> failure_or<function_ptr> override {
     auto subject_expr = ast::expression{};
@@ -580,6 +612,10 @@ class join : public virtual function_plugin {
 public:
   auto name() const -> std::string override {
     return "tql2.join";
+  }
+
+  auto is_deterministic() const -> bool override {
+    return true;
   }
 
   auto make_function(invocation inv, session ctx) const

--- a/libtenzir/builtins/functions/subnet.cpp
+++ b/libtenzir/builtins/functions/subnet.cpp
@@ -24,6 +24,10 @@ public:
     return "tql2.subnet";
   }
 
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
   auto make_function(invocation inv, session ctx) const
     -> failure_or<function_ptr> override {
     auto expr = ast::expression{};

--- a/libtenzir/builtins/functions/time.cpp
+++ b/libtenzir/builtins/functions/time.cpp
@@ -28,6 +28,10 @@ public:
     return "tql2.time";
   }
 
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
   auto make_function(invocation inv, session ctx) const
     -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
@@ -84,6 +88,10 @@ public:
     return "since_epoch";
   }
 
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
   auto make_function(invocation inv, session ctx) const
     -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
@@ -133,6 +141,10 @@ public:
     return "from_epoch";
   }
 
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
   auto make_function(invocation inv, session ctx) const
     -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
@@ -180,6 +192,10 @@ public:
 
   auto name() const -> std::string override {
     return std::string{to_string(ymd_subtype_)};
+  }
+
+  auto is_deterministic() const -> bool override {
+    return true;
   }
 
   auto make_function(invocation inv, session ctx) const
@@ -248,6 +264,10 @@ public:
 
   auto name() const -> std::string override {
     return std::string{to_string(hms_subtype_)};
+  }
+
+  auto is_deterministic() const -> bool override {
+    return true;
   }
 
   auto make_function(invocation inv, session ctx) const
@@ -341,6 +361,10 @@ public:
     return "tql2.now";
   }
 
+  auto is_deterministic() const -> bool override {
+    return false;
+  }
+
   auto make_function(invocation inv, session ctx) const
     -> failure_or<function_ptr> override {
     TRY(argument_parser2::function("now").parse(inv, ctx));
@@ -360,6 +384,10 @@ class format_time : public virtual function_plugin {
 public:
   auto name() const -> std::string override {
     return "tql2.format_time";
+  }
+
+  auto is_deterministic() const -> bool override {
+    return true;
   }
 
   auto make_function(invocation inv, session ctx) const
@@ -414,6 +442,10 @@ class parse_time : public virtual function_plugin {
 public:
   auto name() const -> std::string override {
     return "tql2.parse_time";
+  }
+
+  auto is_deterministic() const -> bool override {
+    return true;
   }
 
   auto make_function(invocation inv, session ctx) const

--- a/libtenzir/builtins/functions/url.cpp
+++ b/libtenzir/builtins/functions/url.cpp
@@ -27,6 +27,10 @@ class plugin final : public function_plugin {
     return Mode == mode::encode ? "encode_url" : "decode_url";
   }
 
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
   auto make_function(invocation inv, session ctx) const
     -> failure_or<function_ptr> override {
     auto expr = ast::expression{};

--- a/libtenzir/builtins/operators/flatten.cpp
+++ b/libtenzir/builtins/operators/flatten.cpp
@@ -32,8 +32,8 @@ public:
   }
 
   auto
-  operator()(generator<table_slice> input,
-             operator_control_plane& ctrl) const -> generator<table_slice> {
+  operator()(generator<table_slice> input, operator_control_plane& ctrl) const
+    -> generator<table_slice> {
     auto seen = std::unordered_set<type>{};
     for (auto&& slice : input) {
       auto result = tenzir::flatten(slice, separator_);
@@ -54,8 +54,8 @@ public:
     return "flatten";
   }
 
-  auto optimize(expression const&,
-                event_order order) const -> optimize_result override {
+  auto optimize(expression const&, event_order order) const
+    -> optimize_result override {
     return optimize_result::order_invariant(*this, order);
   }
 
@@ -74,8 +74,12 @@ public:
     return {.transformation = true};
   }
 
-  auto make_function(invocation inv,
-                     session ctx) const -> failure_or<function_ptr> override {
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
+  auto make_function(invocation inv, session ctx) const
+    -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
     auto sep = std::optional<std::string>{default_flatten_separator};
     TRY(argument_parser2::function("flatten")

--- a/libtenzir/builtins/operators/sort.cpp
+++ b/libtenzir/builtins/operators/sort.cpp
@@ -335,7 +335,7 @@ public:
       = std::vector<std::tuple<std::string /*key*/, bool /*descending*/,
                                bool /*nulls_first*/>>{};
     bool stable = false;
-    if (!p(f, l, stable, sort_args)) {
+    if (! p(f, l, stable, sort_args)) {
       return {
         std::string_view{f, l},
         caf::make_error(ec::syntax_error, fmt::format("failed to parse "
@@ -555,6 +555,10 @@ public:
     std::ranges::transform(inv.args, std::back_inserter(sort_exprs),
                            make_sort_key);
     return std::make_unique<sort_operator2>(std::move(sort_exprs));
+  }
+
+  auto is_deterministic() const -> bool override {
+    return true;
   }
 
   auto make_function(function_plugin::invocation inv, session ctx) const

--- a/libtenzir/builtins/operators/unflatten.cpp
+++ b/libtenzir/builtins/operators/unflatten.cpp
@@ -42,8 +42,8 @@ public:
     return "unflatten";
   }
 
-  auto optimize(expression const& filter,
-                event_order order) const -> optimize_result override {
+  auto optimize(expression const& filter, event_order order) const
+    -> optimize_result override {
     (void)filter;
     return optimize_result::order_invariant(*this, order);
   }
@@ -73,8 +73,12 @@ public:
     return std::make_unique<unflatten_operator>(separator);
   }
 
-  auto make_function(invocation inv,
-                     session ctx) const -> failure_or<function_ptr> override {
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
+  auto make_function(invocation inv, session ctx) const
+    -> failure_or<function_ptr> override {
     auto expr = ast::expression{};
     auto sep = std::optional<std::string>{};
     TRY(argument_parser2::function(name())

--- a/libtenzir/builtins/operators/where_map.cpp
+++ b/libtenzir/builtins/operators/where_map.cpp
@@ -134,7 +134,7 @@ public:
     parser.add(expr, "<expr>");
     parser.parse(p);
     auto normalized_and_validated = normalize_and_validate(expr.inner);
-    if (!normalized_and_validated) {
+    if (! normalized_and_validated) {
       diagnostic::error("invalid expression")
         .primary(expr.source)
         .docs("https://tenzir.com/language/expressions")
@@ -798,6 +798,10 @@ public:
     return std::make_unique<where_ir>(loc, std::move(expr));
   }
 
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
   auto make_function(function_plugin::invocation inv, session ctx) const
     -> failure_or<function_ptr> override {
     return make_where_function(std::move(inv), ctx);
@@ -808,6 +812,10 @@ class map_plugin final : public function_plugin {
 public:
   auto name() const -> std::string override {
     return "tql2.map";
+  }
+
+  auto is_deterministic() const -> bool override {
+    return true;
   }
 
   auto make_function(invocation inv, session ctx) const

--- a/libtenzir/include/tenzir/tql2/eval.hpp
+++ b/libtenzir/include/tenzir/tql2/eval.hpp
@@ -32,7 +32,7 @@ auto const_eval(const ast::expression& expr, diagnostic_handler& dh)
 
 /// Tries to evaluate an expression to a constant value. Emits diagnostics only
 /// if the evaluation succeeded.
-auto try_const_eval(const ast::expression& expr, diagnostic_handler& dh)
+auto try_const_eval(const ast::expression& expr, session ctx)
   -> std::optional<data>;
 
 struct resolve_error {

--- a/libtenzir/include/tenzir/tql2/plugin.hpp
+++ b/libtenzir/include/tenzir/tql2/plugin.hpp
@@ -163,11 +163,7 @@ public:
 
   virtual auto function_name() const -> std::string;
 
-  virtual auto is_deterministic() const -> bool {
-    // TODO: Consider making this pure-virtual or changing the default, as most
-    // functions are deterministic.
-    return false;
-  }
+  virtual auto is_deterministic() const -> bool = 0;
 };
 
 class aggregation_instance {
@@ -289,7 +285,7 @@ public:
     co_yield {};
     if (writer_.allows_joining()) {
       auto p = writer_.instantiate(type{}, ctrl);
-      if (!p) {
+      if (! p) {
         diagnostic::error(p.error())
           .note("failed to instantiate `{}`", name())
           .emit(ctrl.diagnostics());
@@ -314,9 +310,9 @@ public:
           co_yield {};
           continue;
         }
-        if (!state) {
+        if (! state) {
           auto p = writer_.instantiate(slice.schema(), ctrl);
-          if (!p) {
+          if (! p) {
             diagnostic::error(p.error())
               .note("failed to initialize `{}`", name())
               .emit(ctrl.diagnostics());


### PR DESCRIPTION
This fixes the internal `try_const_eval` function, which no longer incorrectly constant-evaluates expressions containing the functions `now` or `random`.

This fixes a bug where some optimizations were applied incorrectly. For example, we previously evaluated the predicate in `if random() < 0.5 { branch = 1 } else { branch = 2 }` just once for the entire pipeline, and now we correctly evaluate it once per event.

- Fixes https://github.com/tenzir/issues/issues/2981