### PR TITLE
Fix IP function docs links

### DIFF
--- a/docs/functions/ip.md
+++ b/docs/functions/ip.md
@@ -36,7 +36,7 @@ from {x: ip("1.2.3.4")}
 [`is_private`](/reference/functions/is_private),
 [`is_global`](/reference/functions/is_global),
 [`is_link_local`](/reference/functions/is_link_local),
-[`ip_type`](/reference/functions/ip_type),
+[`ip_category`](/reference/functions/ip_category),
 [`time`](/reference/functions/time),
 [`uint`](/reference/functions/uint),
 [float](/reference/functions/float),

--- a/docs/functions/is_global.md
+++ b/docs/functions/is_global.md
@@ -54,4 +54,4 @@ from {
 [`is_loopback`](/reference/functions/is_loopback),
 [`is_private`](/reference/functions/is_private),
 [`is_link_local`](/reference/functions/is_link_local),
-[`ip_type`](/reference/functions/ip_type)
+[`ip_category`](/reference/functions/ip_category)

--- a/docs/functions/is_link_local.md
+++ b/docs/functions/is_link_local.md
@@ -51,4 +51,4 @@ from {
 [`is_loopback`](/reference/functions/is_loopback),
 [`is_private`](/reference/functions/is_private),
 [`is_global`](/reference/functions/is_global),
-[`ip_type`](/reference/functions/ip_type)
+[`ip_category`](/reference/functions/ip_category)

--- a/docs/functions/is_loopback.md
+++ b/docs/functions/is_loopback.md
@@ -48,4 +48,4 @@ from {
 [`is_private`](/reference/functions/is_private),
 [`is_global`](/reference/functions/is_global),
 [`is_link_local`](/reference/functions/is_link_local),
-[`ip_type`](/reference/functions/ip_type)
+[`ip_category`](/reference/functions/ip_category)

--- a/docs/functions/is_multicast.md
+++ b/docs/functions/is_multicast.md
@@ -48,4 +48,4 @@ from {
 [`is_private`](/reference/functions/is_private),
 [`is_global`](/reference/functions/is_global),
 [`is_link_local`](/reference/functions/is_link_local),
-[`ip_type`](/reference/functions/ip_type)
+[`ip_category`](/reference/functions/ip_category)

--- a/docs/functions/is_private.md
+++ b/docs/functions/is_private.md
@@ -60,4 +60,4 @@ from {
 [`is_loopback`](/reference/functions/is_loopback),
 [`is_global`](/reference/functions/is_global),
 [`is_link_local`](/reference/functions/is_link_local),
-[`ip_type`](/reference/functions/ip_type)
+[`ip_category`](/reference/functions/ip_category)

--- a/docs/functions/is_v4.md
+++ b/docs/functions/is_v4.md
@@ -41,4 +41,4 @@ from {
 [`is_private`](/reference/functions/is_private),
 [`is_global`](/reference/functions/is_global),
 [`is_link_local`](/reference/functions/is_link_local),
-[`ip_type`](/reference/functions/ip_type)
+[`ip_category`](/reference/functions/ip_category)

--- a/docs/functions/is_v6.md
+++ b/docs/functions/is_v6.md
@@ -41,4 +41,4 @@ from {
 [`is_private`](/reference/functions/is_private),
 [`is_global`](/reference/functions/is_global),
 [`is_link_local`](/reference/functions/is_link_local),
-[`ip_type`](/reference/functions/ip_type)
+[`ip_category`](/reference/functions/ip_category)

--- a/docs/functions/subnet.md
+++ b/docs/functions/subnet.md
@@ -41,7 +41,7 @@ from {x: subnet("1.2.3.4/16")}
 [`is_private`](/reference/functions/is_private),
 [`is_global`](/reference/functions/is_global),
 [`is_link_local`](/reference/functions/is_link_local),
-[`ip_type`](/reference/functions/ip_type),
+[`ip_category`](/reference/functions/ip_category),
 [`time`](/reference/functions/time),
 [`uint`](/reference/functions/uint),
 [float](/reference/functions/float),


### PR DESCRIPTION
## Summary
- Fixed broken links in IP function documentation
- Changed references from `ip_type` to `ip_category` to match the actual function name

## Test plan
- [x] Verified all documentation links now point to the correct function reference

🤖 Generated with [Claude Code](https://claude.ai/code)