### PR TITLE
Fix `from_http` port error

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,7 +17,7 @@
 	shallow = true
 [submodule "libtenzir/aux/caf"]
 	path = libtenzir/aux/caf
-	url = https://github.com/actor-framework/actor-framework
+	url = https://github.com/tenzir/actor-framework
 	shallow = true
 [submodule "libtenzir/aux/pfs"]
 	path = libtenzir/aux/pfs

--- a/changelog/changes/suffer-strain-floor.md
+++ b/changelog/changes/suffer-strain-floor.md
@@ -1,0 +1,11 @@
+---
+title: "Fixed `from_http` default port"
+type: bugfix
+authors: jachris
+pr: 5398
+---
+
+Using the `from_http` operator as a client without explicitly specifying a port
+resulted in an error complaining that the port cannot be zero. This now works as
+expected, meaning that the default port is derived correctly from the URL
+scheme, i.e., 80 for HTTP and 443 for HTTPS.

--- a/libtenzir/src/argument_parser2.cpp
+++ b/libtenzir/src/argument_parser2.cpp
@@ -325,8 +325,12 @@ auto argument_parser2::parse(const ast::entity& self,
             set(located{std::move(pipe).unwrap(), pipe_expr.get_location()});
           },
           [&](auto&) {
-            // FIXME: It looks like this is reachable.
-            TENZIR_UNREACHABLE();
+            // FIXME: This can lead to having two errors for a single parameter
+            // mismatch. But this was previously `TENZIR_UNREACHABLE` and I had
+            // to do a quick fix because it is reachable (e.g. with  `from_http
+            // server=true { read_all }`).
+            emit(diagnostic::error("parameter does not accept pipelines")
+                   .primary(pipe_expr));
           });
         ++positional_idx;
       },

--- a/nix/caf/source.json
+++ b/nix/caf/source.json
@@ -1,7 +1,7 @@
 {
-  "owner": "actor-framework",
+  "owner": "tenzir",
   "repo": "actor-framework",
-  "rev": "139f8e410e249775afaa58f0216b5bbe45c7f16e",
-  "hash": "sha256-ogpyDmrcUS/FipU6mE8lHBqpyKQXtVKA85ed7dQ+6Jk=",
-  "version": "1.0.2+g139f8e410"
+  "rev": "a21907539127ab5847fb982d6764e3fe69ee1fb7",
+  "hash": "sha256-kMnGkZBsLi7J/EDJl5VcyZ+5ac7PCIXScQqves89y2A=",
+  "version": "1.1.0-123-ga21907539"
 }

--- a/nix/update-impl.sh
+++ b/nix/update-impl.sh
@@ -63,4 +63,4 @@ update-source() {
   fi
 }
 
-update-source caf "libtenzir/aux/caf" "1.0.2+g139f8e410"
+update-source caf "libtenzir/aux/caf" "1.1.0-123-ga21907539"

--- a/nix/update-plugins.sh
+++ b/nix/update-plugins.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p coreutils git jq nix-prefetch-github
+#!nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/94035b482d181af0a0f8f77823a790b256b7c3cc.tar.gz
 
 : "${GH_TOKEN:=$GITHUB_TOKEN}"
 

--- a/nix/update.sh
+++ b/nix/update.sh
@@ -23,11 +23,15 @@ command -v docker > /dev/null && {
   if [ "$toplevel/.git" = "$gitdir" ]; then
     docker run \
       -v "${toplevel}:${toplevel}" \
+      -e GITHUB_TOKEN \
+      -e GH_TOKEN \
       nixos/nix "${toplevel}/nix/update.sh"
   else
     docker run \
       -v "${toplevel}:${toplevel}" \
       -v "${gitdir}:${gitdir}" \
+      -e GITHUB_TOKEN \
+      -e GH_TOKEN \
       nixos/nix "${toplevel}/nix/update.sh"
   fi
   exit $?


### PR DESCRIPTION
The updated CAF has a bug with the defaulting of HTTP ports, making it so that `from_http` always returns an error.