### PR TITLE
Fix broken documentation links to Node API reference

### DIFF
--- a/docs/operators/metrics.md
+++ b/docs/operators/metrics.md
@@ -60,7 +60,7 @@ Contains information about all accessed API endpoints, emitted once per second.
 | `params`        | `record`   | The API endpoints parameters passed inused.            |
 
 The schema of the record `params` depends on the API endpoint used. Refer to the
-[API documentation](/reference/node-api) to see the available parameters per endpoint.
+[API documentation](/reference/node/api) to see the available parameters per endpoint.
 
 ### `tenzir.metrics.caf`
 

--- a/docs/operators/openapi.md
+++ b/docs/operators/openapi.md
@@ -1,7 +1,7 @@
 ---
 title: openapi
 category: Node/Inspection
-example: 'openapi'
+example: "openapi"
 ---
 
 Shows the node's OpenAPI specification.
@@ -13,7 +13,7 @@ openapi
 ## Description
 
 The `openapi` operator shows the current Tenzir node's [OpenAPI
-specification](/reference/node-api) for all available REST endpoint plugins.
+specification](/reference/node/api) for all available REST endpoint plugins.
 
 ## Examples
 

--- a/docs/operators/pipeline/list.md
+++ b/docs/operators/pipeline/list.md
@@ -14,7 +14,7 @@ pipeline::list
 
 The `pipeline::list` operator returns the list of all managed pipelines. Managed
 pipelines are pipelines created through the [`/pipeline`
-API](/reference/node-api), which includes all pipelines run through the Tenzir
+API](/reference/node/api), which includes all pipelines run through the Tenzir
 Platform.
 
 ## Examples

--- a/docs/operators/serve.md
+++ b/docs/operators/serve.md
@@ -13,7 +13,7 @@ serve id:string, [buffer_size=int]
 ## Description
 
 The `serve` operator bridges between pipelines and the corresponding `/serve`
-[REST API endpoint](/reference/node-api).
+[REST API endpoint](/reference/node/api).
 
 ![Serve Operator](serve.excalidraw.svg)
 


### PR DESCRIPTION
## Summary

- Fixes broken links in operator documentation that were pointing to `/reference/node-api`
- Updates all 4 occurrences to the correct path `/reference/node/api`

## Details

The link checker identified 9 broken links total, but only 4 were in the `docs/` directory within this repository:
- `docs/operators/openapi.md`
- `docs/operators/serve.md` 
- `docs/operators/metrics.md`
- `docs/operators/pipeline/list.md`

The other 5 broken links appear to be in a separate documentation system outside this repository.

🤖 Generated with [Claude Code](https://claude.ai/code)