### PR TITLE
Properly handle `partition_transformer` shutdown

### DIFF
--- a/changelog/changes/centre-backed-agree.md
+++ b/changelog/changes/centre-backed-agree.md
@@ -1,0 +1,9 @@
+---
+title: "Fixed shutdown hang during storage optimization"
+type: bugfix
+authors: IyeOnline
+pr: 5301
+---
+
+Nodes periodically merge and optimize their storage over time. We fixed a hang
+on shutdown for nodes while this process was ongoing.

--- a/libtenzir/include/tenzir/index.hpp
+++ b/libtenzir/include/tenzir/index.hpp
@@ -306,6 +306,13 @@ struct index_state {
   /// The partitions currently being transformed.
   detail::stable_set<uuid> partitions_in_transformation = {};
 
+  /// The collection of currently active transformers. These need to be
+  /// explicitly shut down if the index actor exists.
+  /// The `disposable` refers to the monitor that would otherwise automatically
+  /// remove the actor from the list if it finished on its own. It must be
+  /// disposed of before shutdown.
+  std::unordered_map<caf::actor_addr, caf::disposable> active_transformers;
+
   /// Actor handle of the filesystem actor.
   filesystem_actor filesystem = {};
 


### PR DESCRIPTION
The index actor keeps track of all currently running `partition_transformer`s and properly shuts them down.

- Fixes https://github.com/tenzir/issues/issues/3009