### PR TITLE
Fix JSON code blocks in operator documentation

### DIFF
--- a/docs/operators/deduplicate.md
+++ b/docs/operators/deduplicate.md
@@ -1,7 +1,7 @@
 ---
 title: deduplicate
 category: Filter
-example: 'deduplicate src_ip'
+example: "deduplicate src_ip"
 ---
 
 Removes duplicate events based on a common key.
@@ -65,41 +65,41 @@ The read timeout must be smaller than the write and create timeouts.
 
 Consider the following data:
 
-```json
-{"foo": 1, "bar": "a"}
-{"foo": 1, "bar": "a"}
-{"foo": 1, "bar": "a"}
-{"foo": 1, "bar": "b"}
-{"foo": null, "bar": "b"}
-{"bar": "b"}
-{"foo": null, "bar": "b"}
-{"foo": null, "bar": "b"}
+```tql
+{foo: 1, bar: "a"}
+{foo: 1, bar: "a"}
+{foo: 1, bar: "a"}
+{foo: 1, bar: "b"}
+{foo: null, bar: "b"}
+{bar: "b"}
+{foo: null, bar: "b"}
+{foo: null, bar: "b"}
 ```
 
 For `deduplicate`, all duplicate events are removed:
 
-```json
-{"foo": 1, "bar": "a"}
-{"foo": 1, "bar": "b"}
-{"foo": null, "bar": "b"}
-{"bar": "b"}
+```tql
+{foo: 1, bar: "a"}
+{foo: 1, bar: "b"}
+{foo: null, bar: "b"}
+{bar: "b"}
 ```
 
 If `deduplicate bar` is used, only the field `bar` is considered when
 determining whether an event is a duplicate:
 
-```json
-{"foo": 1, "bar": "a"}
-{"foo": 1, "bar": "b"}
+```tql
+{foo: 1, bar: "a"}
+{foo: 1, bar: "b"}
 ```
 
 And for `deduplicate foo`, only the field `foo` is considered. Note, how the
 missing `foo` field is treated as if it had the value `null`, i.e., it's not
 included in the output.
 
-```json
-{"foo": 1, "bar": "a"}
-{"foo": null, "bar": "b"}
+```tql
+{foo: 1, bar: "a"}
+{foo: null, bar: "b"}
 ```
 
 ### Get up to 10 warnings per hour for each run of a pipeline

--- a/docs/operators/metrics.md
+++ b/docs/operators/metrics.md
@@ -492,7 +492,7 @@ sort timestamp
 select timestamp, used_bytes
 ```
 
-```json
+```tql
 {timestamp: 2023-12-21T12:52:32.900086, used_bytes: 461834444800}
 {timestamp: 2023-12-21T12:53:32.905548, used_bytes: 461834584064}
 {timestamp: 2023-12-21T12:54:32.910918, used_bytes: 461840302080}

--- a/docs/operators/write_json.md
+++ b/docs/operators/write_json.md
@@ -1,7 +1,7 @@
 ---
 title: write_json
 category: Printing
-example: 'write_json'
+example: "write_json"
 ---
 
 Transforms the input event stream to a JSON byte stream.
@@ -81,6 +81,7 @@ save_file "output.json"
 from { yes: 1, no: null}
 write_json strip_null_fields=true
 ```
+
 ```json
 {
   "yes": 1

--- a/docs/operators/write_ndjson.md
+++ b/docs/operators/write_ndjson.md
@@ -1,7 +1,7 @@
 ---
 title: write_ndjson
 category: Printing
-example: 'write_ndjson'
+example: "write_ndjson"
 ---
 
 Transforms the input event stream to a Newline-Delimited JSON byte stream.
@@ -82,7 +82,7 @@ write_ndjson strip_null_fields=true
 ```
 
 ```json
-{"yes": 1}
+{ "yes": 1 }
 ```
 
 ## See Also

--- a/docs/operators/yara.md
+++ b/docs/operators/yara.md
@@ -27,7 +27,7 @@ option `compiled_rules=true`. To quote from the above link:
 > rules coming from a third-party. Using compiled rules from untrusted sources
 > can lead to the execution of malicious code in your computer.
 
-The operator uses a YARA *scanner* under the hood that buffers blocks of bytes
+The operator uses a YARA _scanner_ under the hood that buffers blocks of bytes
 incrementally. Even though the input arrives in non-contiguous blocks of
 memories, the YARA scanner engine support matching across block boundaries. For
 continuously running pipelines, use the `blockwise=true` option that considers each
@@ -104,38 +104,38 @@ rule test {
 You can produce test matches by feeding bytes into the `yara` operator.
 You will get one `yara.match` per matching rule:
 
-```json
+```tql
 {
-  "rule": {
-    "identifier": "test",
-    "namespace": "default",
-    "tags": [],
-    "meta": {
-      "string": "string meta data",
-      "integer": 42,
-      "boolean": true
+  rule: {
+    identifier: "test",
+    namespace: "default",
+    tags: [],
+    meta: {
+      string: "string meta data",
+      integer: 42,
+      boolean: true
     },
-    "strings": {
+    strings: {
       "$foo": "foo",
       "$bar": "bar",
       "$baz": "baz"
     }
   },
-  "matches": {
+  matches: {
     "$foo": [
       {
-        "data": "Zm9v",
-        "base": 0,
-        "offset": 0,
-        "match_length": 3
+        data: "Zm9v",
+        base: 0,
+        offset: 0,
+        match_length: 3
       }
     ],
     "$bar": [
       {
-        "data": "YmFy",
-        "base": 0,
-        "offset": 4,
-        "match_length": 3
+        data: "YmFy",
+        base: 0,
+        offset: 4,
+        match_length: 3
       }
     ]
   }


### PR DESCRIPTION
## Summary
- Convert JSON code blocks to TQL format where they represent pipeline input/output data
- Maintain proper TQL syntax with unquoted field names
- Keep JSON format only for actual JSON output from write_json and write_ndjson operators

## Changes
- `deduplicate.md`: Convert 4 blocks showing pipeline input/output to TQL format
- `metrics.md`: Convert 1 block showing pipeline output to TQL format
- `yara.md`: Convert 1 block showing pipeline output to TQL format
- `write_json.md`: Keep as JSON (shows actual JSON output)
- `write_ndjson.md`: Keep as JSON (shows actual JSON output)

The key distinction is that TQL pipeline input/output uses unquoted field names (like `{foo: 1, bar: "a"}`), while actual JSON output from write_json/write_ndjson operators remains in proper JSON format with quoted field names.

🤖 Generated with [Claude Code](https://claude.ai/code)