### PR TITLE
Fix v5.3.1 release title

### DIFF
--- a/changelog/releases/v5.3.1.yaml
+++ b/changelog/releases/v5.3.1.yaml
@@ -1,4 +1,4 @@
-title: Fixed  Operator
-description: This release fixes a regression in the  operator, which was not working correctly in v5.3.0.
+title: Fixed Python Operator
+description: This release fixes a regression in the Python operator, which was not working correctly in v5.3.0.
 changes:
   - H36NPOAkm9tjMGVFAL74rLtuMb


### PR DESCRIPTION
Apparently GitHub silently removes inline code blocks in text inputs for `workflow_dispatch` actions.