### PR TITLE
Plans for fixing buffer on the new executor

### DIFF
--- a/.agents/plan-output-task.md
+++ b/.agents/plan-output-task.md
@@ -1,0 +1,55 @@
+Good. Now I can see the full picture. Here's the proposal:
+
+`OperatorOutputBase<Output>` already has `process_sub()` which is explicitly
+documented as callable **in parallel** with other methods and receives
+`Push<Output>&`. So `Push<T>` is already proven thread-safe for concurrent use.
+The precedent exists.
+
+The minimal change is **one new virtual method** on `OperatorOutputBase<Output>`:
+
+```cpp
+/// Long-running concurrent task with access to Push<Output>.
+///
+/// Runs concurrently with process(), process_task(), and all other
+/// operator methods — similar to await_task(), but with the ability
+/// to push output directly.
+///
+/// The executor starts this task after start() and cancels it during
+/// shutdown. The default sleeps forever (no concurrent output).
+///
+/// This enables operators that need to accept input and emit output
+/// at the same time (e.g., a decoupling buffer).
+virtual auto output_task(Push<Output>& push, OpCtx& ctx) -> Task<void> {
+    TENZIR_UNUSED(push, ctx);
+    co_await wait_forever();
+}
+```
+
+Here's how this solves the buffer problem:
+
+```
+upstream → process() ──writes──→ [buffer] ←──reads── output_task() → push → downstream
+              ↑                                           ↑
+              └─ blocks on space_available_  ←── notify ──┘  (concurrent, no deadlock)
+```
+
+- **`process()`**: enqueues input into the buffer. When full, blocks on
+  `space_available_` — safe because `output_task()` runs concurrently and will
+  free space.
+- **`output_task()`**: dequeues from the buffer, pushes downstream via
+  `Push<T>`. When the buffer empties, waits on `data_available_`. When push blocks
+  (slow downstream), it just waits — process() can still run concurrently and fill
+  the buffer.
+- **`finalize()`**: sets `closed`, notifies `output_task()`. Can either return
+  `continue_` (let output_task drain) or drain itself and return `done`.
+
+All four requirements are met:
+- **(R1)** process() and output_task() are concurrent → upstream runs while downstream is slow ✓
+- **(R2)** output_task() actively drains the buffer ✓
+- **(R3)** Single bounded buffer, no secondary queues ✓
+- **(R4)** finalize signals close, output_task drains and returns ✓
+
+The change is **fully backward compatible**: the default sleeps forever, so
+existing operators are unaffected. The executor change is also minimal — start
+`output_task()` as a concurrent coroutine alongside `await_task()`, and cancel
+it on shutdown (same lifecycle management that already exists for `await_task`).

