### PR TITLE
Add a clang based static binary variant

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,11 @@
           nix2container = inputs.nix2container.packages.${system};
           isReleaseBuild = inputs.isReleaseBuild.value;
         };
+        package-clang = pkgs.callPackages ./nix/package.nix {
+          nix2container = inputs.nix2container.packages.${system};
+          isReleaseBuild = inputs.isReleaseBuild.value;
+          forceClang = true;
+        };
       in
       {
         packages =
@@ -52,6 +57,10 @@
             tenzir-de-static = package.tenzir-de-static;
             tenzir = package.tenzir;
             tenzir-static = package.tenzir-static;
+            tenzir-de-clang = package-clang.tenzir-de;
+            tenzir-de-static-clang = package-clang.tenzir-de-static;
+            tenzir-clang = package-clang.tenzir;
+            tenzir-static-clang = package-clang.tenzir-static;
             integration-test-shell = pkgs.mkShell {
               packages = package.tenzir-integration-test-runner;
             };

--- a/nix/empty-libgcc_eh/default.nix
+++ b/nix/empty-libgcc_eh/default.nix
@@ -1,0 +1,15 @@
+{
+  stdenv,
+  runCommand,
+  pkgsBuildHost,
+}:
+# Work around https://github.com/NixOS/nixpkgs/issues/177129.
+# Idea taken from lix / scals.
+runCommand "empty-libgcc_eh" { } ''
+  if $CC -Wno-unused-command-line-argument -x c - -o /dev/null <<< 'int main() {}'; then
+    echo "linking succeeded; please remove empty-gcc-eh workaround" >&2
+    exit 3
+  fi
+  mkdir -p $out/lib
+  ${pkgsBuildHost.binutils-unwrapped}/bin/${stdenv.cc.targetPrefix}ar r $out/lib/libgcc_eh.a
+''

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -16,6 +16,7 @@ in
   pfs = prevPkgs.callPackage ./pfs { };
   speeve = prevPkgs.callPackage ./speeve { };
   uv-bin = prevPkgs.callPackage ./uv-binary { };
+  empty-libgcc_eh = prevPkgs.callPackage ./empty-libgcc_eh { };
 
   pythonPackagesExtensions = prevPkgs.pythonPackagesExtensions ++ [
     (python-finalPkgs: python-prevPkgs: {
@@ -29,7 +30,7 @@ in
   aws-sdk-cpp-tenzir = callFunction ./overrides/aws-sdk-cpp-tenzir.nix {
     inherit (prevPkgs) aws-sdk-cpp;
   };
-  caf = callFunction ./caf { inherit (prevPkgs) caf; };
+  caf = finalPkgs.callPackage ./caf { inherit (prevPkgs) caf; };
   google-cloud-cpp-tenzir = callFunction ./overrides/google-cloud-cpp-tenzir.nix {
     inherit (prevPkgs) google-cloud-cpp;
   };

--- a/nix/overrides/apache-orc.nix
+++ b/nix/overrides/apache-orc.nix
@@ -4,13 +4,14 @@
   protobuf,
 }:
 (apache-orc.overrideAttrs (orig: {
-  patches = (orig.patches or []) ++ [
+  patches = (orig.patches or [ ]) ++ [
     (fetchpatch2 {
       name = "apache-orc-protobuf-31-compat.patch";
       url = "https://github.com/apache/orc/commit/ab5f21ade37569e42c90efde02b95bfcf4bb031d.patch?full_index=1";
       hash = "sha256-JOcTYQ8e+W5oJ9SiQJHGnWaxLTTzJHST901tJnFhK6M=";
     })
   ];
-})).override {
-  protobuf_30 = protobuf;
-}
+})).override
+  {
+    protobuf_30 = protobuf;
+  }

--- a/nix/overrides/jemalloc.nix
+++ b/nix/overrides/jemalloc.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  fetchpatch2,
   jemalloc,
 }:
 jemalloc.overrideAttrs (orig: {
@@ -11,12 +12,32 @@ jemalloc.overrideAttrs (orig: {
       "--enable-stats"
     ];
 
+  patches =
+    (orig.patches or [ ])
+    ++ lib.optionals stdenv.hostPlatform.isStatic [
+      (fetchpatch2 {
+        # This patch is only added so that jemalloc-musl-clang-compat-2 applies cleanly.
+        name = "jemalloc-openbsd-compat.patch";
+        url = "https://github.com/jemalloc/jemalloc/commit/58478412be842e140cc03dbb0c6ce84b2b8d096e.patch?full_index=1";
+        hash = "sha256-xeaddE5rdJtF6qJqfvCNhKHWfPXtvZUgth2PCqdDxqM=";
+      })
+      (fetchpatch2 {
+        name = "jemalloc-musl-clang-compat-1.patch";
+        url = "https://github.com/jemalloc/jemalloc/commit/aba1645f2d65a3b5c46958d7642b46ab3c142cf3.patch?full_index=1";
+        hash = "sha256-9nl5ucc156ha3yO0f0PLH3OH46McOq3Nr8tNRYa+4GE=";
+      })
+      (fetchpatch2 {
+        name = "jemalloc-musl-clang-compat-2.patch";
+        url = "https://github.com/jemalloc/jemalloc/commit/45249cf5a9cfa13c2c62e68e272a391721523b4b.patch?full_index=1";
+        hash = "sha256-JwY8RyrVdpvbwOQaaixS94IFkyQgiJuDmI5DmNNksQE=";
+      })
+    ];
+
   env =
     (orig.env or { })
     // lib.optionalAttrs stdenv.hostPlatform.isStatic {
       EXTRA_CFLAGS = " -fno-omit-frame-pointer";
     };
-  #EXTRA_CFLAGS = if stdenv.hostPlatform.isStatic then " -fno-omit-frame-pointer" else null;
 
   doCheck = orig.doCheck || (!stdenv.hostPlatform.isStatic);
 })

