### PR TITLE
Fix return type of `map` when the input list is empty

### DIFF
--- a/changelog/changes/prompt-factor-future.md
+++ b/changelog/changes/prompt-factor-future.md
@@ -1,0 +1,10 @@
+---
+title: "Return type of `map` for empty lists"
+type: bugfix
+authors: jachris
+pr: 5385
+---
+
+Previously, the `map` function would return the input list when the input was
+empty, possibly producing type warnings downstream. It now correctly returns
+`list<null>` instead.

--- a/libtenzir/builtins/operators/where_map.cpp
+++ b/libtenzir/builtins/operators/where_map.cpp
@@ -483,7 +483,9 @@ auto make_map_function(function_plugin::invocation inv, session ctx)
       auto list_values
         = series{field_list->type.value_type(), field_list->array->values()};
       if (list_values.length() == 0) {
-        return field;
+        return make_list_series(
+          series::null(null_type{}, field_list->array->values()->length()),
+          *field_list->array);
       }
       auto ms = tenzir::eval(args.lambda, list_values, ctx);
       TENZIR_ASSERT(not ms.parts().empty());

--- a/tenzir/tests/exec/functions/list_map/empty_list.tql
+++ b/tenzir/tests/exec/functions/list_map/empty_list.tql
@@ -1,0 +1,6 @@
+from {
+  x: ["test"].where(x => false)
+}
+before = type_of(x)
+x = x.map(y => 42)
+after = type_of(x)

--- a/tenzir/tests/exec/functions/list_map/empty_list.txt
+++ b/tenzir/tests/exec/functions/list_map/empty_list.txt
@@ -1,0 +1,29 @@
+{
+  x: [],
+  before: {
+    name: null,
+    kind: "list",
+    attributes: [],
+    state: {
+      type: {
+        name: null,
+        kind: "string",
+        attributes: [],
+        state: null,
+      },
+    },
+  },
+  after: {
+    name: null,
+    kind: "list",
+    attributes: [],
+    state: {
+      type: {
+        name: null,
+        kind: "null",
+        attributes: [],
+        state: null,
+      },
+    },
+  },
+}


### PR DESCRIPTION
Previously, the `map` function would return the input list type when the input was empty. It now returns `list<null>` instead (because we can't know the target type as that might be dynamic).

🤖 Generated with [Claude Code](https://claude.ai/code)… 
😞 … and modified afterwards because the PR description was just imprecise and wordy without reason.