### PR TITLE
Fix `pipeline::activity` refresh when there are no running pipelines

### DIFF
--- a/changelog/changes/MSvVneBFHeY1Eny6ldFfUt6gdK.md
+++ b/changelog/changes/MSvVneBFHeY1Eny6ldFfUt6gdK.md
@@ -1,0 +1,9 @@
+---
+title: "Pipeline activity refresh without running pipelines"
+type: bugfix
+authors: jachris
+pr: 5278
+---
+
+The `pipeline::activity` operator now always yields new events, even when all
+running pipelines are hidden.


### PR DESCRIPTION
When there are no (non-hidden) pipelines, `pipeline::activity` rotated its internal buffers, but it did not notify subscribers that that the data changed. 