### PR TITLE
Add string padding functions (pad_left and pad_right)

### DIFF
--- a/docs/functions/pad_left.md
+++ b/docs/functions/pad_left.md
@@ -1,0 +1,68 @@
+---
+title: pad_left
+category: String/Transformation
+example: '"hello".pad_left(10)'
+---
+
+Pads a string on the left to a specified length.
+
+```tql
+pad_left(x:string, length:int, [pad_char:string=" "]) -> string
+```
+
+## Description
+
+The `pad_left` function pads the string `x` on the left side with `pad_char` 
+(default: space) until it reaches the specified `length`. If the string is 
+already longer than or equal to the specified length, it returns the original 
+string unchanged.
+
+### `x: string`
+
+The string to pad.
+
+### `length: int`
+
+The target length of the resulting string.
+
+### `pad_char: string = " "`
+
+The character to use for padding. Must be a single character. Defaults to a space.
+
+## Examples
+
+### Pad with spaces
+
+```tql
+from {x: "hello".pad_left(10)}
+```
+
+```tql
+{x: "     hello"}
+```
+
+### Pad with custom character
+
+```tql
+from {x: "42".pad_left(5, "0")}
+```
+
+```tql
+{x: "00042"}
+```
+
+### String already long enough
+
+```tql
+from {x: "hello world".pad_left(5)}
+```
+
+```tql
+{x: "hello world"}
+```
+
+## See Also
+
+[`pad_right`](/reference/functions/pad_right),
+[`trim`](/reference/functions/trim),
+[`trim_start`](/reference/functions/trim_start)

--- a/docs/functions/pad_right.md
+++ b/docs/functions/pad_right.md
@@ -1,0 +1,68 @@
+---
+title: pad_right
+category: String/Transformation
+example: '"hello".pad_right(10)'
+---
+
+Pads a string on the right to a specified length.
+
+```tql
+pad_right(x:string, length:int, [pad_char:string=" "]) -> string
+```
+
+## Description
+
+The `pad_right` function pads the string `x` on the right side with `pad_char` 
+(default: space) until it reaches the specified `length`. If the string is 
+already longer than or equal to the specified length, it returns the original 
+string unchanged.
+
+### `x: string`
+
+The string to pad.
+
+### `length: int`
+
+The target length of the resulting string.
+
+### `pad_char: string = " "`
+
+The character to use for padding. Must be a single character. Defaults to a space.
+
+## Examples
+
+### Pad with spaces
+
+```tql
+from {x: "hello".pad_right(10)}
+```
+
+```tql
+{x: "hello     "}
+```
+
+### Pad with custom character
+
+```tql
+from {x: "hello".pad_right(10, ".")}
+```
+
+```tql
+{x: "hello....."}
+```
+
+### String already long enough
+
+```tql
+from {x: "hello world".pad_right(5)}
+```
+
+```tql
+{x: "hello world"}
+```
+
+## See Also
+
+[`pad_left`](/reference/functions/pad_left),
+[`trim`](/reference/functions/trim),
+[`trim_end`](/reference/functions/trim_end)

--- a/libtenzir/builtins/functions/string.cpp
+++ b/libtenzir/builtins/functions/string.cpp
@@ -211,6 +211,149 @@ private:
   std::string fn_name_;
 };
 
