### PR TITLE
Fix the backwards-compat mode for lambdas

### DIFF
--- a/libtenzir/builtins/operators/where_map.cpp
+++ b/libtenzir/builtins/operators/where_map.cpp
@@ -281,6 +281,7 @@ struct arguments {
         diagnostic::error("expected identifier").primary(expr).emit(ctx);
         return failure::promise();
       }
+      args.lambda.left = std::move(field->id);
       return args;
     }
     for (auto& diag : diags) {


### PR DESCRIPTION
`[1, 2, 3].map(x, x + 1)` should emit a warning and function just the same as `[1, 2, 3].map(x => x + 1)`. Unfortunately, during a rebase, I must've accidentally removed the line that assigned the left-hand side of the lambda expression in this backwards-compat mode.

No changelog entry is needed for this one, as the lambda change hasn't been released yet.