### PR TITLE
Add TQL type definitions

### DIFF
--- a/libtenzir/include/tenzir/fwd.hpp
+++ b/libtenzir/include/tenzir/fwd.hpp
@@ -418,6 +418,7 @@ struct pipeline_expr;
 struct pipeline;
 struct record;
 struct selector_root;
+struct type_expr;
 struct type_stmt;
 struct unary_expr;
 struct underscore;

--- a/libtenzir/include/tenzir/fwd.hpp
+++ b/libtenzir/include/tenzir/fwd.hpp
@@ -418,6 +418,7 @@ struct pipeline_expr;
 struct pipeline;
 struct record;
 struct selector_root;
+struct type_stmt;
 struct unary_expr;
 struct underscore;
 struct unpack;
@@ -425,7 +426,7 @@ struct unpack;
 class field_path;
 
 using statement
-  = variant<invocation, assignment, let_stmt, if_stmt, match_stmt>;
+  = variant<invocation, assignment, let_stmt, if_stmt, match_stmt, type_stmt>;
 
 } // namespace ast
 

--- a/libtenzir/include/tenzir/module.hpp
+++ b/libtenzir/include/tenzir/module.hpp
@@ -9,8 +9,10 @@
 #pragma once
 
 #include "tenzir/defaults.hpp"
+#include "tenzir/detail/heterogeneous_string_hash.hpp"
 #include "tenzir/detail/operators.hpp"
 #include "tenzir/detail/stable_set.hpp"
+#include "tenzir/tql2/ast.hpp"
 #include "tenzir/type.hpp"
 
 #include <caf/expected.hpp>
@@ -95,6 +97,14 @@ caf::expected<symbol_map>
 load_symbols(const detail::stable_set<std::filesystem::path>& module_dirs,
              size_t max_recursion = defaults::max_recursion);
 
+using symbol_map2 = std::unordered_map<std::string, ast::type_def,
+                                       detail::heterogeneous_string_hash,
+                                       detail::heterogeneous_string_equal>;
+
+caf::expected<symbol_map2>
+load_symbols2(const detail::stable_set<std::filesystem::path>& module_dirs,
+              size_t max_recursion = defaults::max_recursion);
+
 /// Loads modules according to the configuration. This is a convenience wrapper
 /// around *get_module_dirs* and *load_module*.
 caf::expected<symbol_map> load_symbols(const caf::actor_system_config& cfg);
@@ -105,6 +115,8 @@ caf::expected<symbol_map> load_symbols(const caf::actor_system_config& cfg);
 /// @returns The loaded taxonomies.
 auto load_taxonomies(const caf::actor_system_config& cfg)
   -> caf::expected<taxonomies>;
+
+auto translate_builtin_type(std::string_view name) -> std::optional<type>;
 
 } // namespace tenzir
 

