### PR TITLE
Remove `meta` keyword

### DIFF
--- a/changelog/changes/cN6XIKaqV5L5dK2pzedsJShuu8.md
+++ b/changelog/changes/cN6XIKaqV5L5dK2pzedsJShuu8.md
@@ -1,0 +1,9 @@
+---
+title: "Remove `meta` keyword"
+type: change
+authors: jachris
+pr: 5275
+---
+
+The identifier `meta` is no longer a keyword and can thus now be used as a
+normal field name.

--- a/libtenzir/include/tenzir/tql2/tokens.hpp
+++ b/libtenzir/include/tenzir/tql2/tokens.hpp
@@ -22,7 +22,7 @@ TENZIR_ENUM(
   // identifiers
   identifier, dollar_ident,
   // keywords
-  this_, if_, else_, match, not_, and_, or_, move, underscore, let, in, meta,
+  this_, if_, else_, match, not_, and_, or_, move, underscore, let, in,
   reserved_keyword,
   // literals
   scalar, true_, false_, null, ip, subnet, datetime,

--- a/libtenzir/src/tql2/parser.cpp
+++ b/libtenzir/src/tql2/parser.cpp
@@ -621,17 +621,8 @@ public:
     if (peek(tk::lbracket)) {
       return parse_list();
     }
-    // TODO: Drop one of the syntax possibilities.
-    if (peek(tk::meta) || peek(tk::at)) {
-      auto begin = location{};
-      auto is_at = false;
-      if (auto meta = accept(tk::meta)) {
-        begin = meta.location;
-        expect(tk::dot);
-      } else {
-        begin = expect(tk::at).location;
-        is_at = true;
-      }
+    if (auto at = accept(tk::at)) {
+      auto begin = at.location;
       auto ident = expect(tk::identifier).as_identifier();
       auto kind = ast::meta_kind{};
       if (ident.name == "name") {
@@ -641,7 +632,7 @@ public:
       } else if (ident.name == "internal") {
         kind = ast::meta::internal;
       } else if (ident.name == "schema") {
-        diagnostic::error("use `{}name` instead", is_at ? "@" : "meta.")
+        diagnostic::error("use `@name` instead")
           .primary(begin.combine(ident))
           .throw_();
       } else if (ident.name == "schema_id") {

--- a/libtenzir/src/tql2/tokens.cpp
+++ b/libtenzir/src/tql2/tokens.cpp
@@ -143,7 +143,6 @@ auto tokenize_permissive(std::string_view content) -> std::vector<token> {
     | X("in", in)
     | X("let", let)
     | X("match", match)
-    | X("meta", meta)
     | X("not", not_)
     | X("null", null)
     | X("or", or_)
@@ -322,7 +321,6 @@ auto describe(token_kind k) -> std::string_view {
     X(line_comment, "`// ...`");
     X(lpar, "`(`");
     X(match, "`match`");
-    X(meta, "`meta`");
     X(minus, "`-`");
     X(move, "`move`");
     X(newline, "newline");


### PR DESCRIPTION
Since we went for `@name` to access event metadata (instead of `meta.name`), the `meta` keyword should be removed.