### PR TITLE
Deprecate `read_lines split_at_null=true`

### DIFF
--- a/changelog/changes/lumber-guess-leave.md
+++ b/changelog/changes/lumber-guess-leave.md
@@ -6,4 +6,4 @@ pr: 5431
 ---
 
 The `split_at_null` option of the `read_lines` operator is now deprecated.
-Instead, you can use `read_delimited "\0"`.
+Use `read_delimited "\0"` instead.

--- a/changelog/changes/lumber-guess-leave.md
+++ b/changelog/changes/lumber-guess-leave.md
@@ -1,0 +1,9 @@
+---
+title: "Deprecation of `split_at_null` option of `read_lines`"
+type: change
+authors: jachris
+pr: 5431
+---
+
+The `split_at_null` option of the `read_lines` operator is now deprecated.
+Instead, you can use `read_delimited "\0"`.

--- a/docs/operators/read_lines.md
+++ b/docs/operators/read_lines.md
@@ -27,6 +27,11 @@ Ignores empty lines in the input.
 
 ### `split_at_null = bool (optional)`
 
+:::caution[Deprecated]
+This option is deprecated. Use
+[`read_delimited_regex`](/reference/operators/read_delimited) instead.
+:::
+
 Use null byte (`\0`) as the delimiter instead of newline characters.
 
 ### `split_at_regex = string (optional)`

--- a/docs/operators/read_lines.md
+++ b/docs/operators/read_lines.md
@@ -29,7 +29,7 @@ Ignores empty lines in the input.
 
 :::caution[Deprecated]
 This option is deprecated. Use
-[`read_delimited_regex`](/reference/operators/read_delimited) instead.
+[`read_delimited`](/reference/operators/read_delimited) instead.
 :::
 
 Use null byte (`\0`) as the delimiter instead of newline characters.

--- a/libtenzir/builtins/formats/lines.cpp
+++ b/libtenzir/builtins/formats/lines.cpp
@@ -324,6 +324,12 @@ class read_lines final
         .emit(ctx);
       return failure::promise();
     }
+    if (args.null) {
+      diagnostic::warning("the `split_at_null` option is deprecated, use "
+                          "`read_delimited` instead")
+        .primary(*args.null)
+        .emit(ctx);
+    }
     if (args.split_at_regex) {
       diagnostic::warning("the `split_at_regex` option is deprecated, use "
                           "`read_delimited_regex` instead")

--- a/tenzir/bats/data/reference/lines/test_parse_null_delimited_events/step_00.ref
+++ b/tenzir/bats/data/reference/lines/test_parse_null_delimited_events/step_00.ref
@@ -1,3 +1,9 @@
 {"line":"1"}
 {"line":"2"}
 {"line":"3"}
+warning: the `split_at_null` option is deprecated, use `read_delimited` instead
+ --> <input>:1:26
+  |
+1 | read_lines split_at_null=true
+  |                          ~~~~ 
+  |


### PR DESCRIPTION
The replacement is `read_delimited "\0"`.