### PR TITLE
Optimize `export | where …` with `this["foo.bar"]` fields

### DIFF
--- a/changelog/changes/charge-father-comply.md
+++ b/changelog/changes/charge-father-comply.md
@@ -1,0 +1,10 @@
+---
+title: "Better query optimization"
+type: change
+authors: jachris
+pr: 5362
+---
+
+Previously, queries that used `export` followed by a `where` that used fields
+such as `this["field name"]` were not optimized. Now, the same optimizations
+apply as with normal fields, improving the performance of such queries.  


### PR DESCRIPTION
Previously, queries such as `export | where this["foo.bar"] == 42` were not optimized with the storage engine.