--- a/.agents/plan-two-operators.md
+++ b/.agents/plan-two-operators.md
@@ -1,0 +1,300 @@
+# Plan: Buffer as Two Operators
+
+## Background
+
+A single `Operator<T, T>` cannot fully decouple upstream from downstream
+with bounded buffering. See the design notes at the top of
+`libtenzir/builtins/operators/buffer.cpp` for the full analysis. This plan
+implements solution (B): split the buffer into two independently-scheduled
+operators connected by shared state.
+
+## Architecture
+
+```
+upstream → WriteBuffer<T> ──enqueue──→ [shared state] ──dequeue──→ ReadBuffer<T> → downstream
+            Operator<T, void>            Mutex<State>              Operator<void, T>
+```
+
+- **WriteBuffer** is a sink (`Operator<T, void>`). It accepts upstream data
+  via `process()` and enqueues it into the shared buffer.
+- **ReadBuffer** is a source (`Operator<void, T>`). It dequeues from the
+  shared buffer via `await_task()`/`process_task()` and pushes downstream.
+- The two operators are separate pipeline nodes. The executor schedules them
+  independently, so `WriteBuffer::process()` can run concurrently with
+  `ReadBuffer::process_task()`.
+
+## Shared state
+
+```cpp
+template <class T>
+struct SharedBufferState {
+  std::queue<T> queue;
+  uint64_t size = 0;
+  uint64_t capacity = 0;
+  bool closed = false;
+};
+
+// Shared between WriteBuffer and ReadBuffer via Arc.
+template <class T>
+struct SharedBuffer {
+  Mutex<SharedBufferState<T>> state;
+  Notify data_available;   // WriteBuffer signals, ReadBuffer waits
+  Notify space_available;  // ReadBuffer signals, WriteBuffer waits
+};
+```
+
+Both operators hold an `Arc<SharedBuffer<T>>`. The `Arc` is created by
+the spawner and captured by both operator constructors.
+
+## WriteBuffer (sink)
+
+```
+class WriteBuffer<T> final : public Operator<T, void>
+```
+
+### process(input, ctx)
+
+Block policy:
+
+```
+while size(input) > 0:
+    lock state
+    free = capacity - state.size
+    if free > 0:
+        [lhs, rhs] = split(input, free)
+        state.queue.push(lhs)
+        state.size += size(lhs)
+        input = rhs
+        unlock
+        data_available.notify_one()
+    else:
+        unlock
+    if size(input) > 0:
+        co_await space_available.wait()
+```
+
+Blocking on `space_available` is safe: ReadBuffer runs independently and
+will dequeue, notifying `space_available`.
+
+Drop policy: same as today — enqueue what fits, drop excess with a warning.
+
+### finalize(ctx)
+
+```
+lock state
+state.closed = true
+unlock
+data_available.notify_one()
+```
+
+Returns `FinalizeBehavior::done`. WriteBuffer has no output to drain.
+
+### snapshot / prepare_snapshot
+
+The buffer contents belong to the shared state. Both operators must
+coordinate during checkpointing. The simplest approach: `prepare_snapshot`
+on ReadBuffer drains the buffer downstream (same as today). WriteBuffer's
+`prepare_snapshot` and `snapshot` are no-ops.
+
+## ReadBuffer (source)
+
+```
+class ReadBuffer<T> final : public Operator<void, T>
+```
+
+### await_task(dh)
+
+```
+loop:
+    lock state
+    if not state.queue.empty():
+        item = state.queue.front(); state.queue.pop()
+        state.size -= size(item)
+        unlock
+        space_available.notify_one()
+        return Option{item}
+    if state.closed:
+        unlock
+        return Option<T>{None}
+    unlock
+    co_await data_available.wait()
+```
+
+### process_task(result, push, ctx)
+
+```
+opt = result.as<Option<T>>()
+if not opt:
+    done_ = true
+    return
+co_await push(*opt)
+```
+
+### state()
+
+Returns `done` when the None sentinel has been received, otherwise
+`unspecified`.
+
+### finalize(push, ctx)
+
+ReadBuffer is a source — `finalize` is called when the executor wants
+to stop the pipeline (e.g., `head` reached its limit). Drain remaining
+buffer contents via push and return `done`.
+
+### prepare_snapshot(push, ctx)
+
+Drain the buffer via push (same as today's implementation).
+
+## Describer / spawner changes
+
+### Problem
+
+The current `Describer::spawner` returns a single `SpawnWith<Args, Input>`,
+which produces one `AnyOperator`. The `GenericIr::spawn()` method returns
+a single `AnyOperator`. We need to return two.
+
+### IR layer: GenericIr::spawn → vector
+
+`ir::Operator::spawn()` currently returns `AnyOperator`. Change it (or add
+a parallel path) so that it can return `std::vector<AnyOperator>`. This
+aligns with `ir::pipeline::spawn()`, which already returns
+`std::vector<AnyOperator>`.
+
+Option 1 — change the return type:
+
+```cpp
+virtual auto spawn(element_type_tag input) && -> std::vector<AnyOperator> = 0;
+```
+
+This is a wide change — every `ir::Operator` subclass must be updated.
+
+Option 2 — add an `expand` step that wraps single operators:
+
+Keep the existing `spawn() → AnyOperator` signature. Add a new method:
+
+```cpp
+virtual auto spawn_all(element_type_tag input) && -> std::vector<AnyOperator> {
+    auto result = std::vector<AnyOperator>{};
+    result.push_back(std::move(*this).spawn(input));
+    return result;
+}
+```
+
+`GenericIr` overrides `spawn_all` when the description requests multiple
+operators. The executor calls `spawn_all` instead of `spawn`. Existing IR
+nodes are unaffected (they inherit the default one-element wrapper).
+
+### Spawner: return multiple operators
+
+Add a new type for multi-operator spawn results:
+
+```cpp
+// Spawns a pair (or more) of operators from a single Args.
+// Returns a vector of AnySpawn, each producing one operator.
+// The first element consumes the input; the last produces the output.
+// Intermediate connections are implicit (the executor wires void→void).
+using MultiSpawn = std::vector<AnySpawn>;
+```
+
+Extend `Description` with an optional multi-spawn path:
+
+```cpp
+struct Description {
+    // ... existing fields ...
+    std::optional<MultiSpawner> multi_spawner;
+};
+```
+
+Where `MultiSpawner` has the same signature as `Spawner` but returns a
+vector of spawn functions instead of one.
+
+### Describer API
+
+Add a method to `Describer` parallel to `spawner()`:
+
+```cpp
+template <class MultiSpawnerFn>
+auto multi_spawner(MultiSpawnerFn fn) -> void;
+```
+
+The lambda receives `DescribeCtx&` and the input type, and returns a
+vector of spawn functions. For the buffer:
+
+```cpp
+d.multi_spawner([...]<class Input>(DescribeCtx& ctx)
+    -> failure_or<Option<MultiSpawnWith<Args, Input>>> {
+    if constexpr (std::same_as<Input, table_slice>) {
+        auto shared = Arc<SharedBuffer<table_slice>>{std::in_place};
+        return std::vector{
+            // WriteBuffer: Input → void
+            SpawnFn<Args, table_slice, void>{
+                [shared](BufferArgs args) {
+                    return WriteBuffer<table_slice>{args, shared};
+                }
+            },
+            // ReadBuffer: void → Input
+            SpawnFn<Args, void, table_slice>{
+                [shared](BufferArgs args) {
+                    return ReadBuffer<table_slice>{args, shared};
+                }
+            },
+        };
+    }
+    // ... same for chunk_ptr ...
+});
+```
+
+### Type inference
+
+`infer_type` for a multi-spawn description chains through the operators:
+input → WriteBuffer (void output) → ReadBuffer (T output) → T. In
+practice the output type equals the input type, which the multi_spawner
+lambda can communicate directly.
+
+### GenericIr integration
+
+In `GenericIr::spawn_all()`, if the description has a `multi_spawner`,
+call it to get the vector of spawn functions, fill args, and produce
+a `vector<AnyOperator>`. The executor inserts all of them into the
+pipeline in order.
+
+## Migration
+
+### Phase 1: infrastructure
+
+1. Add `spawn_all` to `ir::Operator` with the default single-element
+   wrapper.
+2. Update `ir::pipeline::spawn` to call `spawn_all` on each operator and
+   flatten the results.
+3. Add `MultiSpawner` / `multi_spawner()` to `Description` / `Describer`.
+4. Update `GenericIr::spawn_all` to handle multi-spawn descriptions.
+5. Update `GenericIr::infer_type` to chain through multi-spawn types.
+
+### Phase 2: buffer operator
+
+1. Implement `SharedBuffer<T>` (shared state with `Mutex`, `Notify`).
+2. Implement `WriteBuffer<T> : Operator<T, void>`.
+3. Implement `ReadBuffer<T> : Operator<void, T>`.
+4. Update `buffer_plugin::describe()` to use `multi_spawner()`.
+5. Remove the single-operator `Buffer<T>` class.
+6. Keep the crtp `write_buffer_operator` / `read_buffer_operator` for the
+   legacy executor path (they already work correctly).
+
+### Phase 3: cleanup
+
+1. Once the legacy executor is retired, remove the crtp operators and the
+   actor-based buffer state.
+2. Remove the `operator_parser_plugin` / `operator_factory_plugin`
+   inheritance from `buffer_plugin`.
+
+## Verification
+
+The buffer must satisfy all four requirements from the design notes:
+
+- **(R1)** WriteBuffer::process() and ReadBuffer::process_task() run
+  independently. Upstream fills the buffer while downstream is slow. ✓
+- **(R2)** ReadBuffer::await_task() wakes on data_available and drains
+  actively. ✓
+- **(R3)** Single shared buffer bounded by capacity. No secondary queues. ✓
+- **(R4)** WriteBuffer::finalize() sets closed. ReadBuffer sees closed +
+  empty → returns None → done. ✓

--- a/libtenzir/builtins/operators/buffer.cpp
+++ b/libtenzir/builtins/operators/buffer.cpp
@@ -209,17 +209,8 @@ public:
     co_return;
   }
 
