### PR TITLE
Remove noise in `update-ocsf-schemas` CI workflow

### DIFF
--- a/.github/workflows/update-ocsf-schemas.yaml
+++ b/.github/workflows/update-ocsf-schemas.yaml
@@ -43,8 +43,6 @@ jobs:
             Automated update of OCSF schemas from upstream.
 
             This PR was automatically created by the update-ocsf-schemas workflow.
-
-            Triggered by: @${{ github.actor }}
           branch: topic/update-ocsf-schemas
           commit-message: Update OCSF schemas
           labels: maintenance


### PR DESCRIPTION
The "actor" is always the person that last modified the workflow when using the `schedule` trigger. I don't like getting mentions for this.