### PR TITLE
Restore Claude hook for injecting the build directory

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,28 @@
+{
+  "permissions": {
+    "allow": [
+      "Skill(compile)",
+      "Bash(ls:*)",
+      "Bash(tenzir:*)",
+      "Bash(tenzir-node:*)",
+      "Bash(tenzir-unit-test:*)",
+      "Bash(uvx tenzir-test:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh issue list:*)"
+    ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Without this, running `uvx tenzir-test` from Claude makes it not see the correct binaries.