-  /// Accepts upstream data into the buffer.
-  ///
-  /// For the block policy, when the buffer overflows, the oldest buffered
-  /// items are pushed directly downstream via `push`. This avoids the
-  /// deadlock that would occur if we blocked on internal state waiting for
-  /// `process_task()` to drain — `process_task()` is sequential with
-  /// `process()` and can never run while we're suspended.
-  ///
-  /// Blocking on `push()` (downstream backpressure) is safe: it doesn't
-  /// depend on any operator-internal progress.
   auto process(T input, Push<T>& push, OpCtx& ctx) -> Task<void> override {
+    TENZIR_UNUSED(push);
     if (size(input) == 0) {
       co_return;
     }
@@ -250,73 +241,94 @@ public:
           .emit(ctx.dh());
       }
     } else {
-      // Block policy: add everything to the buffer, then push the oldest
-      // items directly downstream until the buffer is back at capacity.
-      {
-        auto guard = co_await state_->lock();
-        guard->queue.push(std::move(input));
-        guard->size += size(input);
-      }
-      // Drain overflow without holding the lock — push may suspend.
-      while (true) {
-        auto guard = co_await state_->lock();
-        if (guard->size <= args_.capacity.inner) {
-          break;
+      // block policy: enqueue what fits, wait for space when full
+      while (size(input) > 0) {
+        {
+          auto guard = co_await state_->lock();
+          const auto free = args_.capacity.inner - guard->size;
+          if (free > 0) {
+            auto [lhs, rhs] = split(input, free);
+            guard->size += size(lhs);
+            guard->queue.push(std::move(lhs));
+            input = std::move(rhs);
+            guard.unlock();
+            data_available_->notify_one();
+          }
         }
-        auto item = std::move(guard->queue.front());
-        guard->queue.pop();
-        guard->size -= size(item);
-        guard.unlock();
-        co_await push(std::move(item));
+        if (size(input) > 0) {
+          co_await space_available_->wait();
+        }
       }
-      // Non-overflowing data is drained from process_task instead,
-      // so it does not block process function.
-      data_available_->notify_one();
     }
     co_return;
   }
 
-  /// Wakes when data is available in the buffer for active draining.
   auto await_task(diagnostic_handler& dh) const -> Task<Any> override {
     TENZIR_UNUSED(dh);
-    co_await data_available_->wait();
-    co_return {};
+    while (true) {
+      {
+        auto guard = co_await state_->lock();
+        if (not guard->queue.empty()) {
+          auto item = std::move(guard->queue.front());
+          guard->queue.pop();
+          guard->size -= size(item);
+          guard.unlock();
+          space_available_->notify_one();
+          co_return Option{std::move(item)};
+        }
+        if (guard->closed) {
+          co_return Option<T>{None{}};
+        }
+      }
+      co_await data_available_->wait();
+    }
   }
 
-  /// Actively drains one batch from the buffer per invocation.
-  ///
-  /// This ensures buffered data flows downstream even when no new input
-  /// arrives, rather than sitting in the buffer until the next overflow.
-  /// Draining one batch at a time keeps the buffer populated so that it
-  /// can absorb upstream bursts between process_task calls.
   auto process_task(Any result, Push<T>& push, OpCtx& ctx)
     -> Task<void> override {
-    TENZIR_UNUSED(result, ctx);
-    auto guard = co_await state_->lock();
-    if (guard->queue.empty()) {
+    TENZIR_UNUSED(ctx);
+    auto* opt = result.try_as<Option<T>>();
+    if (not opt) {
       co_return;
     }
-    auto item = std::move(guard->queue.front());
-    guard->queue.pop();
-    guard->size -= size(item);
-    const auto has_more = not guard->queue.empty();
-    guard.unlock();
-    co_await push(std::move(item));
-    if (has_more) {
-      data_available_->notify_one();
+    if (not *opt) {
+      done_ = true;
+      co_return;
     }
+    co_await push(std::move(**opt));
   }
 
   auto prepare_snapshot(Push<T>& push, OpCtx& ctx) -> Task<void> override {
     TENZIR_UNUSED(ctx);
-    co_return co_await flush(push);
+
+    while (true) {
+      Option<T> item;
+      {
+        auto guard = co_await state_->lock();
+        if (guard->queue.empty()) {
+          co_return;
+        }
+        item = std::move(guard->queue.front());
+        guard->queue.pop();
+        guard->size -= size(*item);
+      }
+      space_available_->notify_one();
+      co_await push(std::move(*item));
+    }
   }
 
-  /// Drains remaining buffer contents downstream and signals completion.
   auto finalize(Push<T>& push, OpCtx& ctx) -> Task<FinalizeBehavior> override {
-    TENZIR_UNUSED(ctx);
-    co_await flush(push);
-    co_return FinalizeBehavior::done;
+    TENZIR_UNUSED(push, ctx);
+    {
+      auto guard = co_await state_->lock();
+      guard->closed = true;
+    }
+    data_available_->notify_one();
+    co_return FinalizeBehavior::continue_;
+  }
+
+  auto state() -> OperatorState override {
+    return done_ ? OperatorState::done : OperatorState::unspecified;
   }
 
   auto snapshot(Serde& serde) -> void override {
@@ -326,23 +338,10 @@ public:
   }
 
 private:
-  auto flush(Push<T>& push) -> Task<void> {
-    while (true) {
-      auto guard = co_await state_->lock();
-      if (guard->queue.empty()) {
-        co_return;
-      }
-      auto item = std::move(guard->queue.front());
-      guard->queue.pop();
-      guard->size -= size(item);
-      guard.unlock();
-      co_await push(std::move(item));
-    }
-  }
-
   struct InternalState {
     std::queue<T> queue = {};
     uint64_t size = 0;
+    bool closed = false;
   };
 
   BufferArgs args_;
@@ -350,6 +349,8 @@ private:
 
   mutable Box<Mutex<InternalState>> state_{std::in_place, InternalState{}};
   mutable Box<Notify> data_available_{std::in_place};
+  mutable Box<Notify> space_available_{std::in_place};
+  bool done_ = false;
 };
 
 class write_buffer_operator final

--- a/libtenzir/builtins/operators/buffer.cpp
+++ b/libtenzir/builtins/operators/buffer.cpp
@@ -209,8 +209,17 @@ public:
     co_return;
   }
 
+  /// Accepts upstream data into the buffer.
+  ///
+  /// For the block policy, when the buffer overflows, the oldest buffered
+  /// items are pushed directly downstream via `push`. This avoids the
+  /// deadlock that would occur if we blocked on internal state waiting for
+  /// `process_task()` to drain — `process_task()` is sequential with
+  /// `process()` and can never run while we're suspended.
+  ///
+  /// Blocking on `push()` (downstream backpressure) is safe: it doesn't
+  /// depend on any operator-internal progress.
   auto process(T input, Push<T>& push, OpCtx& ctx) -> Task<void> override {
-    TENZIR_UNUSED(push);
     if (size(input) == 0) {
       co_return;
     }
@@ -241,94 +250,73 @@ public:
           .emit(ctx.dh());
       }
     } else {
-      // block policy: enqueue what fits, wait for space when full
-      while (size(input) > 0) {
-        {
-          auto guard = co_await state_->lock();
-          const auto free = args_.capacity.inner - guard->size;
-          if (free > 0) {
-            auto [lhs, rhs] = split(input, free);
-            guard->size += size(lhs);
-            guard->queue.push(std::move(lhs));
-            input = std::move(rhs);
-            guard.unlock();
-            data_available_->notify_one();
-          }
-        }
-        if (size(input) > 0) {
-          co_await space_available_->wait();
-        }
+      // Block policy: add everything to the buffer, then push the oldest
+      // items directly downstream until the buffer is back at capacity.
+      {
+        auto guard = co_await state_->lock();
+        guard->queue.push(std::move(input));
+        guard->size += size(input);
       }
+      // Drain overflow without holding the lock — push may suspend.
+      while (true) {
+        auto guard = co_await state_->lock();
+        if (guard->size <= args_.capacity.inner) {
+          break;
+        }
+        auto item = std::move(guard->queue.front());
+        guard->queue.pop();
+        guard->size -= size(item);
+        guard.unlock();
+        co_await push(std::move(item));
+      }
+      // Non-overflowing data is drained from process_task instead,
+      // so it does not block process function.
+      data_available_->notify_one();
     }
     co_return;
   }
 
