### PR TITLE
Fix incorrect name for `list_separator` option

### DIFF
--- a/changelog/changes/should-never-ticket.md
+++ b/changelog/changes/should-never-ticket.md
@@ -1,0 +1,12 @@
+---
+title: "Fixed `list_separator` option name in `print_csv`"
+type: bugfix
+authors: IyeOnline
+pr: 5357
+---
+
+The `print_csv`, `print_ssv` and `print_tsv` functions had an option incorrectly
+named `field_separator`. Instead, these functions have an option `list_separator`
+now, allowing you to change the list separator.
+You cannot set a custom `field_separator` on these functions. If you want to
+print with custom `field_separator`s, use `print_xsv` instead.

--- a/libtenzir/builtins/formats/xsv.cpp
+++ b/libtenzir/builtins/formats/xsv.cpp
@@ -53,7 +53,7 @@ struct xsv_printer_options {
     } else {
       /// Configured case
       TENZIR_ASSERT(not list_separator.inner.empty());
-      parser.named_optional("field_separator", list_separator);
+      parser.named_optional("list_separator", list_separator);
       parser.named_optional("null_value", null_value);
     }
     if (not no_header) {

--- a/tenzir/tests/exec/functions/print/print_csv.tql
+++ b/tenzir/tests/exec/functions/print/print_csv.tql
@@ -1,2 +1,4 @@
-from {str:"hello world", int: 42, duration:10s, time: 2025-02-17, nested:{ x: 0}}
-this = { result: this.print_csv()}
+from \
+  {str:"hello world", int: 42, duration:10s, time: 2025-02-17, nested:{ x: 0}},
+  { a:"hi", l:[1,2]}
+this = { result: this.print_csv(list_separator=";") }

--- a/tenzir/tests/exec/functions/print/print_csv.txt
+++ b/tenzir/tests/exec/functions/print/print_csv.txt
@@ -1,3 +1,6 @@
 {
   result: "hello world,42,10s,2025-02-17T00:00:00Z,0",
 }
+{
+  result: "hi,1;2",
+}


### PR DESCRIPTION
This fixes the incorrectly named `field_separator`
in the configured `print_*sv` functions.
If you want to `print_csv` with custom `field_sepator`s,
use `print_xsv` instead.
