### PR TITLE
Silence ignored package-key warnings on startup

### DIFF
--- a/libtenzir/include/tenzir/package.hpp
+++ b/libtenzir/include/tenzir/package.hpp
@@ -65,7 +65,7 @@ struct package_config final {
 
 struct package_input final {
   std::string name; // required to be non-empty
-  std::string type; // required to be non-empty
+  std::string type; // optional type hint
   std::optional<std::string> description;
   std::optional<std::string> default_;
 

--- a/libtenzir/include/tenzir/package.hpp
+++ b/libtenzir/include/tenzir/package.hpp
@@ -29,8 +29,7 @@ struct package_source final {
 
   auto to_record() const -> record;
 
-  static auto parse(const view<record>& data, std::string_view package_path)
-    -> caf::expected<package_source>;
+  static auto parse(const view<record>& data) -> caf::expected<package_source>;
 
   friend auto inspect(auto& f, package_source& x) -> bool {
     return f.object(x)
@@ -52,8 +51,7 @@ struct package_config final {
 
   auto to_record() const -> record;
 
-  static auto parse(const view<record>& data, std::string_view package_path)
-    -> caf::expected<package_config>;
+  static auto parse(const view<record>& data) -> caf::expected<package_config>;
 
   friend auto inspect(auto& f, package_config& x) -> bool {
     return f.object(x)
@@ -73,8 +71,7 @@ struct package_input final {
 
   auto to_record() const -> record;
 
-  static auto parse(const view<record>& data, std::string_view package_path)
-    -> caf::expected<package_input>;
+  static auto parse(const view<record>& data) -> caf::expected<package_input>;
 
   friend auto inspect(auto& f, package_input& x) -> bool {
     return f.object(x)
@@ -92,7 +89,7 @@ struct package_operator_parameter final {
 
   auto to_record() const -> record;
 
-  static auto parse(const view<record>& data, std::string_view package_path)
+  static auto parse(const view<record>& data)
     -> caf::expected<package_operator_parameter>;
 
   friend auto inspect(auto& f, package_operator_parameter& x) -> bool {
@@ -122,10 +119,9 @@ struct package_operator final {
 
   auto to_record() const -> record;
 
-  static auto parse(const view<record>& data, std::string_view package_path)
+  static auto parse(const view<record>& data)
     -> caf::expected<package_operator>;
-  static auto parse(std::string_view input, std::string_view package_path)
-    -> caf::expected<package_operator>;
+  static auto parse(std::string_view input) -> caf::expected<package_operator>;
 
   friend auto inspect(auto& f, package_operator& x) -> bool {
     return f.object(x)
@@ -145,11 +141,12 @@ struct package_pipeline final {
 
   auto to_record() const -> record;
 
+  static auto parse(const view<record>& data)
+    -> caf::expected<package_pipeline>;
   static auto parse(const view<record>& data, std::string_view package_path)
     -> caf::expected<package_pipeline>;
 
-  static auto parse(std::string_view input, std::string_view package_path)
-    -> caf::expected<package_pipeline>;
+  static auto parse(std::string_view input) -> caf::expected<package_pipeline>;
 
   friend auto inspect(auto& f, package_pipeline& x) -> bool {
     return f.object(x)
@@ -171,8 +168,7 @@ struct package_context final {
 
   auto to_record() const -> record;
 
-  static auto parse(const view<record>& data, std::string_view package_path)
-    -> caf::expected<package_context>;
+  static auto parse(const view<record>& data) -> caf::expected<package_context>;
 
   friend auto inspect(auto& f, package_context& x) -> bool {
     return f.object(x)
@@ -190,10 +186,8 @@ struct package_example final {
 
   auto to_record() const -> record;
 
-  static auto parse(const view<record>& data, std::string_view package_path)
-    -> caf::expected<package_example>;
-  static auto parse(std::string_view input, std::string_view package_path)
-    -> caf::expected<package_example>;
+  static auto parse(const view<record>& data) -> caf::expected<package_example>;
+  static auto parse(std::string_view input) -> caf::expected<package_example>;
 
   friend auto inspect(auto& f, package_example& x) -> bool {
     return f.object(x)
@@ -252,6 +246,7 @@ struct package final {
   // the input.
   std::optional<package_config> config;
 
+  static auto parse(const view<record>& data) -> caf::expected<package>;
   static auto parse(const view<record>& data, std::string_view package_path)
     -> caf::expected<package>;
 

--- a/libtenzir/src/package.cpp
+++ b/libtenzir/src/package.cpp
@@ -135,7 +135,7 @@ auto is_valid_package_identifier(std::string_view value) -> bool {
           .note("invalid package definition")                                  \
           .to_error();                                                         \
       }                                                                        \
-      auto parsed_value = value_type::parse(*value_record, package_path);      \
+      auto parsed_value = value_type::parse(*value_record);                    \
       if (not parsed_value) {                                                  \
         return diagnostic::error(parsed_value.error())                         \
           .note("while parsing key {} for field " #name, key)                  \
@@ -164,7 +164,7 @@ auto is_valid_package_identifier(std::string_view value) -> bool {
           .note("invalid package definition")                                  \
           .to_error();                                                         \
       }                                                                        \
-      auto parsed_value = value_type::parse(*value_record, package_path);      \
+      auto parsed_value = value_type::parse(*value_record);                    \
       if (not parsed_value) {                                                  \
         return diagnostic::error(parsed_value.error())                         \
           .note("while parsing key {} for field " #name, key)                  \
@@ -241,7 +241,7 @@ auto is_valid_package_identifier(std::string_view value) -> bool {
         .note("invalid package definition")                                    \
         .to_error();                                                           \
     }                                                                          \
-    auto parsed = type::parse(*x, package_path);                               \
+    auto parsed = type::parse(*x);                                             \
     if (not parsed) {                                                          \
       return diagnostic::error(parsed.error())                                 \
         .note("while parsing key {} for field " #name, key)                    \
@@ -269,7 +269,7 @@ auto is_valid_package_identifier(std::string_view value) -> bool {
           .note("got a {} instead", type::infer(materialize(item_view)))       \
           .to_error();                                                         \
       }                                                                        \
-      auto item = inner_type::parse(*item_record, package_path);               \
+      auto item = inner_type::parse(*item_record);                             \
       if (not item) {                                                          \
         return diagnostic::error(item.error())                                 \
           .note("invalid package definition")                                  \
@@ -308,8 +308,7 @@ auto is_valid_package_identifier(std::string_view value) -> bool {
     continue;                                                                  \
   }
 
-auto package_input::parse(const view<record>& data,
-                          std::string_view package_path)
+auto package_input::parse(const view<record>& data)
   -> caf::expected<package_input> {
   auto result = package_input{};
   for (const auto& [key, value] : data) {
@@ -317,16 +316,12 @@ auto package_input::parse(const view<record>& data,
     TRY_ASSIGN_STRING_TO_RESULT(type)
     TRY_ASSIGN_OPTIONAL_STRING_TO_RESULT(description)
     TRY_CONVERT_TO_STRING(default, default_);
-    TENZIR_WARN("ignoring unknown key `{}` in `input` entry in package {} "
-                "definition",
-                key, package_path);
   }
   REQUIRED_FIELD(name);
   return result;
 }
 
-auto package_operator_parameter::parse(const view<record>& data,
-                                       std::string_view package_path)
+auto package_operator_parameter::parse(const view<record>& data)
   -> caf::expected<package_operator_parameter> {
   auto result = package_operator_parameter{};
   for (const auto& [key, value] : data) {
@@ -345,25 +340,18 @@ auto package_operator_parameter::parse(const view<record>& data,
       result.default_ = *maybe_string;
       continue;
     }
-    TENZIR_WARN("ignoring unknown key `{}` in `parameter` entry in package {} "
-                "definition",
-                key, package_path);
   }
   REQUIRED_FIELD(name);
   return result;
 }
 
-auto package_source::parse(const view<record>& data,
-                           std::string_view package_path)
+auto package_source::parse(const view<record>& data)
   -> caf::expected<package_source> {
   auto result = package_source{};
   for (const auto& [key, value] : data) {
     TRY_ASSIGN_STRING_TO_RESULT(repository)
     TRY_ASSIGN_STRING_TO_RESULT(directory)
     TRY_ASSIGN_STRING_TO_RESULT(revision)
-    TENZIR_WARN("ignoring unknown key `{}` in `source` entry in package {} "
-                "definition",
-                key, package_path);
   }
   REQUIRED_FIELD(repository)
   REQUIRED_FIELD(directory)
@@ -371,8 +359,7 @@ auto package_source::parse(const view<record>& data,
   return result;
 }
 
-auto package_config::parse(const view<record>& data,
-                           std::string_view package_path)
+auto package_config::parse(const view<record>& data)
   -> caf::expected<package_config> {
   auto result = package_config{};
   for (const auto& [key, value] : data) {
@@ -382,9 +369,6 @@ auto package_config::parse(const view<record>& data,
     TRY_ASSIGN_RECORD_TO_RESULT(overrides);
     TRY_ASSIGN_RECORD_TO_RESULT(metadata);
     TRY_ASSIGN_BOOL_TO_RESULT(disabled);
-    TENZIR_WARN("ignoring unknown key `{}` in `config` entry in package {} "
-                "definition",
-                key, package_path);
   }
   return result;
 }
@@ -393,8 +377,7 @@ namespace {
 
 template <class Value>
 auto parse_operator_parameter_list(std::string_view field_name,
-                                   const Value& value,
-                                   std::string_view package_path)
+                                   const Value& value)
   -> caf::expected<std::vector<package_operator_parameter>> {
   auto result = std::vector<package_operator_parameter>{};
   if (is<caf::none_t>(value)) {
@@ -414,7 +397,7 @@ auto parse_operator_parameter_list(std::string_view field_name,
         .note("invalid package definition")
         .to_error();
     }
-    TRY(auto param, package_operator_parameter::parse(*rec, package_path));
+    TRY(auto param, package_operator_parameter::parse(*rec));
     result.push_back(std::move(param));
   }
   return result;
@@ -516,8 +499,7 @@ auto load_tql_with_frontmatter(std::string_view input)
 
 } // namespace
 
-auto package_operator::parse(const view<record>& data,
-                             std::string_view package_path)
+auto package_operator::parse(const view<record>& data)
   -> caf::expected<package_operator> {
   auto result = package_operator{};
   auto positional_source = std::optional<std::string>{};
@@ -532,8 +514,7 @@ auto package_operator::parse(const view<record>& data,
         .note("invalid package definition")
         .to_error();
     }
-    TRY(auto parsed,
-        parse_operator_parameter_list(field_name, field_value, package_path));
+    TRY(auto parsed, parse_operator_parameter_list(field_name, field_value));
     target = std::move(parsed);
     source = std::string{field_name};
     return {};
@@ -564,9 +545,6 @@ auto package_operator::parse(const view<record>& data,
             }
             continue;
           }
-          TENZIR_WARN("ignoring unknown key `{}` in `args` entry in package {} "
-                      "definition",
-                      subkey, package_path);
         }
         continue;
       }
@@ -582,23 +560,18 @@ auto package_operator::parse(const view<record>& data,
         .note("invalid package definition")
         .to_error();
     }
-    TENZIR_WARN("ignoring unknown key `{}` in `operator` entry in package {} "
-                "definition",
-                key, package_path);
   }
   REQUIRED_FIELD(definition)
   return result;
 }
 
-auto package_operator::parse(std::string_view input,
-                             std::string_view package_path)
+auto package_operator::parse(std::string_view input)
   -> caf::expected<package_operator> {
   TRY(auto rec, load_tql_with_frontmatter(input));
-  return parse(make_view(rec), package_path);
+  return parse(make_view(rec));
 }
 
-auto package_pipeline::parse(const view<record>& data,
-                             std::string_view package_path)
+auto package_pipeline::parse(const view<record>& data)
   -> caf::expected<package_pipeline> {
   auto result = package_pipeline{};
   for (const auto& [key, value] : data) {
@@ -652,26 +625,25 @@ auto package_pipeline::parse(const view<record>& data,
     if (key == "labels") {
       continue;
     }
-    TENZIR_WARN("ignoring unknown key `{}` in `pipeline` entry in package {} "
-                "definition",
-                key, package_path);
   }
   REQUIRED_FIELD(definition)
   return result;
 }
 
-auto package_pipeline::parse(std::string_view input,
-                             std::string_view package_path)
+auto package_pipeline::parse(const view<record>& data, std::string_view)
   -> caf::expected<package_pipeline> {
-  TRY(auto rec, load_tql_with_frontmatter(input));
-  return parse(make_view(rec), package_path);
+  return parse(data);
 }
 
-auto package_context::parse(const view<record>& data,
-                            std::string_view package_path)
+auto package_pipeline::parse(std::string_view input)
+  -> caf::expected<package_pipeline> {
+  TRY(auto rec, load_tql_with_frontmatter(input));
+  return parse(make_view(rec));
+}
+
+auto package_context::parse(const view<record>& data)
   -> caf::expected<package_context> {
   auto result = package_context{};
-  (void)package_path; // Unused, but needed for macro consistency
   for (const auto& [key, value] : data) {
     TRY_ASSIGN_STRING_TO_RESULT(type);
     TRY_ASSIGN_BOOL_TO_RESULT(disabled);
@@ -682,11 +654,9 @@ auto package_context::parse(const view<record>& data,
   return result;
 }
 
-auto package_example::parse(const view<record>& data,
-                            std::string_view package_path)
+auto package_example::parse(const view<record>& data)
   -> caf::expected<package_example> {
   auto result = package_example{};
-  (void)package_path; // Unused, but needed for macro consistency
   for (const auto& [key, value] : data) {
     TRY_ASSIGN_STRING_TO_RESULT(definition);
     TRY_ASSIGN_OPTIONAL_STRING_TO_RESULT(name);
@@ -696,15 +666,13 @@ auto package_example::parse(const view<record>& data,
   return result;
 }
 
-auto package_example::parse(std::string_view input,
-                            std::string_view package_path)
+auto package_example::parse(std::string_view input)
   -> caf::expected<package_example> {
   TRY(auto rec, load_tql_with_frontmatter(input));
-  return parse(make_view(rec), package_path);
+  return parse(make_view(rec));
 }
 
-auto package::parse(const view<record>& data, std::string_view package_path)
-  -> caf::expected<package> {
+auto package::parse(const view<record>& data) -> caf::expected<package> {
   auto result = package{};
   for (const auto& [key, value] : data) {
     TRY_ASSIGN_STRING_TO_RESULT(id);
@@ -720,9 +688,6 @@ auto package::parse(const view<record>& data, std::string_view package_path)
     TRY_ASSIGN_MAP_TO_RESULT(contexts, package_context);
     TRY_ASSIGN_STRUCTURE_TO_RESULT(config, package_config);
     TRY_ASSIGN_LIST_TO_RESULT(examples, package_example);
-    TENZIR_WARN("ignoring unknown key `{}` in `package` entry in package {} "
-                "definition",
-                key, package_path);
   }
   REQUIRED_FIELD(id)
   REQUIRED_FIELD(name)
@@ -750,6 +715,11 @@ auto package::parse(const view<record>& data, std::string_view package_path)
     }
   }
   return result;
+}
+
+auto package::parse(const view<record>& data, std::string_view)
+  -> caf::expected<package> {
+  return parse(data);
 }
 
 auto package_module_name(std::string_view package_id) -> std::string {
@@ -796,7 +766,7 @@ auto load_package_part(const std::filesystem::path& file, auto& dh)
     diagnostic::error(content.error()).note("trying to load {}", file).emit(dh);
     return failure::promise();
   }
-  auto result = Type::parse(*content, file.string());
+  auto result = Type::parse(*content);
   if (not result) {
     diagnostic::error("{}", result.error()).note("from file: {}", file).emit(dh);
     return failure::promise();
@@ -862,7 +832,7 @@ auto package::load(const std::filesystem::path& dir, diagnostic_handler& dh,
     package_record.erase("pipelines");
     package_record.erase("contexts");
   }
-  auto parsed_package = package::parse(make_view(package_record), dir.string());
+  auto parsed_package = package::parse(make_view(package_record));
   if (not parsed_package) {
     diagnostic::error("failed to parse package.yaml")
       .note("in package directory {}", dir)
@@ -895,8 +865,7 @@ auto package::load(const std::filesystem::path& dir, diagnostic_handler& dh,
       had_errors = true;
     }
     TRY(auto config_record, yaml_file_to_record(config_file, dh));
-    auto parsed_config
-      = package_config::parse(make_view(config_record), dir.string());
+    auto parsed_config = package_config::parse(make_view(config_record));
     if (not parsed_config) {
       diagnostic::error("failed to parse package config")
         .note("in package directory {}/", dir)

--- a/libtenzir/src/package.cpp
+++ b/libtenzir/src/package.cpp
@@ -43,6 +43,29 @@ auto is_valid_package_identifier(std::string_view value) -> bool {
   return package_identifier(value);
 }
 
+auto should_ignore_package_key(std::string_view section, std::string_view key)
+  -> bool {
+  // `labels` comes from configured pipelines, and `snippets` is a legacy
+  // library field superseded by `examples`.
+  return (section == "package" and key == "snippets")
+         or (section == "pipeline" and key == "labels");
+}
+
+auto unknown_package_key_error(std::string_view section, std::string_view key)
+  -> caf::error {
+  return diagnostic::error("unknown key `{}` in {} definition", key, section)
+    .note("invalid package definition")
+    .to_error();
+}
+
+auto check_unknown_package_key(std::string_view section, std::string_view key)
+  -> caf::expected<void> {
+  if (should_ignore_package_key(section, key)) {
+    return {};
+  }
+  return unknown_package_key_error(section, key);
+}
+
 } // namespace
 
 #define TRY_CONVERT_TO_STRING(name, field)                                     \
@@ -316,8 +339,10 @@ auto package_input::parse(const view<record>& data)
     TRY_ASSIGN_STRING_TO_RESULT(type)
     TRY_ASSIGN_OPTIONAL_STRING_TO_RESULT(description)
     TRY_CONVERT_TO_STRING(default, default_);
+    return unknown_package_key_error("input", key);
   }
   REQUIRED_FIELD(name);
+  REQUIRED_FIELD(type);
   return result;
 }
 
@@ -340,6 +365,7 @@ auto package_operator_parameter::parse(const view<record>& data)
       result.default_ = *maybe_string;
       continue;
     }
+    return unknown_package_key_error("operator parameter", key);
   }
   REQUIRED_FIELD(name);
   return result;
@@ -352,6 +378,7 @@ auto package_source::parse(const view<record>& data)
     TRY_ASSIGN_STRING_TO_RESULT(repository)
     TRY_ASSIGN_STRING_TO_RESULT(directory)
     TRY_ASSIGN_STRING_TO_RESULT(revision)
+    return unknown_package_key_error("source", key);
   }
   REQUIRED_FIELD(repository)
   REQUIRED_FIELD(directory)
@@ -369,6 +396,7 @@ auto package_config::parse(const view<record>& data)
     TRY_ASSIGN_RECORD_TO_RESULT(overrides);
     TRY_ASSIGN_RECORD_TO_RESULT(metadata);
     TRY_ASSIGN_BOOL_TO_RESULT(disabled);
+    return unknown_package_key_error("config", key);
   }
   return result;
 }
@@ -545,6 +573,7 @@ auto package_operator::parse(const view<record>& data)
             }
             continue;
           }
+          return unknown_package_key_error("operator args", subkey);
         }
         continue;
       }
@@ -560,6 +589,7 @@ auto package_operator::parse(const view<record>& data)
         .note("invalid package definition")
         .to_error();
     }
+    return unknown_package_key_error("operator", key);
   }
   REQUIRED_FIELD(definition)
   return result;
@@ -620,11 +650,7 @@ auto package_pipeline::parse(const view<record>& data)
       result.restart_on_error = *retry_delay;
       continue;
     }
-    // Hack: Ignore the `labels` key so we can reuse this function to
-    // parse configured pipelines as well.
-    if (key == "labels") {
-      continue;
-    }
+    TRY(check_unknown_package_key("pipeline", key));
   }
   REQUIRED_FIELD(definition)
   return result;
@@ -649,6 +675,7 @@ auto package_context::parse(const view<record>& data)
     TRY_ASSIGN_BOOL_TO_RESULT(disabled);
     TRY_ASSIGN_OPTIONAL_STRING_TO_RESULT(description);
     TRY_ASSIGN_STRINGMAP_TO_RESULT(arguments);
+    return unknown_package_key_error("context", key);
   }
   REQUIRED_FIELD(type)
   return result;
@@ -661,6 +688,7 @@ auto package_example::parse(const view<record>& data)
     TRY_ASSIGN_STRING_TO_RESULT(definition);
     TRY_ASSIGN_OPTIONAL_STRING_TO_RESULT(name);
     TRY_ASSIGN_OPTIONAL_STRING_TO_RESULT(description);
+    return unknown_package_key_error("example", key);
   }
   REQUIRED_FIELD(definition)
   return result;
@@ -688,6 +716,7 @@ auto package::parse(const view<record>& data) -> caf::expected<package> {
     TRY_ASSIGN_MAP_TO_RESULT(contexts, package_context);
     TRY_ASSIGN_STRUCTURE_TO_RESULT(config, package_config);
     TRY_ASSIGN_LIST_TO_RESULT(examples, package_example);
+    TRY(check_unknown_package_key("package", key));
   }
   REQUIRED_FIELD(id)
   REQUIRED_FIELD(name)

--- a/libtenzir/src/package.cpp
+++ b/libtenzir/src/package.cpp
@@ -342,7 +342,6 @@ auto package_input::parse(const view<record>& data)
     return unknown_package_key_error("input", key);
   }
   REQUIRED_FIELD(name);
-  REQUIRED_FIELD(type);
   return result;
 }
 
@@ -675,6 +674,25 @@ auto package_context::parse(const view<record>& data)
     TRY_ASSIGN_BOOL_TO_RESULT(disabled);
     TRY_ASSIGN_OPTIONAL_STRING_TO_RESULT(description);
     TRY_ASSIGN_STRINGMAP_TO_RESULT(arguments);
+    if (key == "args") {
+      const auto* x = try_as<view<record>>(&value);
+      if (not x) {
+        return diagnostic::error("args must be a record")
+          .note("invalid package definition")
+          .to_error();
+      }
+      for (auto const& [key, value] : *x) {
+        auto const* value_string = try_as<std::string_view>(&value);
+        if (not value_string) {
+          return diagnostic::error("args values must be strings")
+            .note("while parsing key {} for field args", key)
+            .note("invalid package definition")
+            .to_error();
+        }
+        result.arguments[std::string{key}] = std::string{*value_string};
+      }
+      continue;
+    }
     return unknown_package_key_error("context", key);
   }
   REQUIRED_FIELD(type)

--- a/test/inputs/package-ignored-known-keys.yaml
+++ b/test/inputs/package-ignored-known-keys.yaml
@@ -1,0 +1,25 @@
+id: ignored-known-keys
+name: Ignored Known Keys
+description: Package with known package-spec/legacy keys ignored by the engine.
+
+snippets:
+  - name: Legacy snippet field
+    definition: version
+
+inputs:
+  message:
+    name: Message
+    description: Text to emit.
+    type: string
+    default: hello
+
+pipelines:
+  demo:
+    name: Demo
+    description: Emits one event.
+    labels:
+      - example
+      - ignored-by-engine
+    definition: |
+      from {message: "{{ inputs.message }}"}
+      import

--- a/test/inputs/package-ignored-known-keys.yaml
+++ b/test/inputs/package-ignored-known-keys.yaml
@@ -13,6 +13,12 @@ inputs:
     type: string
     default: hello
 
+contexts:
+  demo-context:
+    type: lookup-table
+    description: Context using the documented args key.
+    args: {}
+
 pipelines:
   demo:
     name: Demo

--- a/test/inputs/package-input-without-type.yaml
+++ b/test/inputs/package-input-without-type.yaml
@@ -1,6 +1,6 @@
-id: missing-input-type
-name: Missing Input Type
-description: Package with an input missing its required type.
+id: input-without-type
+name: Input Without Type
+description: Package with a documented input that omits the optional type.
 
 inputs:
   message:

--- a/test/inputs/package-input-without-type.yaml
+++ b/test/inputs/package-input-without-type.yaml
@@ -14,3 +14,4 @@ pipelines:
     description: Emits one event.
     definition: |
       from {message: "{{ inputs.message }}"}
+      import

--- a/test/inputs/package-missing-input-type.yaml
+++ b/test/inputs/package-missing-input-type.yaml
@@ -1,0 +1,16 @@
+id: missing-input-type
+name: Missing Input Type
+description: Package with an input missing its required type.
+
+inputs:
+  message:
+    name: Message
+    description: Text to emit.
+    default: hello
+
+pipelines:
+  demo:
+    name: Demo
+    description: Emits one event.
+    definition: |
+      from {message: "{{ inputs.message }}"}

--- a/test/inputs/package-unknown-pipeline-key.yaml
+++ b/test/inputs/package-unknown-pipeline-key.yaml
@@ -1,0 +1,11 @@
+id: unknown-pipeline-key
+name: Unknown Pipeline Key
+description: Package with an unknown pipeline key.
+
+pipelines:
+  demo:
+    name: Demo
+    description: Emits one event.
+    schedule: hourly
+    definition: |
+      from {message: "hello"}

--- a/test/inputs/package-unknown-top-level-key.yaml
+++ b/test/inputs/package-unknown-top-level-key.yaml
@@ -1,0 +1,12 @@
+id: unknown-top-level-key
+name: Unknown Top-level Key
+description: Package with an unknown top-level key.
+
+surprise: true
+
+pipelines:
+  demo:
+    name: Demo
+    description: Emits one event.
+    definition: |
+      from {message: "hello"}

--- a/test/tests/node/package/validation/ignored-known-keys.tql
+++ b/test/tests/node/package/validation/ignored-known-keys.tql
@@ -1,0 +1,2 @@
+from_file f"{env("TENZIR_INPUTS")}/package-ignored-known-keys.yaml" { read_yaml }
+package::add

--- a/test/tests/node/package/validation/input-without-type.tql
+++ b/test/tests/node/package/validation/input-without-type.tql
@@ -1,0 +1,2 @@
+from_file f"{env("TENZIR_INPUTS")}/package-input-without-type.yaml" { read_yaml }
+package::add

--- a/test/tests/node/package/validation/missing-input-type.tql
+++ b/test/tests/node/package/validation/missing-input-type.tql
@@ -1,0 +1,6 @@
+---
+error: true
+---
+
+from_file f"{env("TENZIR_INPUTS")}/package-missing-input-type.yaml" { read_yaml }
+package::add

--- a/test/tests/node/package/validation/missing-input-type.tql
+++ b/test/tests/node/package/validation/missing-input-type.tql
@@ -1,6 +1,0 @@
----
-error: true
----
-
-from_file f"{env("TENZIR_INPUTS")}/package-missing-input-type.yaml" { read_yaml }
-package::add

--- a/test/tests/node/package/validation/missing-input-type.txt
+++ b/test/tests/node/package/validation/missing-input-type.txt
@@ -1,9 +1,0 @@
-error: type must be provided
- --> tests/node/package/validation/missing-input-type.tql:6:1
-  |
-6 | package::add
-  | ^^^^^^^^^^^^ 
-  |
-  = note: invalid package definition
-  = note: while parsing key message for field inputs
-  = note: invalid package definition

--- a/test/tests/node/package/validation/missing-input-type.txt
+++ b/test/tests/node/package/validation/missing-input-type.txt
@@ -1,0 +1,9 @@
+error: type must be provided
+ --> tests/node/package/validation/missing-input-type.tql:6:1
+  |
+6 | package::add
+  | ^^^^^^^^^^^^ 
+  |
+  = note: invalid package definition
+  = note: while parsing key message for field inputs
+  = note: invalid package definition

--- a/test/tests/node/package/validation/test.yaml
+++ b/test/tests/node/package/validation/test.yaml
@@ -1,0 +1,3 @@
+suite:
+  name: package-validation
+  mode: parallel

--- a/test/tests/node/package/validation/unknown-pipeline-key.tql
+++ b/test/tests/node/package/validation/unknown-pipeline-key.tql
@@ -1,0 +1,6 @@
+---
+error: true
+---
+
+from_file f"{env("TENZIR_INPUTS")}/package-unknown-pipeline-key.yaml" { read_yaml }
+package::add

--- a/test/tests/node/package/validation/unknown-pipeline-key.txt
+++ b/test/tests/node/package/validation/unknown-pipeline-key.txt
@@ -1,0 +1,9 @@
+error: unknown key `schedule` in pipeline definition
+ --> tests/node/package/validation/unknown-pipeline-key.tql:6:1
+  |
+6 | package::add
+  | ^^^^^^^^^^^^ 
+  |
+  = note: invalid package definition
+  = note: while parsing key demo for field pipelines
+  = note: invalid package definition

--- a/test/tests/node/package/validation/unknown-top-level-key.tql
+++ b/test/tests/node/package/validation/unknown-top-level-key.tql
@@ -1,0 +1,6 @@
+---
+error: true
+---
+
+from_file f"{env("TENZIR_INPUTS")}/package-unknown-top-level-key.yaml" { read_yaml }
+package::add

--- a/test/tests/node/package/validation/unknown-top-level-key.txt
+++ b/test/tests/node/package/validation/unknown-top-level-key.txt
@@ -1,0 +1,7 @@
+error: unknown key `surprise` in package definition
+ --> tests/node/package/validation/unknown-top-level-key.tql:6:1
+  |
+6 | package::add
+  | ^^^^^^^^^^^^ 
+  |
+  = note: invalid package definition


### PR DESCRIPTION
Silence non-actionable package parsing warnings during node startup while keeping real package parsing failures on the diagnostics path.

### Review

- The package parsers now silently ignore unknown keys instead of logging startup warnings.
- Low-level parse helpers drop the unused `package_path` parameter where possible.
- Top-level `package::parse` and `package_pipeline::parse` keep compatibility overloads for existing callers.

### Details

<details>
<summary>⁉️ Motivation</summary>

- `tenzir-node` printed warnings like `ignoring unknown key ... in package ... definition` during startup.
- These messages were not actionable in the startup context and created noisy output.
- Actual package parsing and validation errors remain diagnostics and still surface normally.

</details>

<details>
<summary>🧪 Testing</summary>

- Built `tenzir-unit-test` and `tenzir` in `build/xcode/release`

</details>

<details>
<summary>📌 References</summary>

- Fixes the startup warnings reported for package loading

</details>
