### PR TITLE
Keep alive connection in `to_clickhouse`

### DIFF
--- a/plugins/clickhouse/builtins/to_clickhouse.cpp
+++ b/plugins/clickhouse/builtins/to_clickhouse.cpp
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "clickhouse/easy_client.hpp"
+#include "tenzir/detail/weak_run_delayed.hpp"
 #include "tenzir/tql2/plugin.hpp"
 
 using namespace clickhouse;
@@ -72,6 +73,12 @@ public:
     if (not client) {
       co_return;
     }
+    detail::weak_run_delayed_loop(
+      &ctrl.self(), std::chrono::minutes{10},
+      [&client]() {
+        client->ping();
+      },
+      false);
     for (auto&& slice : input) {
       if (slice.rows() == 0) {
         co_yield {};

--- a/plugins/clickhouse/include/clickhouse/easy_client.hpp
+++ b/plugins/clickhouse/include/clickhouse/easy_client.hpp
@@ -83,6 +83,8 @@ public:
   static auto make(arguments args, diagnostic_handler& dh)
     -> std::unique_ptr<easy_client>;
 
+  void ping();
+
   auto insert(const table_slice& slice) -> bool;
 
 private:

--- a/plugins/clickhouse/src/easy_client.cpp
+++ b/plugins/clickhouse/src/easy_client.cpp
@@ -252,4 +252,8 @@ auto easy_client::insert(const table_slice& slice) -> bool {
   }
   return true;
 }
+
+void easy_client::ping() {
+  client_.Ping();
+}
 } // namespace tenzir::plugins::clickhouse


### PR DESCRIPTION
This keeps the connection to the ClickHouse server alive by pinning it
on a schedule.

- Fixes https://github.com/tenzir/issues/issues/3193
