### PR TITLE
Add user defined operators to packages

### DIFF
--- a/libtenzir/include/tenzir/base_ctx.hpp
+++ b/libtenzir/include/tenzir/base_ctx.hpp
@@ -11,6 +11,8 @@
 #include "tenzir/diagnostics.hpp"
 #include "tenzir/tql2/registry.hpp"
 
+#include <memory>
+
 namespace tenzir {
 
 /// The context that is available during all execution stages of a pipeline.
@@ -20,7 +22,14 @@ namespace tenzir {
 /// type interning, etc.
 class base_ctx {
 public:
-  base_ctx(diagnostic_handler& dh, const registry& reg) : dh_{dh}, reg_{reg} {
+  base_ctx(diagnostic_handler& dh, const registry& reg)
+    : dh_{dh}, reg_ptr_{&reg} {
+  }
+
+  // Own the registry via shared_ptr, useful when using snapshot semantics.
+  base_ctx(diagnostic_handler& dh, std::shared_ptr<const registry> reg)
+    : dh_{dh}, reg_holder_{std::move(reg)} {
+    reg_ptr_ = reg_holder_.get();
   }
 
   // TODO: Consider using inheritance instead.
@@ -35,12 +44,14 @@ public:
   }
 
   explicit(false) operator const registry&() {
-    return reg_;
+    TENZIR_ASSERT(reg_ptr_);
+    return *reg_ptr_;
   }
 
 private:
   std::reference_wrapper<diagnostic_handler> dh_;
-  std::reference_wrapper<const registry> reg_;
+  const registry* reg_ptr_ = nullptr;
+  std::shared_ptr<const registry> reg_holder_{};
 };
 
 } // namespace tenzir

--- a/libtenzir/include/tenzir/package.hpp
+++ b/libtenzir/include/tenzir/package.hpp
@@ -85,6 +85,7 @@ struct package_operator final {
 
   auto to_record() const -> record;
 
+  static auto parse(const view<record>& data) -> caf::expected<package_operator>;
   static auto parse(std::string_view input) -> caf::expected<package_operator>;
 
   friend auto inspect(auto& f, package_operator& x) -> bool {
@@ -210,8 +211,13 @@ struct package final {
 
   static auto parse(const view<record>& data) -> caf::expected<package>;
 
-  static auto load(const std::filesystem::path& path, diagnostic_handler& dh)
+  static auto load(const std::filesystem::path& dir, diagnostic_handler& dh)
     -> failure_or<package>;
+
+  auto id_from_path(const std::filesystem::path& pkg_part,
+                    const std::filesystem::path& parts_base,
+                    diagnostic_handler& dh) const
+    -> failure_or<std::string>;
 
   auto to_record() const -> record;
 
@@ -222,8 +228,9 @@ struct package final {
       f.field("package_icon", x.package_icon),
       f.field("author_icon", x.author_icon),
       f.field("categories", x.categories), f.field("inputs", x.inputs),
-      f.field("pipelines", x.pipelines), f.field("contexts", x.contexts),
-      f.field("examples", x.examples), f.field("config", x.config));
+      f.field("operators", x.operators), f.field("pipelines", x.pipelines),
+      f.field("contexts", x.contexts), f.field("examples", x.examples),
+      f.field("config", x.config));
   }
 };
 

--- a/libtenzir/include/tenzir/package.hpp
+++ b/libtenzir/include/tenzir/package.hpp
@@ -167,8 +167,8 @@ struct package_inputs_map
 };
 
 struct package_operators_map
