### PR TITLE
Docs Driveby

### DIFF
--- a/docs/functions/type_of.md
+++ b/docs/functions/type_of.md
@@ -14,7 +14,7 @@ type_of(x:any) -> record
 
 The `type_of` function returns the type definition of the given value `x`.
 
-:::warning Subject to change
+:::caution[Subject to change]
 This function is designed for internal use of the Tenzir Platform and its output
 format is subject to change without notice.
 :::

--- a/docs/operators/batch.md
+++ b/docs/operators/batch.md
@@ -15,7 +15,7 @@ batch [limit:int, timeout=duration]
 The `batch` operator takes its input and rewrites it into batches of up to the
 desired size.
 
-:::warning[Expert Operator]
+:::caution[Expert Operator]
 The `batch` operator is a lower-level building block that lets users explicitly
 control batching, which otherwise is controlled automatically by Tenzir's
 underlying pipeline execution engine. Use with caution!

--- a/docs/operators/compress.md
+++ b/docs/operators/compress.md
@@ -10,7 +10,7 @@ Compresses a stream of bytes.
 compress codec:string, [level=int]
 ```
 
-:::warning[Deprecated]
+:::caution[Deprecated]
 The `compress` operator is deprecated. You should use the
 [bespoke operators](/reference/operators#encode--decode) instead.
 These operators offer more options for some of the formats.

--- a/docs/operators/decompress.md
+++ b/docs/operators/decompress.md
@@ -10,7 +10,7 @@ Decompresses a stream of bytes.
 decompress codec:string
 ```
 
-:::warning[Deprecated]
+:::caution[Deprecated]
 The `decompress` operator is deprecated. You should use the
 [bespoke operators](/reference/operators#encode--decode) instead.
 :::

--- a/docs/operators/from_file.md
+++ b/docs/operators/from_file.md
@@ -4,7 +4,7 @@ category: Inputs/Events
 example: 'from_file "s3://data/**.json"'
 ---
 
-:::warning[Under Active Development]
+:::caution[Under Active Development]
 This operator is still under active development.
 :::
 

--- a/docs/operators/from_fluent_bit.mdx
+++ b/docs/operators/from_fluent_bit.mdx
@@ -33,7 +33,7 @@ translates to our `from_fluent_bit` operator as follows:
 from_fluent_bit "plugin", options={key1: value1, key2: value2, …}
 ```
 
-:::tip Output to Fluent Bit
+:::tip[Output to Fluent Bit]
 You can output events to Fluent Bit using the [`to_fluent_bit` operator](/reference/operators/to_fluent_bit).
 :::
 

--- a/docs/operators/legacy.md
+++ b/docs/operators/legacy.md
@@ -10,7 +10,7 @@ Provides a compatibility fallback to TQL1 pipelines.
 legacy definition:string
 ```
 
-:::warning[Migrate to TQL2]
+:::caution[Migrate to TQL2]
 The `legacy` operator is deprecated and will be removed in a future release.
 TQL1 features will be removed as-needed without further notice.
 :::

--- a/docs/operators/metrics.md
+++ b/docs/operators/metrics.md
@@ -66,7 +66,7 @@ The schema of the record `params` depends on the API endpoint used. Refer to the
 
 Contains metrics about the CAF (C++ Actor Framework) runtime system.
 
-:::warning[Aimed at Developers]
+:::caution[Aimed at Developers]
 CAF metrics primarily exist for debugging purposes. Actor names and other
 details contained in these metrics are documented only in source code, and we
 may change them without notice. Do not rely on specific actor names or metrics
@@ -253,7 +253,7 @@ Contains a measurement of the available memory on the host.
 Contains input and output measurements over some amount of time for a single
 operator instantiation.
 
-:::warning[Deprecation Notice]
+:::caution[Deprecation Notice]
 Operator metrics are deprecated and will be removed in a future release. Use
 [pipeline metrics](#tenzirmetricspipeline) instead. While they offered great
 insight into the performance of operators, they were not as useful as pipeline

--- a/docs/operators/pipeline/detach.md
+++ b/docs/operators/pipeline/detach.md
@@ -15,7 +15,7 @@ pipeline::detach { … }, [id=string]
 The `pipeline::detach` operator starts a hidden managed pipeline in the node,
 and returns as soon as the pipeline has started.
 
-:::warning[Subject to Change]
+:::caution[Subject to Change]
 This operator primarily exists for testing purposes, where it is often required
 to run pipelines in the background, but to be able to wait until the pipeline
 has started. The operator may change without further notice.

--- a/docs/operators/pipeline/run.md
+++ b/docs/operators/pipeline/run.md
@@ -17,7 +17,7 @@ returns when the pipeline has finished.
 
 Note that pipelines may emit diagnostics after they have finished.
 
-:::warning[Subject to Change]
+:::caution[Subject to Change]
 This operator primarily exists for testing purposes, where it is often required
 to run pipelines with an explicitly specified pipeline id.
 :::

--- a/docs/operators/read_lines.md
+++ b/docs/operators/read_lines.md
@@ -31,7 +31,7 @@ Use null byte (`\0`) as the delimiter instead of newline characters.
 
 ### `split_at_regex = string (optional)`
 
-:::warning Deprecated
+:::caution[Deprecated]
 This option is deprecated. Use
 [`read_delimited_regex`](/reference/operators/read_delimited_regex) instead.
 :::

--- a/docs/operators/read_parquet.md
+++ b/docs/operators/read_parquet.md
@@ -25,7 +25,7 @@ recommend passing the `mmap=true` option to `load_file` to give the parser full 
 over the reads, which leads to better performance and memory usage.
 :::
 
-:::warning[Limitation]
+:::caution[Limitation]
 Tenzir currently assumes that all Parquet files use metadata recognized by
 Tenzir. We plan to lift this restriction in the future.
 :::

--- a/docs/operators/to_fluent_bit.mdx
+++ b/docs/operators/to_fluent_bit.mdx
@@ -32,7 +32,7 @@ translates to our `to_fluent_bit` operator as follows:
 to_fluent_bit "plugin", options={key1: value1, key2:value2, …}
 ```
 
-:::tip Read from Fluent Bit
+:::tip[Read from Fluent Bit]
 You can acquire events from Fluent Bit using the [`from_fluent_bit` operator](/reference/operators/from_fluent_bit).
 :::
 


### PR DESCRIPTION
Some of our Admonitions were not correctly ported to Asides:
* `warning` does not exist
* `[title]`s must be in brackets

This is a docs rendering change only and does not need a changelog entry.
