### PR TITLE
Make save_tcp reconnect on network outages

### DIFF
--- a/changelog/changes/Ezv8Vz2A1XgON7euQJjkNvrhQM.md
+++ b/changelog/changes/Ezv8Vz2A1XgON7euQJjkNvrhQM.md
@@ -1,0 +1,10 @@
+---
+title: `save_tcp` now reconnects on network outages
+type: feature
+authors: tobim
+pr: 5230
+---
+
+The `save_tcp` (`from "tcp://..."`) operator now tries to reconnect in case of recoverable errors such as network outages and in case the remote end disconnects.
+
+You can use the new options `retry_delay: duration` and `max_retry_count: int` to tune the behavior to your needs. The default values are set to 30 seconds and 10 times respectively.

--- a/docs/operators/save_tcp.mdx
+++ b/docs/operators/save_tcp.mdx
@@ -7,18 +7,36 @@ example: 'save_tcp "0.0.0.0:8090", tls=true'
 Saves bytes to a TCP or TLS connection.
 
 ```tql
-save_tcp endpoint:string, [tls=bool, cacert=string, certifle=string,
+save_tcp endpoint:string, [retry_delay=duration, max_retry_count=int,
+                           tls=bool, cacert=string, certifle=string,
                            keyfile=string, skip_peer_verification=bool]
 ```
 
 ## Description
 
-Saves bytes to the given endpoint via TCP or TLS.
+Saves bytes to the given endpoint via TCP or TLS. Attempts to reconnect
+automatically for `max_retry_count` in case of recoverable connection
+errors.
+
+:::note
+Due to the nature of TCP a disconnect can still lead to the loss of
+one batch of data.
+:::
 
 ### `endpoint: string`
 
 The endpoint to which the server will connect. Must be of the form
-`[tcp://]<hostname>:<port>`.
+`[tcp://]<hostname>:<port>`. You can also use an IANA service name instead
+of a numeric port.
+
+### `retry_delay = duration (optional)`
+
+The amount of time to wait before attempting to reconnect in case a connection
+attempt fails and the error is deemed recoverable. Defaults to `30s`.
+
+### `max_retry_count = int (optional)
+The number of retries to attempt in case of connection errors before
+transitioning into the error state. Defaults to `10`.
 
 import TLSOptions from '../../.../../../../partials/operators/TLSOptions.mdx';
 

--- a/docs/operators/save_tcp.mdx
+++ b/docs/operators/save_tcp.mdx
@@ -19,8 +19,8 @@ automatically for `max_retry_count` in case of recoverable connection
 errors.
 
 :::note
-Due to the nature of TCP a disconnect can still lead to the loss of
-one batch of data.
+Due to the nature of TCP a disconnect can still lead to lost and or incomplete
+events on the receiving end.
 :::
 
 ### `endpoint: string`

--- a/libtenzir/builtins/connectors/tcp.cpp
+++ b/libtenzir/builtins/connectors/tcp.cpp
@@ -20,6 +20,7 @@
 #include <boost/asio.hpp>
 #include <boost/asio/ssl.hpp>
 #include <boost/version.hpp>
+#include <caf/actor_from_state.hpp>
 #include <caf/anon_mail.hpp>
 #include <caf/typed_event_based_actor.hpp>
 
