### PR TITLE
Fix `weak_handle` behavior for `nullptr` actors

### DIFF
--- a/libtenzir/include/tenzir/detail/weak_handle.hpp
+++ b/libtenzir/include/tenzir/detail/weak_handle.hpp
@@ -37,7 +37,7 @@ struct weak_handle : caf::weak_actor_ptr {
   ~weak_handle() noexcept = default;
 
   explicit(false) weak_handle(const Handle& handle) noexcept
-    : weak_ptr_{handle->ctrl()} {
+    : weak_ptr_{handle ? handle->ctrl() : caf::weak_actor_ptr{}} {
     // nop
   }
 


### PR DESCRIPTION
Extracted from @tobim's https://github.com/tenzir/tenzir/pull/5451 because we would like to get this in earlier.

No changelog because I think this bug didn't manifest itself for anyone and it's hard to tell where it would.