+class pad : public virtual function_plugin {
+public:
+  explicit pad(std::string name, bool pad_left)
+    : name_{std::move(name)}, pad_left_{pad_left} {
+  }
+
+  auto name() const -> std::string override {
+    return name_;
+  }
+
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
+  auto make_function(invocation inv, session ctx) const
+    -> failure_or<function_ptr> override {
+    auto subject_expr = ast::expression{};
+    auto length_expr = ast::expression{};
+    auto pad_char = std::optional<std::string>{};
+    TRY(argument_parser2::function(name())
+          .positional("x", subject_expr, "string")
+          .positional("length", length_expr, "int")
+          .positional("pad_char", pad_char)
+          .parse(inv, ctx));
+
+    // Default to space if no pad character provided
+    if (not pad_char) {
+      pad_char = " ";
+    }
+
+    return function_use::make([subject_expr = std::move(subject_expr),
+                               length_expr = std::move(length_expr),
+                               pad_char = std::move(pad_char),
+                               pad_left = pad_left_, name = name_](
+                                evaluator eval, session ctx) -> multi_series {
+      auto b = arrow::StringBuilder{};
+
+      for (auto [subject, length] :
+           split_multi_series(eval(subject_expr), eval(length_expr))) {
+        TENZIR_ASSERT(subject.length() == length.length());
+
+        auto f = detail::overload{
+          [&](const arrow::StringArray& subject_array,
+              const arrow::Int64Array& length_array) {
+            for (auto i = int64_t{0}; i < subject_array.length(); ++i) {
+              if (subject_array.IsNull(i) || length_array.IsNull(i)) {
+                check(b.AppendNull());
+                continue;
+              }
+
+              auto str = subject_array.GetView(i);
+              auto target_length = length_array.Value(i);
+
+              if (target_length <= 0) {
+                check(b.Append(""));
+                continue;
+              }
+
+              // For simple string length, we can use the string view's size for
+              // ASCII or count UTF-8 characters manually
+              int64_t str_length = 0;
+              auto ptr = str.data();
+              auto end = ptr + str.size();
+              while (ptr < end) {
+                // Skip UTF-8 continuation bytes (10xxxxxx)
+                if ((*ptr & 0xC0) != 0x80) {
+                  str_length++;
+                }
+                ptr++;
+              }
+
+              if (str_length >= target_length) {
+                // String is already long enough
+                check(b.Append(str));
+                continue;
+              }
+
+              // Validate pad character is single character
+              int64_t pad_char_length = 0;
+              ptr = pad_char->data();
+              end = ptr + pad_char->size();
+              while (ptr < end) {
+                if ((*ptr & 0xC0) != 0x80) {
+                  pad_char_length++;
+                }
+                ptr++;
+              }
+
+              if (pad_char_length != 1) {
+                diagnostic::warning("`{}` expected single character for "
+                                    "padding, "
+                                    "but got `{}` with length {}",
+                                    name, *pad_char, pad_char_length)
+                  .primary(subject_expr)
+                  .emit(ctx);
+                check(b.AppendNull());
+                continue;
+              }
+
+              // Calculate padding needed
+              auto padding_needed
+                = static_cast<size_t>(target_length - str_length);
+              std::string result;
+              result.reserve(str.size() + padding_needed * pad_char->size());
+
+              if (pad_left) {
+                // Pad on the left
+                for (size_t j = 0; j < padding_needed; ++j) {
+                  result += *pad_char;
+                }
+                result += str;
+              } else {
+                // Pad on the right
+                result = str;
+                for (size_t j = 0; j < padding_needed; ++j) {
+                  result += *pad_char;
+                }
+              }
+
+              check(b.Append(result));
+            }
+          },
+          [&](const auto&, const auto&) {
+            // Type mismatch
+            diagnostic::warning("`{}` expected (string, int), but got ({}, {})",
+                                name, subject.type.kind(), length.type.kind())
+              .primary(subject_expr)
+              .emit(ctx);
+            check(b.AppendNulls(subject.length()));
+          },
+        };
+        match(std::tie(*subject.array, *length.array), f);
+      }
+
+      return series{string_type{}, finish(b)};
+    });
+  }
+
+private:
+  std::string name_;
+  bool pad_left_;
+};
+
 class nullary_method : public virtual function_plugin {
 public:
   nullary_method(std::string name, std::string fn_name, type result_ty)
@@ -628,6 +771,9 @@ TENZIR_REGISTER_PLUGIN(match_regex)
 TENZIR_REGISTER_PLUGIN(trim{"trim", "utf8_trim"})
 TENZIR_REGISTER_PLUGIN(trim{"trim_start", "utf8_ltrim"})
 TENZIR_REGISTER_PLUGIN(trim{"trim_end", "utf8_rtrim"})
+
+TENZIR_REGISTER_PLUGIN(pad{"pad_left", true})
+TENZIR_REGISTER_PLUGIN(pad{"pad_right", false})
 
 TENZIR_REGISTER_PLUGIN(nullary_method{"capitalize", "utf8_capitalize",
                                       string_type{}})

--- a/tenzir/tests/exec/functions/string/pad_combined.tql
+++ b/tenzir/tests/exec/functions/string/pad_combined.tql
@@ -1,0 +1,21 @@
+// Test combining pad_left and pad_right
+from {
+  text: "center",
+  // Center text with padding on both sides
+  centered: "center".pad_left(10, "-").pad_right(14, "-"),
+  // Create a formatted table-like output
+  text1: "Name".pad_right(20, " "),
+  text2: "Age".pad_left(5, " "),
+  text3: "City".pad_right(15, " "),
+  // Format numbers with leading zeros
+  num1: "7".pad_left(3, "0"),
+  num2: "42".pad_left(3, "0"),
+  num3: "123".pad_left(3, "0"),
+  // Create a visual separator
+  separator: "".pad_right(40, "="),
+  // Test edge cases with both functions
+  edge1: "".pad_left(3, "x").pad_right(6, "y"),
+  edge2: "abc".pad_left(2).pad_right(1),
+  // Unicode padding combinations
+  unicode_both: "中文".pad_left(6, "←").pad_right(8, "→"),
+}

--- a/tenzir/tests/exec/functions/string/pad_combined.txt
+++ b/tenzir/tests/exec/functions/string/pad_combined.txt
@@ -1,0 +1,14 @@
+{
+  text: "center",
+  centered: "----center----",
+  text1: "Name                ",
+  text2: "  Age",
+  text3: "City           ",
+  num1: "007",
+  num2: "042",
+  num3: "123",
+  separator: "========================================",
+  edge1: "xxxyyy",
+  edge2: "abc",
+  unicode_both: "←←←←中文→→",
+}

--- a/tenzir/tests/exec/functions/string/pad_left.tql
+++ b/tenzir/tests/exec/functions/string/pad_left.tql
@@ -1,0 +1,23 @@
+from {
+  // Basic padding with default space
+  basic: "hello".pad_left(10),
+  // Padding with custom character
+  zeros: "42".pad_left(5, "0"),
+  // String already long enough
+  no_pad: "hello world".pad_left(5),
+  // Empty string
+  empty: "".pad_left(5, "-"),
+  // Single character
+  single: "x".pad_left(3, "."),
+  // Padding with unicode character
+  unicode: "test".pad_left(8, "★"),
+  // Zero length
+  zero_len: "hello".pad_left(0),
+  // Negative length (should return empty)
+  neg_len: "hello".pad_left(-5),
+  // Multi-character pad (should fail)
+  multi_pad: "test".pad_left(10, "ab"),
+  // Null handling
+  null_str: null.pad_left(5),
+  null_len: "test".pad_left(null),
+}

--- a/tenzir/tests/exec/functions/string/pad_left.txt
+++ b/tenzir/tests/exec/functions/string/pad_left.txt
@@ -1,0 +1,33 @@
+{
+  basic: "     hello",
+  zeros: "00042",
+  no_pad: "hello world",
+  empty: "-----",
+  single: "..x",
+  unicode: "★★★★test",
+  zero_len: "",
+  neg_len: "",
+  multi_pad: null,
+  null_str: null,
+  null_len: null,
+}
+warning: `pad_left` expected single character for padding, but got `ab` with length 2
+  --> exec/functions/string/pad_left.tql:19:14
+   |
+19 |   multi_pad: "test".pad_left(10, "ab"),
+   |              ~~~~~~ 
+   |
+
+warning: `pad_left` expected (string, int), but got (null, int64)
+  --> exec/functions/string/pad_left.tql:21:13
+   |
+21 |   null_str: null.pad_left(5),
+   |             ~~~~ 
+   |
+
+warning: `pad_left` expected (string, int), but got (string, null)
+  --> exec/functions/string/pad_left.tql:22:13
+   |
+22 |   null_len: "test".pad_left(null),
+   |             ~~~~~~ 
+   |

--- a/tenzir/tests/exec/functions/string/pad_right.tql
+++ b/tenzir/tests/exec/functions/string/pad_right.tql
@@ -1,0 +1,23 @@
+from {
+  // Basic padding with default space
+  basic: "hello".pad_right(10),
+  // Padding with custom character
+  dots: "hello".pad_right(10, "."),
+  // String already long enough
+  no_pad: "hello world".pad_right(5),
+  // Empty string
+  empty: "".pad_right(5, "="),
+  // Single character
+  single: "y".pad_right(4, "-"),
+  // Padding with unicode character
+  unicode: "test".pad_right(8, "♦"),
+  // Zero length
+  zero_len: "world".pad_right(0),
+  // Negative length (should return empty)
+  neg_len: "world".pad_right(-3),
+  // Multi-character pad (should fail)
+  multi_pad: "test".pad_right(10, "xy"),
+  // Null handling
+  null_str: null.pad_right(5),
+  null_len: "test".pad_right(null),
+}

--- a/tenzir/tests/exec/functions/string/pad_right.txt
+++ b/tenzir/tests/exec/functions/string/pad_right.txt
@@ -1,0 +1,33 @@
+{
+  basic: "hello     ",
+  dots: "hello.....",
+  no_pad: "hello world",
+  empty: "=====",
+  single: "y---",
+  unicode: "test♦♦♦♦",
+  zero_len: "",
+  neg_len: "",
+  multi_pad: null,
+  null_str: null,
+  null_len: null,
+}
+warning: `pad_right` expected single character for padding, but got `xy` with length 2
+  --> exec/functions/string/pad_right.tql:19:14
+   |
+19 |   multi_pad: "test".pad_right(10, "xy"),
+   |              ~~~~~~ 
+   |
+
+warning: `pad_right` expected (string, int), but got (null, int64)
+  --> exec/functions/string/pad_right.tql:21:13
+   |
+21 |   null_str: null.pad_right(5),
+   |             ~~~~ 
+   |
+
+warning: `pad_right` expected (string, int), but got (string, null)
+  --> exec/functions/string/pad_right.tql:22:13
+   |
+22 |   null_len: "test".pad_right(null),
+   |             ~~~~~~ 
+   |


### PR DESCRIPTION
## Summary
- Adds two new string functions: `pad_left` and `pad_right` for padding strings to a specified length
- Both functions support custom padding characters (default: space)
- Proper UTF-8 character counting support

## Changes
- Added `pad` class in `libtenzir/builtins/functions/string.cpp` implementing both padding functions
- Created documentation for both functions in `docs/functions/`
- Added comprehensive integration tests with edge cases

## Usage Examples
```tql
from {x: "hello".pad_left(10)}           // "     hello"
from {x: "42".pad_left(5, "0")}          // "00042"
from {x: "hello".pad_right(10, ".")}     // "hello....."
from {x: "test".pad_left(8, "★")}        // "★★★★test"
```

## Test Plan
- [x] Integration tests added for both functions
- [x] Tests cover edge cases: empty strings, zero/negative lengths, multi-character padding (error), null handling
- [x] UTF-8 character support tested with unicode padding characters
- [x] All tests passing

🤖 Generated with [Claude Code](https://claude.ai/code)