### PR TITLE
Add `from_udp` operator

### DIFF
--- a/changelog/changes/court-stands-bought.md
+++ b/changelog/changes/court-stands-bought.md
@@ -20,11 +20,10 @@ from_udp "0.0.0.0:1234"
 
 ```tql
 {
-  data: b"Hello, UDP!\n",
+  data: "Hello, UDP!\n",
   peer: {
     ip: 192.168.1.100,
     port: 54321,
-    hostname: null,
   },
 }
 ```
@@ -37,7 +36,7 @@ from_udp "0.0.0.0:1234", resolve_hostnames=true
 
 ```tql
 {
-  data: b"Hello, UDP!\n",
+  data: "Hello, UDP!\n",
   peer: {
     ip: 192.168.1.100,
     port: 54321,

--- a/changelog/changes/court-stands-bought.md
+++ b/changelog/changes/court-stands-bought.md
@@ -45,11 +45,3 @@ from_udp "0.0.0.0:1234", resolve_hostnames=true
   },
 }
 ```
-
-Filter UDP data by sender and parse as Syslog afterwards:
-
-```tql
-from_udp "0.0.0.0:514"
-where peer.ip in [192.168.1.0/24]
-syslog = data.parse_syslog()
-```

--- a/changelog/changes/court-stands-bought.md
+++ b/changelog/changes/court-stands-bought.md
@@ -1,0 +1,55 @@
+---
+title: "Receive UDP datagrams as events"
+type: feature
+authors: mavam
+pr: 5375
+---
+
+The new `from_udp` operator receives UDP datagrams and outputs structured events
+containing both the data and peer information.
+
+Unlike `load_udp` which outputs raw bytes, `from_udp` produces events with
+metadata about the sender, making it ideal for security monitoring and network
+analysis where knowing the source of each datagram is important.
+
+Each received datagram becomes an event with this structure:
+
+```tql
+from_udp "0.0.0.0:1234"
+```
+
+```tql
+{
+  data: b"Hello, UDP!\n",
+  peer: {
+    ip: 192.168.1.100,
+    port: 54321,
+    hostname: null,
+  },
+}
+```
+
+Enable hostname resolution for DNS lookups (disabled by default for performance):
+
+```tql
+from_udp "0.0.0.0:1234", resolve_hostnames=true
+```
+
+```tql
+{
+  data: b"Hello, UDP!\n",
+  peer: {
+    ip: 192.168.1.100,
+    port: 54321,
+    hostname: "client.example.com",
+  },
+}
+```
+
+Filter UDP data by sender and parse as Syslog afterwards:
+
+```tql
+from_udp "0.0.0.0:514"
+where peer.ip in [192.168.1.0/24]
+syslog = data.parse_syslog()
+```

--- a/docs/operators/from_udp.md
+++ b/docs/operators/from_udp.md
@@ -18,7 +18,7 @@ a structured event containing the data and peer information.
 Unlike [`load_udp`](/reference/operators/load_udp), which outputs raw bytes,
 `from_udp` produces structured events with metadata about the sender.
 
-### `endpoint: str`
+### `endpoint: string`
 
 The address to listen on. Must be of the format: `[udp://]host:port`.
 

--- a/docs/operators/from_udp.md
+++ b/docs/operators/from_udp.md
@@ -7,7 +7,7 @@ example: 'from_udp "0.0.0.0:8090"'
 Receives UDP datagrams and outputs structured events.
 
 ```tql
-from_udp endpoint:str, [resolve_hostnames=bool]
+from_udp endpoint:str, [resolve_hostnames=bool], [binary=bool]
 ```
 
 ## Description
@@ -32,13 +32,20 @@ Perform DNS lookups to resolve hostnames for sender IP addresses.
 Defaults to `false` since DNS lookups can be slow and may impact performance
 when receiving many datagrams.
 
