### PR TITLE
Some backlog cleaning

### DIFF
--- a/libtenzir/CMakeLists.txt
+++ b/libtenzir/CMakeLists.txt
@@ -287,8 +287,8 @@ endif ()
 dependency_summary("CURL" PkgConfig::PC_CURL "Dependencies")
 
 # Link against fmt.
-find_package(fmt 7.1.3 REQUIRED)
-string(APPEND TENZIR_FIND_DEPENDENCY_LIST "\nfind_package(fmt 7.1.3 REQUIRED)")
+find_package(fmt 10.0.0 REQUIRED)
+string(APPEND TENZIR_FIND_DEPENDENCY_LIST "\nfind_package(fmt 10.0.0 REQUIRED)")
 target_link_libraries(libtenzir PUBLIC fmt::fmt)
 dependency_summary("fmt" fmt::fmt "Dependencies")
 

--- a/libtenzir/builtins/connectors/email.cpp
+++ b/libtenzir/builtins/connectors/email.cpp
@@ -167,6 +167,10 @@ public:
     };
   }
 
+  auto detached() const -> bool override {
+    return true;
+  }
+
   auto optimize(const expression&, event_order) const
     -> optimize_result override {
     return do_not_optimize(*this);

--- a/libtenzir/builtins/connectors/udp.cpp
+++ b/libtenzir/builtins/connectors/udp.cpp
@@ -161,6 +161,10 @@ public:
     return udp_loader_impl(ctrl, args_);
   }
 
+  auto detached() const -> bool override {
+    return true;
+  }
+
   auto optimize(const expression&, event_order) const
     -> optimize_result override {
     return do_not_optimize(*this);
@@ -239,6 +243,10 @@ public:
           .emit(ctrl.diagnostics());
       }
     }
+  }
+
+  auto detached() const -> bool override {
+    return true;
   }
 
   auto optimize(const expression&, event_order) const

--- a/libtenzir/include/tenzir/variant_traits.hpp
+++ b/libtenzir/include/tenzir/variant_traits.hpp
@@ -12,6 +12,8 @@
 #include "tenzir/detail/assert.hpp"
 #include "tenzir/detail/overload.hpp"
 
+#include <caf/detail/pretty_type_name.hpp>
+
 #include <utility>
 #include <variant>
 
@@ -336,7 +338,16 @@ auto as(V&& v) -> forward_like_t<V, T> {
   using bare = std::remove_cvref_t<V>;
   constexpr auto alternative_index = detail::variant_index<bare, T>;
   const auto current_index = variant_traits<bare>::index(v);
-  TENZIR_ASSERT(current_index == alternative_index);
+  TENZIR_ASSERT(current_index == alternative_index,
+                "invalid variant access: [current: `{} ({})`] != [requested: "
+                "`{} ({})`]",
+                current_index,
+                match(std::forward<V>(v),
+                      []<typename H>(const H&) {
+                        return caf::detail::pretty_type_name(
+                          typeid(std::remove_cvref_t<H>));
+                      }),
+                alternative_index, caf::detail::pretty_type_name(typeid(T)));
   return detail::variant_get<alternative_index>(std::forward<V>(v));
 };
 

--- a/libtenzir/test/variant_traits.cpp
+++ b/libtenzir/test/variant_traits.cpp
@@ -207,4 +207,9 @@ TEST(expression) {
     });
 }
 
+TEST(fail) {
+  auto v = variant<int, double>{};
+  CAF_CHECK_THROWS_AS(as<double>(v), tenzir::panic_exception);
+}
+
 } // namespace tenzir

--- a/plugins/azure-blob-storage/builtins/load_plugin.cpp
+++ b/plugins/azure-blob-storage/builtins/load_plugin.cpp
@@ -80,6 +80,10 @@ public:
     }
   }
 
+  auto detached() const -> bool override {
+    return true;
+  }
+
   auto name() const -> std::string override {
     return "tql2.load_azure_blob_storage";
   }

--- a/plugins/azure-blob-storage/builtins/save_plugin.cpp
+++ b/plugins/azure-blob-storage/builtins/save_plugin.cpp
@@ -81,6 +81,10 @@ public:
     }
   }
 
+  auto detached() const -> bool override {
+    return true;
+  }
+
   auto name() const -> std::string override {
     return "tql2.save_azure_blob_storage";
   }

--- a/plugins/gcs/include/operator.hpp
+++ b/plugins/gcs/include/operator.hpp
@@ -124,6 +124,10 @@ public:
     }
   }
 
+  auto detached() const -> bool override {
+    return true;
+  }
+
   auto optimize(const expression&, event_order) const
     -> optimize_result override {
     return do_not_optimize(*this);
@@ -215,6 +219,10 @@ public:
           .emit(ctrl.diagnostics());
       }
     }
+  }
+
+  auto detached() const -> bool override {
+    return true;
   }
 
   auto optimize(const expression&, event_order) const

--- a/plugins/google-cloud-pubsub/builtins/load_plugin.cpp
+++ b/plugins/google-cloud-pubsub/builtins/load_plugin.cpp
@@ -113,6 +113,10 @@ public:
     }
   }
 
