### PR TITLE
Treat non 2xx responses from Azure DCEs as errors

### DIFF
--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -1,5 +1,5 @@
 {
-  "hash": "sha256-tAjxcljB6+TCFHVGdltxekPSWdQ2CF8jZEt8T2Ovxw4=",
+  "hash": "sha256-SYM1uU08ajTngKP7yvNvWwdrh31Hmifh8hjsXAERV80=",
   "name": "tenzir-plugins.tar.gz",
-  "url": "https://github.com/tenzir/tenzir-plugins/archive/42826db6efbb2f1b4b62ea26e08a7f12ebe24f11.tar.gz"
+  "url": "https://github.com/tenzir/tenzir-plugins/archive/edffd52501b903b311db7a8ae117c6de899a4407.tar.gz"
 }


### PR DESCRIPTION
These used to emit warnings before, but any non 2xx response indicates a remote error, and there is no point in continuing.