+### `binary = bool (optional)`
+
+Output datagram data as binary (`blob`) instead of text (`string`).
+
+Defaults to `false`. When `false`, the data field contains a UTF-8 string.
+When `true`, the data field contains raw bytes as a blob.
+
 ## Output Schema
 
 Each UDP datagram produces one event with the following structure:
 
 ```json
 {
-  "data": <bytes>,
+  "data": <string|blob>, // string by default, blob when binary=true
   "peer": {
     "ip": <ip>,
     "port": <uint64>,
@@ -59,7 +66,7 @@ This might output events like:
 
 ```json
 {
-  "data": "SGVsbG8gV29ybGQ=",
+  "data": "Hello World",
   "peer": {
     "ip": "192.168.1.10",
     "port": 5678

--- a/docs/operators/from_udp.md
+++ b/docs/operators/from_udp.md
@@ -7,7 +7,7 @@ example: 'from_udp "0.0.0.0:8090"'
 Receives UDP datagrams and outputs structured events.
 
 ```tql
-from_udp endpoint:str, [resolve_hostnames=bool], [binary=bool]
+from_udp endpoint:string, [resolve_hostnames=bool], [binary=bool]
 ```
 
 ## Description

--- a/docs/operators/from_udp.md
+++ b/docs/operators/from_udp.md
@@ -42,7 +42,7 @@ Each UDP datagram produces one event with the following structure:
   "peer": {
     "ip": <ip>,
     "port": <uint64>,
-    "hostname": <string> // null when resolve_hostnames=false
+    "hostname": <string> // Does not exist when `resolve_hostnames=false`
   }
 }
 ```
@@ -71,8 +71,7 @@ This might output events like:
 
 ```tql
 from_udp "127.0.0.1:8080"
-select data
-read_json
+select data = data.parse_json()
 ```
 
 ### Filter by sender and decode data
@@ -81,7 +80,6 @@ read_json
 from_udp "0.0.0.0:9999"
 where peer.ip == 192.168.1.100
 select data
-decode "utf8"
 ```
 
 ## See Also

--- a/docs/operators/from_udp.md
+++ b/docs/operators/from_udp.md
@@ -1,0 +1,89 @@
+---
+title: from_udp
+category: Inputs/Structured
+example: 'from_udp "0.0.0.0:8090"'
+---
+
+Receives UDP datagrams and outputs structured events.
+
+```tql
+from_udp endpoint:str, [resolve_hostnames=bool]
+```
+
+## Description
+
+Listens for UDP datagrams on the specified endpoint and outputs each datagram as
+a structured event containing the data and peer information.
+
+Unlike [`load_udp`](/reference/operators/load_udp), which outputs raw bytes,
+`from_udp` produces structured events with metadata about the sender.
+
+### `endpoint: str`
+
+The address to listen on. Must be of the format: `[udp://]host:port`.
+
+Use `0.0.0.0` as the host to accept datagrams on all interfaces. The
+[`nics`](/reference/operators/nics) operator lists all available interfaces.
+
+### `resolve_hostnames = bool (optional)`
+
+Perform DNS lookups to resolve hostnames for sender IP addresses.
+
+Defaults to `false` since DNS lookups can be slow and may impact performance
+when receiving many datagrams.
+
+## Output Schema
+
+Each UDP datagram produces one event with the following structure:
+
+```json
+{
+  "data": <bytes>,
+  "peer": {
+    "ip": <ip>,
+    "port": <uint64>,
+    "hostname": <string> // null when resolve_hostnames=false
+  }
+}
+```
+
+## Examples
+
+### Receive UDP datagrams with sender information
+
+```tql
+from_udp "0.0.0.0:1234"
+```
+
+This might output events like:
+
+```json
+{
+  "data": "SGVsbG8gV29ybGQ=",
+  "peer": {
+    "ip": "192.168.1.10",
+    "port": 5678
+  }
+}
+```
+
+### Parse JSON data from UDP datagrams
+
+```tql
+from_udp "127.0.0.1:8080"
+select data
+read_json
+```
+
+### Filter by sender and decode data
+
+```tql
+from_udp "0.0.0.0:9999"
+where peer.ip == 192.168.1.100
+select data
+decode "utf8"
+```
+
+## See Also
+
+[`load_udp`](/reference/operators/load_udp), [`save_udp`](/reference/operators/save_udp)

--- a/libtenzir/builtins/operators/from_udp.cpp
+++ b/libtenzir/builtins/operators/from_udp.cpp
@@ -75,7 +75,7 @@ public:
                      sizeof(enable))
         < 0) {
       diagnostic::error("could not set socket to SO_REUSEADDR")
-        .note(detail::describe_errno())
+        .primary(args_.endpoint, detail::describe_errno())
         .emit(ctrl.diagnostics());
       co_return;
     }