+  /// Wakes when data is available in the buffer for active draining.
   auto await_task(diagnostic_handler& dh) const -> Task<Any> override {
     TENZIR_UNUSED(dh);
-    while (true) {
-      {
-        auto guard = co_await state_->lock();
-        if (not guard->queue.empty()) {
-          auto item = std::move(guard->queue.front());
-          guard->queue.pop();
-          guard->size -= size(item);
-          guard.unlock();
-          space_available_->notify_one();
-          co_return Option{std::move(item)};
-        }
-        if (guard->closed) {
-          co_return Option<T>{None{}};
-        }
-      }
-      co_await data_available_->wait();
-    }
+    co_await data_available_->wait();
+    co_return {};
   }
 
+  /// Actively drains one batch from the buffer per invocation.
+  ///
+  /// This ensures buffered data flows downstream even when no new input
+  /// arrives, rather than sitting in the buffer until the next overflow.
+  /// Draining one batch at a time keeps the buffer populated so that it
+  /// can absorb upstream bursts between process_task calls.
   auto process_task(Any result, Push<T>& push, OpCtx& ctx)
     -> Task<void> override {
-    TENZIR_UNUSED(ctx);
-    auto* opt = result.try_as<Option<T>>();
-    if (not opt) {
+    TENZIR_UNUSED(result, ctx);
+    auto guard = co_await state_->lock();
+    if (guard->queue.empty()) {
       co_return;
     }
-    if (not *opt) {
-      done_ = true;
-      co_return;
+    auto item = std::move(guard->queue.front());
+    guard->queue.pop();
+    guard->size -= size(item);
+    const auto has_more = not guard->queue.empty();
+    guard.unlock();
+    co_await push(std::move(item));
+    if (has_more) {
+      data_available_->notify_one();
     }
-    co_await push(std::move(**opt));
   }
 
   auto prepare_snapshot(Push<T>& push, OpCtx& ctx) -> Task<void> override {
     TENZIR_UNUSED(ctx);
-
-    while (true) {
-      Option<T> item;
-      {
-        auto guard = co_await state_->lock();
-        if (guard->queue.empty()) {
-          co_return;
-        }
-        item = std::move(guard->queue.front());
-        guard->queue.pop();
-        guard->size -= size(*item);
-      }
-      space_available_->notify_one();
-      co_await push(std::move(*item));
-    }
+    co_return co_await flush(push);
   }
 
+  /// Drains remaining buffer contents downstream and signals completion.
   auto finalize(Push<T>& push, OpCtx& ctx) -> Task<FinalizeBehavior> override {
-    TENZIR_UNUSED(push, ctx);
-    {
-      auto guard = co_await state_->lock();
-      guard->closed = true;
-    }
-    data_available_->notify_one();
-    co_return FinalizeBehavior::continue_;
-  }
-
-  auto state() -> OperatorState override {
-    return done_ ? OperatorState::done : OperatorState::unspecified;
+    TENZIR_UNUSED(ctx);
+    co_await flush(push);
+    co_return FinalizeBehavior::done;
   }
 
   auto snapshot(Serde& serde) -> void override {
@@ -338,10 +326,23 @@ public:
   }
 
 private:
+  auto flush(Push<T>& push) -> Task<void> {
+    while (true) {
+      auto guard = co_await state_->lock();
+      if (guard->queue.empty()) {
+        co_return;
+      }
+      auto item = std::move(guard->queue.front());
+      guard->queue.pop();
+      guard->size -= size(item);
+      guard.unlock();
+      co_await push(std::move(item));
+    }
+  }
+
   struct InternalState {
     std::queue<T> queue = {};
     uint64_t size = 0;
-    bool closed = false;
   };
 
   BufferArgs args_;
@@ -349,8 +350,6 @@ private:
 
   mutable Box<Mutex<InternalState>> state_{std::in_place, InternalState{}};
   mutable Box<Notify> data_available_{std::in_place};
-  mutable Box<Notify> space_available_{std::in_place};
-  bool done_ = false;
 };
 
 class write_buffer_operator final

--- a/libtenzir/builtins/operators/buffer.cpp
+++ b/libtenzir/builtins/operators/buffer.cpp
@@ -101,15 +101,6 @@
 // with bounded buffering. The sequential constraint between process() and
 // process_task() makes it structurally impossible to accept new data and
 // push buffered data at the same time.
-//
-// Full decoupling requires two independent operators in the pipeline (as
-// the legacy crtp_operator path does with write_buffer_operator and
-// read_buffer_operator connected by an actor side-channel). The Describer/
-// spawner mechanism would need to be extended to support returning a
-// pipeline of two operators from describe().
-//
-// The current implementation uses approach (3) as the best available
-// compromise within a single operator.
 
 #include <tenzir/argument_parser.hpp>
 #include <tenzir/async/mutex.hpp>

--- a/libtenzir/builtins/operators/buffer.cpp
+++ b/libtenzir/builtins/operators/buffer.cpp
@@ -6,6 +6,111 @@
 // SPDX-FileCopyrightText: (c) 2024 The Tenzir Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+// ## Buffer Operator — Design Notes
+//
+// ### Goal
+//
+// The buffer operator decouples upstream from downstream using a bounded
+// queue of configurable capacity. The requirements are:
+//
+//   (R1) Upstream must be able to continue producing data while downstream
+//        is slow, as long as the buffer has free capacity.
+//   (R2) Buffered data must be forwarded downstream even when no new input
+//        arrives (active draining).
+//   (R3) The total amount of buffered data must be bounded by the configured
+//        capacity (no unbounded secondary queues).
+//   (R4) The operator must terminate after upstream ends and all buffered
+//        data has been delivered.
+//
+// ### Why a single Operator<T, T> cannot satisfy all requirements
+//
+// The executor schedules operator methods as follows:
+//
+//   - process() and process_task() are SEQUENTIAL: the executor never runs
+//     them concurrently. One must complete before the other can start.
+//   - await_task() runs CONCURRENTLY with process() and process_task().
+//   - Spawned tasks (ctx.spawn_task) run concurrently with everything, but
+//     do not have access to Push<T>, so they cannot emit data downstream.
+//   - Push<T> is only available inside process(), process_task(),
+//     finalize(), and prepare_snapshot().
+//
+// A true decoupling buffer needs two concurrent activities:
+//
+//   (A) A producer that accepts upstream data into the buffer.
+//       → This is process().
+//   (B) A consumer that drains the buffer to downstream.
+//       → This must call push(), so it can only be process_task()
+//         (or finalize/prepare_snapshot, but those are one-shot).
+//
+// Because (A) and (B) are sequential, they block each other:
+//
+//   - If process_task() blocks on push() (downstream slow), process()
+//     cannot run, so upstream stalls even when the buffer has free space.
+//     This violates (R1).
+//
+//   - If process() blocks waiting for buffer space, process_task() cannot
+//     run to drain the buffer, because it is sequential with process().
+//     This deadlocks.
+//
+// ### Approaches explored
+//
+// 1. await_task/process_task drain loop (original new-executor attempt)
+//
+//    process() writes to the buffer and blocks when full (waiting on a
+//    Notify). await_task() wakes when data is available and returns it.
+//    process_task() pushes it downstream.
+//
+//    FAILS: When process() blocks on a full buffer, process_task() cannot
+//    run (sequential), so the buffer never drains. Deadlocks when a single
+//    input batch exceeds ~2× the buffer capacity.
+//
+// 2. Spawned drain task with output queue
+//
+//    A ctx.spawn_task() background coroutine moves data from the buffer
+//    into a BoundedQueue. await_task() dequeues from the BoundedQueue and
+//    process_task() pushes downstream.
+//
+//    FAILS: The drain task eventually blocks on the BoundedQueue (full
+//    because process_task is blocked on push). Once blocked, the drain task
+//    can no longer free buffer space. process() blocks waiting for space,
+//    process_task() can't run → deadlock. Increasing the BoundedQueue
+//    capacity only raises the threshold, doesn't eliminate it, and violates
+//    (R3).
+//
+// 3. Overflow push from process()
+//
+//    process() adds input to the buffer, then pushes the oldest items
+//    directly downstream (via its own push reference) until the buffer is
+//    back at capacity. await_task()/process_task() actively drain the
+//    buffer between process() calls.
+//
+//    PARTIALLY WORKS: No deadlock — process() only blocks on downstream
+//    push, never on internal state. Buffer capacity is respected. Active
+//    draining via process_task() ensures buffered data flows when no new
+//    input arrives.
+//
+//    LIMITATION: When process_task() blocks on push() (slow downstream),
+//    process() cannot run (sequential), so upstream stalls. This violates
+//    (R1): the buffer cannot absorb new data while the consumer side is
+//    blocked on downstream backpressure. The operator degrades to a FIFO
+//    pipe with capacity-sized latency rather than a true decoupling buffer.
+//
+// ### Conclusion
+//
+// A single Operator<T, T> cannot fully decouple upstream from downstream
+// with bounded buffering. The sequential constraint between process() and
+// process_task() makes it structurally impossible to accept new data and
+// push buffered data at the same time.
+//
+// Full decoupling requires two independent operators in the pipeline (as
+// the legacy crtp_operator path does with write_buffer_operator and
+// read_buffer_operator connected by an actor side-channel). The Describer/
+// spawner mechanism would need to be extended to support returning a
+// pipeline of two operators from describe().
+//
+// The current implementation uses approach (3) as the best available
+// compromise within a single operator.
+
 #include <tenzir/argument_parser.hpp>
 #include <tenzir/async/mutex.hpp>
 #include <tenzir/async/notify.hpp>


### PR DESCRIPTION
Current implementation of buffer deadlocks easily. I don't know how this was not caught in the initial PR.

It seems like it is not possible to implement wanted behavior with current Operator interface. I had opus document the requirements and outline why it is not possible.

Possible ways forward:
- explore changing Operator API somehow that would not disrupt other operators too much,
- implement buffer using two Operators, like the old executor did.

Resolves TNZ-39