### PR TITLE
Fix CAF message metrics collection

### DIFF
--- a/docs/operators/metrics.md
+++ b/docs/operators/metrics.md
@@ -81,12 +81,26 @@ in production systems.
 
 The record `system` has the following schema:
 
-| Field                | Type    | Description                                     |
-| :------------------- | :------ | :---------------------------------------------- |
-| `running_actors`     | `int64` | Number of currently running actors.             |
-| `queued_messages`    | `int64` | Number of messages waiting in actor mailboxes.  |
-| `processed_messages` | `int64` | Number of messages processed since last metric. |
-| `rejected_messages`  | `int64` | Number of messages rejected since last metric.  |
+| Field               | Type     | Description                                                       |
+| :------------------ | :------- | :---------------------------------------------------------------- |
+| `running_actors`    | `int64`  | Number of currently running actors.                               |
+| `all_messages`      | `record` | Information about the total message metrics                       |
+| `messages_by_actor` | `list`   | Information about the message metrics, keyed the receiving actor. |
+
+The `all_messages` has the following schema:
+
+| Field       | Type    | Description                   |
+| :---------- | :------ | :---------------------------- |
+| `processed` | `int64` | Number of processed messages. |
+| `rejected`  | `int64` | Number of rejected messages.  |
+
+The `messages_by_actor` field is a `list` of `record` with the following schema:
+
+| Field       | Type     | Description                                                                                 |
+| :---------- | :------- | :------------------------------------------------------------------------------------------ |
+| `name`      | `string` | The name of the receiving actor. This may be null for messages without an associated actor. |
+| `processed` | `int64`  | Number of processed messages.                                                               |
+| `rejected`  | `int64`  | Number of rejected messages.                                                                |
 
 The record `middleman` has the following schema:
 

--- a/libtenzir/builtins/metrics/caf.cpp
+++ b/libtenzir/builtins/metrics/caf.cpp
@@ -6,6 +6,8 @@
 // SPDX-FileCopyrightText: (c) 2024 The Tenzir Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+#include "tenzir/detail/heterogeneous_string_hash.hpp"
+
 #include <tenzir/plugin.hpp>
 #include <tenzir/type.hpp>
 
@@ -14,19 +16,49 @@
 #include <caf/telemetry/int_gauge.hpp>
 #include <caf/telemetry/metric_registry.hpp>
 #include <caf/typed_event_based_actor.hpp>
