### PR TITLE
Enable compression for `write_bitz`

### DIFF
--- a/changelog/changes/weird-stone-truck.md
+++ b/changelog/changes/weird-stone-truck.md
@@ -1,0 +1,10 @@
+---
+title: "Compression for `write_bitz`"
+type: feature
+authors: dominiklohmann
+pr: 5335
+---
+
+Tenzir's internal wire format, which is accessible through the `read_bitz` and
+`write_bitz` operators, now uses Zstd compression internally, resulting in a
+significantly smaller output size. This change is backwards-compatible.

--- a/libtenzir/builtins/formats/bitz.cpp
+++ b/libtenzir/builtins/formats/bitz.cpp
@@ -132,8 +132,8 @@ public:
           co_yield {};
           co_return;
         }
-        auto printer
-          = check(pipeline::internal_parse_as_operator("write feather"));
+        auto printer = check(pipeline::internal_parse_as_operator(
+          "write feather --compression-type zstd"));
         TENZIR_ASSERT(printer);
         auto untyped_instance = check(printer->instantiate(
           [](auto slice) -> generator<table_slice> {


### PR DESCRIPTION
This change makes the output of `write_bitz` a lot more compact by enabling column-level compression for it.