### PR TITLE
Disable pipeline subprocesses by default

### DIFF
--- a/changelog/changes/center-carpet-useful.md
+++ b/changelog/changes/center-carpet-useful.md
@@ -5,9 +5,8 @@ authors: tobim
 pr: 5233
 ---
 
-Pipelines that are running in a node are now partially moved to a subprocess for
-improved error resilience and resource utilization. Operators that need to
-communicate with a component still run inside the main node process for
-architectural reasons. You can set `tenzir.disable-pipeline-subprocesses: true`
-in `tenzir.yaml` or `TENZIR_DISABLE_PIPELINE_SUBPROCESSES=true` on the command
-line to opt out. This feature is enabled by default on Linux.
+We added an experimental feature to run node-independent operators of a pipeline
+in dedicated subprocesses. This brings improved error resilience and resource
+utilization. You can opt-in to this feature with the setting
+`tenzir.disable-pipeline-subprocesses: false` in `tenzir.yaml`. We plan to
+enable this feature by default in the future.

--- a/libtenzir/include/tenzir/defaults.hpp
+++ b/libtenzir/include/tenzir/defaults.hpp
@@ -286,7 +286,7 @@ inline constexpr auto packaged_pipeline_restart_on_error
 /// Whether to disable pipeline subprocesses.
 inline constexpr bool disable_pipeline_subprocesses =
 #if TENZIR_LINUX
-  false;
+  true;
 #else
   true;
 #endif


### PR DESCRIPTION
We discovered issues with pipeline subprocesses with high-volume pipelines. This change disables the feature by default until the cause for this is found and resolved.