+#include <tsl/robin_map.h>
 
 namespace tenzir::plugins::caf_system {
 
 namespace {
 
+class message_metric_t {
+public:
+  auto add(int64_t value) -> void {
+    total_ += value;
+  }
+  auto rotate() -> int64_t {
+    const auto ret = total_ - last_total_;
+    last_total_ = total_;
+    total_ = 0;
+    return ret;
+  }
+  auto last_total() -> int64_t {
+    return last_total_;
+  }
+
+private:
+  int64_t last_total_ = {};
+  int64_t total_ = {};
+};
+
+struct bundled_message_metric_t {
+  message_metric_t processed;
+  message_metric_t rejected;
+};
+
 struct metric {
   struct system_t {
     int64_t running_actors = {};
-    int64_t queued_messages = {};
-    int64_t processed_messages = {};
-    int64_t total_processed_messages = {};
-    int64_t rejected_messages = {};
-    int64_t total_rejected_messages = {};
+    /// Message Metrics for all messages (unnamed + per actor)
+    bundled_message_metric_t all_messages;
+    /// Message Metrics that did not provide a name label
+    bundled_message_metric_t unnamed_messages;
+    /// Message Metrics per actor name
+    tsl::robin_map<std::string, bundled_message_metric_t,
+                   detail::heterogeneous_string_hash,
+                   detail::heterogeneous_string_equal>
+      actor_messages;
   };
 
   struct middleman_t {
@@ -53,7 +85,50 @@ struct metric {
   std::unordered_map<std::string, actor_t> actors = {};
 };
 
+auto get_actor_name(const caf::telemetry::metric* metric)
+  -> std::optional<std::string_view> {
+  constexpr static auto get_value = [](const auto& label) -> std::string_view {
+    return label.name();
+  };
+  const auto actor_name_it
+    = std::ranges::find(metric->labels(), std::string_view{"name"}, get_value);
+  if (actor_name_it == metric->labels().end()) {
+    return std::nullopt;
+  }
+  return actor_name_it->value();
+}
+
 struct caf_collector {
+  void collect_system_counter(const caf::telemetry::metric_family* family,
+                              const caf::telemetry::metric* metric,
+                              const caf::telemetry::int_counter* impl) {
+    message_metric_t bundled_message_metric_t::* member = nullptr;
+    if (family->name() == "processed-messages") {
+      member = &bundled_message_metric_t::processed;
+    } else if (family->name() == "rejected-messages") {
+      member = &bundled_message_metric_t::rejected;
+    }
+    if (member == nullptr) {
+      return;
+    }
+    const auto value = impl->value();
+    (result.system.all_messages.*member).add(value);
+    const auto actor_name = get_actor_name(metric);
+    if (not actor_name) {
+      (result.system.unnamed_messages.*member).add(value);
+      return;
+    }
+    auto it = result.system.actor_messages.find(*actor_name);
+    if (it == result.system.actor_messages.end()) {
+      auto inserted = false;
+      std::tie(it, inserted)
+        = result.system.actor_messages.try_emplace(std::string{*actor_name});
+      TENZIR_ASSERT(inserted);
+    }
+    auto& m = it.value();
+    (m.*member).add(value);
+  }
+
   template <class T>
   void operator()(const caf::telemetry::metric_family* family,
                   const caf::telemetry::metric* metric, const T* impl) {
@@ -63,26 +138,9 @@ struct caf_collector {
           result.system.running_actors = impl->value();
           return;
         }
-        if (family->name() == "queued-messages") {
-          result.system.queued_messages = impl->value();
-          return;
-        }
       }
       if constexpr (std::same_as<T, caf::telemetry::int_counter>) {
-        if (family->name() == "processed-messages") {
-          const auto value = impl->value();
-          result.system.processed_messages
-            = value - result.system.total_processed_messages;
-          result.system.total_processed_messages = value;
-          return;
-        }
-        if (family->name() == "rejected-messages") {
-          const auto value = impl->value();
-          result.system.rejected_messages
-            = value - result.system.total_rejected_messages;
-          result.system.total_rejected_messages = value;
-          return;
-        }
+        collect_system_counter(family, metric, impl);
       }
     }
     if (family->prefix() == "caf.middleman") {
@@ -154,13 +212,38 @@ struct caf_collector {
     }
   }
 
+  auto messages_by_actor() -> list {
+    auto res = list{};
+    res.reserve(result.system.actor_messages.size() + 1);
+    auto& r = as<record>(res.emplace_back(record{}));
+    r.reserve(3);
+    r.try_emplace("name", caf::none);
+    r.try_emplace("processed",
+                  result.system.unnamed_messages.processed.rotate());
+    r.try_emplace("rejected", result.system.unnamed_messages.rejected.rotate());
+    for (auto it = result.system.actor_messages.begin();
+         it != result.system.actor_messages.end(); ++it) {
+      auto& k = it.key();
+      auto& v = it.value();
+      auto& r = as<record>(res.emplace_back(record{}));
+      r.reserve(3);
+      r.try_emplace("name", k);
+      r.try_emplace("processed", v.processed.rotate());
+      r.try_emplace("rejected", v.rejected.rotate());
+    }
+    return res;
+  }
+
   auto operator()() -> caf::expected<record> {
     system.metrics().collect(*this);
     auto system_metric = record{
       {"running_actors", result.system.running_actors},
-      {"queued_messages", result.system.queued_messages},
-      {"processed_messages", result.system.processed_messages},
-      {"rejected_messages", result.system.rejected_messages},
+      {"all_messages",
+       record{
+         {"processed", result.system.all_messages.processed.rotate()},
+         {"rejected", result.system.all_messages.rejected.rotate()},
+       }},
+      {"messages_by_actor", messages_by_actor()},
     };
     auto middleman_metric = record{
       {"inbound_messages_size", result.middleman.inbound_messages_size},
@@ -207,13 +290,20 @@ public:
 
   auto metric_layout() const -> record_type override {
     return record_type{
-      {"system",
-       record_type{
-         {"running_actors", int64_type{}},
-         {"queued_messages", int64_type{}},
-         {"processed_messages", int64_type{}},
-         {"rejected_messages", int64_type{}},
-       }},
+      {"system", record_type{{"running_actors", int64_type{}},
+                             {"all_messages",
+                              record_type{
+                                {"processed", int64_type{}},
+                                {"rejected", int64_type{}},
+                              }},
+                             {
+                               "messages_by_actor",
+                               list_type{record_type{
+                                 {"name", string_type{}},
+                                 {"processed", int64_type{}},
+                                 {"rejected", int64_type{}},
+                               }},
+                             }}},
       {"middleman",
        record_type{
          {"inbound_messages_size", int64_type{}},


### PR DESCRIPTION
CAF invokes the message collector multiple times per collection step,
with metrics from different actors that are differentiated only by `name`
label.

This broke our assumption that the collector would be invoked once per
timestep only and hence our computations were completely broken.

With this PR, the computation is moved out of the collector itself into
our own component, where we have the necessary exactly-once guarantee.

I've also gone ahead and collected the metrics one a per-actor level as
well, although for that to be really useful, we will need to name our
exec-node actors.

An example pipeline to test this would be:

```
let $resolution = 1min
let $timeframe = 3h

metrics "caf"
messages_without_actor = system.messages_by_actor.where( x => x.name == null).get(0,null)
exec_nodes = system.messages_by_actor.where( x => x.name == "exec-node").get(0,null)
node = system.messages_by_actor.where( x => x.name == "node").get(0,null)
pipeline_executor = system.messages_by_actor.where( x => x.name == "pipeline-executor").get(0,null)
drop system.messages_by_actor

chart_area x=timestamp, y={
    "total proccessed": mean(system.all_messages.processed),
    "total rejected": mean(system.all_messages.rejected),
    "without actor": mean(messages_without_actor.processed?),
    "exec nodes (sum)": mean(exec_nodes.processed?),
    "node actor": mean(node.processed?),
    "pipeline executors (sum)": mean(pipeline_executor.processed?),
  }, resolution=$resolution, x_min=now()-$timeframe

```
