### PR TITLE
Bump Docker image build to Arrow 21

### DIFF
--- a/libtenzir/CMakeLists.txt
+++ b/libtenzir/CMakeLists.txt
@@ -63,10 +63,10 @@ TenzirCompileFlatBuffers(
 # -- arrow ---------------------------------------------------------------------
 
 find_package(Arrow REQUIRED CONFIG)
-if (Arrow_VERSION_MAJOR LESS 13)
+if (Arrow_VERSION_MAJOR LESS 18)
   message(
     FATAL_ERROR
-      "Tenzir requires at least Arrow version 13.0, but found ${ARROW_VERSION}")
+      "Tenzir requires at least Arrow version 18.0, but found ${ARROW_VERSION}")
 endif ()
 mark_as_advanced(
   BROTLI_COMMON_LIBRARY
@@ -98,6 +98,18 @@ else ()
     Arrow::arrow_static
     INTERFACE Azure::azure-identity Azure::azure-storage-blobs
               Azure::azure-storage-files-datalake)
+endif ()
+if (ARROW_VERSION VERSION_GREATER_EQUAL "21.0.0")
+  find_package(ArrowCompute REQUIRED CONFIG)
+  string(
+    APPEND
+    TENZIR_FIND_DEPENDENCY_LIST
+    "\nfind_package(ArrowCompute REQUIRED CONFIG)")
+  if (BUILD_SHARED_LIBS)
+    set(ARROW_COMPUTE_LIBRARY ArrowCompute::arrow_compute_shared)
+  else ()
+    set(ARROW_COMPUTE_LIBRARY ArrowCompute::arrow_compute_static)
+  endif ()
 endif ()
 
 # -- boost ---------------------------------------------------------------------
@@ -371,7 +383,7 @@ string(APPEND TENZIR_FIND_DEPENDENCY_LIST "\nfind_package(libmaxminddb)")
 dependency_summary("libmaxminddb" maxminddb::maxminddb "Dependencies")
 
 # Link against Apache Arrow.
-target_link_libraries(libtenzir PUBLIC ${ARROW_LIBRARY})
+target_link_libraries(libtenzir PUBLIC ${ARROW_LIBRARY} ${ARROW_COMPUTE_LIBRARY})
 dependency_summary("Apache Arrow" ${ARROW_LIBRARY} "Dependencies")
 
 # Link against Boost.

--- a/libtenzir/include/tenzir/module.hpp
+++ b/libtenzir/include/tenzir/module.hpp
@@ -8,10 +8,6 @@
 
 #pragma once
 
-#include "tenzir/concept/printable/core.hpp"
-#include "tenzir/concept/printable/print.hpp"
-#include "tenzir/concept/printable/string/char.hpp"
-#include "tenzir/concept/printable/string/string.hpp"
 #include "tenzir/defaults.hpp"
 #include "tenzir/detail/operators.hpp"
 #include "tenzir/detail/stable_set.hpp"
@@ -20,7 +16,6 @@
 #include <caf/expected.hpp>
 
 #include <filesystem>
-#include <string>
 #include <string_view>
 #include <vector>
 

--- a/libtenzir/src/pattern.cpp
+++ b/libtenzir/src/pattern.cpp
@@ -29,7 +29,6 @@ auto pattern::make(std::string str, pattern_options options) noexcept
   -> caf::expected<pattern> {
   auto opts = re2::RE2::Options(re2::RE2::CannedOptions::Quiet);
   opts.set_case_sensitive(!options.case_insensitive);
-  auto regex = re2::RE2(str, opts);
   auto result = pattern{};
   result.str_ = std::move(str);
   result.options_ = options;

--- a/scripts/debian/build-arrow-package.sh
+++ b/scripts/debian/build-arrow-package.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-: "${ARROW_TAG=apache-arrow-19.0.0}"
+: "${ARROW_TAG=apache-arrow-21.0.0}"
 : "${ARROW_VERSION=$(printf '%s' "$ARROW_TAG" | sed 's@[^0-9]*\(.*\)@\1@')}"
 
 CMAKE_INSTALL_PREFIX=/usr/local
@@ -24,6 +24,7 @@ apt-get install --no-install-recommends -y \
   libboost-system-dev \
   libcurl4-openssl-dev \
   libminizip-dev \
+  libre2-dev \
   libsasl2-dev \
   libssl-dev \
   libabsl-dev \
@@ -73,5 +74,5 @@ checkinstall \
   --pkgversion="${ARROW_VERSION}" \
   --pkgrelease="TENZIR" \
   --pkgname=arrow \
-  --requires="libc6,libboost-filesystem-dev,libboost-system-dev,libcurl4,libgcc1,libssl3,libstdc++6,libxml2,zlib1g" \
+  --requires="libc6,libboost-filesystem-dev,libboost-system-dev,libcurl4,libgcc1,libre2-11,libssl3,libstdc++6,libxml2,zlib1g" \
   cmake --install build --strip

--- a/tenzir/tenzir.cpp
+++ b/tenzir/tenzir.cpp
@@ -25,6 +25,7 @@
 #include "tenzir/tql2/parser.hpp"
 #include "tenzir/tql2/resolve.hpp"
 
+#include <arrow/compute/api.h>
 #include <arrow/util/compression.h>
 #include <arrow/util/utf8.h>
 #include <caf/actor_registry.hpp>
@@ -178,6 +179,13 @@ private:
 auto main(int argc, char** argv) -> int try {
   using namespace tenzir;
   arrow::util::InitializeUTF8();
+#if ARROW_VERSION_MAJOR >= 21
+  if (auto status = arrow::compute::Initialize(); not status.ok()) {
+    fmt::println(stderr, "failed to initialize arrow compute functions: {}",
+                 status.message());
+    return EXIT_FAILURE;
+  }
+#endif
   // Set a signal handler for fatal conditions. Prints a backtrace if support
   // for that is enabled.
   if (SIG_ERR == std::signal(SIGSEGV, fatal_handler)) [[unlikely]] {

--- a/tenzir/tenzir.cpp
+++ b/tenzir/tenzir.cpp
@@ -14,7 +14,7 @@
 #include "tenzir/detail/settings.hpp"
 #include "tenzir/detail/signal_handlers.hpp"
 #include "tenzir/diagnostics.hpp"
-#include "tenzir/legacy_type.hpp"
+#include "tenzir/legacy_type.hpp" // IWYU pragma: keep
 #include "tenzir/logger.hpp"
 #include "tenzir/module.hpp"
 #include "tenzir/modules.hpp"
@@ -40,7 +40,6 @@
 #include <csignal>
 #include <cstdlib>
 #include <iostream>
-#include <queue>
 #include <ranges>
 #include <string_view>
 #include <thread>


### PR DESCRIPTION
From Arrow 21 on the compute functions are shipped as a separate library, so we adjust the build scaffold and initialize the functions on startup.
