### PR TITLE
Change `resolve_enumerations` to use new `replace`

### DIFF
--- a/changelog/changes/screen-queen-strike.md
+++ b/changelog/changes/screen-queen-strike.md
@@ -1,0 +1,9 @@
+---
+title: "Fixed crash when writing out enumerations"
+type: bugfix
+authors: IyeOnline
+pr: 5434
+---
+
+We fixed a rare crash that could occur when writing/printing enumeration values
+in various formats.


### PR DESCRIPTION
This should fix any crashes based on issues with `transform_columns`
and also properly work nested types such as lists.

- Fixes https://github.com/tenzir/issues/issues/3017