+  auto detached() const -> bool override {
+    return true;
+  }
+
   auto name() const -> std::string override {
     return "tql2.load_google_cloud_pubsub";
   }

--- a/plugins/google-cloud-pubsub/builtins/save_plugin.cpp
+++ b/plugins/google-cloud-pubsub/builtins/save_plugin.cpp
@@ -73,6 +73,10 @@ public:
     }
   }
 
+  auto detached() const -> bool override {
+    return true;
+  }
+
   auto name() const -> std::string override {
     return "tql2.save_google_cloud_pubsub";
   }

--- a/plugins/kafka/include/kafka/operator.hpp
+++ b/plugins/kafka/include/kafka/operator.hpp
@@ -172,6 +172,10 @@ public:
     }
   }
 
+  auto detached() const -> bool override {
+    return true;
+  }
+
   auto optimize(const expression&, event_order) const
     -> optimize_result override {
     return do_not_optimize(*this);
@@ -280,6 +284,10 @@ public:
       // buffered messages if you like".
       client->poll(0ms);
     }
+  }
+
+  auto detached() const -> bool override {
+    return true;
   }
 
   auto optimize(const expression&, event_order) const

--- a/plugins/nic/include/operator.hpp
+++ b/plugins/nic/include/operator.hpp
@@ -182,6 +182,10 @@ public:
     }
   }
 
+  auto detached() const -> bool override {
+    return true;
+  }
+
   auto optimize(const expression&, event_order) const
     -> optimize_result override {
     return do_not_optimize(*this);

--- a/plugins/s3/include/operator.hpp
+++ b/plugins/s3/include/operator.hpp
@@ -136,6 +136,10 @@ public:
     }
   }
 
+  auto detached() const -> bool override {
+    return true;
+  }
+
   auto optimize(const expression&, event_order) const
     -> optimize_result override {
     return do_not_optimize(*this);
@@ -219,6 +223,10 @@ public:
           .emit(ctrl.diagnostics());
       }
     }
+  }
+
+  auto detached() const -> bool override {
+    return true;
   }
 
   auto optimize(const expression&, event_order) const

--- a/plugins/sqs/include/operator.hpp
+++ b/plugins/sqs/include/operator.hpp
@@ -200,6 +200,10 @@ public:
     }
   }
 
+  auto detached() const -> bool override {
+    return true;
+  }
+
   auto optimize(const expression&, event_order) const
     -> optimize_result override {
     return do_not_optimize(*this);
@@ -248,6 +252,10 @@ public:
         ctrl.diagnostics().emit(std::move(d));
       }
     }
+  }
+
+  auto detached() const -> bool override {
+    return true;
   }
 
   auto optimize(const expression&, event_order) const

--- a/plugins/zmq/include/operator.hpp
+++ b/plugins/zmq/include/operator.hpp
@@ -393,6 +393,10 @@ public:
     }
   }
 
+  auto detached() const -> bool override {
+    return true;
+  }
+
   auto optimize(expression const&, event_order) const
     -> optimize_result override {
     return do_not_optimize(*this);
@@ -449,6 +453,10 @@ public:
         diagnostic::error(error).emit(ctrl.diagnostics());
       }
     }
+  }
+
+  auto detached() const -> bool override {
+    return true;
   }
 
   auto optimize(expression const&, event_order) const

--- a/web/docs/development/build-from-source.md
+++ b/web/docs/development/build-from-source.md
@@ -39,7 +39,7 @@ Every [release](https://github.com/tenzir/tenzir/releases) of Tenzir includes an
 |✓|[yaml-cpp](https://github.com/jbeder/yaml-cpp)|>= 0.6.2|Required for reading YAML configuration files.|
 |✓|[simdjson](https://github.com/simdjson/simdjson)|>= 3.10.0|Required for high-performance JSON parsing. (Bundled as submodule.)|
 |✓|[spdlog](https://github.com/gabime/spdlog)|>= 1.5|Required for logging.|
-|✓|[fmt](https://fmt.dev)|>= 9.1.1|Required for formatted text output.|
+|✓|[fmt](https://fmt.dev)|>= 10.0.0|Required for formatted text output.|
 |✓|[xxHash](https://github.com/Cyan4973/xxHash)|>= 0.8.0|Required for computing fast hash digests.|
 |✓|[robin-map](https://github.com/Tessil/robin-map)|>= 0.6.3|Fast hash map and hash set using robin hood hashing. (Bundled as subtree.)|
 |✓|[fast_float](https://github.com/FastFloat/fast_float)|>= 3.2.0|Required for parsing floating point numbers. (Bundled as submodule.)|


### PR DESCRIPTION
This PR

- Aligns our `{fmt}` requirements to 10.0.0. Fixes https://github.com/tenzir/issues/issues/2983
- Marks all connectors ported to dedicated operators as `detached`. Fixes https://github.com/tenzir/issues/issues/3043
- Improves failed variant access assertion message. Fixes https://github.com/tenzir/issues/issues/3052