### PR TITLE
Make message argument optional in to_kafka operator

### DIFF
--- a/docs/operators/to_kafka.md
+++ b/docs/operators/to_kafka.md
@@ -7,7 +7,7 @@ example: 'to_kafka "topic", message=this.print_json()'
 Sends messages to an Apache Kafka topic.
 
 ```tql
-to_kafka topic:string, message:blob|string, [key=string, timestamp=time,
+to_kafka topic:string, [message=blob|string, key=string, timestamp=time,
          options=record, aws_iam=record]
 ```
 
@@ -33,9 +33,11 @@ include them:
 
 The Kafka topic to send messages to.
 
-### `message: blob|string`
+### `message = blob|string (optional)`
 
 An expression that evaluates to the message content for each row.
+
+Defaults to `this.print_json()` when not specified.
 
 ### `key = string (optional)`
 
@@ -63,18 +65,20 @@ If specified, enables using AWS IAM Authentication for MSK. The keys must be
 non-empty when specified.
 
 Available keys:
+
 - `region`: Region of the MSK Clusters. Must be specified when using IAM.
 - `assume_role`: Optional Role ARN to assume.
 - `session_name`: Optional session name to use when assuming a role.
 - `external_id`: Optional external id to use when assuming a role.
 
 The operator will try to get credentials in the following order:
+
 1. Checks your environment variables for AWS Credentials.
 2. Checks your `$HOME/.aws/credentials` file for a profile and credentials
 3. Contacts and logs in to a trusted identity provider. The login information to
    these providers can either be on the environment variables: `AWS_ROLE_ARN`,
-`AWS_WEB_IDENTITY_TOKEN_FILE`, `AWS_ROLE_SESSION_NAME` or on a profile in your
-`$HOME/.aws/credentials`.
+   `AWS_WEB_IDENTITY_TOKEN_FILE`, `AWS_ROLE_SESSION_NAME` or on a profile in your
+   `$HOME/.aws/credentials`.
 4. Checks for an external method set as part of a profile on `$HOME/.aws/config`
    to generate or look up credentials that are not directly supported by AWS.
 5. Contacts the ECS Task Role to request credentials if Environment variable
@@ -84,7 +88,14 @@ The operator will try to get credentials in the following order:
 
 ## Examples
 
-### Send JSON-formatted events to topic `events`
+### Send JSON-formatted events to topic `events` (using default)
+
+```tql
+subscribe "logs"
+to_kafka "events"
+```
+
+### Send JSON-formatted events with explicit message
 
 ```tql
 subscribe "logs"

--- a/plugins/kafka/builtins/to_kafka.cpp
+++ b/plugins/kafka/builtins/to_kafka.cpp
@@ -23,7 +23,7 @@ namespace {
 struct to_kafka_args {
   location op;
   std::string topic;
-  ast::expression message;
+  std::optional<ast::expression> message;
   std::optional<located<std::string>> key;
   std::optional<located<time>> timestamp;
   located<record> options;
@@ -76,12 +76,19 @@ public:
     });
     const auto key = args_.key ? args_.key->inner : "";
     const auto timestamp = args_.timestamp ? args_.timestamp->inner : time{};
+    // Create default expression if message not provided
+    auto message_expr = args_.message.value_or(ast::function_call{
+      ast::entity{{ast::identifier{"print_json", location::unknown}}},
+      {ast::this_{location::unknown}},
+      location::unknown,
+      true // method call
+    });
     for (const auto& slice : input) {
       if (slice.rows() == 0) {
         co_yield {};
         continue;
       }
-      const auto& ms = eval(args_.message, slice, dh);
+      const auto& ms = eval(message_expr, slice, dh);
       for (const auto& s : ms) {
         match(
           *s.array,
@@ -90,7 +97,7 @@ public:
             for (auto i = int64_t{}; i < array.length(); ++i) {
               if (array.IsNull(i)) {
                 diagnostic::warning("expected `string` or `blob`, got `null`")
-                  .primary(args_.message)
+                  .primary(message_expr)
                   .emit(dh);
                 continue;
               }
@@ -103,7 +110,7 @@ public:
           [&](const auto&) {
             diagnostic::warning("expected `string` or `blob`, got `{}`",
                                 s.type.kind())
-              .primary(args_.message)
+              .primary(message_expr)
               .emit(dh);
           });
       }


### PR DESCRIPTION
## Summary
- Made the `message` argument optional in the `to_kafka` operator
- Defaults to `this.print_json()` when not specified
- Updated documentation to reflect the optional parameter

## Changes
- Changed `message` field to `std::optional<ast::expression>` in the `to_kafka_args` struct
- Added logic to create a default AST expression for `this.print_json()` when message is not provided
- Updated documentation with the new optional parameter syntax and examples

## Test plan
- [ ] Verify that `to_kafka "topic"` works and sends JSON-formatted messages
- [ ] Verify that `to_kafka "topic", message=this.print_json()` still works as before
- [ ] Verify that custom message expressions still work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)