### PR TITLE
Support custom source versions for `to_amazon_security_lake`

### DIFF
--- a/changelog/changes/delete-topic-state.md
+++ b/changelog/changes/delete-topic-state.md
@@ -1,0 +1,9 @@
+---
+title: "Fixed `to_amazon_security_lake` partitioning"
+type: bugfix
+authors: IyeOnline
+pr: 5369
+---
+
+The `to_amazon_security_lake` incorrectly partitioned as `…/accountID=…`. It now
+uses the correct `…/accountId=…`.

--- a/changelog/changes/plant-ending-center.md
+++ b/changelog/changes/plant-ending-center.md
@@ -1,0 +1,14 @@
+---
+title: "Versioned sources in `to_amazon_security_lake` operator"
+type: feature
+authors: IyeOnline
+pr: 5369
+---
+
+The `to_amazon_security_lake` operator now supports versioned custom sources,
+such as
+
+```tql
+let $lake_url = "s3://aws-security-data-lake-eu-west-2-lake-abcdefghijklmnopqrstuvwxyz1234/ext/tnz-ocsf-dns/1.0/"
+to_amazon_security_lake $lake_url, …
+```


### PR DESCRIPTION
We now support trailing slashes and custom source versions in the S3 URL for `to_amazon_security_lake`

See https://github.com/tenzir/tenzir-plugins/pull/426