### PR TITLE
Fix musl warnings and stabilize xsv test

### DIFF
--- a/libtenzir/builtins/formats/cef.cpp
+++ b/libtenzir/builtins/formats/cef.cpp
@@ -43,6 +43,7 @@ namespace {
 auto unescape(std::string_view::iterator begin, std::string_view::iterator end,
               std::back_insert_iterator<std::string> out)
   -> std::string_view::iterator {
+  TENZIR_UNUSED(end);
   TENZIR_ASSERT_EXPENSIVE(*std::prev(begin) == '\\');
   TENZIR_ASSERT_EXPENSIVE(begin < end);
   switch (*begin) {

--- a/libtenzir/builtins/formats/grok.cpp
+++ b/libtenzir/builtins/formats/grok.cpp
@@ -755,7 +755,7 @@ public:
       return std::make_unique<parser_adapter<grok_parser>>(grok_parser{
         std::move(pattern_definitions), std::move(raw_pattern),
         indexed_captures, include_unnamed, std::move(opts), ctx.dh()});
-    } catch (diagnostic diag) {
+    } catch (diagnostic& diag) {
       std::move(diag).modify().emit(ctx);
       return failure::promise();
     } catch (...) {
@@ -825,7 +825,7 @@ public:
           return multi_series{std::move(output)};
         });
       });