-  : public detail::flat_map<std::string, package_operator> {
-  using super = detail::flat_map<std::string, package_operator>;
+  : public detail::flat_map<std::vector<std::string>, package_operator> {
+  using super = detail::flat_map<std::vector<std::string>, package_operator>;
   using super::super;
 };
 
@@ -213,11 +213,6 @@ struct package final {
 
   static auto load(const std::filesystem::path& dir, diagnostic_handler& dh)
     -> failure_or<package>;
-
-  auto id_from_path(const std::filesystem::path& pkg_part,
-                    const std::filesystem::path& parts_base,
-                    diagnostic_handler& dh) const
-    -> failure_or<std::string>;
 
   auto to_record() const -> record;
 

--- a/libtenzir/include/tenzir/tql2/entity_path.hpp
+++ b/libtenzir/include/tenzir/tql2/entity_path.hpp
@@ -10,13 +10,17 @@
 
 #include "tenzir/detail/debug_writer.hpp"
 #include "tenzir/detail/enum.hpp"
+#include <string>
 
 namespace tenzir {
 
-/// Entities are currently either rooted in the standard package, or in the
-/// config package. Once we support modules from user-defined packages, this
-/// closed enum should be opened up to allow referencing them.
-TENZIR_ENUM(entity_pkg, std, cfg);
+/// The package namespace in which an entity is looked up.
+///
+/// Historically this was a closed enum with values 'std' and 'cfg'. We now use
+/// strings to allow arbitrary package roots (e.g., packages::<id>).
+using entity_pkg = std::string;
+inline constexpr std::string_view entity_pkg_std = "std";
+inline constexpr std::string_view entity_pkg_cfg = "cfg";
 
 /// Models the available entity namespaces.
 TENZIR_ENUM(entity_ns, op, fn, mod);
@@ -39,7 +43,7 @@ public:
     return not segments_.empty();
   }
 
-  auto pkg() const -> entity_pkg {
+  auto pkg() const -> const entity_pkg& {
     TENZIR_ASSERT(resolved());
     return pkg_;
   }

--- a/libtenzir/include/tenzir/tql2/registry.hpp
+++ b/libtenzir/include/tenzir/tql2/registry.hpp
@@ -12,6 +12,9 @@
 #include "tenzir/detail/scope_guard.hpp"
 #include "tenzir/tql2/plugin.hpp"
 
+#include <memory>
+#include <mutex>
+
 namespace tenzir {
 
 struct module_def;
@@ -120,27 +123,69 @@ public:
   auto function_names() const -> std::vector<std::string>;
   auto module_names() const -> std::vector<std::string>;
 
-  /// Register an entity. This should only be done on startup.
-  void add(entity_pkg package, std::string_view name, entity_def def);
+  /// Register an entity. This should only be done on startup or when
+  /// constructing a new snapshot of the registry.
+  void add(const entity_pkg& package, std::string_view name, entity_def def);
+
+  /// Create a deep copy of this registry. Used for snapshot-style updates.
+  auto clone() const -> std::unique_ptr<registry>;
+
+  /// Add a module definition at the given path, creating parent modules as
+  /// necessary. Fails with an assertion if a module already exists there.
+  void add_module(const entity_pkg& package, std::string_view path,
+                  std::unique_ptr<module_def> mod);
+
+  /// Replace (or create) a module definition at the given path, creating
+  /// parent modules as necessary.
+  void replace_module(const entity_pkg& package, std::string_view path,
+                      std::unique_ptr<module_def> mod);
+
+  /// Remove the module at the given path. Parent modules are left intact. If
+  /// the name entry becomes empty (no fn/op/mod), it is erased.
+  void remove_module(const entity_pkg& package, std::string_view path);
 
 private:
   /// Get the root module for the given package.
-  auto root(entity_pkg package) -> module_def&;
-  auto root(entity_pkg package) const -> const module_def&;
-
-  module_def std_;
-  module_def cfg_;
+  auto root(const entity_pkg& package) -> module_def&;
+  auto root(const entity_pkg& package) const -> const module_def&;
+  std::unordered_map<std::string, module_def, detail::heterogeneous_string_hash,
+                     std::equal_to<>> roots_;
 };
 
 // TODO: This should be attached to the `session` object. However, because we
 // are still in the process of upgrading everything, we cannot consistently pass
 // this around.
-auto global_registry() -> const registry&;
+/// Return the current global registry snapshot.
+auto global_registry() -> std::shared_ptr<const registry>;
 
-/// Obtain a mutable reference to the global registry.
-///
-/// This may only be used if nothing else accesses the registry concurrently.
-auto global_registry_mut() -> registry&;
+// Note: Mutable access to a global registry is intentionally not exposed
+// anymore; use clone() and publish via a swap in higher-level control flows.
+
+/// RAII guard to serialize a full clone->update->publish cycle.
+class registry_update_guard {
+public:
+  registry_update_guard(const registry_update_guard&) = delete;
+  registry_update_guard& operator=(const registry_update_guard&) = delete;
+  registry_update_guard(registry_update_guard&&) noexcept = default;
+  registry_update_guard& operator=(registry_update_guard&&) noexcept = default;
+  ~registry_update_guard() = default;
+
+  /// Return the current global registry snapshot while holding the lock.
+  auto current() const -> std::shared_ptr<const registry>;
+
+  /// Publish a new global registry snapshot while holding the lock.
+  void publish(std::shared_ptr<const registry> next) const;
+
+private:
+  friend registry_update_guard begin_registry_update();
+  explicit registry_update_guard(std::unique_lock<std::mutex> lock)
+    : lock_{std::move(lock)} {}
+
+  std::unique_lock<std::mutex> lock_;
+};
+
+/// Acquire the registry update lock to perform clone->update->publish atomically.
+auto begin_registry_update() -> registry_update_guard;
 
 auto thread_local_registry() -> const registry*;
 

--- a/libtenzir/src/package.cpp
+++ b/libtenzir/src/package.cpp
@@ -601,6 +601,7 @@ auto make_id(const std::filesystem::path& pkg_part,
 
 auto package::load(const std::filesystem::path& dir, diagnostic_handler& dh)
   -> failure_or<package> {
+  bool had_errors = false;
   auto package_file = dir / "package.yaml";
   std::error_code ec;
   if (not std::filesystem::exists(package_file, ec)) {
@@ -719,6 +720,41 @@ auto package::load(const std::filesystem::path& dir, diagnostic_handler& dh)
                          std::back_inserter(path), [](auto component) {
                            return std::string{component};
                          });
+          // Validate that all path segments are valid TQL identifiers:
+          // first char [A-Za-z_], subsequent [A-Za-z0-9_].
+          auto is_valid_ident = [](std::string_view s) -> bool {
+            if (s.empty())
+              return false;
+            auto is_alpha = [](unsigned char c) {
+              return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
+            };
+            auto is_alnum_us = [&](unsigned char c) {
+              return is_alpha(c) || (c >= '0' && c <= '9') || c == '_';
+            };
+            if (!(is_alpha(static_cast<unsigned char>(s[0])) || s[0] == '_'))
+              return false;
+            for (size_t i = 1; i < s.size(); ++i) {
+              if (!is_alnum_us(static_cast<unsigned char>(s[i])))
+                return false;
+            }
+            return true;
+          };
+          bool valid = true;
+          for (const auto& seg : path) {
+            if (!is_valid_ident(seg)) {
+              diagnostic::error(
+                "invalid operator path segment '{}' (must match [A-Za-z_][A-Za-z0-9_]*)",
+                seg)
+                .note("in operator file {}", operator_file.path())
+                .emit(dh);
+              valid = false;
+              break;
+            }
+          }
+          if (!valid) {
+            had_errors = true;
+            continue;
+          }
           parsed_package->operators.emplace(std::move(path),
                                             std::move(*operator_));
         }
@@ -763,6 +799,8 @@ auto package::load(const std::filesystem::path& dir, diagnostic_handler& dh)
       return failure::promise();
     }
   }
+  if (had_errors)
+    return failure::promise();
   return *parsed_package;
 }
 

--- a/libtenzir/src/session.cpp
+++ b/libtenzir/src/session.cpp
@@ -47,7 +47,7 @@ auto session::has_failure() const -> bool {
 
 auto session::reg() -> const registry& {
   // TODO: The registry should be attached to a session instead.
-  return global_registry();
+  return *global_registry();
 }
 
 auto session::dh() -> diagnostic_handler& {

--- a/libtenzir/src/tql2/registry.cpp
+++ b/libtenzir/src/tql2/registry.cpp
@@ -75,9 +75,18 @@ auto operator_def::make(operator_factory_plugin::invocation inv,
 
 thread_local const registry* g_thread_local_registry = nullptr;
 
+// Global snapshot holder with early atexit reset to avoid late teardown issues.
 static auto global_registry_atom()
   -> std::atomic<std::shared_ptr<const registry>>& {
   static std::atomic<std::shared_ptr<const registry>> atom{};
+  static std::once_flag registered;
+  std::call_once(registered, [] {
+    // Clear the snapshot early during shutdown to avoid late destruction of
+    // shared resources that may depend on other singletons.
+    std::atexit([] {
+      atom.store({}, std::memory_order_release);
+    });
+  });
   return atom;
 }
 
@@ -167,9 +176,10 @@ auto registry::try_get(const entity_path& path) const
     auto it = current->defs.find(segments[i]);
     if (it == current->defs.end()) {
       if (i == 0) {
-        TENZIR_INFO("registry.try_get: root '{}' missing first segment '{}' in ns {}. Available entries: {}",
-                    path.pkg(), segments[i], path.ns(),
-                    fmt::join(std::views::keys(current->defs), ", "));
+        TENZIR_DEBUG(
+          "registry.try_get: root '{}' missing first segment '{}' in ns {}. entries=[{}]",
+          path.pkg(), segments[i], path.ns(),
+          fmt::join(std::views::keys(current->defs), ", "));
       }
       // No such entity.
       return error{i, false};

--- a/libtenzir/src/tql2/registry.cpp
+++ b/libtenzir/src/tql2/registry.cpp
@@ -13,6 +13,9 @@
 #include "tenzir/tql2/exec.hpp"
 
 #include <ranges>
+#include <atomic>
+#include <memory>
+#include <mutex>
 
 namespace tenzir {
 
@@ -71,6 +74,17 @@ auto operator_def::make(operator_factory_plugin::invocation inv,
 
 thread_local const registry* g_thread_local_registry = nullptr;
 
+static auto global_registry_atom()
+  -> std::atomic<std::shared_ptr<const registry>>& {
+  static std::atomic<std::shared_ptr<const registry>> atom{};
+  return atom;
+}
+
+static auto global_registry_mutex() -> std::mutex& {
+  static std::mutex mtx;
+  return mtx;
+}
+
 auto thread_local_registry() -> const registry* {
   return g_thread_local_registry;
 }
@@ -79,40 +93,53 @@ void set_thread_local_registry(const registry* reg) {
   g_thread_local_registry = reg;
 }
 
-auto global_registry_mut() -> registry& {
-  static auto reg = std::invoke([] {
-    auto reg = registry{};
-    for (auto op : plugins::get<operator_factory_plugin>()) {
-      auto name = op->name();
-      // TODO: We prefixed some operators with "tql2." to prevent name clashes
-      // with the legacy operators. We should get rid of this eventually.
-      if (name.starts_with("tql2.")) {
-        name.erase(0, 5);
+auto global_registry() -> std::shared_ptr<const registry> {
+  auto& atom = global_registry_atom();
+  auto reg = atom.load(std::memory_order_acquire);
+  if (!reg) [[unlikely]] {
+    static std::once_flag init_once;
+    std::call_once(init_once, [&] {
+      auto init = std::make_shared<registry>();
+      for (auto op : plugins::get<operator_factory_plugin>()) {
+        auto name = op->name();
+        if (name.starts_with("tql2.")) {
+          name.erase(0, 5);
+        }
+        init->add(std::string{entity_pkg_std}, name, native_operator{nullptr, op});
       }
-      reg.add(entity_pkg::std, name, native_operator{nullptr, op});
-    }
-    for (auto op : plugins::get<operator_compiler_plugin>()) {
-      auto name = op->operator_name();
-      if (name.starts_with("tql2.")) {
-        name.erase(0, 5);
+      for (auto op : plugins::get<operator_compiler_plugin>()) {
+        auto name = op->operator_name();
+        if (name.starts_with("tql2.")) {
+          name.erase(0, 5);
+        }
+        init->add(std::string{entity_pkg_std}, name, native_operator{op, nullptr});
       }
-      reg.add(entity_pkg::std, name, native_operator{op, nullptr});
-    }
-    for (auto fn : plugins::get<function_plugin>()) {
-      auto name = fn->function_name();
-      // TODO: Same here.
-      if (name.starts_with("tql2.")) {
-        name.erase(0, 5);
+      for (auto fn : plugins::get<function_plugin>()) {
+        auto name = fn->function_name();
+        if (name.starts_with("tql2.")) {
+          name.erase(0, 5);
+        }
+        init->add(std::string{entity_pkg_std}, name, std::ref(*fn));
       }
-      reg.add(entity_pkg::std, name, std::ref(*fn));
-    }
-    return reg;
-  });
+      atom.store(std::shared_ptr<const registry>{init},
+                 std::memory_order_release);
+    });
+    reg = atom.load(std::memory_order_acquire);
+  }
   return reg;
 }
 
-auto global_registry() -> const registry& {
-  return global_registry_mut();
+auto begin_registry_update() -> registry_update_guard {
+  return registry_update_guard{std::unique_lock<std::mutex>{global_registry_mutex()}};
+}
+
+auto registry_update_guard::current() const -> std::shared_ptr<const registry> {
+  // Ensure a snapshot exists by going through the public accessor.
+  return global_registry();
+}
+
+void registry_update_guard::publish(std::shared_ptr<const registry> next) const {
+  global_registry_atom().store(std::move(next), std::memory_order_release);
 }
 
 auto registry::get(const ast::function_call& call) const
@@ -191,16 +218,15 @@ auto registry::module_names() const -> std::vector<std::string> {
 }
 
 auto registry::entity_names(entity_ns ns) const -> std::vector<std::string> {
-  // TODO: This does not really return the reachable entity names if the names
-  // from `cfg_` shadow names from `std_`.
   auto result = std::vector<std::string>{};
-  gather_names(std_, ns, "", result);
-  gather_names(cfg_, ns, "", result);
+  for (const auto& [_, mod] : roots_) {
+    gather_names(mod, ns, "", result);
+  }
   std::ranges::sort(result);
   return result;
 }
 
-void registry::add(entity_pkg package, std::string_view name, entity_def def) {
+void registry::add(const entity_pkg& package, std::string_view name, entity_def def) {
   TENZIR_ASSERT(not name.empty());
   auto path = detail::split(name, "::");
   TENZIR_ASSERT(not path.empty());
@@ -247,21 +273,109 @@ void registry::add(entity_pkg package, std::string_view name, entity_def def) {
     });
 }
 
-auto registry::root(entity_pkg package) -> module_def& {
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-  return const_cast<module_def&>(std::as_const(*this).root(package));
+void registry::add_module(const entity_pkg& package, std::string_view name,
+                          std::unique_ptr<module_def> mod) {
+  TENZIR_ASSERT(!name.empty());
+  auto path = detail::split(name, "::");
+  TENZIR_ASSERT(!path.empty());
+  // Find or create parent module.
+  auto parent = &root(package);
+  for (auto& segment : path) {
+    if (&segment == &path.back()) {
+      break;
+    }
+    auto& set = parent->defs[std::string{segment}];
+    if (not set.mod) {
+      set.mod = std::make_unique<module_def>();
+    }
+    parent = set.mod.get();
+  }
+  auto& set = parent->defs[std::string{path.back()}];
+  TENZIR_ASSERT(!set.mod && "module already exists at path");
+  set.mod = std::move(mod);
 }
 
-auto registry::root(entity_pkg package) const -> const module_def& {
-  return std::invoke([&]() -> const module_def& {
-    switch (package) {
-      case entity_pkg::std:
-        return std_;
-      case entity_pkg::cfg:
-        return cfg_;
+void registry::replace_module(const entity_pkg& package, std::string_view name,
+                              std::unique_ptr<module_def> mod) {
+  TENZIR_ASSERT(!name.empty());
+  auto path = detail::split(name, "::");
+  TENZIR_ASSERT(!path.empty());
+  auto parent = &root(package);
+  for (auto& segment : path) {
+    if (&segment == &path.back()) {
+      break;
     }
-    TENZIR_UNREACHABLE();
-  });
+    auto& set = parent->defs[std::string{segment}];
+    if (not set.mod) {
+      set.mod = std::make_unique<module_def>();
+    }
+    parent = set.mod.get();
+  }
+  auto& set = parent->defs[std::string{path.back()}];
+  set.mod = std::move(mod);
+}
+
+void registry::remove_module(const entity_pkg& package, std::string_view name) {
+  TENZIR_ASSERT(!name.empty());
+  auto path = detail::split(name, "::");
+  TENZIR_ASSERT(!path.empty());
+  auto parent = &root(package);
+  for (auto& segment : path) {
+    if (&segment == &path.back()) {
+      break;
+    }
+    auto it = parent->defs.find(std::string{segment});
+    if (it == parent->defs.end() || !it->second.mod) {
+      // Nothing to remove; path does not exist.
+      return;
+    }
+    parent = it->second.mod.get();
+  }
+  auto it = parent->defs.find(std::string{path.back()});
+  if (it == parent->defs.end()) {
+    return;
+  }
+  it->second.mod.reset();
+  if (!it->second.fn && !it->second.op && !it->second.mod) {
+    parent->defs.erase(it);
+  }
+}
+
+namespace {
+auto clone_module(const module_def& src) -> std::unique_ptr<module_def> {
+  auto out = std::make_unique<module_def>();
+  for (const auto& [k, v] : src.defs) {
+    entity_set set{};
+    set.fn = v.fn;
+    set.op = v.op; // deep copy of optional operator_def
+    if (v.mod) {
+      set.mod = clone_module(*v.mod);
+    }
+    out->defs.emplace(k, std::move(set));
+  }
+  return out;
+}
+} // namespace
+
+auto registry::clone() const -> std::unique_ptr<registry> {
+  auto out = std::make_unique<registry>();
+  for (const auto& [name, mod] : roots_) {
+    auto cloned = clone_module(mod);
+    out->roots_.emplace(name, std::move(*cloned));
+  }
+  return out;
+}
+
+auto registry::root(const entity_pkg& package) -> module_def& {
+  return roots_[package];
+}
+
+auto registry::root(const entity_pkg& package) const -> const module_def& {
+  if (auto it = roots_.find(package); it != roots_.end()) {
+    return it->second;
+  }
+  static const module_def empty;
+  return empty;
 }
 
 } // namespace tenzir

--- a/libtenzir/src/tql2/registry.cpp
+++ b/libtenzir/src/tql2/registry.cpp
@@ -13,6 +13,7 @@
 #include "tenzir/tql2/exec.hpp"
 
 #include <ranges>
+#include <tenzir/logger.hpp>
 #include <atomic>
 #include <memory>
 #include <mutex>
@@ -165,6 +166,11 @@ auto registry::try_get(const entity_path& path) const
   for (auto i = size_t{0}; i < segments.size(); ++i) {
     auto it = current->defs.find(segments[i]);
     if (it == current->defs.end()) {
+      if (i == 0) {
+        TENZIR_INFO("registry.try_get: root '{}' missing first segment '{}' in ns {}. Available entries: {}",
+                    path.pkg(), segments[i], path.ns(),
+                    fmt::join(std::views::keys(current->defs), ", "));
+      }
       // No such entity.
       return error{i, false};
     }

--- a/libtenzir/src/tql2/resolve.cpp
+++ b/libtenzir/src/tql2/resolve.cpp
@@ -18,10 +18,6 @@
 #include <tsl/robin_map.h>
 
 #include <ranges>
-#include <tenzir/logger.hpp>
-
-#undef TENZIR_DEBUG
-#define TENZIR_DEBUG TENZIR_INFO
 
 namespace tenzir {
 
@@ -39,9 +35,6 @@ public:
     }
     TENZIR_ASSERT(not x.path.empty());
     TENZIR_ASSERT(context_ != context_t::none);
-    TENZIR_DEBUG("resolver: visiting entity with raw path '{}'", fmt::join(
-                   std::views::transform(x.path, &ast::identifier::name),
-                   "::"));
     // We use the following logic:
     // - Look at the first segment.
     // - Use its name + namespace (mod/fn/op) for lookup as user-defined.
@@ -50,7 +43,6 @@ public:
     const auto target_ns
       = context_ == context_t::op_name ? entity_ns::op : entity_ns::fn;
     const auto first_ns = x.path.size() == 1 ? target_ns : entity_ns::mod;
-    TENZIR_DEBUG("resolver: target_ns={}, first_ns={}", target_ns, first_ns);
     const auto report_not_found = [&](const std::vector<ast::identifier>& path,
                                       size_t idx, entity_ns ns) {
       result_ = failure::promise();
@@ -126,14 +118,9 @@ public:
       for (auto pkg : {std::string{entity_pkg_cfg}, std::string{entity_pkg_std},
                        std::string{"packages"}}) {
         auto path = entity_path{pkg, {x.path[0].name}, first_ns};
-        TENZIR_DEBUG("resolver: probing root='{}' segment='{}' ns={}",
-                     pkg, x.path[0].name, first_ns);
         if (is<entity_ref>(reg_.try_get(path))) {
-          TENZIR_DEBUG("resolver: found root='{}' for first segment '{}'", pkg,
-                       x.path[0].name);
           return pkg;
         }
-        TENZIR_DEBUG("resolver: not found in root '{}'", pkg);
       }
       return std::nullopt;
     });
@@ -148,20 +135,15 @@ public:
       segments.push_back(segment.name);
     };
     auto path = entity_path{*pkg, std::move(segments), target_ns};
-    TENZIR_DEBUG("resolver: probing full path='{}::{}/{}'", *pkg,
-                 fmt::join(path.segments(), "::"), target_ns);
     auto result = reg_.try_get(path);
     auto err = try_as<registry::error>(result);
     if (err) {
-      TENZIR_DEBUG("resolver: failed to resolve at segment {} (other_exists={})",
-                   err->segment, err->other_exists);
       TENZIR_ASSERT(err->segment < x.path.size());
       auto is_last = err->segment == path.segments().size() - 1;
       auto error_ns = is_last ? target_ns : entity_ns::mod;
       report_not_found(x.path, err->segment, error_ns);
       return;
     }
-    TENZIR_DEBUG("resolver: success resolving entity");
     x.ref = std::move(path);
   }
 

--- a/libtenzir/src/tql2/resolve.cpp
+++ b/libtenzir/src/tql2/resolve.cpp
@@ -18,6 +18,10 @@
 #include <tsl/robin_map.h>
 
 #include <ranges>
+#include <tenzir/logger.hpp>
+
+#undef TENZIR_DEBUG
+#define TENZIR_DEBUG TENZIR_INFO
 
 namespace tenzir {
 
@@ -35,6 +39,9 @@ public:
     }
     TENZIR_ASSERT(not x.path.empty());
     TENZIR_ASSERT(context_ != context_t::none);
+    TENZIR_DEBUG("resolver: visiting entity with raw path '{}'", fmt::join(
+                   std::views::transform(x.path, &ast::identifier::name),
+                   "::"));
     // We use the following logic:
     // - Look at the first segment.
     // - Use its name + namespace (mod/fn/op) for lookup as user-defined.
@@ -43,6 +50,7 @@ public:
     const auto target_ns
       = context_ == context_t::op_name ? entity_ns::op : entity_ns::fn;
     const auto first_ns = x.path.size() == 1 ? target_ns : entity_ns::mod;
+    TENZIR_DEBUG("resolver: target_ns={}, first_ns={}", target_ns, first_ns);
     const auto report_not_found = [&](const std::vector<ast::identifier>& path,
                                       size_t idx, entity_ns ns) {
       result_ = failure::promise();
@@ -114,11 +122,18 @@ public:
     // Because there currently is no way to bring additional entities into the
     // scope, we can directly dispatch to the registry.
     auto pkg = std::invoke([&]() -> std::optional<entity_pkg> {
-      for (auto pkg : {entity_pkg::cfg, entity_pkg::std}) {
+      // Resolution precedence: cfg (user overrides) -> std (builtins) -> packages (installed)
+      for (auto pkg : {std::string{entity_pkg_cfg}, std::string{entity_pkg_std},
+                       std::string{"packages"}}) {
         auto path = entity_path{pkg, {x.path[0].name}, first_ns};
+        TENZIR_DEBUG("resolver: probing root='{}' segment='{}' ns={}",
+                     pkg, x.path[0].name, first_ns);
         if (is<entity_ref>(reg_.try_get(path))) {
+          TENZIR_DEBUG("resolver: found root='{}' for first segment '{}'", pkg,
+                       x.path[0].name);
           return pkg;
         }
+        TENZIR_DEBUG("resolver: not found in root '{}'", pkg);
       }
       return std::nullopt;
     });
@@ -133,15 +148,20 @@ public:
       segments.push_back(segment.name);
     };
     auto path = entity_path{*pkg, std::move(segments), target_ns};
+    TENZIR_DEBUG("resolver: probing full path='{}::{}/{}'", *pkg,
+                 fmt::join(path.segments(), "::"), target_ns);
     auto result = reg_.try_get(path);
     auto err = try_as<registry::error>(result);
     if (err) {
+      TENZIR_DEBUG("resolver: failed to resolve at segment {} (other_exists={})",
+                   err->segment, err->other_exists);
       TENZIR_ASSERT(err->segment < x.path.size());
       auto is_last = err->segment == path.segments().size() - 1;
       auto error_ns = is_last ? target_ns : entity_ns::mod;
       report_not_found(x.path, err->segment, error_ns);
       return;
     }
+    TENZIR_DEBUG("resolver: success resolving entity");
     x.ref = std::move(path);
   }
 

--- a/libtenzir/src/tql2/tokens.cpp
+++ b/libtenzir/src/tql2/tokens.cpp
@@ -366,7 +366,7 @@ auto validate_utf8(std::string_view content, session ctx) -> failure_or<void> {
     return {};
   }
   // TODO: Consider reporting offset.
-  diagnostic::error("found invalid UTF8").note("content: {}", content).emit(ctx);
+  diagnostic::error("found invalid UTF8").emit(ctx);
   return failure::promise();
 }
 

--- a/libtenzir/src/tql2/tokens.cpp
+++ b/libtenzir/src/tql2/tokens.cpp
@@ -366,7 +366,7 @@ auto validate_utf8(std::string_view content, session ctx) -> failure_or<void> {
     return {};
   }
   // TODO: Consider reporting offset.
-  diagnostic::error("found invalid UTF8").emit(ctx);
+  diagnostic::error("found invalid UTF8").note("content: {}", content).emit(ctx);
   return failure::promise();
 }
 

--- a/tenzir/tenzir.cpp
+++ b/tenzir/tenzir.cpp
@@ -411,8 +411,6 @@ auto main(int argc, char** argv) -> int try {
           dh->emit(std::move(diag));
         }
         resolved.push_back(udo.first);
-        global_registry_mut().add(entity_pkg::cfg, udo.first,
-                                  user_defined_operator{std::move(udo.second)});
       }
       if (resolved.empty()) {
         for (auto& diag : unresolved_diags) {
@@ -421,6 +419,22 @@ auto main(int argc, char** argv) -> int try {
         TENZIR_ERROR("failed to resolve user-defined operators: `{}`",
                      fmt::join(udos | std::ranges::views::keys, "`, `"));
         return EXIT_FAILURE;
+      }
+      {
+        auto to_add = std::vector<std::pair<std::string, ast::pipeline>>{};
+        to_add.reserve(resolved.size());
+        for (const auto& name : resolved) {
+          auto it = udos.find(name);
+          TENZIR_ASSERT(it != udos.end());
+          to_add.emplace_back(it->first, std::move(it->second));
+        }
+        auto guard = begin_registry_update();
+        auto base = guard.current();
+        auto next = base->clone();
+        for (auto& [name, def] : to_add) {
+          next->add(std::string{entity_pkg_cfg}, name, user_defined_operator{std::move(def)});
+        }
+        guard.publish(std::shared_ptr<const registry>{std::move(next)});
       }
       for (const auto& name : std::exchange(resolved, {})) {
         udos.erase(name);


### PR DESCRIPTION
This extends the package format with user defined operators.
A packaged operator can be used from a pipeline after the package is installed on a node.
A packaged operator can be called with
```
<package_id>::[operator_module_id::]<operator_id>
```

TODO:
- [ ] docs
- [ ] cleanups
- [ ] thorough integration tests