### PR TITLE
Fix hang for operators with infinite idle timeout

### DIFF
--- a/changelog/next/bug-fixes/5219--cache-buffer-hang.md
+++ b/changelog/next/bug-fixes/5219--cache-buffer-hang.md
@@ -1,0 +1,2 @@
+We fixed a hang in the `cache` and `buffer` operators when their input finished.
+This also prevented the node from shutting down cleanly.

--- a/libtenzir/src/execution_node.cpp
+++ b/libtenzir/src/execution_node.cpp
@@ -966,14 +966,21 @@ struct exec_node_state {
     TENZIR_TRACE("{} {} schedules run with a delay of {}", *self, op->name(),
                  data{backoff});
     run_scheduled = true;
-    if (backoff == duration::zero()) {
-      self->delay_fn([this] {
+    if (backoff > duration::zero()) {
+      backoff_disposable = self->delay_for_fn(backoff, [this] {
         run_scheduled = false;
         run();
       });
       return;
     }
-    backoff_disposable = self->delay_for_fn(backoff, [this] {
+    if (use_backoff) {
+      backoff_disposable = self->run_delayed_weak(duration::zero(), [this] {
+        run_scheduled = false;
+        run();
+      });
+      return;
+    }
+    self->delay_fn([this] {
       run_scheduled = false;
       run();
     });

--- a/libtenzir/src/execution_node.cpp
+++ b/libtenzir/src/execution_node.cpp
@@ -966,15 +966,8 @@ struct exec_node_state {
     TENZIR_TRACE("{} {} schedules run with a delay of {}", *self, op->name(),
                  data{backoff});
     run_scheduled = true;
-    if (backoff > duration::zero()) {
-      backoff_disposable = self->delay_for_fn(backoff, [this] {
-        run_scheduled = false;
-        run();
-      });
-      return;
-    }
     if (use_backoff) {
-      backoff_disposable = self->run_delayed_weak(duration::zero(), [this] {
+      backoff_disposable = self->run_delayed_weak(backoff, [this] {
         run_scheduled = false;
         run();
       });


### PR DESCRIPTION
This fixes a regression introduced with the recent change to use `delay` over `run_delayed_weak` for the scheduler loop in the execution nodes.

Turns out that it is a bad idea to go delay -> schedule -> delay -> schedule -> … (ad infinitum) because that effectively bypasses CAF's limit for how many actions can run inline. This change breaks this loop.