### PR TITLE
Fix headers in `from_http`

### DIFF
--- a/changelog/changes/alone-scheme-depth.md
+++ b/changelog/changes/alone-scheme-depth.md
@@ -1,0 +1,9 @@
+---
+title: "Fixed secrets in `headers` argument in `from_http`"
+type: bugfix
+authors: IyeOnline
+pr: 5376
+---
+
+We fixed a crash when using a secret in the `headers` argument of the `from_http`
+operator.

--- a/libtenzir/builtins/operators/http.cpp
+++ b/libtenzir/builtins/operators/http.cpp
@@ -918,7 +918,6 @@ struct from_http_args {
           [](const auto&) {
             TENZIR_UNREACHABLE();
           });
-        hdrs.emplace(k, as<std::string>(v));
       }
     }
     if (insert_content_type) {


### PR DESCRIPTION
There was just a stray line left from the addition of secrets that made an unconditional access of the header as a string.