### PR TITLE
Make build script's build-dir discovery portable on macOS

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -23,7 +23,7 @@ else
   latest_mtime=0
   while IFS= read -r -d '' f; do
     m=$(stat "${stat_mtime_fmt[@]}" "$f")
-    if (( m > latest_mtime )); then
+    if ((m > latest_mtime)); then
       latest_mtime=$m
       latest_cache=$f
     fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,13 +13,21 @@ if [[ -n ${BUILD_DIR:-} ]]; then
   build_dir="$BUILD_DIR"
 else
   # Pick the configured build dir with the most recently modified CMakeCache.txt.
-  latest_cache=$(
-    find "$repo_root/build" -type f -name CMakeCache.txt -print0 2>/dev/null |
-      xargs -0 -r stat --format '%Y %n' |
-      LC_ALL=C sort -k1,1nr -k2,2 |
-      head -n 1 |
-      cut -d' ' -f2-
-  )
+  # stat(1) has incompatible syntax between GNU and BSD (macOS); pick per platform.
+  if [[ "$(uname)" == "Darwin" ]]; then
+    stat_mtime_fmt=(-f '%m')
+  else
+    stat_mtime_fmt=(--format '%Y')
+  fi
+  latest_cache=""
+  latest_mtime=0
+  while IFS= read -r -d '' f; do
+    m=$(stat "${stat_mtime_fmt[@]}" "$f")
+    if (( m > latest_mtime )); then
+      latest_mtime=$m
+      latest_cache=$f
+    fi
+  done < <(find "$repo_root/build" -type f -name CMakeCache.txt -print0 2>/dev/null)
   if [[ -n "$latest_cache" ]]; then
     build_dir=$(dirname "$latest_cache")
   else


### PR DESCRIPTION
## Problem

Running `scripts/build.sh` on macOS failed with:

```
stat: illegal option -- -
usage: stat [-FLnq] [-f format | -l | -r | -s | -x] [-t timefmt] [file ...]
```

The auto-discovery for the most recent `CMakeCache.txt` used
`stat --format '%Y %n'` and `xargs -r`, both of which are GNU-only and
unavailable in BSD `stat`/`xargs` on Darwin.

## Solution

Detect the platform once and pick the right `stat` format flags
(`-f '%m'` on Darwin, `--format '%Y'` elsewhere). Replace the `xargs`
pipeline with a NUL-delimited `while read -d ''` loop that tracks the
latest mtime directly, which also sidesteps `xargs -r`.

## Review

`scripts/build.sh` is the only file touched. Verified on macOS that the
discovery loop finds the expected `build/release/CMakeCache.txt`. Behavior
on Linux is unchanged aside from moving the mtime comparison from
`sort | head` to a shell loop.