--- a/nix/tenzir/plugins/default.nix
+++ b/nix/tenzir/plugins/default.nix
@@ -1,4 +1,5 @@
 {
+  stdenv,
   callPackage,
   tenzir,
   tenzir-plugins-srcs,
@@ -9,7 +10,7 @@ let
     name: src:
     callPackage ./generic.nix {
       name = "tenzir-plugin-${name}";
-      inherit src tenzir;
+      inherit stdenv src tenzir;
     };
 in
 builtins.mapAttrs f tenzir-plugins-srcs

--- a/nix/update.sh
+++ b/nix/update.sh
@@ -19,10 +19,13 @@ echo "mainroot = ${mainroot}"
 echo "gitdir = ${gitdir}"
 
 command -v docker > /dev/null && {
-  echo "Updating with with a nix docker container..."
+  echo "Updating with a nix docker container..."
   if [ "$toplevel/.git" = "$gitdir" ]; then
     docker run \
       -v "${toplevel}:${toplevel}" \
+      -e GIT_CONFIG_COUNT=1 \
+      -e GIT_CONFIG_KEY_0=safe.directory \
+      -e GIT_CONFIG_VALUE_0=${toplevel} \
       -e GITHUB_TOKEN \
       -e GH_TOKEN \
       nixos/nix "${toplevel}/nix/update.sh"
@@ -30,6 +33,9 @@ command -v docker > /dev/null && {
     docker run \
       -v "${toplevel}:${toplevel}" \
       -v "${gitdir}:${gitdir}" \
+      -e GIT_CONFIG_COUNT=1 \
+      -e GIT_CONFIG_KEY_0=safe.directory \
+      -e GIT_CONFIG_VALUE_0=${toplevel} \
       -e GITHUB_TOKEN \
       -e GH_TOKEN \
       nixos/nix "${toplevel}/nix/update.sh"
@@ -42,6 +48,9 @@ command -v podman > /dev/null && {
   if [ "$toplevel/.git" = "$gitdir" ]; then
     podman run \
       -v "${toplevel}:${toplevel}" \
+      -e GIT_CONFIG_COUNT=1 \
+      -e GIT_CONFIG_KEY_0=safe.directory \
+      -e GIT_CONFIG_VALUE_0=${toplevel} \
       -e GITHUB_TOKEN \
       -e GH_TOKEN \
       nixos/nix "${toplevel}/nix/update.sh"
@@ -49,6 +58,9 @@ command -v podman > /dev/null && {
     podman run \
       -v "${toplevel}:${toplevel}" \
       -v "${gitdir}:${gitdir}" \
+      -e GIT_CONFIG_COUNT=1 \
+      -e GIT_CONFIG_KEY_0=safe.directory \
+      -e GIT_CONFIG_VALUE_0=${toplevel} \
       -e GITHUB_TOKEN \
       -e GH_TOKEN \
       nixos/nix "${toplevel}/nix/update.sh"


### PR DESCRIPTION
This builds CAF and tenzir with clang instead of GCC.
Build with `nix build .#tenzir-static-clang`.