--- a/libtenzir/include/tenzir/modules.hpp
+++ b/libtenzir/include/tenzir/modules.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "tenzir/module.hpp"
 #include "tenzir/taxonomies.hpp"
 
 namespace tenzir::modules {
@@ -15,7 +16,7 @@ namespace tenzir::modules {
 /// Initialize the global module and concepts registries.
 ///
 /// Must be called at most once.
-void init(symbol_map mod, concepts_map concepts);
+void init(symbol_map mod, symbol_map2 mod2, concepts_map concepts);
 
 /// Returns the schema with the given name, if it exists.
 ///

--- a/libtenzir/include/tenzir/multi_series_builder_argument_parser.hpp
+++ b/libtenzir/include/tenzir/multi_series_builder_argument_parser.hpp
@@ -13,7 +13,6 @@
 #include "tenzir/multi_series_builder.hpp"
 
 #include <tenzir/error.hpp>
-#include <tenzir/module.hpp>
 #include <tenzir/operator_plugin.hpp>
 #include <tenzir/plugin.hpp>
 
@@ -79,7 +78,6 @@ private:
   // options by checking/setting values here
   // this is only relevant to tql1
 public:
-  std::vector<tenzir::type> schemas_;
   bool has_manual_defaults_ = false;
   bool is_tql1_ = false;
   multi_series_builder::settings_type settings_ = {};

--- a/libtenzir/include/tenzir/tql2/ast.hpp
+++ b/libtenzir/include/tenzir/tql2/ast.hpp
@@ -191,7 +191,7 @@ using expression_kinds
   = detail::type_list<record, list, meta, this_, root_field, pipeline_expr,
                       constant, field_access, index_expr, binary_expr,
                       unary_expr, function_call, lambda_expr, underscore,
-                      unpack, assignment, dollar_var, format_expr>;
+                      unpack, assignment, dollar_var, format_expr, type_expr>;
 
 using expression_kind = detail::tl_apply_t<expression_kinds, variant>;
 
@@ -783,13 +783,14 @@ struct match_stmt {
 struct type_def;
 struct record_def;
 
-using type_kind = variant<record_def, identifier>;
+using type_kinds = caf::type_list<record_def, identifier>;
+using type_kind = caf::detail::tl_apply_t<type_kinds, variant>;
 
 struct type_def {
   type_def() = default;
 
   template <class T>
-    requires(detail::tl_contains<type_kind, std::remove_cvref_t<T>>::value)
+    requires(detail::tl_contains<type_kinds, std::remove_cvref_t<T>>::value)
   explicit(false) type_def(T&& x)
     : kind{std::make_unique<type_kind>(std::forward<T>(x))} {
   }
@@ -802,7 +803,10 @@ struct type_def {
 
   std::unique_ptr<type_kind> kind;
 
-  friend auto inspect(auto& f, type_def& x) -> bool;
+  template <class Inspector>
+  friend auto inspect(Inspector& f, type_def& x) -> bool;
+
+  auto get_location() const -> location;
 };
 
 struct record_def {
@@ -824,6 +828,10 @@ struct record_def {
     return f.object(x).fields(f.field("begin", x.begin),
                               f.field("fields", x.fields),
                               f.field("end", x.end));
+  }
+
+  auto get_location() const -> location {
+    return begin.combine(end);
   }
 };
 
@@ -891,10 +899,34 @@ struct format_expr {
   }
 };
 
+struct type_expr {
+  type_expr() = default;
+
+  type_expr(location keyword, type_def def)
+    : keyword{keyword}, def{std::move(def)} {
+  }
+
+  location keyword;
+  type_def def;
+
+  friend auto inspect(auto& f, type_expr& x) -> bool {
+    return f.object(x).fields(f.field("keyword", x.keyword),
+                              f.field("def", x.def));
+  }
+
+  auto get_location() const -> struct location {
+    return keyword.combine(def);
+  }
+};
+
 inline expression::~expression() = default;
 inline expression::expression(expression&&) noexcept = default;
 inline auto expression::operator=(expression&&) noexcept
   -> expression& = default;
+
+inline type_def::~type_def() = default;
+inline type_def::type_def(type_def&&) noexcept = default;
+inline auto type_def::operator=(type_def&&) noexcept -> type_def& = default;
 
 template <class Result, class... Fs>
 auto expression::match(Fs&&... fs) & -> decltype(auto) {
@@ -925,6 +957,46 @@ inline pipeline::pipeline(std::vector<statement> body) : body{std::move(body)} {
 inline pipeline::~pipeline() = default;
 inline pipeline::pipeline(pipeline&&) noexcept = default;
 inline auto pipeline::operator=(pipeline&&) noexcept -> pipeline& = default;
+
+} // namespace tenzir::ast
+
+namespace tenzir {
+
+template <>
+class variant_traits<ast::expression> {
+public:
+  static constexpr auto count = detail::tl_size<ast::expression_kinds>::value;
+
+  static auto index(const ast::expression& x) -> size_t {
+    TENZIR_ASSERT(x.kind);
+    return x.kind->index();
+  }
+
+  template <size_t I>
+  static auto get(const ast::expression& x) -> decltype(auto) {
+    return *std::get_if<I>(&*x.kind);
+  }
+};
+
+template <>
+class variant_traits<ast::type_def> {
+public:
+  static constexpr auto count = detail::tl_size<ast::type_kinds>::value;
+
+  static auto index(const ast::type_def& x) -> size_t {
+    TENZIR_ASSERT(x.kind);
+    return x.kind->index();
+  }
+
+  template <size_t I>
+  static auto get(const ast::type_def& x) -> decltype(auto) {
+    return *std::get_if<I>(&*x.kind);
+  }
+};
+
+} // namespace tenzir
+
+namespace tenzir::ast {
 
 /// AST node visitor with mutable access.
 ///
@@ -1091,7 +1163,7 @@ protected:
   }
 
   void enter(ast::type_stmt& x) {
-    TENZIR_UNIMPLEMENTED();
+    TENZIR_TODO();
     TENZIR_UNUSED(x);
   }
 
@@ -1108,10 +1180,25 @@ protected:
     }
   }
 
+  void enter(ast::type_expr& x) {
+    go(x.def);
+  }
+
+  void enter(ast::type_def& x) {
+    match(x);
+  }
+
+  void enter(ast::record_def& x) {
+    for (auto& f : x.fields) {
+      go(f.name);
+      go(f.type);
+    }
+  }
+
 private:
   template <class T>
   void match(T& x) {
-    x.match([&](auto& y) {
+    tenzir::match(x, [&](auto& y) {
       self().visit(y);
     });
   }
@@ -1140,9 +1227,9 @@ private:
 };
 
 template <class Inspector>
-auto inspect(Inspector& f, expression& x) -> bool {
+auto inspect(Inspector& f, type_def& x) -> bool {
   if constexpr (Inspector::is_loading) {
-    x.kind = std::make_unique<expression_kind>();
+    x.kind = std::make_unique<type_kind>();
   } else {
     if (auto dbg = as_debug_writer(f);
         dbg and not detail::make_dependent<Inspector>(x.kind)) {
@@ -1154,9 +1241,9 @@ auto inspect(Inspector& f, expression& x) -> bool {
 }
 
 template <class Inspector>
-auto inspect(Inspector& f, type_def& x) -> bool {
+auto inspect(Inspector& f, expression& x) -> bool {
   if constexpr (Inspector::is_loading) {
-    x.kind = std::make_unique<type_kind>();
+    x.kind = std::make_unique<expression_kind>();
   } else {
     if (auto dbg = as_debug_writer(f);
         dbg && not detail::make_dependent<Inspector>(x.kind)) {
@@ -1170,22 +1257,6 @@ auto inspect(Inspector& f, type_def& x) -> bool {
 } // namespace tenzir::ast
 
 namespace tenzir {
-
-template <>
-class variant_traits<ast::expression> {
-public:
-  static constexpr auto count = detail::tl_size<ast::expression_kinds>::value;
-
-  static auto index(const ast::expression& x) -> size_t {
-    TENZIR_ASSERT(x.kind);
-    return x.kind->index();
-  }
-
-  template <size_t I>
-  static auto get(const ast::expression& x) -> decltype(auto) {
-    return *std::get_if<I>(&*x.kind);
-  }
-};
 
 auto is_true_literal(const ast::expression& y) -> bool;
 

--- a/libtenzir/include/tenzir/tql2/ast.hpp
+++ b/libtenzir/include/tenzir/tql2/ast.hpp
@@ -780,6 +780,67 @@ struct match_stmt {
   }
 };
 
+struct type_def;
+struct record_def;
+
+using type_kind = variant<record_def, identifier>;
+
+struct type_def {
+  type_def() = default;
+
+  template <class T>
+    requires(detail::tl_contains<type_kind, std::remove_cvref_t<T>>::value)
+  explicit(false) type_def(T&& x)
+    : kind{std::make_unique<type_kind>(std::forward<T>(x))} {
+  }
+
+  ~type_def();
+  type_def(const type_def&);
+  type_def(type_def&&) noexcept;
+  auto operator=(const type_def&) -> type_def&;
+  auto operator=(type_def&&) noexcept -> type_def&;
+
+  std::unique_ptr<type_kind> kind;
+
+  friend auto inspect(auto& f, type_def& x) -> bool;
+};
+
+struct record_def {
+  struct field {
+    identifier name;
+    type_def type;
+
+    friend auto inspect(auto& f, field& x) -> bool {
+      return f.object(x).fields(f.field("name", x.name),
+                                f.field("type", x.type));
+    }
+  };
+
+  location begin;
+  std::vector<field> fields;
+  location end;
+
+  friend auto inspect(auto& f, record_def& x) -> bool {
+    return f.object(x).fields(f.field("begin", x.begin),
+                              f.field("fields", x.fields),
+                              f.field("end", x.end));
+  }
+};
+
+struct type_stmt {
+  location type_location;
+  identifier name;
+  location equals;
+  type_def type;
+
+  friend auto inspect(auto& f, type_stmt& x) -> bool {
+    return f.object(x).fields(f.field("type_location", x.type_location),
+                              f.field("name", x.name),
+                              f.field("equals", x.equals),
+                              f.field("type", x.type));
+  }
+};
+
 struct pipeline_expr {
   pipeline_expr() = default;
 
@@ -1029,6 +1090,11 @@ protected:
     TENZIR_UNUSED(x);
   }
 
+  void enter(ast::type_stmt& x) {
+    TENZIR_UNIMPLEMENTED();
+    TENZIR_UNUSED(x);
+  }
+
   void enter(ast::format_expr& x) {
     for (auto& s : x.segments) {
       tenzir::match(
@@ -1080,6 +1146,20 @@ auto inspect(Inspector& f, expression& x) -> bool {
   } else {
     if (auto dbg = as_debug_writer(f);
         dbg and not detail::make_dependent<Inspector>(x.kind)) {
+      return dbg->fmt_value("<invalid>");
+    }
+    TENZIR_ASSERT(x.kind);
+  }
+  return f.apply(*detail::make_dependent<Inspector>(x.kind));
+}
+
+template <class Inspector>
+auto inspect(Inspector& f, type_def& x) -> bool {
+  if constexpr (Inspector::is_loading) {
+    x.kind = std::make_unique<type_kind>();
+  } else {
+    if (auto dbg = as_debug_writer(f);
+        dbg && not detail::make_dependent<Inspector>(x.kind)) {
       return dbg->fmt_value("<invalid>");
     }
     TENZIR_ASSERT(x.kind);

--- a/libtenzir/include/tenzir/tql2/ast.hpp
+++ b/libtenzir/include/tenzir/tql2/ast.hpp
@@ -651,6 +651,10 @@ struct invocation {
   entity op;
   std::vector<expression> args;
 
+  auto get_location() const -> location {
+    return op.get_location();
+  }
+
   friend auto inspect(auto& f, invocation& x) -> bool {
     return f.object(x).fields(f.field("op", x.op), f.field("args", x.args));
   }
@@ -783,7 +787,18 @@ struct match_stmt {
 struct type_def;
 struct record_def;
 
-using type_kinds = caf::type_list<record_def, identifier>;
+struct type_name {
+  identifier id;
+
+  template <typename Inspector>
+  auto inspect(Inspector& f, type_name& x) -> bool;
+
+  auto get_location() const -> location {
+    return id.get_location();
+  }
+};
+
+using type_kinds = caf::type_list<record_def, type_name>;
 using type_kind = caf::detail::tl_apply_t<type_kinds, variant>;
 
 struct type_def {
@@ -837,7 +852,7 @@ struct record_def {
 
 struct type_stmt {
   location type_location;
-  identifier name;
+  type_name name;
   location equals;
   type_def type;
 
@@ -846,6 +861,26 @@ struct type_stmt {
                               f.field("name", x.name),
                               f.field("equals", x.equals),
                               f.field("type", x.type));
+  }
+};
+
+struct type_expr {
+  type_expr() = default;
+
+  type_expr(location keyword, type_def def)
+    : keyword{keyword}, def{std::move(def)} {
+  }
+
+  location keyword;
+  type_def def;
+
+  friend auto inspect(auto& f, type_expr& x) -> bool {
+    return f.object(x).fields(f.field("keyword", x.keyword),
+                              f.field("def", x.def));
+  }
+
+  auto get_location() const -> struct location {
+    return keyword.combine(def);
   }
 };
 
@@ -896,26 +931,6 @@ struct format_expr {
 
   auto get_location() const -> struct location {
     return location;
-  }
-};
-
-struct type_expr {
-  type_expr() = default;
-
-  type_expr(location keyword, type_def def)
-    : keyword{keyword}, def{std::move(def)} {
-  }
-
-  location keyword;
-  type_def def;
-
-  friend auto inspect(auto& f, type_expr& x) -> bool {
-    return f.object(x).fields(f.field("keyword", x.keyword),
-                              f.field("def", x.def));
-  }
-
-  auto get_location() const -> struct location {
-    return keyword.combine(def);
   }
 };
 
@@ -1163,8 +1178,8 @@ protected:
   }
 
   void enter(ast::type_stmt& x) {
-    TENZIR_TODO();
-    TENZIR_UNUSED(x);
+    go(x.name);
+    go(x.type);
   }
 
   void enter(ast::format_expr& x) {
@@ -1178,6 +1193,10 @@ protected:
           go(r.expr);
         });
     }
+  }
+
+  void enter(ast::type_name& x) {
+    go(x.id);
   }
 
   void enter(ast::type_expr& x) {
@@ -1225,6 +1244,11 @@ private:
     return static_cast<Self&>(*this);
   }
 };
+
+template <typename Inspector>
+auto inspect(Inspector& f, type_name& x) -> bool {
+  return f.apply(x.id);
+}
 
 template <class Inspector>
 auto inspect(Inspector& f, type_def& x) -> bool {

--- a/libtenzir/include/tenzir/tql2/ast.hpp
+++ b/libtenzir/include/tenzir/tql2/ast.hpp
@@ -786,6 +786,7 @@ struct match_stmt {
 
 struct type_def;
 struct record_def;
+struct list_def;
 
 struct type_name {
   identifier id;
@@ -798,7 +799,7 @@ struct type_name {
   }
 };
 
-using type_kinds = caf::type_list<record_def, type_name>;
+using type_kinds = caf::type_list<record_def, type_name, list_def>;
 using type_kind = caf::detail::tl_apply_t<type_kinds, variant>;
 
 struct type_def {
@@ -843,6 +844,21 @@ struct record_def {
     return f.object(x).fields(f.field("begin", x.begin),
                               f.field("fields", x.fields),
                               f.field("end", x.end));
+  }
+
+  auto get_location() const -> location {
+    return begin.combine(end);
+  }
+};
+
+struct list_def {
+  location begin;
+  type_def type;
+  location end;
+
+  friend auto inspect(auto& f, list_def& x) -> bool {
+    return f.object(x).fields(f.field("begin", x.begin),
+                              f.field("type", x.type), f.field("end", x.end));
   }
 
   auto get_location() const -> location {
@@ -1212,6 +1228,10 @@ protected:
       go(f.name);
       go(f.type);
     }
+  }
+
+  void enter(ast::list_def& x) {
+    go(x.type);
   }
 
 private:

--- a/libtenzir/src/ir.cpp
+++ b/libtenzir/src/ir.cpp
@@ -573,7 +573,7 @@ auto ast::pipeline::compile(compile_ctx ctx) and -> failure_or<ir::pipeline> {
         diagnostic::error("`match` is not implemented yet").primary(x).emit(ctx);
         return failure::promise();
       },
-      [&](ast::type_stmt& x) -> failure_or<void> {
+      [&](ast::type_stmt x) -> failure_or<void> {
         diagnostic::error(
           "type declarations are not yet supported within pipelines")
           .primary(x.type_location)

--- a/libtenzir/src/ir.cpp
+++ b/libtenzir/src/ir.cpp
@@ -572,6 +572,9 @@ auto ast::pipeline::compile(compile_ctx ctx) and -> failure_or<ir::pipeline> {
       [&](ast::match_stmt x) -> failure_or<void> {
         diagnostic::error("`match` is not implemented yet").primary(x).emit(ctx);
         return failure::promise();
+      },
+      [&](ast::type_stmt& x) -> failure_or<void> {
+        TENZIR_TODO();
       });
     TRY(result);
   }

--- a/libtenzir/src/ir.cpp
+++ b/libtenzir/src/ir.cpp
@@ -574,7 +574,11 @@ auto ast::pipeline::compile(compile_ctx ctx) and -> failure_or<ir::pipeline> {
         return failure::promise();
       },
       [&](ast::type_stmt& x) -> failure_or<void> {
-        TENZIR_TODO();
+        diagnostic::error(
+          "type declarations are not yet supported within pipelines")
+          .primary(x.type_location)
+          .emit(ctx);
+        return failure::promise();
       });
     TRY(result);
   }

--- a/libtenzir/src/module.cpp
+++ b/libtenzir/src/module.cpp
@@ -348,6 +348,9 @@ load_symbols2(const detail::stable_set<std::filesystem::path>& module_dirs,
             TRY(match(field.type));
           }
           return {};
+        },
+        [this](const ast::list_def& def) -> caf::expected<void> {
+          return match(def.type);
         });
     }
     symbol_map2& res;

--- a/libtenzir/src/module.cpp
+++ b/libtenzir/src/module.cpp
@@ -22,12 +22,15 @@
 #include "tenzir/logger.hpp"
 #include "tenzir/modules.hpp"
 #include "tenzir/plugin.hpp"
+#include "tenzir/session.hpp"
 #include "tenzir/taxonomies.hpp"
+#include "tenzir/tql2/parser.hpp"
 
 #include <caf/actor_system_config.hpp>
 #include <caf/deserializer.hpp>
 
 #include <filesystem>
+#include <iostream>
 #include <string_view>
 
 namespace tenzir {
@@ -207,6 +210,153 @@ load_symbols(const detail::stable_set<std::filesystem::path>& module_dirs,
     TENZIR_ASSERT(directory_module->empty());
   }
   return global_symbols;
+}
+
+auto translate_builtin_type(std::string_view name) -> std::optional<type> {
+  using namespace std::string_view_literals;
+  using p = std::pair<std::string_view, type>;
+  const static auto m = std::unordered_map<std::string_view, type>{
+    p{"bool"sv, bool_type{}},
+    p{"int"sv, int64_type{}},
+    p{"uint"sv, uint64_type{}},
+    p{"float"sv, double_type{}},
+    p{"duration"sv, duration_type{}},
+    p{"time"sv, time_type{}},
+    p{"string"sv, string_type{}},
+    p{"blob"sv, blob_type{}},
+    p{"ip"sv, ip_type{}},
+    p{"subnet"sv, subnet_type{}},
+    p{"null"sv, null_type{}},
+    p{"secret"sv, secret_type{}},
+  };
+  const auto it = m.find(name);
+  if (it != m.end()) {
+    return it->second;
+  }
+  return std::nullopt;
+}
+
+caf::expected<symbol_map2>
+load_symbols2(const detail::stable_set<std::filesystem::path>& module_dirs,
+              size_t max_recursion) {
+  auto res = symbol_map2{};
+  if (max_recursion == 0) {
+    return ec::recursion_limit_reached;
+  }
+  for (const auto& dir : module_dirs) {
+    TENZIR_VERBOSE("loading schemas from {}", dir);
+    std::error_code err{};
+    if (! std::filesystem::exists(dir, err)) {
+      TENZIR_DEBUG("{} skips non-existing directory: {}", __func__, dir);
+      continue;
+    }
+    auto filter = [](const std::filesystem::path& f) {
+      return f.extension() == ".tql";
+    };
+    auto module_files
+      = detail::filter_dir(dir, std::move(filter), max_recursion);
+    for (const auto& f : *module_files) {
+      TENZIR_DEBUG("loading schema {}", f);
+      auto str = detail::load_contents(f);
+      TENZIR_ASSERT(str);
+      auto dh = make_diagnostic_printer(location_origin{f, *str},
+                                        color_diagnostics::yes, std::cerr);
+      auto sp = session_provider::make(*dh);
+      auto ast = parse(*str, sp.as_session());
+      if (not ast) {
+        return ec::silent;
+      }
+      auto failed = false;
+      for (auto& stmt : ast->body) {
+        match(
+          stmt, [](ast::type_stmt&) {},
+          [&dh = *dh, &failed](auto& x) {
+            diagnostic::error("expected type statement").primary(x).emit(dh);
+            failed = true;
+          });
+      }
+      if (failed) {
+        return ec::silent;
+      }
+      ast = parse_pipeline_with_bad_diagnostics(*str, sp.as_session());
+      TENZIR_ASSERT(ast);
+      for (auto& stmt : ast->body) {
+        auto& t = as<ast::type_stmt>(stmt);
+        const auto [_, success]
+          = res.try_emplace(std::move(t.name.id.name), std::move(t.type));
+        if (not success) {
+          diagnostic::error("type `{}` already exists", t.name.id.name)
+            .primary(t.name.get_location())
+            .emit(*dh);
+          return ec::silent;
+        }
+      }
+    }
+  }
+  auto dh
+    = make_diagnostic_printer(std::nullopt, color_diagnostics::yes, std::cerr);
+  struct visitor {
+    visitor(symbol_map2& res, diagnostic_handler& dh) : res{res}, dh{dh} {
+    }
+
+    auto validate() -> caf::expected<void> {
+      for (const auto& [name, def] : res) {
+        TENZIR_ASSERT(recursed.empty());
+        auto t = translate_builtin_type(name);
+        if (t) {
+          diagnostic::error("cannot redefine builtin type `{}`", name).emit(dh);
+          return ec::silent;
+        }
+        TRY(validate_name(name));
+      }
+      return {};
+    }
+
+  private:
+    auto validate_name(std::string_view name) -> caf::expected<void> {
+      if (checked.contains(name)) {
+        return {};
+      }
+      auto t = translate_builtin_type(name);
+      if (t) {
+        return {};
+      }
+      auto it = res.find(name);
+      if (it == res.end()) {
+        diagnostic::error("could not resolve name `{}`", name).emit(dh);
+        return ec::silent;
+      }
+      auto [_, success] = recursed.insert(name);
+      if (not success) {
+        diagnostic::error("found recursion in type `{}`", name).emit(dh);
+        return ec::silent;
+      }
+      auto r = match(it->second);
+      auto x = recursed.erase(name);
+      TENZIR_ASSERT(x == 1);
+      return r;
+    }
+
+    auto match(const ast::type_def& def) -> caf::expected<void> {
+      return tenzir::match(
+        def,
+        [this](const ast::type_name& name) {
+          return validate_name(name.id.name);
+        },
+        [this](const ast::record_def& def) -> caf::expected<void> {
+          for (auto& field : def.fields) {
+            TRY(match(field.type));
+          }
+          return {};
+        });
+    }
+    symbol_map2& res;
+    diagnostic_handler& dh;
+    std::set<std::string_view> recursed;
+    std::set<std::string_view> checked;
+  };
+  TRY((visitor{res, *dh}).validate());
+  return res;
 }
 
 caf::expected<symbol_map> load_symbols(const caf::actor_system_config& cfg) {

--- a/libtenzir/src/modules.cpp
+++ b/libtenzir/src/modules.cpp
@@ -16,6 +16,7 @@
 
 #include <mutex>
 #include <utility>
+#include <vector>
 
 namespace tenzir::modules {
 
@@ -23,11 +24,10 @@ namespace {
 
 struct global_module_registry {
   std::mutex mutex;
-  boost::unordered_flat_map<std::string, variant<type, legacy_type>,
-                            detail::heterogeneous_string_hash,
-                            detail::heterogeneous_string_equal>
+  boost::unordered_flat_map<
+    std::string, variant<type, legacy_type, ast::type_def>,
+    detail::heterogeneous_string_hash, detail::heterogeneous_string_equal>
     types;
-
   concepts_map concepts;
 };
 
@@ -40,7 +40,7 @@ auto get_impl() -> global_module_registry& {
 
 } // namespace
 
-void init(symbol_map symbols, concepts_map concepts) {
+void init(symbol_map symbols, symbol_map2 symbols2, concepts_map concepts) {
   TENZIR_ASSERT(not initialized);
   auto& impl = get_impl();
   auto lock = std::unique_lock{impl.mutex};
@@ -50,9 +50,70 @@ void init(symbol_map symbols, concepts_map concepts) {
       impl.types.emplace(name, std::move(ty));
     }
   }
+  for (auto& [name, def] : symbols2) {
+    auto [_, success] = impl.types.emplace(name, std::move(def));
+    TENZIR_ASSERT(success,
+                  "name conflict between .schema and .tql type definition for "
+                  "schema `{}`",
+                  name);
+  }
   get_impl().concepts = std::move(concepts);
   initialized = true;
 }
+
+namespace {
+struct visitor {
+  global_module_registry& global;
+
+  auto operator()(ast::type_def& def, std::string_view alias = {}) -> type {
+    auto converted = match(def);
+    if (! alias.empty() && converted.name() != alias) {
+      return type{alias, converted};
+    }
+    return converted;
+  }
+
+private:
+  auto match(ast::type_def& def) -> type {
+    return tenzir::match(
+      def,
+      [&](ast::type_name& name) -> type {
+        return resolve(name.id.name);
+      },
+      [&](ast::record_def& record) -> type {
+        auto fields = std::vector<struct record_type::field>{};
+        fields.reserve(record.fields.size());
+        for (auto& field : record.fields) {
+          fields.emplace_back(field.name.name, (*this)(field.type));
+        }
+        return type{record_type{fields}};
+      });
+  }
+
+  auto resolve(std::string_view name) -> type {
+    if (auto builtin = translate_builtin_type(name)) {
+      return *builtin;
+    }
+    auto it = global.types.find(name);
+    TENZIR_ASSERT(it != global.types.end());
+    return tenzir::match(
+      it->second,
+      [](const type& ty) {
+        return ty;
+      },
+      [&](legacy_type& legacy) {
+        auto converted = type::from_legacy_type(legacy);
+        it->second = converted;
+        return converted;
+      },
+      [&](ast::type_def& def) {
+        auto converted = (*this)(def, name);
+        it->second = converted;
+        return converted;
+      });
+  }
+};
+} // namespace
 
 auto get_schema(std::string_view name) -> std::optional<type> {
   auto& global = get_impl();
@@ -70,6 +131,11 @@ auto get_schema(std::string_view name) -> std::optional<type> {
     },
     [&](const legacy_type& legacy) {
       auto converted = type::from_legacy_type(legacy);
+      it->second = converted;
+      return converted;
+    },
+    [&](ast::type_def& def) -> type {
+      auto converted = visitor{global}(def, it->first);
       it->second = converted;
       return converted;
     });

--- a/libtenzir/src/modules.cpp
+++ b/libtenzir/src/modules.cpp
@@ -87,6 +87,10 @@ private:
           fields.emplace_back(field.name.name, (*this)(field.type));
         }
         return type{record_type{fields}};
+      },
+      [&](ast::list_def& list) -> type {
+        auto value = (*this)(list.type);
+        return type{list_type{std::move(value)}};
       });
   }
 

--- a/libtenzir/src/tql2/ast.cpp
+++ b/libtenzir/src/tql2/ast.cpp
@@ -279,6 +279,9 @@ auto expression::get_location() const -> location {
       },
       [&](format_expr const& x) {
         result = result.combine(x.get_location());
+      },
+      [&](type_expr const& x) {
+        result = result.combine(x.get_location());
       });
   }
   return result;

--- a/libtenzir/src/tql2/ast.cpp
+++ b/libtenzir/src/tql2/ast.cpp
@@ -301,6 +301,30 @@ auto expression::operator=(expression const& other) -> expression& {
   return *this;
 }
 
+type_def::type_def(type_def const& other) {
+  static_assert(
+    detail::tl_empty<
+      detail::tl_filter_not_t<type_kinds, std::is_copy_constructible>>::value);
+  if (other.kind) {
+    kind = std::make_unique<type_kind>(*other.kind);
+  } else {
+    kind = nullptr;
+  }
+}
+
+auto type_def::operator=(type_def const& other) -> type_def& {
+  if (this != &other) {
+    *this = type_def{other};
+  }
+  return *this;
+}
+
+auto type_def::get_location() const -> location {
+  return match(*kind, [](const auto& x) -> location {
+    return x.get_location();
+  });
+}
+
 } // namespace tenzir::ast
 
 namespace tenzir {

--- a/libtenzir/src/tql2/exec.cpp
+++ b/libtenzir/src/tql2/exec.cpp
@@ -503,7 +503,7 @@ auto compile_resolved(ast::pipeline&& pipe, session ctx)
         TENZIR_UNREACHABLE();
       },
       [&](ast::type_stmt&) -> failure_or<void> {
-        TENZIR_TODO();
+        TENZIR_UNREACHABLE();
       });
     if (result.is_error()) {
       fail = result.error();

--- a/libtenzir/src/tql2/exec.cpp
+++ b/libtenzir/src/tql2/exec.cpp
@@ -501,6 +501,9 @@ auto compile_resolved(ast::pipeline&& pipe, session ctx)
       },
       [&](ast::let_stmt&) -> failure_or<void> {
         TENZIR_UNREACHABLE();
+      },
+      [&](ast::type_stmt&) -> failure_or<void> {
+        TENZIR_TODO();
       });
     if (result.is_error()) {
       fail = result.error();

--- a/libtenzir/src/tql2/parser.cpp
+++ b/libtenzir/src/tql2/parser.cpp
@@ -334,6 +334,16 @@ public:
     if (auto id = accept(tk::identifier)) {
       return type_name{id.as_identifier()};
     }
+    if (auto lbracket = accept(tk::lbracket)) {
+      auto scope = ignore_newlines(true);
+      auto type = parse_type_def();
+      auto rbracket = expect(tk::rbracket);
+      return ast::list_def{
+        lbracket.location,
+        std::move(type),
+        rbracket.location,
+      };
+    }
     auto start = expect(tk::lbrace).location;
     auto scope = ignore_newlines(true);
     auto fields = std::vector<ast::record_def::field>{};

--- a/libtenzir/src/tql2/parser.cpp
+++ b/libtenzir/src/tql2/parser.cpp
@@ -294,7 +294,7 @@ public:
       return ast::invocation{std::move(call->fn), std::move(call->args)};
     }
     if (auto* type_expr = try_as<ast::type_expr>(unary_expr)) {
-      auto* ident = try_as<ast::identifier>(type_expr->def);
+      auto* ident = try_as<ast::type_name>(type_expr->def);
       if (not ident) {
         diagnostic::error("expected identifier").primary(*type_expr).throw_();
       }
@@ -302,7 +302,7 @@ public:
       auto def = parse_type_def();
       return ast::type_stmt{
         type_expr->keyword,
-        std::move(*ident),
+        ast::type_name{std::move(*ident)},
         equal,
         std::move(def),
       };
@@ -332,7 +332,7 @@ public:
 
   auto parse_type_def() -> ast::type_def {
     if (auto id = accept(tk::identifier)) {
-      return {id.as_identifier()};
+      return type_name{id.as_identifier()};
     }
     auto start = expect(tk::lbrace).location;
     auto scope = ignore_newlines(true);

--- a/libtenzir/src/tql2/parser.cpp
+++ b/libtenzir/src/tql2/parser.cpp
@@ -323,6 +323,11 @@ public:
                   : nullptr;
     if (root) {
       auto entity = parse_entity(std::move(root->id));
+      if (entity.path.size() == 1 and entity.path[0].name == "type") {
+        diagnostic::error("expected identifier after `type` declaration")
+          .primary(entity)
+          .throw_();
+      }
       return parse_invocation(std::move(entity));
     }
     diagnostic::error("{}", "expected `=` after selector")

--- a/libtenzir/src/tql2/parser.cpp
+++ b/libtenzir/src/tql2/parser.cpp
@@ -266,7 +266,7 @@ public:
       return parse_invocation(std::move(entity));
     }
     auto unary_expr = parse_unary_expression();
-    if (auto call = std::get_if<ast::function_call>(&*unary_expr.kind)) {
+    if (auto* call = try_as<ast::function_call>(unary_expr)) {
       // TODO: We patch a top-level function call to be an operator invocation
       // instead. This could be done differently by slightly rewriting the
       // parser. Because this is not (yet) reflected in the AST, the optional
@@ -293,6 +293,20 @@ public:
       }
       return ast::invocation{std::move(call->fn), std::move(call->args)};
     }
+    if (auto* type_expr = try_as<ast::type_expr>(unary_expr)) {
+      auto* ident = try_as<ast::identifier>(type_expr->def);
+      if (not ident) {
+        diagnostic::error("expected identifier").primary(*type_expr).throw_();
+      }
+      auto equal = expect(tk::equal).location;
+      auto def = parse_type_def();
+      return ast::type_stmt{
+        type_expr->keyword,
+        std::move(*ident),
+        equal,
+        std::move(def),
+      };
+    }
     auto left = to_selector(std::move(unary_expr));
     if (auto equal = accept(tk::equal)) {
       auto right = parse_expression();
@@ -314,6 +328,30 @@ public:
     diagnostic::error("{}", "expected `=` after selector")
       .primary(next_location())
       .throw_();
+  }
+
+  auto parse_type_def() -> ast::type_def {
+    if (auto id = accept(tk::identifier)) {
+      return {id.as_identifier()};
+    }
+    auto start = expect(tk::lbrace).location;
+    auto scope = ignore_newlines(true);
+    auto fields = std::vector<ast::record_def::field>{};
+    while (not peek(tk::rbrace)) {
+      auto name = expect(tk::identifier).as_identifier();
+      expect(tk::colon);
+      auto def = parse_type_def();
+      fields.emplace_back(std::move(name), std::move(def));
+      if (not peek(tk::rbrace)) {
+        expect(tk::comma);
+      }
+    }
+    auto end = expect(tk::rbrace);
+    return ast::record_def{
+      start,
+      std::move(fields),
+      end.location,
+    };
   }
 
   auto parse_invocation(entity op, std::vector<ast::expression> args)
@@ -439,6 +477,8 @@ public:
   auto parse_expression(int min_prec = 0) -> ast::expression {
     return parse_expression(parse_unary_expression(), min_prec);
   }
+
+  // TODO: Future us/ast problem with type expressions
 
   auto parse_entity() -> ast::entity {
     return parse_entity(expect(tk::identifier).as_identifier());
@@ -697,9 +737,18 @@ public:
         .primary(next_location())
         .throw_();
     }
+    auto id = std::move(entity.path.front());
+    if (id.name == "type") {
+      if (peek(tk::identifier) or peek(tk::lbrace)) {
+        return ast::type_expr{
+          id.location,
+          parse_type_def(),
+        };
+      }
+    }
     auto question_mark = accept(tk::question_mark);
     return ast::root_field{
-      std::move(entity.path[0]),
+      std::move(id),
       static_cast<bool>(question_mark),
     };
   }

--- a/libtenzir/src/tql2/parser.cpp
+++ b/libtenzir/src/tql2/parser.cpp
@@ -509,6 +509,15 @@ public:
   }
 
   auto parse_unary_expression() -> ast::expression {
+    if (peek_identifier("type")
+        and (silent_peek_n(tk::identifier, 1) or silent_peek_n(tk::lbrace, 1)
+             or silent_peek_n(tk::rbrace, 1))) {
+      auto type_kw = expect(tk::identifier).location;
+      return ast::type_expr{
+        type_kw,
+        parse_type_def(),
+      };
+    }
     if (auto op = peek_unary_op()) {
       auto location = advance();
       auto expr = parse_expression(precedence(*op));
@@ -753,14 +762,6 @@ public:
         .throw_();
     }
     auto id = std::move(entity.path.front());
-    if (id.name == "type") {
-      if (peek(tk::identifier) or peek(tk::lbrace)) {
-        return ast::type_expr{
-          id.location,
-          parse_type_def(),
-        };
-      }
-    }
     auto question_mark = accept(tk::question_mark);
     return ast::root_field{
       std::move(id),
@@ -1348,6 +1349,10 @@ public:
     // TODO: Does this count as trying the token?
     tries_.push_back(kind);
     return silent_peek(kind);
+  }
+
+  auto peek_identifier(std::string_view name) -> bool {
+    return peek(tk::identifier) && token_string(next_) == name;
   }
 
   // TODO: Can we get rid of this?

--- a/libtenzir/src/tql2/parser.cpp
+++ b/libtenzir/src/tql2/parser.cpp
@@ -337,7 +337,8 @@ public:
 
   auto parse_type_def() -> ast::type_def {
     if (auto id = accept(tk::identifier)) {
-      return type_name{id.as_identifier()};
+      using tn = struct type_name;
+      return tn{id.as_identifier()};
     }
     if (auto lbracket = accept(tk::lbracket)) {
       auto scope = ignore_newlines(true);

--- a/libtenzir/src/tql2/resolve.cpp
+++ b/libtenzir/src/tql2/resolve.cpp
@@ -182,6 +182,22 @@ public:
     }
   }
 
+  void visit(ast::type_stmt& x) {
+    diagnostic::error(
+      "type declarations are not yet supported within pipelines")
+      .primary(x.type_location)
+      .hint("put it into a `.tql` file in the schema directory")
+      .emit(diag_);
+    result_ = failure::promise();
+  }
+
+  void visit(ast::type_expr& x) {
+    diagnostic::error("type expressions are not yet supported")
+      .primary(x.keyword)
+      .emit(diag_);
+    result_ = failure::promise();
+  }
+
   template <class T>
   void visit(T& x) {
     enter(x);

--- a/tenzir/tenzir.cpp
+++ b/tenzir/tenzir.cpp
@@ -282,12 +282,20 @@ auto main(int argc, char** argv) -> int try {
     TENZIR_ERROR("failed to read schema dirs: {}", symbols.error());
     return EXIT_FAILURE;
   }
+  auto symbols2 = load_symbols2(get_module_dirs(cfg));
+  if (not symbols2) {
+    if (symbols2 != ec::silent) {
+      TENZIR_ERROR("failed to read schema dirs: {}", symbols2.error());
+    }
+    return EXIT_FAILURE;
+  }
   auto taxonomies = load_taxonomies(cfg);
   if (not taxonomies) {
     TENZIR_ERROR("failed to load concepts: {}", taxonomies.error());
     return EXIT_FAILURE;
   }
-  modules::init(std::move(*symbols), std::move(taxonomies->concepts));
+  modules::init(std::move(*symbols), std::move(*symbols2),
+                std::move(taxonomies->concepts));
   // Set up pipeline aliases.
   using namespace std::literals;
   auto aliases = std::unordered_map<std::string, std::string>{};


### PR DESCRIPTION
This implements the TQL syntax for types: `type x = {y: int, z: [string]}` for statements, and `type {x: int}` for anonymous type expressions. The actual implementation only works with `.tql` files in the `schema` directory, but everything was done such that it will eventually work within pipelines. I think we should merge this PR without changelog and docs for now, since the feature is not fully finished, but it's pretty clear that the approach in this PR is the right one and basically pushes us half-way to where we want to be.