### PR TITLE
Resolve ToC-ToU issue in `to_clickhouse`

### DIFF
--- a/changelog/changes/dealer-employ-period.md
+++ b/changelog/changes/dealer-employ-period.md
@@ -1,0 +1,9 @@
+---
+title: "Fixed issue with table creation in `to_clickhouse`"
+type: bugfix
+authors: IyeOnline
+pr: 5360
+---
+
+Multiple `to_clickhouse` operators can now attempt to create the same ClickHouse
+table at the same time without an error.

--- a/plugins/clickhouse/src/easy_client.cpp
+++ b/plugins/clickhouse/src/easy_client.cpp
@@ -129,7 +129,6 @@ auto easy_client::create_table(const tenzir::record_type& schema)
   -> failure_or<void> {
   TENZIR_ASSERT(args_.primary);
   auto columns = std::string{};
-  auto trafos = transformer_record::schema_transformations{};
   auto primary_found = false;
   auto path = path_type{};
   /// TODO: This should really be merged with the transformer itself. Its an
@@ -144,15 +143,8 @@ auto easy_client::create_table(const tenzir::record_type& schema)
     TRY(auto clickhouse_typename,
         type_to_clickhouse_typename(path, t, not is_primary, dh_));
     TENZIR_ASSERT(not clickhouse_typename.empty());
-    auto functions
-      = make_functions_from_clickhouse(path, clickhouse_typename, dh_);
     path.pop_back();
-    TENZIR_ASSERT(functions,
-                  "expected to get functions for top level columns {}", k);
     primary_found |= is_primary;
-    const auto [it, success]
-      = trafos.try_emplace(std::string{k}, std::move(functions));
-    TENZIR_ASSERT(success);
   }
   if (not primary_found) {
     diagnostic::error(
@@ -162,18 +154,21 @@ auto easy_client::create_table(const tenzir::record_type& schema)
       .emit(dh_);
     return failure::promise();
   }
-  transformations_ = transformer_record{"UNUSED", std::move(trafos)};
   constexpr static std::string_view engine = "MergeTree";
   TRY(auto clickhouse_columns,
       plain_clickhouse_tuple_elements(path, schema, dh_, args_.primary->inner));
-  auto query_text = fmt::format("CREATE TABLE {}"
-                                " {}"
-                                " ENGINE = {}"
-                                " ORDER BY {}",
-                                args_.table.inner, clickhouse_columns, engine,
-                                args_.primary->inner);
+  const auto creation_modifier
+    = args_.mode.inner == mode::create_append ? "IF NOT EXISTS" : "";
+  auto query_text
+    = fmt::format("CREATE TABLE {} {}"
+                  " {}"
+                  " ENGINE = {}"
+                  " ORDER BY {}",
+                  creation_modifier, args_.table.inner, clickhouse_columns,
+                  engine, args_.primary->inner);
   auto query = Query{query_text};
   client_.Execute(query);
+  TRY(get_schema_transformations());
   return {};
 }
 


### PR DESCRIPTION
This resolves the ToC-ToU issue in `to_clickhouse`.
The table creation is now guarded with `IF NOT EXISTS`. To ensure that
the arrow -> clickhouse-cpp transformations match the ClickHouse table,
they are now always parsed from the table definition instead of being
created alongside it.

- Fixed https://github.com/tenzir/issues/issues/3184
