### PR TITLE
Fix bug in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -224,7 +224,7 @@ jobs:
           gh release create "${{ github.event.inputs.version }}" \
             --title "${{ github.event.inputs.title }}" \
             --notes "$RELEASE_NOTES" \
-            --latest "${{ steps.release_type.outputs.is_latest }}"
+            ${{ steps.release_type.outputs.is_latest && '--latest' || '--latest=false' }}
 
       - name: Output success message (latest release)
         if: steps.release_type.outputs.is_latest == 'true'


### PR DESCRIPTION
The recent additions to support backport releases introduced a slight regression in the last step of the release workflow. This wasn't a problem for v5.5, as this was easy to fix up manually by just running the step manually, and this change fixes it for future releases.