### PR TITLE
Make `ocsf::derive` also map enum lists

### DIFF
--- a/.agents/references/data-access.md
+++ b/.agents/references/data-access.md
@@ -26,7 +26,7 @@ for (auto row : values3(array)) {
 - `value_at()` — From `arrow_table_slice.hpp`, also legacy
 - `.values()` method — Use free function `values3()` instead
 
-## Working with Records and Lists
+## Working with records and lists
 
 Access nested data through `view3<record>` and `view3<list>`:
 
@@ -40,7 +40,15 @@ for (auto&& doc : docs.values3()) {
 }
 ```
 
-## Never Materialize
+## Prefer Arrow accessors over offset arithmetic
+
+When you inspect Arrow list layout, use Arrow's semantic accessors. For example,
+compare per-row list lengths with `arrow::ListArray::value_length(i)` instead
+of subtracting adjacent offsets yourself. If two arrays are columns from the same
+slice, their outer `length()` is an invariant; assert that invariant instead of
+turning it into fallback behavior.
+
+## Never materialize
 
 Do not convert Arrow data to `record` or `list` types. Keep data in columnar
 form and operate on it directly during iteration.

--- a/.agents/references/data-building.md
+++ b/.agents/references/data-building.md
@@ -41,7 +41,16 @@ auto nested = builder.record().field(*path).record();
 nested.field("value").data(int64_t{1});
 ```
 
-## Arrow Builder Patterns
+## Rebuilding Arrow lists
+
+When you rebuild a list array from values derived from `origin.values()`, use
+`dangerously_rejoin_list_series` and keep its precondition: the values must come
+from `origin.values()` without slicing. When you rebuild from the flattened
+values referenced by a sliced list array, first call `rebase_list_array_buffers`
+and then pass the returned buffers to `make_list_series_with_offsets`. This
+makes the offset rebasing explicit at the call site.
+
+## Arrow builder patterns
 
 When building Arrow arrays directly, always use `check()`:
 

--- a/changelog/unreleased/ocsf-enum-list-derivation.md
+++ b/changelog/unreleased/ocsf-enum-list-derivation.md
@@ -1,0 +1,11 @@
+---
+title: OCSF enum list derivation
+type: feature
+authors:
+  - mavam
+  - codex
+pr: 5354
+created: 2026-04-30T16:47:58.705871Z
+---
+
+`ocsf::derive` now derives OCSF enum sibling fields for lists, not just scalar enum fields. For example, DNS answers with `flag_ids: [1, 3, 4]` now also get `flags: ["Authoritative Answer", "Recursion Desired", "Recursion Available"]`, and the reverse direction works for `flags` to `flag_ids` as well.

--- a/changelog/unreleased/ocsf-enum-list-derivation.md
+++ b/changelog/unreleased/ocsf-enum-list-derivation.md
@@ -2,6 +2,7 @@
 title: OCSF enum list derivation
 type: feature
 authors:
+  - jachris
   - mavam
   - codex
 pr: 5354

--- a/libtenzir/builtins/operators/ocsf.cpp
+++ b/libtenzir/builtins/operators/ocsf.cpp
@@ -285,7 +285,7 @@ private:
     -> basic_series<list_type> {
     auto values = cast(series{input.type.value_type(), input.array->values()},
                        ty.value_type(), path.list());
-    return make_list_series(values, *input.array);
+    return dangerously_rejoin_list_series(values, *input.array);
   }
 
   auto is_profile_enabled(const type& ty) -> bool {
@@ -589,7 +589,7 @@ private:
     -> basic_series<list_type> {
     auto values = trim(series{input.type.value_type(), input.array->values()},
                        ty.value_type());
-    return make_list_series(values, *input.array);
+    return dangerously_rejoin_list_series(values, *input.array);
   }
 
   auto trim(series input, const type& ty) -> series {
@@ -862,8 +862,8 @@ auto process_cast_slice(const table_slice& slice, location self,
         .emit(dh);
       return make_string_list_function(nullptr);
     }
-    auto name_lists
-      = make_list_series(series{string_type{}, name_array}, *extensions_lists);
+    auto name_lists = dangerously_rejoin_list_series(
+      series{string_type{}, name_array}, *extensions_lists);
     return make_string_list_function(std::move(name_lists.array));
   });
   // Figure out longest slices that share:
@@ -999,7 +999,8 @@ private:
   auto derive(basic_series<list_type> input, const list_type& ty,
               value_path path) -> basic_series<list_type> {
     auto values = derive(input.list_values(), ty.value_type(), path.list());
-    return make_list_series(values, *input.array);
+    return make_list_series_with_offsets(
+      values, rebase_list_array_buffers(*input.array));
   }
 
   auto derive(series input, const type& ty, value_path path) -> series {
@@ -1218,19 +1219,17 @@ private:
 
   auto same_list_layout(const arrow::ListArray& lhs,
                         const arrow::ListArray& rhs) -> bool {
-    if (lhs.length() != rhs.length() or lhs.null_count() != rhs.null_count()) {
+    TENZIR_ASSERT_EQ(lhs.length(), rhs.length());
+    if (lhs.null_count() != rhs.null_count()) {
       return false;
     }
-    const auto lhs_base = lhs.value_offset(0);
-    const auto rhs_base = rhs.value_offset(0);
     for (auto i = int64_t{0}; i < lhs.length(); ++i) {
-      if (lhs.value_offset(i) - lhs_base != rhs.value_offset(i) - rhs_base
+      if (lhs.value_length(i) != rhs.value_length(i)
           or lhs.IsValid(i) != rhs.IsValid(i)) {
         return false;
       }
     }
-    return lhs.value_offset(lhs.length()) - lhs_base
-           == rhs.value_offset(rhs.length()) - rhs_base;
+    return true;
   }
 
   auto string_list_from_int_list(const series& int_field,
@@ -1259,7 +1258,8 @@ private:
                                            int_field.length());
     }
     auto string_values = string_from_int(int_values, enum_id, int_path.list());
-    return make_list_series(string_values, *int_list->array);
+    return make_list_series_with_offsets(
+      string_values, rebase_list_array_buffers(*int_list->array));
   }
 
   auto
@@ -1292,7 +1292,8 @@ private:
     }
     auto int_values
       = int_from_string(string_values, enum_id, string_path.list());
-    return make_list_series(int_values, *string_list->array);
+    return make_list_series_with_offsets(
+      int_values, rebase_list_array_buffers(*string_list->array));
   }
 
   auto