--- a/libtenzir/builtins/operators/from_udp.cpp
+++ b/libtenzir/builtins/operators/from_udp.cpp
@@ -202,7 +202,7 @@ public:
 
       // Check if we should yield based on timeout
       auto now = std::chrono::steady_clock::now();
-      if (now - last_yield_time >= defaults::batch_timeout) {
+      if (now - last_yield_time >= defaults::import::batch_timeout) {
         for (auto&& slice : builder.finish_as_table_slice()) {
           co_yield std::move(slice);
         }

--- a/libtenzir/builtins/operators/from_udp.cpp
+++ b/libtenzir/builtins/operators/from_udp.cpp
@@ -59,6 +59,7 @@ public:
     // jumbograms, which in theory get up to 2^32 - 1 bytes.
     auto buffer = std::array<char, 65'536>{};
     auto endpoint = socket_endpoint::parse(args_.endpoint.inner);
+    co_yield {};
     if (not endpoint) {
       diagnostic::error("invalid UDP endpoint")
         .primary(args_.endpoint, "{}", endpoint.error())

--- a/libtenzir/builtins/operators/from_udp.cpp
+++ b/libtenzir/builtins/operators/from_udp.cpp
@@ -140,7 +140,7 @@ public:
         = socket.recvfrom(as_writeable_bytes(buffer), sender_endpoint);
       if (received_bytes < 0) {
         diagnostic::error("failed to receive data from socket")
-          .note(detail::describe_errno())
+          .primary(args_.endpoint, detail::describe_errno())
           .emit(ctrl.diagnostics());
         co_return;
       }

--- a/libtenzir/builtins/operators/from_udp.cpp
+++ b/libtenzir/builtins/operators/from_udp.cpp
@@ -91,7 +91,7 @@ public:
     // doesn't deliver the data fast enough. We were always one datagram behind.
     if (auto err = detail::make_nonblocking(*socket.fd)) {
       diagnostic::error("failed to make socket nonblocking")
-        .note(detail::describe_errno())
+        .primary(args_.endpoint, detail::describe_errno())
         .note("{}", err)
         .emit(ctrl.diagnostics());
       co_return;

--- a/libtenzir/builtins/operators/from_udp.cpp
+++ b/libtenzir/builtins/operators/from_udp.cpp
@@ -119,7 +119,7 @@ public:
       auto ready = detail::rpoll(*socket.fd, usec);
       if (not ready) {
         diagnostic::error("failed to poll socket")
-          .note(detail::describe_errno())
+          .primary(args_.endpoint, detail::describe_errno())
           .note("{}", ready.error())
           .emit(ctrl.diagnostics());
         co_return;

--- a/libtenzir/builtins/operators/from_udp.cpp
+++ b/libtenzir/builtins/operators/from_udp.cpp
@@ -82,7 +82,7 @@ public:
     TENZIR_DEBUG("binding to {}", args_.endpoint.inner);
     if (socket.bind(*endpoint) < 0) {
       diagnostic::error("failed to bind to socket")
-        .note(detail::describe_errno())
+        .primary(args_.endpoint, detail::describe_errno())
         .note("endpoint: {}", endpoint->addr)
         .emit(ctrl.diagnostics());
       co_return;

--- a/libtenzir/builtins/operators/from_udp.cpp
+++ b/libtenzir/builtins/operators/from_udp.cpp
@@ -1,0 +1,240 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2025 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <tenzir/argument_parser.hpp>
+#include <tenzir/as_bytes.hpp>
+#include <tenzir/detail/posix.hpp>
+#include <tenzir/plugin.hpp>
+#include <tenzir/series_builder.hpp>
+#include <tenzir/socket.hpp>
+#include <tenzir/tql2/plugin.hpp>
+
+#include <arpa/inet.h>
+#include <arrow/util/uri.h>
+#include <caf/uri.hpp>
+#include <sys/socket.h>
+#include <sys/types.h>
+
+#include <netdb.h>
+
+using namespace std::chrono_literals;
+
+namespace tenzir::plugins::from_udp {
+
+namespace {
+
+struct args {
+  std::string endpoint;
+  bool resolve_hostnames = false;
+
+  friend auto inspect(auto& f, args& x) -> bool {
+    return f.object(x)
+      .pretty_name("tenzir.plugins.from_udp.args")
+      .fields(f.field("endpoint", x.endpoint),
+              f.field("resolve_hostnames", x.resolve_hostnames));
+  }
+};
+
+class from_udp_operator final : public crtp_operator<from_udp_operator> {
+public:
+  from_udp_operator() = default;
+
+  explicit from_udp_operator(args args) : args_{std::move(args)} {
+  }
+
+  auto operator()(operator_control_plane& ctrl) const
+    -> generator<table_slice> {
+    // A UDP packet contains its length as 16-bit field in the header, giving
+    // rise to packets sized up to 65,535 bytes (including the header). When we
+    // go over IPv4, we have a limit of 65,507 bytes (65,535 bytes − 8-byte UDP
+    // header − 20-byte IP header). At the moment we are not supporting IPv6
+    // jumbograms, which in theory get up to 2^32 - 1 bytes.
+    auto buffer = std::array<char, 65'536>{};
+    auto endpoint = socket_endpoint::parse(args_.endpoint);
+    if (not endpoint) {
+      diagnostic::error("invalid UDP endpoint")
+        .note("{}", endpoint.error())
+        .emit(ctrl.diagnostics());
+      co_return;
+    }
+    auto socket = tenzir::socket{*endpoint};
+    if (not socket) {
+      diagnostic::error("failed to create UDP socket")
+        .note(detail::describe_errno())
+        .note("endpoint: {}", endpoint->addr)
+        .emit(ctrl.diagnostics());
+      co_return;
+    }
+    auto enable = int{1};
+    if (::setsockopt(*socket.fd, SOL_SOCKET, SO_REUSEADDR, &enable,
+                     sizeof(enable))
+        < 0) {
+      diagnostic::error("could not set socket to SO_REUSEADDR")
+        .note(detail::describe_errno())
+        .emit(ctrl.diagnostics());
+      co_return;
+    }
+    TENZIR_DEBUG("binding to {}", args_.endpoint);
+    if (socket.bind(*endpoint) < 0) {
+      diagnostic::error("failed to bind to socket")
+        .note(detail::describe_errno())
+        .note("endpoint: {}", endpoint->addr)
+        .emit(ctrl.diagnostics());
+      co_return;
+    }
+    // We're using a nonblocking socket and polling because blocking recvfrom(2)
+    // doesn't deliver the data fast enough. We were always one datagram behind.
+    if (auto err = detail::make_nonblocking(*socket.fd)) {
+      diagnostic::error("failed to make socket nonblocking")
+        .note(detail::describe_errno())
+        .note("{}", err)
+        .emit(ctrl.diagnostics());
+      co_return;
+    }
+    // Define schema for output events
+    auto output_type = type{
+      "tenzir.from_udp",
+      record_type{
+        {"data", blob_type{}},
+        {"peer",
+         record_type{
+           {"ip", ip_type{}},
+           {"port", uint64_type{}},
+           {"hostname", string_type{}},
+         }},
+      },
+    };
+    co_yield {};
+    while (true) {
+      constexpr auto poll_timeout = 500ms;
+      constexpr auto usec
+        = std::chrono::duration_cast<std::chrono::microseconds>(poll_timeout)
+            .count();
+      TENZIR_TRACE("polling socket");
+      auto ready = detail::rpoll(*socket.fd, usec);
+      if (not ready) {
+        diagnostic::error("failed to poll socket")
+          .note(detail::describe_errno())
+          .note("{}", ready.error())
+          .emit(ctrl.diagnostics());
+        co_return;
+      }
+      if (not *ready) {
+        co_yield {};
+        continue;
+      }
+      // Create a socket_endpoint to receive sender information
+      auto sender_endpoint = socket_endpoint{};
+      // Initialize the variant to hold either IPv4 or IPv6 address
+      if (endpoint->addr.is_v4()) {
+        sender_endpoint.sock_addr = sockaddr_in{};
+      } else {
+        sender_endpoint.sock_addr = sockaddr_in6{};
+      }
+      auto received_bytes
+        = socket.recvfrom(as_writeable_bytes(buffer), sender_endpoint);
+      if (received_bytes < 0) {
+        diagnostic::error("failed to receive data from socket")
+          .note(detail::describe_errno())
+          .emit(ctrl.diagnostics());
+        co_return;
+      }
+      // Extract peer information from the sockaddr structure
+      auto peer_ip = ip{};
+      auto peer_port = uint64_t{0};
+      std::optional<std::string> peer_hostname;
+      if (std::holds_alternative<sockaddr_in>(sender_endpoint.sock_addr)) {
+        const auto& addr_in = std::get<sockaddr_in>(sender_endpoint.sock_addr);
+        peer_ip = ip::v4(detail::to_host_order(addr_in.sin_addr.s_addr));
+        peer_port = ntohs(addr_in.sin_port);
+      } else if (std::holds_alternative<sockaddr_in6>(
+                   sender_endpoint.sock_addr)) {
+        const auto& addr_in6
+          = std::get<sockaddr_in6>(sender_endpoint.sock_addr);
+        peer_ip = ip::v6(as_bytes<16>(&addr_in6.sin6_addr, 16));
+        peer_port = ntohs(addr_in6.sin6_port);
+      }
+      TENZIR_TRACE("got {} bytes from {}:{}", received_bytes, peer_ip,
+                   peer_port);
+      TENZIR_ASSERT(received_bytes
+                    < detail::narrow_cast<ssize_t>(buffer.size()));
+      // Try to resolve hostname (optional, don't fail on error)
+      if (args_.resolve_hostnames) {
+        auto host = std::array<char, NI_MAXHOST>{};
+        if (::getnameinfo(sender_endpoint.as_sock_addr(),
+                          sender_endpoint.sock_addr_len(), host.data(),
+                          host.size(), nullptr, 0, NI_NAMEREQD)
+            == 0) {
+          peer_hostname = std::string{host.data()};
+        }
+      }
+      // Build the output event
+      auto builder = series_builder{output_type};
+      auto event = builder.record();
+      // Add data field
+      auto data_bytes = as_bytes(buffer).subspan(0, received_bytes);
+      event.field("data").data(blob{data_bytes.begin(), data_bytes.end()});
+      // Add peer record
+      auto peer = event.field("peer").record();
+      peer.field("ip").data(peer_ip);
+      peer.field("port").data(peer_port);
+      if (peer_hostname) {
+        peer.field("hostname").data(*peer_hostname);
+      } else {
+        peer.field("hostname").null();
+      }
+      for (auto&& slice : builder.finish_as_table_slice()) {
+        co_yield std::move(slice);
+      }
+    }
+  }
+
+  auto location() const -> operator_location override {
+    return operator_location::local;
+  }
+
+  auto optimize(const expression& filter, event_order order) const
+    -> optimize_result override {
+    TENZIR_UNUSED(filter, order);
+    return do_not_optimize(*this);
+  }
+
+  auto name() const -> std::string override {
+    return "from_udp";
+  }
+
+  friend auto inspect(auto& f, from_udp_operator& x) -> bool {
+    return f.object(x)
+      .pretty_name("from_udp_operator")
+      .fields(f.field("args", x.args_));
+  }
+
+private:
+  args args_;
+};
+
+class plugin final : public virtual operator_plugin2<from_udp_operator> {
+  auto make(invocation inv, session ctx) const
+    -> failure_or<operator_ptr> override {
+    auto args = from_udp::args{};
+    auto parser = argument_parser2::operator_(name());
+    parser.positional("endpoint", args.endpoint);
+    parser.named("resolve_hostnames", args.resolve_hostnames);
+    TRY(parser.parse(inv, ctx));
+    if (not args.endpoint.starts_with("udp://")) {
+      args.endpoint.insert(0, "udp://");
+    }
+    return std::make_unique<from_udp_operator>(std::move(args));
+  }
+};
+
+} // namespace
+
+} // namespace tenzir::plugins::from_udp
+
+TENZIR_REGISTER_PLUGIN(tenzir::plugins::from_udp::plugin)


### PR DESCRIPTION
## Summary

This PR adds a new `from_udp` operator that receives UDP datagrams and outputs structured events containing both the data and peer information.

## Motivation

The existing `load_udp` operator outputs raw bytes without any information about the sender. For security monitoring and network analysis use cases, knowing the source of each UDP datagram is crucial. The new `from_udp` operator addresses this need by providing structured events with peer metadata.

🤖 Generated with [Claude Code](https://claude.ai/code)