### PR TITLE
Disable regression tests for v5.3.0 & v5.3.1

### DIFF
--- a/.github/workflows/tenzir.yaml
+++ b/.github/workflows/tenzir.yaml
@@ -106,7 +106,7 @@ jobs:
             dated_limit_version=$(printf "$dated_versions" | grep $limit_version)
             # We filter out versions older than limit_version, v4.28.0 and
             # v4.31.0 because they were broken and failed to upload.
-            filtered_versions=$(printf "$dated_versions" | awk '-F#' '{if($0>="'$dated_limit_version'")print$2}' | grep -v 'v4.28.0' | grep -v 'v4.31.0')
+            filtered_versions=$(printf "$dated_versions" | awk '-F#' '{if($0>="'$dated_limit_version'")print$2}' | grep -v 'v4.28.0' | grep -v 'v4.31.0' | grep -v 'v5.3.0' | grep -v 'v5.3.1')
             version_matrix="$(printf "$filtered_versions\nlatest\n" | jq -R | jq -sc 'map({version: .})')"
           else
             version_matrix="$(printf "latest\n" | jq -R | jq -sc 'map({version: .})')"


### PR DESCRIPTION
We yanked the 5.3.1 release, causing the regression test to no longer work. This simply filters the versions from the matrix.

- Fixes https://github.com/tenzir/issues/issues/3084