-    } catch (diagnostic diag) {
+    } catch (diagnostic& diag) {
       std::move(diag).modify().emit(ctx);
       return failure::promise();
     } catch (...) {

--- a/libtenzir/builtins/formats/leef.cpp
+++ b/libtenzir/builtins/formats/leef.cpp
@@ -60,6 +60,7 @@ namespace {
 auto unescape(std::string_view::iterator begin, std::string_view::iterator end,
               std::back_insert_iterator<std::string> out)
   -> std::string_view::iterator {
+  TENZIR_UNUSED(end);
   TENZIR_ASSERT_EXPENSIVE(*std::prev(begin) == '\\');
   TENZIR_ASSERT_EXPENSIVE(begin < end);
   switch (*begin) {

--- a/libtenzir/builtins/formats/xsv.cpp
+++ b/libtenzir/builtins/formats/xsv.cpp
@@ -1116,7 +1116,7 @@ public:
     co_await pusher_.push(msb_->yield_ready_as_table_slice(now), push);
   }
 
-  auto finalize(Push<table_slice>& push, OpCtx& ctx)
+  auto finalize(Push<table_slice>& push, OpCtx&)
     -> Task<FinalizeBehavior> override {
     if (not msb_) {
       co_return FinalizeBehavior::done;

--- a/libtenzir/builtins/metrics/memory.cpp
+++ b/libtenzir/builtins/metrics/memory.cpp
@@ -208,6 +208,7 @@ auto make_chunk_info() -> record {
   };
 }
 
+#if TENZIR_ALLOCATOR_MAY_USE_SYSTEM
 auto make_malloc_metrics() -> record {
   auto result = record{};
   result.reserve(7);
@@ -243,6 +244,7 @@ auto make_malloc_metrics() -> record {
 #endif
   return result;
 }
+#endif
 
 #if TENZIR_LINUX
 auto parse_proc_kb_value(std::string_view line, std::string_view key)

--- a/libtenzir/builtins/operators/assert_secret.cpp
+++ b/libtenzir/builtins/operators/assert_secret.cpp
@@ -59,7 +59,7 @@ public:
     }
   }
 
-  auto process(table_slice input, Push<table_slice>& push, OpCtx& ctx)
+  auto process(table_slice input, Push<table_slice>& push, OpCtx&)
     -> Task<void> override {
     // Pass through data (should not be called since we return done)
     co_await push(std::move(input));

--- a/libtenzir/builtins/operators/export.cpp
+++ b/libtenzir/builtins/operators/export.cpp
@@ -117,7 +117,7 @@ public:
     bridge_ = std::move(*result);
   }
 
-  auto await_task(diagnostic_handler& dh) const -> Task<Any> override {
+  auto await_task(diagnostic_handler&) const -> Task<Any> override {
     if (done_) {
       // TODO: Properly suspend.
       co_await wait_forever();

--- a/libtenzir/builtins/operators/head.cpp
+++ b/libtenzir/builtins/operators/head.cpp
@@ -22,7 +22,7 @@ public:
   explicit Head(HeadArgs args) : remaining_{args.count} {
   }
 
-  auto process(table_slice input, Push<table_slice>& push, OpCtx& ctx)
+  auto process(table_slice input, Push<table_slice>& push, OpCtx&)
     -> Task<void> override {
     // TODO: Do we want to guarantee this?
     TENZIR_ASSERT(remaining_ > 0);

--- a/libtenzir/builtins/operators/print.cpp
+++ b/libtenzir/builtins/operators/print.cpp
@@ -133,7 +133,7 @@ public:
             std::erase_if(chunks, [](const chunk_ptr& chunk) {
               return not chunk or chunk->size() == 0;
             });
-          } catch (diagnostic diag) {
+          } catch (diagnostic& diag) {
             std::move(diag)
               .modify()
               .severity(severity::warning)

--- a/libtenzir/builtins/operators/taste.cpp
+++ b/libtenzir/builtins/operators/taste.cpp
@@ -72,7 +72,7 @@ public:
   explicit Taste(TasteArgs args) : limit_{args.limit} {
   }
 
-  auto process(table_slice input, Push<table_slice>& push, OpCtx& ctx)
+  auto process(table_slice input, Push<table_slice>& push, OpCtx&)
     -> Task<void> override {
     auto it = schemas_.find(input.schema());
     if (it == schemas_.end()) {

--- a/libtenzir/builtins/operators/tcp-listen.cpp
+++ b/libtenzir/builtins/operators/tcp-listen.cpp
@@ -244,7 +244,7 @@ auto make_connection(connection_actor::stateful_pointer<connection_state> self,
     [self](std::exception_ptr exception) -> caf::error {
       try {
         std::rethrow_exception(exception);
-      } catch (diagnostic diag) {
+      } catch (diagnostic& diag) {
         self->state().ctrl->diagnostics().emit(std::move(diag));
         return {};
       } catch (const std::exception& err) {

--- a/libtenzir/include/tenzir/cast.hpp
+++ b/libtenzir/include/tenzir/cast.hpp
@@ -886,6 +886,7 @@ struct cast_helper<enumeration_type, enumeration_type> {
        std::shared_ptr<type_to_arrow_array_t<enumeration_type>> array,
        const enumeration_type& to)
     -> std::shared_ptr<type_to_arrow_array_t<enumeration_type>> {
+    TENZIR_UNUSED(from, to);
     TENZIR_ASSERT_EXPENSIVE(can_cast(from, to));
     return array;
   }

--- a/libtenzir/include/tenzir/cast.hpp
+++ b/libtenzir/include/tenzir/cast.hpp
@@ -228,6 +228,7 @@ struct cast_helper<Type, Type> {
                    std::shared_ptr<type_to_arrow_array_t<Type>> from_array,
                    const Type& to_type)
     -> std::shared_ptr<type_to_arrow_array_t<Type>> {
+    TENZIR_UNUSED(from_type, to_type);
     TENZIR_ASSERT_EXPENSIVE(can_cast(from_type, to_type));
     return from_array;
   }

--- a/libtenzir/include/tenzir/detail/enum.hpp
+++ b/libtenzir/include/tenzir/detail/enum.hpp
@@ -62,7 +62,7 @@
     return tenzir::detail::inspect_enum_str(                                   \
       f, x, {TENZIR_PP_FOR(TENZIR_ENUM_STR, __VA_ARGS__)});                    \
   }                                                                            \
-  [[maybe_unused]] void adl_tenzir_macro_enum(name)
+  [[maybe_unused]] inline void adl_tenzir_macro_enum(name) {}
 
 namespace tenzir {
 

--- a/libtenzir/src/arrow_fs.cpp
+++ b/libtenzir/src/arrow_fs.cpp
@@ -207,7 +207,7 @@ auto ArrowFsOperator::process_task(Any result, Push<table_slice>&, OpCtx& ctx)
     });
 }
 
-auto ArrowFsOperator::finish_sub(SubKeyView key, Push<table_slice>&, OpCtx& ctx)
+auto ArrowFsOperator::finish_sub(SubKeyView key, Push<table_slice>&, OpCtx&)
   -> Task<void> {
   auto slot = static_cast<size_t>(as<int64_t>(key));
   co_await results_->enqueue(SubFinished{slot});

--- a/libtenzir/src/arrow_memory_pool.cpp
+++ b/libtenzir/src/arrow_memory_pool.cpp
@@ -96,7 +96,7 @@ public:
   }
 
   auto Free(uint8_t* ptr, int64_t size, int64_t alignment) -> void override {
-    (void)alignment; // alignment is not needed for free
+    TENZIR_UNUSED(size, alignment);
     TENZIR_ASSERT_EXPENSIVE(ptr != nullptr);
     if (ptr == kZeroSizeArea) {
       TENZIR_ASSERT_EXPENSIVE(size == 0);

--- a/libtenzir/src/async/executor.cpp
+++ b/libtenzir/src/async/executor.cpp
@@ -1004,7 +1004,7 @@ private:
       driver_.add(pull_upstream());
       driver_.add(from_control_.recv());
       co_await main_loop();
-    } catch (folly::OperationCancelled) {
+    } catch (folly::OperationCancelled const&) {
       // Sanity check: We should only propagate this if we actually got cancelled.
       auto cancelled = cancellation_token.isCancellationRequested();
       LOGV("shutting down operator after cancellation: {}", cancelled);

--- a/libtenzir/src/catalog.cpp
+++ b/libtenzir/src/catalog.cpp
@@ -324,9 +324,11 @@ auto catalog_state::lookup_impl(const expression& expr,
             }
             case meta_extractor::schema_id: {
               auto result = catalog_lookup_result::candidate_info{};
-              for (const auto& [part_id, part_syn] : partition_synopses) {
+#if TENZIR_ENABLE_ASSERTIONS
+              for (const auto& [_, part_syn] : partition_synopses) {
                 TENZIR_ASSERT_EXPENSIVE(part_syn->schema == schema);
               }
+#endif
               if (evaluate(schema.make_fingerprint(), x.op, d)) {
                 for (const auto& [part_id, part_syn] : partition_synopses) {
                   result.partition_infos.emplace_back(part_id, *part_syn);

--- a/libtenzir/src/detail/string.cpp
+++ b/libtenzir/src/detail/string.cpp
@@ -22,6 +22,7 @@ namespace detail {
 auto quoting_escaping_policy::basic_unescape_operation(
   std::string_view::iterator begin, std::string_view::iterator end,
   std::back_insert_iterator<std::string> out) -> std::string_view::iterator {
+  TENZIR_UNUSED(end);
   TENZIR_ASSERT_EXPENSIVE(*std::prev(begin) == '\\');
   TENZIR_ASSERT_EXPENSIVE(begin < end);
   switch (*begin) {

--- a/libtenzir/src/store.cpp
+++ b/libtenzir/src/store.cpp
@@ -186,6 +186,7 @@ default_passive_store_actor::behavior_type default_passive_store(
       // everything.
       const auto num_events = self->state().store->num_events();
       TENZIR_DEBUG("{} erases {} events", *self, num_events);
+      TENZIR_UNUSED(selection);
       TENZIR_ASSERT_EXPENSIVE(rank(selection) == 0
                               || rank(selection) == num_events);
       auto rp = self->make_response_promise<uint64_t>();
@@ -226,6 +227,7 @@ default_active_store_actor::behavior_type default_active_store(
       // For new, partition-local stores we know that we always erase
       // everything.
       const auto num_events = self->state().store->num_events();
+      TENZIR_UNUSED(selection);
       TENZIR_ASSERT_EXPENSIVE(rank(selection) == 0
                               || rank(selection) == num_events);
       // We don't actually need to erase anything in the store itself, but

--- a/plugins/clickhouse/builtins/to_clickhouse.cpp
+++ b/plugins/clickhouse/builtins/to_clickhouse.cpp
@@ -204,11 +204,12 @@ public:
       .primary = std::move(primary),
       .operator_location = args_.operator_location,
     };
-    auto ok = co_await ctx.resolve_secrets({
+    auto requests = std::vector<secret_request>{
       make_secret_request("host", args_.host, client_args.host, dh),
       make_secret_request("user", args_.user, client_args.user, dh),
       make_secret_request("password", args_.password, client_args.password, dh),
-    });
+    };
+    auto ok = co_await ctx.resolve_secrets(std::move(requests));
     if (not ok) {
       state_->done.store(true, std::memory_order_release);
       co_return;

--- a/test/tests/operators/xsv/error_write_csv_heterogeneous_schemas.tql
+++ b/test/tests/operators/xsv/error_write_csv_heterogeneous_schemas.tql
@@ -6,3 +6,4 @@ from_stdin { read_ndjson }
 batch 1
 drop_null_fields
 write_csv
+discard

--- a/test/tests/operators/xsv/error_write_csv_heterogeneous_schemas.txt
+++ b/test/tests/operators/xsv/error_write_csv_heterogeneous_schemas.txt
@@ -1,4 +1,2 @@
-x,y
-1,2
 error: multiple schemas are not supported when header is enabled
  = note: got schema `tenzir.unknown` after schema `tenzir.unknown`


### PR DESCRIPTION
## 🔍 Problem
- The musl CI build emits a set of compiler warnings across `libtenzir` and plugins.
- The `error_write_csv_heterogeneous_schemas` integration test is flaky because it expects partial stdout from a pipeline that later fails.

## 🛠️ Solution
- Remove the warning sites by cleaning up unused parameters, catching polymorphic exceptions by reference, and fixing the remaining enum/coroutine/helper warnings.
- Make the xsv integration test assert only the deterministic error path by discarding `write_csv` output before comparison.

## 💬 Review
- Review the nontrivial warning fixes in `detail/enum.hpp`, `to_clickhouse.cpp`, `catalog.cpp`, and the xsv test change.
- No changelog entry: this is internal cleanup and test stabilization.