### PR TITLE
More lenient RFC 3164 Syslog parsing

### DIFF
--- a/changelog/changes/passed-shell-bottle.md
+++ b/changelog/changes/passed-shell-bottle.md
@@ -1,0 +1,24 @@
+---
+title: "More lenient RFC 3164 Syslog parsing"
+type: feature
+authors: IyeOnline
+pr: 5426
+---
+
+Our syslog parser now allows for a `.` character in the tag/app_name
+field and any character in the `process_id` field.
+This allows you to parse the log:
+```
+<21>Aug 18 12:00:00 hostname_redacted .NetRuntime[-]: content...
+```
+```tql
+{
+  facility: 2,
+  severity: 5,
+  timestamp: "Aug 18 12:00:00",
+  hostname: "hostname_redacted",
+  app_name: ".NetRuntime",
+  process_id: "-",
+  content: "content...",
+}
+```

--- a/libtenzir/include/tenzir/arrow_table_slice.hpp
+++ b/libtenzir/include/tenzir/arrow_table_slice.hpp
@@ -141,6 +141,9 @@ template <concrete_type Type>
 auto value_at([[maybe_unused]] const Type& type,
               const type_to_arrow_array_storage_t<Type>& arr, int64_t row)
   -> view<type_to_data_t<Type>> {
+  TENZIR_ASSERT_EXPENSIVE(row < arr.length(),
+                          "{} is out of bounds for {}-array of length {}", row,
+                          arr.length(), type_kind{tag_v<Type>});
   TENZIR_ASSERT_EXPENSIVE(!arr.IsNull(row));
   if constexpr (std::is_same_v<Type, null_type>) {
     return caf::none;

--- a/libtenzir/src/cast.cpp
+++ b/libtenzir/src/cast.cpp
@@ -14,11 +14,11 @@
 
 namespace tenzir {
 
-auto cast(table_slice from_slice, const type& to_schema) noexcept
-  -> table_slice {
+auto cast(table_slice from_slice, const type& to_schema) -> table_slice {
   TENZIR_ASSERT_EXPENSIVE(can_cast(from_slice.schema(), to_schema));
-  if (from_slice.schema() == to_schema)
+  if (from_slice.schema() == to_schema) {
     return from_slice;
+  }
   const auto from_batch = to_record_batch(from_slice);
   const auto from_struct_array = check(from_batch->ToStructArray());
   const auto to_struct_array


### PR DESCRIPTION
Our syslog parser now allows for a `.` character in the tag/app_name
field and a `-` for the process ID, which will be treated as `null`.
