### PR TITLE
Preserve metadata in `ocsf::derive` and `ocsf::trim`

### DIFF
--- a/changelog/changes/badge-server-street.md
+++ b/changelog/changes/badge-server-street.md
@@ -1,0 +1,10 @@
+---
+title: "Metadata handling of `ocsf::derive`"
+type: bugfix
+authors: jachris
+pr: 5402
+---
+
+The `ocsf::derive` operator now correctly uses the metadata (such as `@name`) of
+the incoming event instead of overwriting it with the internal metadata used to
+encode OCSF schemas.

--- a/changelog/changes/badge-server-street.md
+++ b/changelog/changes/badge-server-street.md
@@ -1,10 +1,10 @@
 ---
-title: "Metadata handling of `ocsf::derive`"
+title: "Metadata handling of `ocsf::derive` and `ocsf::trim`"
 type: bugfix
 authors: jachris
 pr: 5402
 ---
 
-The `ocsf::derive` operator now correctly uses the metadata (such as `@name`) of
-the incoming event instead of overwriting it with the internal metadata used to
-encode OCSF schemas.
+The `ocsf::derive` and `ocsf::trim` operators now correctly preserve the
+metadata (such as `@name`) of the incoming event instead of overwriting it with
+the internal metadata used to encode OCSF schemas.

--- a/libtenzir/builtins/operators/ocsf.cpp
+++ b/libtenzir/builtins/operators/ocsf.cpp
@@ -749,8 +749,8 @@ private:
       // Do not attempt derivation in variant fields.
       return input;
     }
-    auto name = ty.name();
-    auto attributes = collect(ty.attributes());
+    auto name = input.type.name();
+    auto attributes = collect(input.type.attributes());
     return match(
       std::tie(input, ty),
       [&]<class Type>(basic_series<Type> input, const Type& ty) -> series {
@@ -944,8 +944,7 @@ private:
         if (it != enum_lookup.end()) {
           string_result = it->second;
         } else {
-          diagnostic::warning("found invalid value for field `{}`", *int_value,
-                              int_path)
+          diagnostic::warning("found invalid value for field `{}`", int_path)
             .primary(self_)
             .note("got {}", *int_value)
             .emit(dh_);

--- a/libtenzir/builtins/operators/ocsf.cpp
+++ b/libtenzir/builtins/operators/ocsf.cpp
@@ -516,8 +516,8 @@ private:
       // Do not attempt trimming in variant fields.
       return input;
     }
-    auto name = ty.name();
-    auto attributes = collect(ty.attributes());
+    auto name = input.type.name();
+    auto attributes = collect(input.type.attributes());
     return match(
       std::tie(input, ty),
       [&]<class Type>(basic_series<Type> input, const Type& ty) -> series {


### PR DESCRIPTION
Previously, the outgoing events were assigned names such as `_ocsf.v1_5_0.dns_activity` because we copied the metadata from our internal schema encoding instead.