@@ -34,20 +35,24 @@ namespace tenzir::plugins::tcp {
 
 namespace {
 
-using tcp_bridge_actor = caf::typed_actor<
-  // Connect to a TCP endpoint.
-  auto(atom::connect, bool tls, std::string cacert, std::string certfile,
-       std::string keyfile, bool skip_peer_verification, std::string hostname,
-       std::string port)
-    ->caf::result<void>,
-  // Wait for an incoming TCP connection.
-  auto(atom::accept, std::string hostname, std::string port,
-       std::string tls_certfile, std::string tls_keyfile)
-    ->caf::result<void>,
-  // Read up to the number of bytes from the socket.
-  auto(atom::read, uint64_t buffer_size)->caf::result<chunk_ptr>,
-  // Write a chunk to the socket.
-  auto(atom::write, chunk_ptr chunk)->caf::result<void>>;
+struct tcp_bridge_actor_traits {
+  using signatures = caf::type_list<
+    // Connect to a TCP endpoint.
+    auto(atom::connect, bool tls, std::string cacert, std::string certfile,
+         std::string keyfile, bool skip_peer_verification, std::string hostname,
+         std::string port)
+      ->caf::result<void>,
+    // Wait for an incoming TCP connection.
+    auto(atom::accept, std::string hostname, std::string port,
+         std::string tls_certfile, std::string tls_keyfile)
+      ->caf::result<void>,
+    // Read up to the number of bytes from the socket.
+    auto(atom::read, uint64_t buffer_size)->caf::result<chunk_ptr>,
+    // Write a chunk to the socket.
+    auto(atom::write, chunk_ptr chunk)->caf::result<void>>;
+};
+
+using tcp_bridge_actor = caf::typed_actor<tcp_bridge_actor_traits>;
 
 struct tcp_metrics {
   auto emit() -> void {
@@ -77,397 +82,384 @@ struct tcp_metrics {
   uint64_t bytes_written = {};
 };
 
-struct tcp_bridge_state {
-  static constexpr auto name = "tcp-loader-bridge";
+class tcp_bridge {
+public:
+  [[maybe_unused]] static constexpr auto name = "tcp-bridge";
 
-  tcp_bridge_state() = default;
-
-  ~tcp_bridge_state() noexcept {
-    io_ctx->stop();
-    worker.join();
-    metrics.emit();
+  tcp_bridge(tcp_bridge_actor::pointer self, metric_handler metric_handler)
+    : self_{self} {
+    io_ctx_ = std::make_shared<boost::asio::io_context>();
+    socket_.emplace(*io_ctx_);
+    worker_ = std::thread([io_ctx = io_ctx_]() {
+      auto guard = boost::asio::make_work_guard(*io_ctx);
+      io_ctx->run();
+    });
+    metrics_.metric_handler = std::move(metric_handler);
+    detail::weak_run_delayed_loop(
+      self_, std::chrono::seconds{1},
+      [this] {
+        metrics_.emit();
+      },
+      /*run_immediately=*/false);
   }
 
-  // The `io_context` running the async callbacks.
-  std::shared_ptr<boost::asio::io_context> io_ctx = {};
-  std::thread worker = {};
+  ~tcp_bridge() noexcept {
+    io_ctx_->stop();
+    worker_.join();
+    metrics_.emit();
+  }
 
-  // The TCP socket holding our connection.
-  // (always exists, but wrapped in an optional because `socket`
-  //  isn't default-constructible)
-  std::optional<boost::asio::ip::tcp::socket> socket = {};
+  auto make_behavior() -> tcp_bridge_actor::behavior_type {
+    return {
+      [this](atom::connect, bool tls, const std::string& cacert,
+             const std::string& certfile, const std::string& keyfile,
+             bool skip_peer_verification, const std::string& hostname,
+             const std::string& service) -> caf::result<void> {
+        return connect(tls, cacert, certfile, keyfile, skip_peer_verification,
+                       hostname, service);
+      },
+      [this](atom::accept, const std::string& hostname,
+             const std::string& service, const std::string& tls_certfile,
+             const std::string& tls_keyfile) -> caf::result<void> {
+        return accept(hostname, service, tls_certfile, tls_keyfile);
+      },
+      [this](atom::read, uint64_t buffer_size) -> caf::result<chunk_ptr> {
+        return read(buffer_size);
+      },
+      [this](atom::write, chunk_ptr chunk) -> caf::result<void> {
+        return write(std::move(chunk));
+      },
+    };
+  }
 
-  // TLS stream wrapping `socket` if we're in TLS mode.
-  std::optional<boost::asio::ssl::context> ssl_ctx = {};
-  std::optional<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&>>
-    tls_socket = {};
-
-  // Acceptor if we're in 'listen' mode.
-  std::optional<boost::asio::ip::tcp::acceptor> acceptor = {};
-
-  // Promise that is delivered when a connection is established.
-  caf::typed_response_promise<void> connection_rp = {};
-
-  // Promise that is delivered whenever new data arrives.
-  caf::typed_response_promise<chunk_ptr> read_rp = {};
-
-  // Promise that is delivered whenever new data is sent.
-  caf::typed_response_promise<void> write_rp = {};
-
-  // Storage for incoming data.
-  std::vector<char> read_buffer = {};
-
-  // Metrics.
-  tcp_metrics metrics = {};
-};
-
-auto make_tcp_bridge(tcp_bridge_actor::stateful_pointer<tcp_bridge_state> self,
-                     metric_handler metric_handler)
-  -> tcp_bridge_actor::behavior_type {
-  self->state().io_ctx = std::make_shared<boost::asio::io_context>();
-  self->state().socket.emplace(*self->state().io_ctx);
-  self->state().worker = std::thread([io_ctx = self->state().io_ctx]() {
-    auto guard = boost::asio::make_work_guard(*io_ctx);
-    io_ctx->run();
-  });
-  self->state().metrics.metric_handler = std::move(metric_handler);
-  detail::weak_run_delayed_loop(
-    self, std::chrono::seconds{1},
-    [self] {
-      self->state().metrics.emit();
-    },
-    /*run_immediately=*/false);
-  return {
-    [self](atom::connect, bool tls, const std::string& cacert,
-           const std::string& certfile, const std::string& keyfile,
-           bool skip_peer_verification, const std::string& hostname,
-           const std::string& service) -> caf::result<void> {
-      if (self->state().connection_rp.pending()) {
-        return caf::make_error(ec::logic_error,
-                               fmt::format("{} cannot connect while a connect "
-                                           "request is pending",
-                                           *self));
-      }
-      auto resolver = boost::asio::ip::tcp::resolver{*self->state().io_ctx};
-      auto ec = boost::system::error_code{};
-      auto endpoints = resolver.resolve(hostname, service, ec);
-      if (ec) {
-        return caf::make_error(ec::system_error,
-                               fmt::format("failed to resolve '{}': {}",
-                                           hostname, ec.message()));
-      }
+private:
+  auto connect(bool tls, const std::string& cacert, const std::string& certfile,
+               const std::string& keyfile, bool skip_peer_verification,
+               const std::string& hostname, const std::string& service)
+    -> caf::result<void> {
+    if (connection_rp_.pending()) {
+      return caf::make_error(ec::logic_error,
+                             fmt::format("{} cannot connect while a connect "
+                                         "request is pending",
+                                         *self_));
+    }
+    auto resolver = boost::asio::ip::tcp::resolver{*io_ctx_};
+    auto ec = boost::system::error_code{};
+    auto endpoints = resolver.resolve(hostname, service, ec);
+    if (ec) {
+      return caf::make_error(ec::system_error,
+                             fmt::format("failed to resolve '{}': {}", hostname,
+                                         ec.message()));
+    }
 #if TENZIR_LINUX
-      const auto& endpoint = endpoints.begin()->endpoint();
-      auto sfd
-        = ::socket(endpoint.protocol().family(), SOCK_STREAM | SOCK_CLOEXEC,
-                   endpoint.protocol().protocol());
-      TENZIR_ASSERT(sfd >= 0);
-      self->state().socket->assign(endpoint.protocol(), sfd);
+    const auto& endpoint = endpoints.begin()->endpoint();
+    auto sfd
+      = ::socket(endpoint.protocol().family(), SOCK_STREAM | SOCK_CLOEXEC,
+                 endpoint.protocol().protocol());
+    TENZIR_ASSERT(sfd >= 0);
+    socket_->assign(endpoint.protocol(), sfd);
 #endif
-      if (tls) {
-        self->state().ssl_ctx.emplace(boost::asio::ssl::context::tls_client);
-        self->state().ssl_ctx->set_default_verify_paths();
-        auto ec = boost::system::error_code{};
-        if (skip_peer_verification) {
-          self->state().ssl_ctx->set_verify_mode(boost::asio::ssl::verify_none);
-        } else {
-          self->state().ssl_ctx->set_verify_mode(
-            boost::asio::ssl::verify_peer
-            | boost::asio::ssl::verify_fail_if_no_peer_cert);
-          if (not cacert.empty()) {
-            if (self->state().ssl_ctx->load_verify_file(cacert, ec).failed()) {
-              return caf::make_error(ec::system_error,
-                                     fmt::format("failed to load cacert file "
-                                                 "`{}`: {}",
-                                                 cacert, ec.message()));
-            }
-          }
-        }
-        if (not certfile.empty()) {
-          if (self->state()
-                .ssl_ctx->use_certificate_chain_file(certfile, ec)
-                .failed()) {
-            return caf::make_error(
-              ec::system_error, fmt::format("failed to load certfile `{}`: {}",
-                                            certfile, ec.message()));
-          }
-        }
-        if (not keyfile.empty()) {
-          if (self->state()
-                .ssl_ctx
-                ->use_private_key_file(keyfile, boost::asio::ssl::context::pem,
-                                       ec)
-                .failed()) {
-            return caf::make_error(
-              ec::system_error, fmt::format("failed to load keyfile `{}`: {}",
-                                            keyfile, ec.message()));
-          }
-        }
-        self->state().tls_socket.emplace(*self->state().socket,
-                                         *self->state().ssl_ctx);
-        auto tls_handle = self->state().tls_socket->native_handle();
-        if (SSL_set1_host(tls_handle, hostname.c_str()) != 1) {
-          return caf::make_error(ec::system_error,
-                                 "failed to enable host name verification");
-        }
-        if (not SSL_set_tlsext_host_name(tls_handle, hostname.c_str())) {
-          return caf::make_error(ec::system_error, "failed to set SNI");
-        }
-      }
-      self->state().connection_rp = self->make_response_promise<void>();
-      boost::asio::async_connect(
-        *self->state().socket, endpoints,
-        [self, weak_hdl = caf::actor_cast<caf::weak_actor_ptr>(self)](
-          boost::system::error_code ec,
-          const boost::asio::ip::tcp::endpoint& endpoint) {
-#if TENZIR_MACOS
-          auto fcntl_error = std::optional<caf::error>{};
-          if (::fcntl(self->state().socket->native_handle(), F_SETFD,
-                      FD_CLOEXEC)
-              != 0) {
-            auto error = detail::describe_errno();
-            fcntl_error = diagnostic::error("failed to configure TLS socket")
-                            .hint("{}", error)
-                            .to_error();
-          }
-#endif
-          self->state().metrics.port = endpoint.port();
-          self->state().metrics.handle
-            = fmt::to_string(self->state().socket->native_handle());
-          if (auto hdl = weak_hdl.lock()) {
-            caf::anon_mail(caf::make_action([self, ec, endpoint
-#if TENZIR_MACOS
-                                             ,
-                                             fcntl_error
-#endif
-            ]() mutable {
-              if (ec) {
-                return self->state().connection_rp.deliver(caf::make_error(
-                  ec::system_error,
-                  fmt::format("connection failed: {}", ec.message())));
-              }
-#if TENZIR_MACOS
-              if (fcntl_error) {
-                return self->state().connection_rp.deliver(*fcntl_error);
-              }
-#endif
-              if (self->state().tls_socket) {
-                self->state().tls_socket->handshake(
-                  boost::asio::ssl::stream<boost::asio::ip::tcp::socket>::client,
-                  ec);
-                if (ec) {
-                  return self->state().connection_rp.deliver(caf::make_error(
-                    ec::system_error,
-                    fmt::format("TLS client handshake failed: {}",
-                                ERR_get_error())));
-                }
-              }
-              TENZIR_VERBOSE("tcp connector connected to {}",
-                             endpoint.address().to_string());
-              return self->state().connection_rp.deliver();
-            }))
-              .send(caf::actor_cast<caf::actor>(hdl));
-          }
-        });
-      return self->state().connection_rp;
-    },
-    [self](atom::accept, const std::string& hostname,
-           const std::string& service, const std::string& certfile,
-           const std::string& keyfile) -> caf::result<void> {
+    if (tls) {
+      ssl_ctx_.emplace(boost::asio::ssl::context::tls_client);
+      ssl_ctx_->set_default_verify_paths();
       auto ec = boost::system::error_code{};
-      auto resolver = boost::asio::ip::tcp::resolver{*self->state().io_ctx};
-      auto endpoints = resolver.resolve(hostname, service, ec);
-      if (ec || endpoints.empty()) {
-        return caf::make_error(
-          ec::system_error, fmt::format("failed to resolve host {}, service {}",
-                                        hostname, service));
-      }
-      auto resolver_entry = *endpoints.begin();
-      auto endpoint = resolver_entry.endpoint();
-      self->state().metrics.port = endpoint.port();
-      // Create a new acceptor and bind to provided endpoint.
-      try {
-        self->state().acceptor.emplace(*self->state().io_ctx);
-        self->state().acceptor->open(endpoint.protocol());
-        auto reuse_address = boost::asio::socket_base::reuse_address(true);
-        self->state().acceptor->set_option(reuse_address);
-        self->state().acceptor->bind(endpoint);
-        if (::fcntl(self->state().acceptor->native_handle(), F_SETFD,
-                    FD_CLOEXEC)
-            != 0) {
-          auto error = detail::describe_errno();
-          return diagnostic::error("failed to configure TLS socket")
-            .hint("{}", error)
-            .to_error();
-        }
-#if BOOST_VERSION >= 108700
-        const auto max_connections
-          = boost::asio::socket_base::max_listen_connections;
-#else
-        const auto max_connections = boost::asio::socket_base::max_connections;
-#endif
-        self->state().acceptor->listen(max_connections);
-        self->state().metrics.handle
-          = fmt::to_string(self->state().acceptor->native_handle());
-      } catch (std::exception& e) {
-        return caf::make_error(ec::system_error,
-                               fmt::format("failed to bind to endpoint: {}",
-                                           e.what()));
-      }
-      TENZIR_VERBOSE("tcp connector listens on endpoint {}:{}",
-                     endpoint.address().to_string(), endpoint.port());
-      self->state().connection_rp = self->make_response_promise<void>();
-      self->state().acceptor->async_accept(
-        [self, certfile, keyfile,
-         weak_hdl = caf::actor_cast<caf::weak_actor_ptr>(self)](
-          boost::system::error_code ec, boost::asio::ip::tcp::socket peer) {
-          TENZIR_VERBOSE("tcp connector accepted incoming request");
-          auto fcntl_error = std::optional<caf::error>{};
-          if (::fcntl(peer.native_handle(), F_SETFD, FD_CLOEXEC) != 0) {
-            auto error = detail::describe_errno();
-            fcntl_error = diagnostic::error("failed to configure TLS socket")
-                            .hint("{}", error)
-                            .to_error();
-          }
-          if (auto hdl = weak_hdl.lock()) {
-            caf::anon_mail(caf::make_action([self, certfile, keyfile, ec,
-                                             peer = std::move(peer),
-                                             fcntl_error = std::move(
-                                               fcntl_error)]() mutable {
-              if (ec) {
-                return self->state().connection_rp.deliver(caf::make_error(
-                  ec::system_error,
-                  fmt::format("failed to accept: {}", ec.message())));
-              }
-              if (fcntl_error) {
-                return self->state().connection_rp.deliver(*fcntl_error);
-              }
-              self->state().socket.emplace(std::move(peer));
-              if (not certfile.empty()) {
-                self->state().ssl_ctx.emplace(
-                  boost::asio::ssl::context::tls_server);
-                self->state().ssl_ctx->use_certificate_chain_file(certfile);
-                self->state().ssl_ctx->use_private_key_file(
-                  keyfile, boost::asio::ssl::context::pem);
-                self->state().ssl_ctx->set_verify_mode(
-                  boost::asio::ssl::verify_none);
-                self->state().tls_socket.emplace(*self->state().socket,
-                                                 *self->state().ssl_ctx);
-                auto server_context = boost::asio::ssl::stream<
-                  boost::asio::ip::tcp::socket>::server;
-                self->state().tls_socket->handshake(server_context, ec);
-                if (ec) {
-                  return self->state().connection_rp.deliver(caf::make_error(
-                    ec::system_error,
-                    fmt::format("TLS handshake failed: {}", ec.message())));
-                }
-              }
-              return self->state().connection_rp.deliver();
-            }))
-              .send(caf::actor_cast<caf::actor>(hdl));
-          }
-        });
-      return self->state().connection_rp;
-    },
-    [self](atom::read, uint64_t buffer_size) -> caf::result<chunk_ptr> {
-      if (self->state().connection_rp.pending()) {
-        return caf::make_error(ec::logic_error,
-                               fmt::format("{} cannot read while a connect "
-                                           "request is pending",
-                                           *self));
-      }
-      if (self->state().read_rp.pending()) {
-        return caf::make_error(ec::logic_error,
-                               fmt::format("{} cannot read while a read "
-                                           "request is pending",
-                                           *self));
-      }
-      self->state().read_buffer.resize(buffer_size);
-      self->state().read_rp = self->make_response_promise<chunk_ptr>();
-      auto on_read
-        = [self, weak_hdl = caf::actor_cast<caf::weak_actor_ptr>(self)](
-            boost::system::error_code ec, size_t length) {
-            if (auto hdl = weak_hdl.lock()) {
-              // TODO: Potential optimization: We could at this point already
-              // eagerly start the next read.
-              caf::anon_mail(caf::make_action([self, ec, length] {
-                if (ec) {
-                  return self->state().read_rp.deliver(caf::make_error(
-                    ec::system_error, fmt::format("failed to read "
-                                                  "from TCP socket: "
-                                                  "{}",
-                                                  ec.message())));
-                }
-                self->state().metrics.reads++;
-                self->state().metrics.bytes_read += length;
-                self->state().read_buffer.resize(length);
-                self->state().read_buffer.shrink_to_fit();
-                return self->state().read_rp.deliver(
-                  chunk::make(std::exchange(self->state().read_buffer, {})));
-              }))
-                .send(caf::actor_cast<caf::actor>(hdl));
-            }
-          };
-      auto asio_buffer
-        = boost::asio::buffer(self->state().read_buffer, buffer_size);
-      if (self->state().tls_socket) {
-        self->state().tls_socket->async_read_some(asio_buffer, on_read);
+      if (skip_peer_verification) {
+        ssl_ctx_->set_verify_mode(boost::asio::ssl::verify_none);
       } else {
-        self->state().socket->async_read_some(asio_buffer, on_read);
+        ssl_ctx_->set_verify_mode(
+          boost::asio::ssl::verify_peer
+          | boost::asio::ssl::verify_fail_if_no_peer_cert);
+        if (not cacert.empty()) {
+          if (ssl_ctx_->load_verify_file(cacert, ec).failed()) {
+            return caf::make_error(ec::system_error,
+                                   fmt::format("failed to load cacert file "
+                                               "`{}`: {}",
+                                               cacert, ec.message()));
+          }
+        }
       }
-      return self->state().read_rp;
-    },
-    [self](atom::write, chunk_ptr chunk) -> caf::result<void> {
-      if (self->state().connection_rp.pending()) {
-        return caf::make_error(ec::logic_error,
-                               fmt::format("{} cannot write while a connect "
-                                           "request is pending",
-                                           *self));
+      if (not certfile.empty()) {
+        if (ssl_ctx_->use_certificate_chain_file(certfile, ec).failed()) {
+          return caf::make_error(ec::system_error,
+                                 fmt::format("failed to load certfile `{}`: {}",
+                                             certfile, ec.message()));
+        }
       }
-      if (self->state().write_rp.pending()) {
-        return caf::make_error(ec::logic_error,
-                               fmt::format("{} cannot write while a write "
-                                           "request is pending",
-                                           *self));
+      if (not keyfile.empty()) {
+        if (ssl_ctx_
+              ->use_private_key_file(keyfile, boost::asio::ssl::context::pem,
+                                     ec)
+              .failed()) {
+          return caf::make_error(ec::system_error,
+                                 fmt::format("failed to load keyfile `{}`: {}",
+                                             keyfile, ec.message()));
+        }
       }
-      self->state().write_rp = self->make_response_promise<void>();
-      auto on_write = [self, chunk,
-                       weak_hdl = caf::actor_cast<caf::weak_actor_ptr>(self)](
-                        boost::system::error_code ec, size_t length) {
+      tls_socket_.emplace(*socket_, *ssl_ctx_);
+      auto tls_handle = tls_socket_->native_handle();
+      if (SSL_set1_host(tls_handle, hostname.c_str()) != 1) {
+        return caf::make_error(ec::system_error,
+                               "failed to enable host name verification");
+      }
+      if (not SSL_set_tlsext_host_name(tls_handle, hostname.c_str())) {
+        return caf::make_error(ec::system_error, "failed to set SNI");
+      }
+    }
+    connection_rp_ = self_->make_response_promise<void>();
+    boost::asio::async_connect(
+      *socket_, endpoints,
+      [this, weak_hdl = caf::actor_cast<caf::weak_actor_ptr>(self_)](
+        boost::system::error_code ec,
+        const boost::asio::ip::tcp::endpoint& endpoint) {
+#if TENZIR_MACOS
+        auto fcntl_error = std::optional<caf::error>{};
+        if (::fcntl(socket_->native_handle(), F_SETFD, FD_CLOEXEC) != 0) {
+          auto error = detail::describe_errno();
+          fcntl_error = diagnostic::error("failed to configure TLS socket")
+                          .hint("{}", error)
+                          .to_error();
+        }
+#endif
+        metrics_.port = endpoint.port();
+        metrics_.handle = fmt::to_string(socket_->native_handle());
         if (auto hdl = weak_hdl.lock()) {
-          caf::anon_mail(caf::make_action([self, chunk, ec, length] {
+          caf::anon_mail(caf::make_action([this, ec, endpoint
+#if TENZIR_MACOS
+                                           ,
+                                           fcntl_error
+#endif
+          ]() mutable {
             if (ec) {
-              self->state().write_rp.deliver(
-                caf::make_error(ec::system_error,
-                                fmt::format("failed to write to TCP socket: {}",
-                                            ec.message())));
-              return;
+              return connection_rp_.deliver(caf::make_error(
+                ec::system_error,
+                fmt::format("connection failed: {}", ec.message())));
             }
-            self->state().metrics.writes++;
-            self->state().metrics.bytes_written += length;
-            if (length < chunk->size()) {
-              auto remainder = chunk->slice(length);
-              self->state().write_rp.delegate(
-                static_cast<tcp_bridge_actor>(self), atom::write_v,
-                std::move(remainder));
-              return;
+#if TENZIR_MACOS
+            if (fcntl_error) {
+              return connection_rp_.deliver(*fcntl_error);
             }
-            TENZIR_ASSERT(length == chunk->size());
-            self->state().write_rp.deliver();
+#endif
+            if (tls_socket_) {
+              tls_socket_->handshake(
+                boost::asio::ssl::stream<boost::asio::ip::tcp::socket>::client,
+                ec);
+              if (ec) {
+                return connection_rp_.deliver(
+                  caf::make_error(ec::system_error,
+                                  fmt::format("TLS client handshake failed: {}",
+                                              ERR_get_error())));
+              }
+            }
+            TENZIR_VERBOSE("tcp connector connected to {}",
+                           endpoint.address().to_string());
+            return connection_rp_.deliver();
           }))
             .send(caf::actor_cast<caf::actor>(hdl));
         }
-      };
-      auto asio_buffer = boost::asio::buffer(chunk->data(), chunk->size());
-      if (self->state().tls_socket) {
-        self->state().tls_socket->async_write_some(asio_buffer, on_write);
-      } else {
-        self->state().socket->async_write_some(asio_buffer, on_write);
+      });
+    return connection_rp_;
+  }
+
+  auto accept(const std::string& hostname, const std::string& service,
+              const std::string& certfile, const std::string& keyfile)
+    -> caf::result<void> {
+    auto ec = boost::system::error_code{};
+    auto resolver = boost::asio::ip::tcp::resolver{*io_ctx_};
+    auto endpoints = resolver.resolve(hostname, service, ec);
+    if (ec || endpoints.empty()) {
+      return caf::make_error(
+        ec::system_error, fmt::format("failed to resolve host {}, service {}",
+                                      hostname, service));
+    }
+    auto resolver_entry = *endpoints.begin();
+    auto endpoint = resolver_entry.endpoint();
+    metrics_.port = endpoint.port();
+    // Create a new acceptor and bind to provided endpoint.
+    try {
+      acceptor_.emplace(*io_ctx_);
+      acceptor_->open(endpoint.protocol());
+      auto reuse_address = boost::asio::socket_base::reuse_address(true);
+      acceptor_->set_option(reuse_address);
+      acceptor_->bind(endpoint);
+      if (::fcntl(acceptor_->native_handle(), F_SETFD, FD_CLOEXEC) != 0) {
+        auto error = detail::describe_errno();
+        return diagnostic::error("failed to configure TLS socket")
+          .hint("{}", error)
+          .to_error();
       }
-      return self->state().write_rp;
-    },
-  };
-}
+#if BOOST_VERSION >= 108700
+      const auto max_connections
+        = boost::asio::socket_base::max_listen_connections;
+#else
+      const auto max_connections = boost::asio::socket_base::max_connections;
+#endif
+      acceptor_->listen(max_connections);
+      metrics_.handle = fmt::to_string(acceptor_->native_handle());
+    } catch (std::exception& e) {
+      return caf::make_error(ec::system_error,
+                             fmt::format("failed to bind to endpoint: {}",
+                                         e.what()));
+    }
+    TENZIR_VERBOSE("tcp connector listens on endpoint {}:{}",
+                   endpoint.address().to_string(), endpoint.port());
+    connection_rp_ = self_->make_response_promise<void>();
+    acceptor_->async_accept([this, certfile, keyfile,
+                             weak_hdl = caf::actor_cast<caf::weak_actor_ptr>(
+                               self_)](boost::system::error_code ec,
+                                       boost::asio::ip::tcp::socket peer) {
+      TENZIR_VERBOSE("tcp connector accepted incoming request");
+      auto fcntl_error = std::optional<caf::error>{};
+      if (::fcntl(peer.native_handle(), F_SETFD, FD_CLOEXEC) != 0) {
+        auto error = detail::describe_errno();
+        fcntl_error = diagnostic::error("failed to configure TLS socket")
+                        .hint("{}", error)
+                        .to_error();
+      }
+      if (auto hdl = weak_hdl.lock()) {
+        caf::anon_mail(
+          caf::make_action([this, certfile, keyfile, ec, peer = std::move(peer),
+                            fcntl_error = std::move(fcntl_error)]() mutable {
+            if (ec) {
+              return connection_rp_.deliver(caf::make_error(
+                ec::system_error,
+                fmt::format("failed to accept: {}", ec.message())));
+            }
+            if (fcntl_error) {
+              return connection_rp_.deliver(*fcntl_error);
+            }
+            socket_.emplace(std::move(peer));
+            if (not certfile.empty()) {
+              ssl_ctx_.emplace(boost::asio::ssl::context::tls_server);
+              ssl_ctx_->use_certificate_chain_file(certfile);
+              ssl_ctx_->use_private_key_file(keyfile,
+                                             boost::asio::ssl::context::pem);
+              ssl_ctx_->set_verify_mode(boost::asio::ssl::verify_none);
+              tls_socket_.emplace(*socket_, *ssl_ctx_);
+              auto server_context
+                = boost::asio::ssl::stream<boost::asio::ip::tcp::socket>::server;
+              tls_socket_->handshake(server_context, ec);
+              if (ec) {
+                return connection_rp_.deliver(caf::make_error(
+                  ec::system_error,
+                  fmt::format("TLS handshake failed: {}", ec.message())));
+              }
+            }
+            return connection_rp_.deliver();
+          }))
+          .send(caf::actor_cast<caf::actor>(hdl));
+      }
+    });
+    return connection_rp_;
+  }
+
+  auto read(uint64_t buffer_size) -> caf::result<chunk_ptr> {
+    if (connection_rp_.pending()) {
+      return caf::make_error(ec::logic_error,
+                             fmt::format("{} cannot read while a connect "
+                                         "request is pending",
+                                         *self_));
+    }
+    if (read_rp_.pending()) {
+      return caf::make_error(ec::logic_error,
+                             fmt::format("{} cannot read while a read "
+                                         "request is pending",
+                                         *self_));
+    }
+    read_buffer_.resize(buffer_size);
+    read_rp_ = self_->make_response_promise<chunk_ptr>();
+    auto on_read = [this, weak_hdl
+                          = caf::actor_cast<caf::weak_actor_ptr>(self_)](
+                     boost::system::error_code ec, size_t length) {
+      if (auto hdl = weak_hdl.lock()) {
+        caf::anon_mail(caf::make_action([this, ec, length] {
+          if (ec) {
+            return read_rp_.deliver(
+              caf::make_error(ec::system_error, fmt::format("failed to read "
+                                                            "from TCP socket: "
+                                                            "{}",
+                                                            ec.message())));
+          }
+          metrics_.reads++;
+          metrics_.bytes_read += length;
+          read_buffer_.resize(length);
+          read_buffer_.shrink_to_fit();
+          return read_rp_.deliver(chunk::make(std::exchange(read_buffer_, {})));
+        }))
+          .send(caf::actor_cast<caf::actor>(hdl));
+      }
+    };
+    auto asio_buffer = boost::asio::buffer(read_buffer_, buffer_size);
+    if (tls_socket_) {
+      tls_socket_->async_read_some(asio_buffer, on_read);
+    } else {
+      socket_->async_read_some(asio_buffer, on_read);
+    }
+    return read_rp_;
+  }
+
+  auto write(chunk_ptr chunk) -> caf::result<void> {
+    if (connection_rp_.pending()) {
+      return caf::make_error(ec::logic_error,
+                             fmt::format("{} cannot write while a connect "
+                                         "request is pending",
+                                         *self_));
+    }
+    if (write_rp_.pending()) {
+      return caf::make_error(ec::logic_error,
+                             fmt::format("{} cannot write while a write "
+                                         "request is pending",
+                                         *self_));
+    }
+    write_rp_ = self_->make_response_promise<void>();
+    auto on_write = [this, chunk,
+                     weak_hdl = caf::actor_cast<caf::weak_actor_ptr>(self_)](
+                      boost::system::error_code ec, size_t length) {
+      if (auto hdl = weak_hdl.lock()) {
+        caf::anon_mail(caf::make_action([this, chunk, ec, length] {
+          if (ec) {
+            write_rp_.deliver(caf::make_error(
+              ec::system_error,
+              fmt::format("failed to write to TCP socket: {}", ec.message())));
+            return;
+          }
+          metrics_.writes++;
+          metrics_.bytes_written += length;
+          if (length < chunk->size()) {
+            auto remainder = chunk->slice(length);
+            write_rp_.delegate(static_cast<tcp_bridge_actor>(self_),
+                               atom::write_v, std::move(remainder));
+            return;
+          }
+          TENZIR_ASSERT(length == chunk->size());
+          write_rp_.deliver();
+        }))
+          .send(caf::actor_cast<caf::actor>(hdl));
+      }
+    };
+    auto asio_buffer = boost::asio::buffer(chunk->data(), chunk->size());
+    if (tls_socket_) {
+      tls_socket_->async_write_some(asio_buffer, on_write);
+    } else {
+      socket_->async_write_some(asio_buffer, on_write);
+    }
+    return write_rp_;
+  }
+
+  // Member variables
+  tcp_bridge_actor::pointer self_ = {};
+  std::shared_ptr<boost::asio::io_context> io_ctx_ = {};
+  std::thread worker_ = {};
+  std::optional<boost::asio::ip::tcp::socket> socket_ = {};
+  std::optional<boost::asio::ssl::context> ssl_ctx_ = {};
+  std::optional<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&>>
+    tls_socket_ = {};
+  std::optional<boost::asio::ip::tcp::acceptor> acceptor_ = {};
+  caf::typed_response_promise<void> connection_rp_ = {};
+  caf::typed_response_promise<chunk_ptr> read_rp_ = {};
+  caf::typed_response_promise<void> write_rp_ = {};
+  std::vector<char> read_buffer_ = {};
+  tcp_metrics metrics_ = {};
+};
 
 struct connector_args : ssl_options {
   std::string hostname = {};
@@ -543,17 +535,18 @@ public:
     auto make
       = [](loader_args args,
            operator_control_plane& ctrl) mutable -> generator<chunk_ptr> {
-      auto tcp_bridge = ctrl.self().spawn(make_tcp_bridge,
-                                          ctrl.metrics({
-                                            "tenzir.metrics.tcp",
-                                            record_type{
-                                              {"handle", string_type{}},
-                                              {"reads", uint64_type{}},
-                                              {"writes", uint64_type{}},
-                                              {"bytes_read", uint64_type{}},
-                                              {"bytes_written", uint64_type{}},
-                                            },
-                                          }));
+      auto tcp_bridge
+        = ctrl.self().spawn(caf::actor_from_state<class tcp_bridge>,
+                            ctrl.metrics({
+                              "tenzir.metrics.tcp",
+                              record_type{
+                                {"handle", string_type{}},
+                                {"reads", uint64_type{}},
+                                {"writes", uint64_type{}},
+                                {"bytes_read", uint64_type{}},
+                                {"bytes_written", uint64_type{}},
+                              },
+                            }));
       do {
         if (args.connect) {
           auto cacert = args.cacert.has_value()
@@ -673,17 +666,17 @@ public:
         return caf::make_error(ec::invalid_argument);
       }
     }
-    auto tcp_bridge
-      = ctrl.self().spawn(make_tcp_bridge, ctrl.metrics({
-                                             "tenzir.metrics.tcp",
-                                             record_type{
-                                               {"handle", string_type{}},
-                                               {"reads", uint64_type{}},
-                                               {"writes", uint64_type{}},
-                                               {"bytes_read", uint64_type{}},
-                                               {"bytes_written", uint64_type{}},
-                                             },
-                                           }));
+    auto tcp_bridge = ctrl.self().spawn(caf::actor_from_state<class tcp_bridge>,
+                                        ctrl.metrics({
+                                          "tenzir.metrics.tcp",
+                                          record_type{
+                                            {"handle", string_type{}},
+                                            {"reads", uint64_type{}},
+                                            {"writes", uint64_type{}},
+                                            {"bytes_read", uint64_type{}},
+                                            {"bytes_written", uint64_type{}},
+                                          },
+                                        }));
 
     if (not args_.listen) {
       auto cacert = args_.cacert.has_value()
@@ -905,8 +898,8 @@ public:
         {"bytes_written", uint64_type{}},
       },
     });
-    auto tcp_bridge
-      = ctrl.self().spawn(make_tcp_bridge, std::move(tcp_metrics));
+    auto tcp_bridge = ctrl.self().spawn(caf::actor_from_state<class tcp_bridge>,
+                                        std::move(tcp_metrics));
     if (not args_.listen) {
       auto cacert = args_.cacert.has_value()
                       ? args_.cacert->inner

--- a/libtenzir/builtins/connectors/tcp.cpp
+++ b/libtenzir/builtins/connectors/tcp.cpp
@@ -135,6 +135,7 @@ public:
     io_ctx_->stop();
     worker_.join();
     metrics_.emit();
+    retry_timer_->cancel();
   }
 
   auto make_behavior() -> tcp_bridge_actor::behavior_type {

--- a/libtenzir/builtins/connectors/tcp.cpp
+++ b/libtenzir/builtins/connectors/tcp.cpp
@@ -631,9 +631,10 @@ public:
         {"bytes_written", uint64_type{}},
       },
     });
-    auto tcp_bridge = ctrl.self().spawn(caf::actor_from_state<class tcp_bridge>,
-                                        std::move(tcp_metrics),
-                                        ctrl.shared_diagnostics(), args_);
+    auto tcp_bridge
+      = ctrl.self().spawn<caf::linked>(caf::actor_from_state<class tcp_bridge>,
+                                       std::move(tcp_metrics),
+                                       ctrl.shared_diagnostics(), args_);
     if (not args_.listen) {
       ctrl.self()
         .mail(atom::connect_v)

--- a/nix/update-impl.sh
+++ b/nix/update-impl.sh
@@ -8,6 +8,8 @@ dir=$(dirname "$(readlink -f "$0")")
 toplevel=$(git -C "${dir}" rev-parse --show-toplevel)
 mainroot="$(git -C "${dir}" rev-parse --path-format=absolute --show-toplevel)"
 
+set -x
+
 get-submodule-rev() {
   local _submodule="$1"
   git -C "${toplevel}" submodule status -- "${_submodule}" | cut -c2- | cut -d' ' -f 1
@@ -24,7 +26,10 @@ update-source-github() {
   _rev="$(get-submodule-rev "${_submodule}")"
   if [[ "${_version}" == "" ]]; then
     git -C "${toplevel}" submodule update --init "${_submodule}"
-    git -C "${_path}" fetch --tags
+    local _upstream
+    _upstream="$(curl https://api.github.com/repos/tenzir/actor-framework | jq -r .parent.html_url)"
+    git -C "${_path}" remote add upstream "${_upstream}"
+    git -C "${_path}" fetch --tags --all
     _version="$(git -C "${_path}" describe --tag)"
   fi
 
@@ -59,5 +64,7 @@ update-source() {
     exit 1
   fi
 }
+
+git config --list --show-origin
 
 update-source caf "libtenzir/aux/caf" "1.0.2+g4a2fc51c09"

--- a/tenzir/bats/data/reference/pipelines_local/test_parse_operators/step_14.ref
+++ b/tenzir/bats/data/reference/pipelines_local/test_parse_operators/step_14.ref
@@ -4,5 +4,5 @@ error: loader for `scheme` scheme could not be found
 1 | from scheme://foo.json read json
   |      ^^^^^^ 
   |
-  = hint: must be one of -, file, stdin, tcp
+  = hint: must be one of -, file, stdin
   = docs: https://docs.tenzir.com/connectors

--- a/tenzir/bats/data/reference/pipelines_local/test_parse_operators/step_15.ref
+++ b/tenzir/bats/data/reference/pipelines_local/test_parse_operators/step_15.ref
@@ -4,5 +4,5 @@ error: loader for `scheme` scheme could not be found
 1 | from scheme:foo.json read json
   |      ^^^^^^ 
   |
-  = hint: must be one of -, file, stdin, tcp
+  = hint: must be one of -, file, stdin
   = docs: https://docs.tenzir.com/connectors

--- a/tenzir/bats/data/reference/pipelines_local/test_parse_operators/step_19.ref
+++ b/tenzir/bats/data/reference/pipelines_local/test_parse_operators/step_19.ref
@@ -4,5 +4,5 @@ error: loader `filee` could not be found
 1 | load filee | read json
   |      ^^^^^ 
   |
-  = hint: must be one of -, file, stdin, tcp
+  = hint: must be one of -, file, stdin
   = docs: https://docs.tenzir.com/connectors

--- a/tenzir/tests/exec/operators/save_tcp/reconnect.tql
+++ b/tenzir/tests/exec/operators/save_tcp/reconnect.tql
@@ -5,7 +5,7 @@ pipeline::detach {
     from {message: "Hello, world!"}
   }
   write_lines
-  save_tcp "0.0.0.0:3000", max_retry_delay=1s
+  save_tcp "0.0.0.0:3000", retry_delay=1s
 }
 
 load_tcp "0.0.0.0:3000" {

--- a/tenzir/tests/exec/operators/save_tcp/reconnect.tql
+++ b/tenzir/tests/exec/operators/save_tcp/reconnect.tql
@@ -1,0 +1,15 @@
+// node: true
+
+pipeline::detach {
+  every 50ms {
+    from {message: "Hello, world!"}
+  }
+  write_lines
+  save_tcp "0.0.0.0:3000", max_retry_delay=1s
+}
+
+load_tcp "0.0.0.0:3000" {
+  read_lines
+  head 1 // cut the connection after one event
+}
+head 3 // wait for at least three connections

--- a/tenzir/tests/exec/operators/save_tcp/reconnect.txt
+++ b/tenzir/tests/exec/operators/save_tcp/reconnect.txt
@@ -1,0 +1,9 @@
+{
+  line: "Hello, world!",
+}
+{
+  line: "Hello, world!",
+}
+{
+  line: "Hello, world!",
+}

--- a/tenzir/tests/run.py
+++ b/tenzir/tests/run.py
@@ -50,7 +50,7 @@ def parse_test_config(test_file, coverage=False):
     # Define valid configuration keys and their default values
     config = {
         "error": False,
-        "timeout": 10,  # Default timeout of 10 seconds
+        "timeout": 20,  # Default timeout of 20 seconds
         "test": "exec",  # Default to exec runner
         "node": False,  # Default to not using a node
         "skip": None,   # Optional skip reason


### PR DESCRIPTION
The `save_tcp` (`from "tcp://..."`) operator now tries to reconnect in case of recoverable errors such as network outages and in case the remote end disconnects.

You can use the new options `retry_delay: duration` and `max_retry_count: int` to tune the behavior to your needs. The default values are set to 30 seconds and 10 times respectively.

This PR also removes the TQL1 TCP connector plugin.