### PR TITLE
Fix metadata series length in `from_http_server_operator`

### DIFF
--- a/changelog/changes/poetry-almost-mobile.md
+++ b/changelog/changes/poetry-almost-mobile.md
@@ -1,0 +1,9 @@
+---
+title: "from_http server=true` assertion failures"
+type: bugfix
+authors: raxyte
+pr: 5325
+---
+
+`from_http server=true` failed with internal assertions and stopped the pipeline on
+receiving requests when `metadata_field` was specified.


### PR DESCRIPTION
Additionally, removes an incorrect `std::move()`.