### PR TITLE
Add SNI support to `from_http` and fix thread counts

### DIFF
--- a/changelog/changes/credit-relax-origin.md
+++ b/changelog/changes/credit-relax-origin.md
@@ -1,0 +1,8 @@
+---
+title: "SNI support in `from_http`"
+type: bugfix
+authors: tobim
+pr: 5288
+---
+
+The `from_http` operator now correctly sets the domain for TLS SNI (Server Name Indication).

--- a/changelog/changes/insist-remain-worry.md
+++ b/changelog/changes/insist-remain-worry.md
@@ -1,0 +1,8 @@
+---
+title: "CPU limits in containers"
+type: bugfix
+authors: dominiklohmann
+pr: 5288
+---
+
+Nodes now correctly respect cgroup CPU limits on Linux. Previously, such limits were ignored, and the node always used the physical number of cores available, unless a lower number was explicitly configured through the `caf.scheduler.max-threads` option. This bug fix may improve performance and resource utilization for nodes running in environments with such limitations.

--- a/nix/caf/source.json
+++ b/nix/caf/source.json
@@ -1,7 +1,7 @@
 {
   "owner": "actor-framework",
   "repo": "actor-framework",
-  "rev": "b8651098cc47d7082ef820fe90904eb607edf530",
-  "hash": "sha256-UxXVxd3/zeH5hAChjEkECncR+b/HkFjvOZolI0x++oQ=",
-  "version": "1.0.2+g4301aaa5e"
+  "rev": "4a2fc51c09bb923ee261c36370c71a8e3d9b0d03",
+  "hash": "sha256-Qy0WSIpnio2MbuqoBWV59hXBcGwP0JJ2G3O3kvo8ePI=",
+  "version": "1.0.2+g4a2fc51c09"
 }

--- a/nix/update-impl.sh
+++ b/nix/update-impl.sh
@@ -60,4 +60,4 @@ update-source() {
   fi
 }
 
-update-source caf "libtenzir/aux/caf" "1.0.2+g4301aaa5e"
+update-source caf "libtenzir/aux/caf" "1.0.2+g4a2fc51c09"


### PR DESCRIPTION
This change sets the correct domain for TLS SNI support and adds support for CGROUP core count limits by bumping to the latest commit on the CAF main branch.