### PR TITLE
Fix workflow that updates OCSF schemas

### DIFF
--- a/.github/workflows/update-ocsf-schemas.yaml
+++ b/.github/workflows/update-ocsf-schemas.yaml
@@ -19,6 +19,12 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Reset branch to latest main
+        run: |
+          git fetch origin main
+          git checkout -B topic/update-ocsf-schemas origin/main
+          git push origin topic/update-ocsf-schemas --force
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
The current workflow does not properly reset the branch that it uses to the current state of `main`.