### PR TITLE
Add is_empty function

### DIFF
--- a/changelog/changes/attack-global-living.md
+++ b/changelog/changes/attack-global-living.md
@@ -1,0 +1,43 @@
+---
+title: "Check if your data is truly empty"
+type: feature
+authors: mavam
+pr: 5403
+---
+
+Ever stared at your security logs wondering if that suspicious-looking field is
+actually empty or just pretending? We've all been there. That's why we added
+`is_empty()` - a universal emptiness detector that works on strings, lists, and
+records.
+
+```tql
+from {
+  id: "evt-12345",
+  tags: ["malware", "c2"],
+  metadata: {},
+  description: "",
+  iocs: []
+}
+has_metadata = not metadata.is_empty()
+has_description = not description.is_empty()
+has_iocs = not iocs.is_empty()
+```
+
+```tql
+{
+  id: "evt-12345",
+  tags: [
+    "malware",
+    "c2",
+  ],
+  metadata: {},
+  description: "",
+  iocs: [],
+  has_metadata: false,
+  has_description: false,
+  has_iocs: false,
+}
+```
+
+No more checking `length() == 0` or wondering if that field exists but is
+empty. Just ask `is_empty()` and move on with your threat hunting!

--- a/docs/functions/has.md
+++ b/docs/functions/has.md
@@ -38,6 +38,8 @@ this = {
   has_z: false,
 }
 ```
+
 ## See Also
 
+[`is_empty`](/reference/functions/is_empty),
 [`keys`](/reference/functions/keys)

--- a/docs/functions/is_empty.md
+++ b/docs/functions/is_empty.md
@@ -13,7 +13,13 @@ is_empty(x:string|list|record) -> bool
 ## Description
 
 The `is_empty` function returns `true` if the input value is empty and `false`
-otherwise. The function works on three types:
+otherwise.
+
+### `x: string|list|record`
+
+The value to check for emptiness.
+
+The function works on three types:
 
 - **Strings**: Returns `true` for empty strings (`""`)
 - **Lists**: Returns `true` for empty lists (`[]`)

--- a/docs/functions/is_empty.md
+++ b/docs/functions/is_empty.md
@@ -1,0 +1,92 @@
+---
+title: is_empty
+category: Misc
+example: '"".is_empty()'
+---
+
+Checks whether a value is empty.
+
+```tql
+is_empty(x:string|list|record) -> bool
+```
+
+## Description
+
+The `is_empty` function returns `true` if the input value is empty and `false`
+otherwise. The function works on three types:
+
+- **Strings**: Returns `true` for empty strings (`""`)
+- **Lists**: Returns `true` for empty lists (`[]`)
+- **Records**: Returns `true` for empty records (`{}`)
+
+For `null` values, the function returns `null`. For unsupported types, the
+function emits a warning and returns `null`.
+
+## Examples
+
+### Check if a string is empty
+
+```tql
+from {
+  empty: "".is_empty(),
+  not_empty: "hello".is_empty(),
+}
+```
+
+```tql
+{
+  empty: true,
+  not_empty: false,
+}
+```
+
+### Check if a list is empty
+
+```tql
+from {
+  empty: [].is_empty(),
+  not_empty: [1, 2, 3].is_empty(),
+}
+```
+
+```tql
+{
+  empty: true,
+  not_empty: false,
+}
+```
+
+### Check if a record is empty
+
+```tql
+from {
+  empty: {}.is_empty(),
+  not_empty: {a: 1, b: 2}.is_empty(),
+}
+```
+
+```tql
+{
+  empty: true,
+  not_empty: false,
+}
+```
+
+### Null handling
+
+```tql
+from {
+  result: null.is_empty(),
+}
+```
+
+```tql
+{
+  result: null,
+}
+```
+
+## See Also
+
+[`length`](/reference/functions/length),
+[`has`](/reference/functions/has)

--- a/docs/functions/length.md
+++ b/docs/functions/length.md
@@ -1,7 +1,7 @@
 ---
 title: length
 category: List
-example: '[1,2,3].length()'
+example: "[1,2,3].length()"
 ---
 
 Retrieves the length of a list.
@@ -28,5 +28,6 @@ from {n: [1, 2, 3].length()}
 
 ## See Also
 
+[`is_empty`](/reference/functions/is_empty),
 [`length_bytes`](/reference/functions/length_bytes),
 [`length_chars`](/reference/functions/length_chars)

--- a/tenzir/tests/exec/functions/is_empty.tql
+++ b/tenzir/tests/exec/functions/is_empty.tql
@@ -1,0 +1,30 @@
+// Test is_empty function with all types
+from {
+  // Test strings
+  empty_string: "".is_empty(),
+  non_empty_string: "hello".is_empty(),
+  space_string: " ".is_empty(),
+  
+  // Test lists
+  empty_list: [].is_empty(),
+  non_empty_list: [1, 2, 3].is_empty(),
+  single_element: [42].is_empty(),
+  
+  // Test records
+  empty_record: {}.is_empty(),
+  non_empty_record: {a: 1, b: 2}.is_empty(),
+  single_field: {x: null}.is_empty(),
+  
+  // Test null handling
+  null_value: null.is_empty(),
+  
+  // Test with unsupported types (should emit warning and return null)
+  integer: 42.is_empty(),
+  boolean: true.is_empty(),
+  double: 3.14.is_empty(),
+  
+  // Test with nested data structures
+  nested_empty_list: [[], [], []].is_empty(),
+  nested_empty_record: {a: {}, b: {}}.is_empty(),
+  complex_record: {name: "test", items: []}.is_empty(),
+}

--- a/tenzir/tests/exec/functions/is_empty.txt
+++ b/tenzir/tests/exec/functions/is_empty.txt
@@ -1,0 +1,38 @@
+{
+  empty_string: true,
+  non_empty_string: false,
+  space_string: false,
+  empty_list: true,
+  non_empty_list: false,
+  single_element: false,
+  empty_record: true,
+  non_empty_record: false,
+  single_field: false,
+  null_value: null,
+  integer: null,
+  boolean: null,
+  double: null,
+  nested_empty_list: false,
+  nested_empty_record: false,
+  complex_record: false,
+}
+warning: expected `string`, `list`, or `record`, got `int64`
+  --> exec/functions/is_empty.tql:22:12
+   |
+22 |   integer: 42.is_empty(),
+   |            ~~ 
+   |
+
+warning: expected `string`, `list`, or `record`, got `bool`
+  --> exec/functions/is_empty.tql:23:12
+   |
+23 |   boolean: true.is_empty(),
+   |            ~~~~ 
+   |
+
+warning: expected `string`, `list`, or `record`, got `double`
+  --> exec/functions/is_empty.tql:24:11
+   |
+24 |   double: 3.14.is_empty(),
+   |           ~~~~ 
+   |


### PR DESCRIPTION
## Summary

- Adds `is_empty()` function for strings, lists, and records
- Returns `true` for empty values, `false` for non-empty, `null` for null/unsupported types

## Test plan

- Added integration tests and documentation
- All tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)