### PR TITLE
Remove caution aside from `from_file`

### DIFF
--- a/docs/operators/from_file.md
+++ b/docs/operators/from_file.md
@@ -4,10 +4,6 @@ category: Inputs/Events
 example: 'from_file "s3://data/**.json"'
 ---
 
-:::caution[Under Active Development]
-This operator is still under active development.
-:::
-
 Reads one or multiple files from a filesystem.
 
 ```tql


### PR DESCRIPTION
This PR improves the docs by removing a no-longer-need caution aside.
