### PR TITLE
Remove missed duplicate of `meta` keyword

### DIFF
--- a/changelog/changes/cN6XIKaqV5L5dK2pzedsJShuu8.md
+++ b/changelog/changes/cN6XIKaqV5L5dK2pzedsJShuu8.md
@@ -2,7 +2,7 @@
 title: "Remove `meta` keyword"
 type: change
 authors: jachris
-pr: 5275
+pr: [5275, 5276]
 ---
 
 The identifier `meta` is no longer a keyword and can thus now be used as a

--- a/libtenzir/src/tql2/tokens.cpp
+++ b/libtenzir/src/tql2/tokens.cpp
@@ -152,7 +152,7 @@ auto tokenize_permissive(std::string_view content) -> std::vector<token> {
 #undef X
     | ignore((
         lit{"self"} | "is" | "as" | "use" /*| "type"*/ | "return" | "def" | "function"
-        | "fn" | "meta" | "super" | "for" | "while" | "mod" | "module"
+        | "fn" | "super" | "for" | "while" | "mod" | "module"
       ) >> !continue_ident) ->* [] { return tk::reserved_keyword; }
     | ignore('$' >> identifier)
       ->* [] { return tk::dollar_ident; }


### PR DESCRIPTION
The lexer had two copies of the `meta` keyword, and #5275 only removed one.