### PR TITLE
Allow dynamic topics in `publish`

### DIFF
--- a/changelog/changes/token-welsh-thread.md
+++ b/changelog/changes/token-welsh-thread.md
@@ -1,0 +1,14 @@
+---
+title: "Publishing to dynamic topics"
+type: feature
+authors: dominiklohmann
+pr: 5294
+---
+
+The `publish` operator now allows for dynamic topics to be derived from each
+individual event.
+
+For example, assuming Suricata logs, `publish f"suricata.{event_type}"` now
+publishes to the topic `suricata.alert` for alert events and `suricata.flow` for
+flow events. This works with any expression that evaluates to a string,
+including `publish @name` to use the schema name of the event.

--- a/docs/operators/publish.md
+++ b/docs/operators/publish.md
@@ -38,7 +38,7 @@ from "conn.log.gz" {
 publish "zeek"
 ```
 
-### Publish Suriacata events under a dynamic topic depending on their event type
+### Publish Suricata events under a dynamic topic depending on their event type
 
 ```tql
 from "eve.json" {

--- a/docs/operators/publish.md
+++ b/docs/operators/publish.md
@@ -9,6 +9,7 @@ Publishes events to a channel with a topic.
 ```tql
 publish [topic:string]
 ```
+
 ## Description
 
 The `publish` operator publishes events at a node in a channel with the
@@ -27,12 +28,23 @@ publishes events to the topic `main`.
 
 ## Examples
 
-### Publish Zeek connection logs under the topic `zeek`
+### Publish Zeek connection logs under the fixed topic `zeek`
 
 ```tql
-load_file "conn.log"
-read_zeek_tsv
+from "conn.log.gz" {
+  decompress_gzip
+  read_zeek_tsv
+}
 publish "zeek"
+```
+
+### Publish Suriacata events under a dynamic topic depending on their event type
+
+```tql
+from "eve.json" {
+  read_suricata
+}
+publish f"suricata.{event_type}"
 ```
 
 ## See Also

--- a/libtenzir/include/tenzir/group.hpp
+++ b/libtenzir/include/tenzir/group.hpp
@@ -14,41 +14,47 @@
 
 namespace tenzir {
 
-template <class T>
+template <class Rng>
 struct group_result {
-  T value;
-  int64_t begin;
-  int64_t end;
+  using value_type = typename std::ranges::range_value_t<Rng>;
+  using difference_type = typename std::ranges::range_difference_t<Rng>;
+
+  value_type value;
+  difference_type begin;
+  difference_type end;
 };
 
-// Adapts a generator to produce groups of consecutive elements.
+// Adapts a forward range to produce groups of consecutive elements.
 template <std::ranges::forward_range Rng>
 auto group(Rng&& values) // NOLINT(cppcoreguidelines-missing-std-forward)
-  -> generator<group_result<std::ranges::range_value_t<Rng>>> {
+  -> generator<group_result<Rng>> {
+  using result_type = group_result<Rng>;
+  using difference_type = typename result_type::difference_type;
   auto it = std::ranges::begin(values);
   const auto end = std::ranges::end(values);
   if (it == end) {
     co_return;
   }
-  auto current_begin = int64_t{0};
+  auto current_begin = difference_type{0};
   auto current_pos = current_begin;
   auto current_value = *it;
   ++it;
   ++current_pos;
   while (it != end) {
-    if (*it != current_value) {
-      co_yield group_result<std::ranges::range_value_t<Rng>>{
+    auto next_value = std::forward_like<Rng>(*it);
+    if (next_value != current_value) {
+      co_yield result_type{
         .value = current_value,
         .begin = current_begin,
         .end = current_pos,
       };
-      current_value = *it;
+      current_value = std::move(next_value);
       current_begin = current_pos;
     }
     ++it;
     ++current_pos;
   }
-  co_yield group_result<std::ranges::range_value_t<Rng>>{
+  co_yield result_type{
     .value = current_value,
     .begin = current_begin,
     .end = current_pos,

--- a/libtenzir/include/tenzir/group.hpp
+++ b/libtenzir/include/tenzir/group.hpp
@@ -1,0 +1,58 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2025 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <tenzir/generator.hpp>
+
+#include <ranges>
+
+namespace tenzir {
+
+template <class T>
+struct group_result {
+  T value;
+  int64_t begin;
+  int64_t end;
+};
+
+// Adapts a generator to produce groups of consecutive elements.
+template <std::ranges::forward_range Rng>
+auto group(Rng&& values) // NOLINT(cppcoreguidelines-missing-std-forward)
+  -> generator<group_result<std::ranges::range_value_t<Rng>>> {
+  auto it = std::ranges::begin(values);
+  const auto end = std::ranges::end(values);
+  if (it == end) {
+    co_return;
+  }
+  auto current_begin = int64_t{0};
+  auto current_pos = current_begin;
+  auto current_value = *it;
+  ++it;
+  ++current_pos;
+  while (it != end) {
+    if (*it != current_value) {
+      co_yield group_result<std::ranges::range_value_t<Rng>>{
+        .value = current_value,
+        .begin = current_begin,
+        .end = current_pos,
+      };
+      current_value = *it;
+      current_begin = current_pos;
+    }
+    ++it;
+    ++current_pos;
+  }
+  co_yield group_result<std::ranges::range_value_t<Rng>>{
+    .value = current_value,
+    .begin = current_begin,
+    .end = current_pos,
+  };
+}
+
+} // namespace tenzir

--- a/libtenzir/include/tenzir/rebatch.hpp
+++ b/libtenzir/include/tenzir/rebatch.hpp
@@ -1,0 +1,41 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2025 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "tenzir/table_slice.hpp"
+
+#include <ranges>
+#include <vector>
+
+namespace tenzir {
+
+template <template <class...> class Container = std::vector,
+          std::ranges::forward_range Rng>
+  requires(std::same_as<std::ranges::range_value_t<Rng>, table_slice>)
+auto rebatch(Rng events, size_t max_size = defaults::import::table_slice_size)
+  -> Container<table_slice> {
+  TENZIR_ASSERT(max_size > 0);
+  auto results = Container<table_slice>{};
+  auto start = events.begin();
+  auto rows = start->rows();
+  const auto end = events.end();
+  for (auto it = std::next(start); it < end; ++it) {
+    rows += it->rows();
+    if (it->schema() == start->schema() and rows < max_size) {
+      continue;
+    }
+    results.push_back(concatenate({start, it}));
+    start = it;
+    rows = start->rows();
+  }
+  results.push_back(concatenate({start, end}));
+  return results;
+}
+
+} // namespace tenzir


### PR DESCRIPTION
This changes the `publish` operator to no longer expect its topic to be a constant. Instead, the topic can now be derived from each individual event.

As a small optimization on the side, this also removes the implicit `batch` operator before `publish`, moving a more efficient logic into the operator itself. The operator now also only emits metrics at most once every second per schema, and one additional time at the end of its input per schema if necessary. Previously, it emitted a metric for each batch of events.