### PR TITLE
Minor docs fixups

### DIFF
--- a/docs/operators/context/list.md
+++ b/docs/operators/context/list.md
@@ -1,6 +1,6 @@
 ---
 title: context::list
-category: Contexts, Packages
+category: Contexts
 example: "context::list"
 ---
 

--- a/docs/operators/package/list.md
+++ b/docs/operators/package/list.md
@@ -1,5 +1,5 @@
 ---
-title: packag::list
+title: package::list
 category: Packages
 example: "package::list"
 ---

--- a/docs/operators/package/remove.md
+++ b/docs/operators/package/remove.md
@@ -1,6 +1,6 @@
 ---
 title: package::remove
-category: Contexts
+category: Packages
 example: 'package::remove "suricata-ocsf"'
 ---
 
@@ -28,5 +28,4 @@ package::remove "suricata-ocsf"
 
 ## See Also
 
-[`list`](/reference/operators/package/list),
 [`package::add`](/reference/operators/package/add)


### PR DESCRIPTION
This simply fixes a typo and a category error in the operator docs.