@@ -1344,8 +1345,10 @@ private:
           = derive_bidirectionally(*int_values, *string_values, enum_id,
                                    int_path.list(), string_path.list());
         return {
-          make_list_series(derived_ints, *int_list->array),
-          make_list_series(derived_strings, *string_list->array),
+          make_list_series_with_offsets(
+            derived_ints, rebase_list_array_buffers(*int_list->array)),
+          make_list_series_with_offsets(
+            derived_strings, rebase_list_array_buffers(*string_list->array)),
         };
       }
       diagnostic::warning("field `{}` must be `int`, but got `{}`", int_path,

--- a/libtenzir/builtins/operators/ocsf.cpp
+++ b/libtenzir/builtins/operators/ocsf.cpp
@@ -998,8 +998,7 @@ private:
 
   auto derive(basic_series<list_type> input, const list_type& ty,
               value_path path) -> basic_series<list_type> {
-    auto values = derive(series{input.type.value_type(), input.array->values()},
-                         ty.value_type(), path.list());
+    auto values = derive(input.list_values(), ty.value_type(), path.list());
     return make_list_series(values, *input.array);
   }
 
@@ -1050,8 +1049,8 @@ private:
       = boost::unordered_flat_map<std::string_view, series>{};
     for (auto&& [name, field_ty] : ty.fields()) {
       auto enum_attr = field_ty.attribute("enum");
-      if (not enum_attr or is<list_type>(field_ty)) {
-        continue; // Skip non-enums and enum lists.
+      if (not enum_attr) {
+        continue; // Skip non-enums.
       }
       auto sibling_attr = field_ty.attribute("sibling");
       if (not sibling_attr) {
@@ -1074,11 +1073,11 @@ private:
       } else if (int_it != input_lookup.end()) {
         // Only enum exists - derive sibling.
         derived_siblings[string_name]
-          = string_from_int(int_it->second, *enum_attr, int_path);
+          = derive_string_from_int(int_it->second, *enum_attr, int_path);
       } else if (string_it != input_lookup.end()) {
         // Only sibling exists - derive enum.
         derived_enums[int_name]
-          = int_from_string(string_it->second, *enum_attr, string_path);
+          = derive_int_from_string(string_it->second, *enum_attr, string_path);
       }
     }
     // Phase 2: Emit fields in original input order.
@@ -1098,8 +1097,8 @@ private:
       }
       const auto& field_ty = schema_it->second;
       auto enum_attr = field_ty.attribute("enum");
-      if (enum_attr and not is<list_type>(field_ty)) {
-        // This is an enum field (non-list).
+      if (enum_attr) {
+        // This is an enum field.
         auto sibling_attr = field_ty.attribute("sibling");
         if (not sibling_attr) {
           // Treat as regular field if schema invariant is violated.
@@ -1200,6 +1199,100 @@ private:
     return make_record_series(fields, *input.array);
   }
 
+  auto derive_string_from_int(const series& int_field, std::string_view enum_id,
+                              value_path int_path) -> series {
+    if (int_field.as<list_type>()) {
+      return string_list_from_int_list(int_field, enum_id, int_path);
+    }
+    return string_from_int(int_field, enum_id, int_path);
+  }
+
+  auto derive_int_from_string(const series& string_field,
+                              std::string_view enum_id, value_path string_path)
+    -> series {
+    if (string_field.as<list_type>()) {
+      return int_list_from_string_list(string_field, enum_id, string_path);
+    }
+    return int_from_string(string_field, enum_id, string_path);
+  }
+
+  auto same_list_offsets(const arrow::ListArray& lhs,
+                         const arrow::ListArray& rhs) -> bool {
+    if (lhs.length() != rhs.length()) {
+      return false;
+    }
+    const auto lhs_base = lhs.value_offset(0);
+    const auto rhs_base = rhs.value_offset(0);
+    for (auto i = int64_t{0}; i <= lhs.length(); ++i) {
+      if (lhs.value_offset(i) - lhs_base != rhs.value_offset(i) - rhs_base) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  auto string_list_from_int_list(const series& int_field,
+                                 std::string_view enum_id, value_path int_path)
+    -> basic_series<list_type> {
+    if (int_field.as<null_type>()) {
+      return basic_series<list_type>::null(list_type{string_type{}},
+                                           int_field.length());
+    }
+    auto int_list = int_field.as<list_type>();
+    if (not int_list) {
+      diagnostic::warning("expected field `{}` to be `list<int>`, but got `{}`",
+                          int_path, int_field.type.kind())
+        .primary(self_)
+        .emit(dh_);
+      return basic_series<list_type>::null(list_type{string_type{}},
+                                           int_field.length());
+    }
+    auto int_values = int_list->list_values();
+    if (not int_values.as<int64_type>()) {
+      diagnostic::warning("expected field `{}` to be `list<int>`, but got `{}`",
+                          int_path, int_field.type.kind())
+        .primary(self_)
+        .emit(dh_);
+      return basic_series<list_type>::null(list_type{string_type{}},
+                                           int_field.length());
+    }
+    auto string_values = string_from_int(int_values, enum_id, int_path.list());
+    return make_list_series(string_values, *int_list->array);
+  }
+
+  auto
+  int_list_from_string_list(const series& string_field,
+                            std::string_view enum_id, value_path string_path)
+    -> basic_series<list_type> {
+    if (string_field.as<null_type>()) {
+      return basic_series<list_type>::null(list_type{int64_type{}},
+                                           string_field.length());
+    }
+    auto string_list = string_field.as<list_type>();
+    if (not string_list) {
+      diagnostic::warning("expected field `{}` to be `list<string>`, but got "
+                          "`{}`",
+                          string_path, string_field.type.kind())
+        .primary(self_)
+        .emit(dh_);
+      return basic_series<list_type>::null(list_type{int64_type{}},
+                                           string_field.length());
+    }
+    auto string_values = string_list->list_values();
+    if (not string_values.as<string_type>()) {
+      diagnostic::warning("expected field `{}` to be `list<string>`, but got "
+                          "`{}`",
+                          string_path, string_field.type.kind())
+        .primary(self_)
+        .emit(dh_);
+      return basic_series<list_type>::null(list_type{int64_type{}},
+                                           string_field.length());
+    }
+    auto int_values
+      = int_from_string(string_values, enum_id, string_path.list());
+    return make_list_series(int_values, *string_list->array);
+  }
+
   auto
   derive_bidirectionally(const series& int_field, const series& string_field,
                          std::string_view enum_id, value_path int_path,
@@ -1208,8 +1301,49 @@ private:
     if (not int_array) {
       if (int_field.as<null_type>()) {
         return {
-          int_from_string(string_field, enum_id, string_path),
+          derive_int_from_string(string_field, enum_id, string_path),
           string_field,
+        };
+      }
+      if (auto int_list = int_field.as<list_type>()) {
+        auto string_list = string_field.as<list_type>();
+        if (not string_list) {
+          if (string_field.as<null_type>()) {
+            return {
+              int_field,
+              derive_string_from_int(int_field, enum_id, int_path),
+            };
+          }
+          diagnostic::warning("field `{}` must be `list<string>`, but got `{}`",
+                              string_path, string_field.type.kind())
+            .primary(self_)
+            .emit(dh_);
+          return {int_field, string_field};
+        }
+        auto int_values = int_list->list_values().as<int64_type>();
+        auto string_values = string_list->list_values().as<string_type>();
+        if (not int_values or not string_values) {
+          diagnostic::warning("fields `{}` and `{}` must be `list<int>` and "
+                              "`list<string>`",
+                              int_path, string_path)
+            .primary(self_)
+            .emit(dh_);
+          return {int_field, string_field};
+        }
+        if (not same_list_offsets(*int_list->array, *string_list->array)) {
+          diagnostic::warning("found inconsistent list lengths between `{}` "
+                              "and `{}`",
+                              int_path, string_path)
+            .primary(self_)
+            .emit(dh_);
+          return {int_field, string_field};
+        }
+        auto [derived_ints, derived_strings]
+          = derive_bidirectionally(*int_values, *string_values, enum_id,
+                                   int_path.list(), string_path.list());
+        return {
+          make_list_series(derived_ints, *int_list->array),
+          make_list_series(derived_strings, *string_list->array),
         };
       }
       diagnostic::warning("field `{}` must be `int`, but got `{}`", int_path,
@@ -1223,11 +1357,11 @@ private:
       if (string_field.as<null_type>()) {
         return {
           int_field,
-          string_from_int(int_field, enum_id, int_path),
+          derive_string_from_int(int_field, enum_id, int_path),
         };
       }
-      diagnostic::warning("field `{}` must be `int`, but got `{}`", int_path,
-                          int_field.type.kind())
+      diagnostic::warning("field `{}` must be `string`, but got `{}`",
+                          string_path, string_field.type.kind())
         .primary(self_)
         .emit(dh_);
       return {int_field, string_field};

--- a/libtenzir/builtins/operators/ocsf.cpp
+++ b/libtenzir/builtins/operators/ocsf.cpp
@@ -1216,19 +1216,21 @@ private:
     return int_from_string(string_field, enum_id, string_path);
   }
 
-  auto same_list_offsets(const arrow::ListArray& lhs,
-                         const arrow::ListArray& rhs) -> bool {
-    if (lhs.length() != rhs.length()) {
+  auto same_list_layout(const arrow::ListArray& lhs,
+                        const arrow::ListArray& rhs) -> bool {
+    if (lhs.length() != rhs.length() or lhs.null_count() != rhs.null_count()) {
       return false;
     }
     const auto lhs_base = lhs.value_offset(0);
     const auto rhs_base = rhs.value_offset(0);
-    for (auto i = int64_t{0}; i <= lhs.length(); ++i) {
-      if (lhs.value_offset(i) - lhs_base != rhs.value_offset(i) - rhs_base) {
+    for (auto i = int64_t{0}; i < lhs.length(); ++i) {
+      if (lhs.value_offset(i) - lhs_base != rhs.value_offset(i) - rhs_base
+          or lhs.IsValid(i) != rhs.IsValid(i)) {
         return false;
       }
     }
-    return true;
+    return lhs.value_offset(lhs.length()) - lhs_base
+           == rhs.value_offset(rhs.length()) - rhs_base;
   }
 
   auto string_list_from_int_list(const series& int_field,
@@ -1330,8 +1332,8 @@ private:
             .emit(dh_);
           return {int_field, string_field};
         }
-        if (not same_list_offsets(*int_list->array, *string_list->array)) {
-          diagnostic::warning("found inconsistent list lengths between `{}` "
+        if (not same_list_layout(*int_list->array, *string_list->array)) {
+          diagnostic::warning("found inconsistent list layout between `{}` "
                               "and `{}`",
                               int_path, string_path)
             .primary(self_)

--- a/libtenzir/builtins/operators/where_map.cpp
+++ b/libtenzir/builtins/operators/where_map.cpp
@@ -547,15 +547,8 @@ auto make_map_function(function_invocation inv, session ctx)
       const auto n_parts = ms.parts().size();
       if (n_parts == 1) {
         auto& values = ms.parts().front();
-        auto [offsets, null_bitmap]
-          = rebase_list_array_buffers(*field_list->array);
-        return series{
-          list_type{values.type},
-          std::make_shared<arrow::ListArray>(
-            list_type{values.type}.to_arrow_type(), field_list->array->length(),
-            std::move(offsets), values.array, std::move(null_bitmap),
-            field_list->array->null_count()),
-        };
+        return make_list_series_with_offsets(
+          values, rebase_list_array_buffers(*field_list->array));
       }
       // If there is more than one part, we need to rebuild batches by merging
       // the parts that should be part of the same event/list and splitting

--- a/libtenzir/include/tenzir/replace_columns.hpp
+++ b/libtenzir/include/tenzir/replace_columns.hpp
@@ -119,7 +119,7 @@ struct replace_visitor {
     if (not nested_replacement) {
       return std::nullopt;
     }
-    return make_list_series(*nested_replacement, *l.array);
+    return dangerously_rejoin_list_series(*nested_replacement, *l.array);
   }
 
   auto operator()(const basic_series<record_type>& r) -> std::optional<series> {

--- a/libtenzir/include/tenzir/series.hpp
+++ b/libtenzir/include/tenzir/series.hpp
@@ -265,18 +265,28 @@ auto make_record_series(std::span<const series_field> fields,
 
 /// Returns a list series with the given inner values, and the list structure
 /// derived from an existing `arrow::ListArray`.
-/// The values may either be derived from `origin.values()` or from the
-/// flattened values referenced by `origin`.
-auto make_list_series(const series& values, const arrow::ListArray& origin)
+/// BE CAREFUL WHEN USING THIS FUNCTION.
+/// `values` must be directly derived from `origin.values()` with no slicing.
+/// Otherwise this breaks for a sliced `origin`.
+auto dangerously_rejoin_list_series(const series& values,
+                                    const arrow::ListArray& origin)
   -> basic_series<list_type>;
 
 /// Buffers needed to construct a zero-based `arrow::ListArray` from a
-/// (possibly sliced) source `arrow::ListArray`.  Pass these with `offset=0`
-/// to the `ListArray` constructor together with the new values array.
+/// (possibly sliced) source `arrow::ListArray`.
 struct rebased_list_buffers {
   std::shared_ptr<arrow::Buffer> offsets;     // length+1 Int32 entries, [0]==0
   std::shared_ptr<arrow::Buffer> null_bitmap; // nullptr if source has no nulls
+  int64_t length = 0;
+  int64_t null_count = 0;
+  int64_t value_length = 0;
 };
+
+/// Returns a list series with the given inner values and a zero-based list
+/// structure, typically returned from `rebase_list_array_buffers`.
+auto make_list_series_with_offsets(const series& values,
+                                   rebased_list_buffers buffers)
+  -> basic_series<list_type>;
 
 /// Produces zero-based offset and null-bitmap buffers for `list`, suitable for
 /// constructing a new `arrow::ListArray` whose values array starts at index 0.

--- a/libtenzir/include/tenzir/series.hpp
+++ b/libtenzir/include/tenzir/series.hpp
@@ -107,6 +107,10 @@ struct basic_series {
     }
   }
 
+  /// Returns the flattened values referenced by this list series.
+  auto list_values() const -> series
+    requires(std::same_as<Type, list_type>);
+
   auto field(std::string_view name) const -> std::optional<series>
     requires(std::same_as<Type, record_type>);
 
@@ -261,9 +265,8 @@ auto make_record_series(std::span<const series_field> fields,
 
 /// Returns a list series with the given inner values, and the list structure
 /// derived from an existing `arrow::ListArray`.
-/// BE CAREFUL WHEN USING THIS FUNCTION.
-/// `values` must be directly derived from `origin.values()` with no slicing.
-/// Otherwise this breaks for a sliced `origin`
+/// The values may either be derived from `origin.values()` or from the
+/// flattened values referenced by `origin`.
 auto make_list_series(const series& values, const arrow::ListArray& origin)
   -> basic_series<list_type>;
 

--- a/libtenzir/src/series.cpp
+++ b/libtenzir/src/series.cpp
@@ -27,6 +27,16 @@ auto flatten(series s, std::string_view flatten_separator)
 }
 
 template <class Type>
+auto basic_series<Type>::list_values() const -> series
+  requires(std::same_as<Type, list_type>)
+{
+  const auto begin = array->value_offset(0);
+  const auto end = array->value_offset(array->length());
+  return {type.value_type(),
+          check(array->values()->SliceSafe(begin, end - begin))};
+}
+
+template <class Type>
 auto basic_series<Type>::field(std::string_view name) const
   -> std::optional<series>
   requires(std::same_as<Type, record_type>)
@@ -46,6 +56,7 @@ auto basic_series<Type>::fields() const -> generator<series_field>
 }
 
 template struct basic_series<record_type>;
+template struct basic_series<list_type>;
 
 auto make_record_series(std::span<const series_field> fields,
                         const arrow::StructArray& origin)
@@ -76,8 +87,20 @@ auto make_record_series(std::span<const series_field> fields,
 
 auto make_list_series(const series& values, const arrow::ListArray& origin)
   -> basic_series<list_type> {
-  /// If this triggers, most likely your `values` were not directly generated
-  /// from `origin.values()`.
+  const auto begin = origin.value_offset(0);
+  const auto end = origin.value_offset(origin.length());
+  if (values.array->length() == end - begin) {
+    auto [offsets, null_bitmap] = rebase_list_array_buffers(origin);
+    return {
+      list_type{values.type},
+      std::make_shared<arrow::ListArray>(
+        arrow::list(values.type.to_arrow_type()), origin.length(),
+        std::move(offsets), values.array, std::move(null_bitmap),
+        origin.null_count(), 0),
+    };
+  }
+  // If this triggers, most likely your `values` were not directly generated
+  // from `origin.values()`.
   TENZIR_ASSERT_GEQ(values.array->length(), origin.values()->length());
   return {
     list_type{values.type},

--- a/libtenzir/src/series.cpp
+++ b/libtenzir/src/series.cpp
@@ -85,22 +85,11 @@ auto make_record_series(std::span<const series_field> fields,
   };
 }
 
-auto make_list_series(const series& values, const arrow::ListArray& origin)
+auto dangerously_rejoin_list_series(const series& values,
+                                    const arrow::ListArray& origin)
   -> basic_series<list_type> {
-  const auto begin = origin.value_offset(0);
-  const auto end = origin.value_offset(origin.length());
-  if (values.array->length() == end - begin) {
-    auto [offsets, null_bitmap] = rebase_list_array_buffers(origin);
-    return {
-      list_type{values.type},
-      std::make_shared<arrow::ListArray>(
-        arrow::list(values.type.to_arrow_type()), origin.length(),
-        std::move(offsets), values.array, std::move(null_bitmap),
-        origin.null_count(), 0),
-    };
-  }
-  // If this triggers, most likely your `values` were not directly generated
-  // from `origin.values()`.
+  /// If this triggers, most likely your `values` were not directly generated
+  /// from `origin.values()`.
   TENZIR_ASSERT_GEQ(values.array->length(), origin.values()->length());
   return {
     list_type{values.type},
@@ -111,13 +100,29 @@ auto make_list_series(const series& values, const arrow::ListArray& origin)
   };
 }
 
+/// Returns a list series with the given inner values and a zero-based list
+/// structure, typically returned from `rebase_list_array_buffers`.
+auto make_list_series_with_offsets(const series& values,
+                                   rebased_list_buffers buffers)
+  -> basic_series<list_type> {
+  TENZIR_ASSERT_EQ(values.array->length(), buffers.value_length);
+  return {
+    list_type{values.type},
+    std::make_shared<arrow::ListArray>(
+      arrow::list(values.type.to_arrow_type()), buffers.length,
+      std::move(buffers.offsets), values.array, std::move(buffers.null_bitmap),
+      buffers.null_count, 0),
+  };
+}
+
 auto rebase_list_array_buffers(const arrow::ListArray& list)
   -> rebased_list_buffers {
   const auto n = list.length();
   const auto base = list.value_offset(0);
   // Fast path: buffer is already zero-based.
   if (base == 0 and list.offset() == 0) {
-    return {list.value_offsets(), list.null_bitmap()};
+    return {list.value_offsets(), list.null_bitmap(), n, list.null_count(),
+            list.value_offset(n)};
   }
   // General case: build normalized offsets and (optionally) null bitmap.
   auto offset_builder
@@ -139,7 +144,8 @@ auto rebase_list_array_buffers(const arrow::ListArray& list)
     }
   }
   offset_builder.UnsafeAppend(list.value_offset(n) - base);
-  return {check(offset_builder.Finish()), std::move(null_bitmap)};
+  return {check(offset_builder.Finish()), std::move(null_bitmap), n,
+          list.null_count(), list.value_offset(n) - base};
 }
 
 } // namespace tenzir

--- a/test/tests/operators/ocsf/derive/dns_activity_bidirectional_flag_lists.tql
+++ b/test/tests/operators/ocsf/derive/dns_activity_bidirectional_flag_lists.tql
@@ -1,0 +1,19 @@
+// Test ocsf::derive with DNS answer flag_ids and flags present.
+// This verifies element-wise derivation of null list elements in both directions.
+
+from {
+  metadata: {
+    version: "1.5.0",
+  },
+  class_uid: 4003,  // DNS Activity
+  activity_id: 2,   // Response
+  answers: [
+    {
+      rdata: "192.168.1.1",
+      flag_ids: [1, null, 4],
+      flags: [null, "Truncated Response", "Recursion Available"],
+      ttl: 300,
+    },
+  ],
+}
+ocsf::derive

--- a/test/tests/operators/ocsf/derive/dns_activity_bidirectional_flag_lists.txt
+++ b/test/tests/operators/ocsf/derive/dns_activity_bidirectional_flag_lists.txt
@@ -1,0 +1,25 @@
+{
+  metadata: {
+    version: "1.5.0",
+  },
+  class_name: "DNS Activity",
+  class_uid: 4003,
+  activity_id: 2,
+  activity_name: "Response",
+  answers: [
+    {
+      rdata: "192.168.1.1",
+      flag_ids: [
+        1,
+        2,
+        4,
+      ],
+      flags: [
+        "Authoritative Answer",
+        "Truncated Response",
+        "Recursion Available",
+      ],
+      ttl: 300,
+    },
+  ],
+}

--- a/test/tests/operators/ocsf/derive/dns_activity_bidirectional_null_empty_flag_lists.tql
+++ b/test/tests/operators/ocsf/derive/dns_activity_bidirectional_null_empty_flag_lists.tql
@@ -1,0 +1,32 @@
+// Test ocsf::derive with null-vs-empty DNS answer flag_ids/flags lists.
+// This verifies that bidirectional list derivation stays column-wise and treats
+// different outer list validity as an inconsistent layout.
+
+from {
+  metadata: {
+    version: "1.5.0",
+  },
+  class_uid: 4003,  // DNS Activity
+  activity_id: 2,   // Response
+  answers: [
+    {
+      rdata: "192.168.1.1",
+      flag_ids: null,
+      flags: [],
+      ttl: 300,
+    },
+    {
+      rdata: "192.168.1.2",
+      flag_ids: [],
+      flags: null,
+      ttl: 600,
+    },
+    {
+      rdata: "192.168.1.3",
+      flag_ids: [1],
+      flags: ["Authoritative Answer"],
+      ttl: 900,
+    },
+  ],
+}
+ocsf::derive

--- a/test/tests/operators/ocsf/derive/dns_activity_bidirectional_null_empty_flag_lists.txt
+++ b/test/tests/operators/ocsf/derive/dns_activity_bidirectional_null_empty_flag_lists.txt
@@ -9,20 +9,31 @@
   answers: [
     {
       rdata: "192.168.1.1",
+      flag_ids: null,
+      flags: [],
+      ttl: 300,
+    },
+    {
+      rdata: "192.168.1.2",
+      flag_ids: [],
+      flags: null,
+      ttl: 600,
+    },
+    {
+      rdata: "192.168.1.3",
       flag_ids: [
         1,
       ],
       flags: [
         "Authoritative Answer",
-        "Recursion Desired",
       ],
-      ttl: 300,
+      ttl: 900,
     },
   ],
 }
 warning: found inconsistent list layout between `answers[].flag_ids` and `answers[].flags`
-  --> tests/operators/ocsf/derive/dns_activity_mismatched_flag_lists.tql:19:1
+  --> tests/operators/ocsf/derive/dns_activity_bidirectional_null_empty_flag_lists.tql:32:1
    |
-19 | ocsf::derive
+32 | ocsf::derive
    | ~~~~~~~~~~~~ 
    |

--- a/test/tests/operators/ocsf/derive/dns_activity_flag_ids_after_subslice.tql
+++ b/test/tests/operators/ocsf/derive/dns_activity_flag_ids_after_subslice.tql
@@ -1,0 +1,25 @@
+// Test ocsf::derive with DNS answer flag_ids after a class/version split.
+// This verifies list enum derivation for sliced Arrow list arrays.
+
+from {
+  metadata: {
+    version: "1.6.0",
+  },
+  class_uid: 4003,  // DNS Activity
+  activity_id: 2,   // Response
+  answers: [],
+}, {
+  metadata: {
+    version: "1.5.0",
+  },
+  class_uid: 4003,  // DNS Activity
+  activity_id: 2,   // Response
+  answers: [
+    {
+      rdata: "192.168.1.1",
+      flag_ids: [1, 3, 4],
+      ttl: 300,
+    },
+  ],
+}
+ocsf::derive

--- a/test/tests/operators/ocsf/derive/dns_activity_flag_ids_after_subslice.txt
+++ b/test/tests/operators/ocsf/derive/dns_activity_flag_ids_after_subslice.txt
@@ -1,0 +1,35 @@
+{
+  metadata: {
+    version: "1.6.0",
+  },
+  class_name: "DNS Activity",
+  class_uid: 4003,
+  activity_id: 2,
+  activity_name: "Response",
+  answers: [],
+}
+{
+  metadata: {
+    version: "1.5.0",
+  },
+  class_name: "DNS Activity",
+  class_uid: 4003,
+  activity_id: 2,
+  activity_name: "Response",
+  answers: [
+    {
+      rdata: "192.168.1.1",
+      flag_ids: [
+        1,
+        3,
+        4,
+      ],
+      flags: [
+        "Authoritative Answer",
+        "Recursion Desired",
+        "Recursion Available",
+      ],
+      ttl: 300,
+    },
+  ],
+}

--- a/test/tests/operators/ocsf/derive/dns_activity_flags.tql
+++ b/test/tests/operators/ocsf/derive/dns_activity_flags.tql
@@ -1,0 +1,18 @@
+// Test ocsf::derive with dns_activity containing DNS answer flags.
+// This verifies reverse derivation from list<string> to list<int> enum fields.
+
+from {
+  metadata: {
+    version: "1.5.0",
+  },
+  class_uid: 4003,  // DNS Activity
+  activity_id: 2,   // Response
+  answers: [
+    {
+      rdata: "192.168.1.1",
+      flags: ["Authoritative Answer", "Recursion Desired", "Recursion Available"],
+      ttl: 300,
+    },
+  ],
+}
+ocsf::derive

--- a/test/tests/operators/ocsf/derive/dns_activity_flags.txt
+++ b/test/tests/operators/ocsf/derive/dns_activity_flags.txt
@@ -1,0 +1,25 @@
+{
+  metadata: {
+    version: "1.5.0",
+  },
+  class_name: "DNS Activity",
+  class_uid: 4003,
+  activity_id: 2,
+  activity_name: "Response",
+  answers: [
+    {
+      rdata: "192.168.1.1",
+      flag_ids: [
+        1,
+        3,
+        4,
+      ],
+      flags: [
+        "Authoritative Answer",
+        "Recursion Desired",
+        "Recursion Available",
+      ],
+      ttl: 300,
+    },
+  ],
+}

--- a/test/tests/operators/ocsf/derive/dns_activity_mismatched_flag_lists.tql
+++ b/test/tests/operators/ocsf/derive/dns_activity_mismatched_flag_lists.tql
@@ -1,0 +1,19 @@
+// Test ocsf::derive with DNS answer flag_ids and flags of different lengths.
+// This verifies that mismatched enum/sibling list pairs are diagnosed and left unchanged.
+
+from {
+  metadata: {
+    version: "1.5.0",
+  },
+  class_uid: 4003,  // DNS Activity
+  activity_id: 2,   // Response
+  answers: [
+    {
+      rdata: "192.168.1.1",
+      flag_ids: [1],
+      flags: ["Authoritative Answer", "Recursion Desired"],
+      ttl: 300,
+    },
+  ],
+}
+ocsf::derive

--- a/test/tests/operators/ocsf/derive/dns_activity_mismatched_flag_lists.txt
+++ b/test/tests/operators/ocsf/derive/dns_activity_mismatched_flag_lists.txt
@@ -1,0 +1,28 @@
+{
+  metadata: {
+    version: "1.5.0",
+  },
+  class_name: "DNS Activity",
+  class_uid: 4003,
+  activity_id: 2,
+  activity_name: "Response",
+  answers: [
+    {
+      rdata: "192.168.1.1",
+      flag_ids: [
+        1,
+      ],
+      flags: [
+        "Authoritative Answer",
+        "Recursion Desired",
+      ],
+      ttl: 300,
+    },
+  ],
+}
+warning: found inconsistent list lengths between `answers[].flag_ids` and `answers[].flags`
+  --> tests/operators/ocsf/derive/dns_activity_mismatched_flag_lists.tql:19:1
+   |
+19 | ocsf::derive
+   | ~~~~~~~~~~~~ 
+   |

--- a/test/tests/operators/ocsf/derive/dns_activity_multiple_flag_ids.tql
+++ b/test/tests/operators/ocsf/derive/dns_activity_multiple_flag_ids.tql
@@ -1,0 +1,23 @@
+// Test ocsf::derive with dns_activity containing multiple dns_answer.flag_ids
+// This test verifies that the derive operator can handle multiple flag_ids in dns_answer within dns_activity
+
+from {
+  metadata: {
+    version: "1.5.0",
+  },
+  class_uid: 4003,  // DNS Activity
+  activity_id: 2,   // Response
+  answers: [
+    {
+      rdata: "192.168.1.1",
+      flag_ids: [1, 3, 4],  // Authoritative Answer, Recursion Desired, Recursion Available
+      ttl: 300,
+    },
+    {
+      rdata: "192.168.1.2",
+      flag_ids: [2, 5],     // Truncated Response, Authentic Data
+      ttl: 600,
+    },
+  ],
+}
+ocsf::derive

--- a/test/tests/operators/ocsf/derive/dns_activity_multiple_flag_ids.txt
+++ b/test/tests/operators/ocsf/derive/dns_activity_multiple_flag_ids.txt
@@ -1,0 +1,37 @@
+{
+  metadata: {
+    version: "1.5.0",
+  },
+  class_name: "DNS Activity",
+  class_uid: 4003,
+  activity_id: 2,
+  activity_name: "Response",
+  answers: [
+    {
+      rdata: "192.168.1.1",
+      flag_ids: [
+        1,
+        3,
+        4,
+      ],
+      flags: [
+        "Authoritative Answer",
+        "Recursion Desired",
+        "Recursion Available",
+      ],
+      ttl: 300,
+    },
+    {
+      rdata: "192.168.1.2",
+      flag_ids: [
+        2,
+        5,
+      ],
+      flags: [
+        "Truncated Response",
+        "Authentic Data",
+      ],
+      ttl: 600,
+    },
+  ],
+}

--- a/test/tests/operators/ocsf/derive/dns_activity_outer_null_flag_ids.tql
+++ b/test/tests/operators/ocsf/derive/dns_activity_outer_null_flag_ids.tql
@@ -1,0 +1,23 @@
+// Test ocsf::derive with a null outer DNS answer flag_ids list.
+// This verifies that deriving list enum siblings preserves null list slots.
+
+from {
+  metadata: {
+    version: "1.5.0",
+  },
+  class_uid: 4003,  // DNS Activity
+  activity_id: 2,   // Response
+  answers: [
+    {
+      rdata: "192.168.1.1",
+      flag_ids: [1, 3],
+      ttl: 300,
+    },
+    {
+      rdata: "192.168.1.2",
+      flag_ids: null,
+      ttl: 600,
+    },
+  ],
+}
+ocsf::derive

--- a/test/tests/operators/ocsf/derive/dns_activity_outer_null_flag_ids.txt
+++ b/test/tests/operators/ocsf/derive/dns_activity_outer_null_flag_ids.txt
@@ -1,0 +1,29 @@
+{
+  metadata: {
+    version: "1.5.0",
+  },
+  class_name: "DNS Activity",
+  class_uid: 4003,
+  activity_id: 2,
+  activity_name: "Response",
+  answers: [
+    {
+      rdata: "192.168.1.1",
+      flag_ids: [
+        1,
+        3,
+      ],
+      flags: [
+        "Authoritative Answer",
+        "Recursion Desired",
+      ],
+      ttl: 300,
+    },
+    {
+      rdata: "192.168.1.2",
+      flag_ids: null,
+      flags: null,
+      ttl: 600,
+    },
+  ],
+}


### PR DESCRIPTION
## 🔍 Problem

`ocsf::derive` derives scalar OCSF enum sibling fields, but skipped enum fields wrapped in lists. This left nested list enums such as DNS answer `flag_ids`/`flags` only partially normalized.

## 🛠️ Solution

- Derive enum siblings for `list<int>` and `list<string>` fields in both directions.
- Preserve sliced list-array offsets when rebuilding derived list fields.
- Validate bidirectional list pairs element-wise when both enum and sibling lists are present.
- Add regression coverage for forward, reverse, bidirectional, multi-list, and sliced-list derivation.

## 💬 Review

Focus on the Arrow list offset handling in `series::list_values()` and `make_list_series()`, plus the mixed scalar/list dispatch in `ocsf::derive`.
