### PR TITLE
Add new ZeroMQ operators

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -77,6 +77,7 @@ rec {
     (pkgs.python3.withPackages (ps: [
       ps.trustme
       ps.pymysql
+      ps.pyzmq
     ]))
     tenzir-test
   ];

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -42,14 +42,14 @@ rec {
 
   tenzir-test = pkgs.python3Packages.buildPythonPackage rec {
     pname = "tenzir-test";
-    version = "1.7.1";
+    version = "1.7.7";
     pyproject = true;
 
     src = pkgs.fetchFromGitHub {
       owner = "tenzir";
       repo = "test";
       tag = "v${version}";
-      hash = "sha256-kMH7vikx3mTU3pj1CM9JAjXbKwuliFZqIIsjRsiNJOk=";
+      hash = "sha256-/+7Og/6VFxbnW8RhtvOkn9EfrjbIMHnuVkLtgSjM/fQ=";
     };
 
     build-system = with pkgs.python3Packages; [ hatchling ];

--- a/nix/tenzir/check.nix
+++ b/nix/tenzir/check.nix
@@ -23,6 +23,7 @@ stdenvNoCC.mkDerivation {
       py3 = pkgsBuildBuild.python3.withPackages (ps: [
         ps.datetime
         ps.pyarrow
+        ps.pyzmq
         ps.python-box
         ps.trustme
       ]);

--- a/plugins/zmq/builtins/from_zmq.cpp
+++ b/plugins/zmq/builtins/from_zmq.cpp
@@ -94,7 +94,6 @@ public:
       auto prefix = const_eval(*args_.prefix, ctx.dh());
       if (not prefix) {
         request_stop();
-        done_ = true;
         co_return;
       }
       auto* str = try_as<std::string>(&*prefix);
@@ -125,9 +124,6 @@ public:
 
   auto await_task(diagnostic_handler& dh) const -> Task<Any> override {
     TENZIR_UNUSED(dh);
-    if (done_) {
-      co_await wait_forever();
-    }
     co_return co_await message_queue_->dequeue();
   }
 
@@ -140,10 +136,10 @@ public:
     co_await co_match(
       std::move(*message),
       [&](StartupError error) -> Task<void> {
+        request_stop();
         diagnostic::error("{}", error.message)
           .primary(args_.endpoint.source)
           .emit(ctx);
-        done_ = true;
         co_return;
       },
       [&](ReceiveError error) -> Task<void> {
@@ -152,12 +148,10 @@ public:
           .note("{}", error.message)
           .emit(ctx);
         request_stop();
-        maybe_finish();
         co_return;
       },
       [&](ReadLoopFinished) -> Task<void> {
         read_loop_finished_ = true;
-        maybe_finish();
         co_return;
       },
       [&](chunk_ptr payload) -> Task<void> {
@@ -178,7 +172,6 @@ public:
         auto parser = args_.parser.inner;
         if (not parser.substitute(substitute_ctx{{ctx}, nullptr}, true)) {
           request_stop();
-          maybe_finish();
           co_return;
         }
         TENZIR_ASSERT(next_sub_id_ <= static_cast<uint64_t>(
@@ -188,7 +181,6 @@ public:
         auto sub = ctx.get_sub(make_view(key));
         if (not sub) {
           request_stop();
-          maybe_finish();
           co_return;
         }
         ++active_parsers_;
@@ -196,7 +188,6 @@ public:
         auto push_result = co_await sub_pipeline.push(std::move(payload));
         if (push_result.is_err()) {
           request_stop();
-          maybe_finish();
         }
         co_await sub_pipeline.close();
       });
@@ -211,18 +202,16 @@ public:
     -> Task<void> override {
     TENZIR_ASSERT(active_parsers_ > 0);
     --active_parsers_;
-    maybe_finish();
     co_return;
   }
 
   auto stop(OpCtx&) -> Task<void> override {
     request_stop();
-    maybe_finish();
     co_return;
   }
 
   auto state() -> OperatorState override {
-    return done_ ? OperatorState::done : OperatorState::unspecified;
+    return is_done() ? OperatorState::done : OperatorState::unspecified;
   }
 
 private:
@@ -234,10 +223,8 @@ private:
     static_cast<void>(control_queue_->try_enqueue(std::monostate{}));
   }
 
-  auto maybe_finish() -> void {
-    if (stop_requested_ and active_parsers_ == 0 and read_loop_finished_) {
-      done_ = true;
-    }
+  auto is_done() const -> bool {
+    return stop_requested_ and active_parsers_ == 0 and read_loop_finished_;
   }
 
   static auto read_loop(std::shared_ptr<Runtime> runtime,
@@ -270,7 +257,6 @@ private:
   std::shared_ptr<ControlQueue> control_queue_
     = std::make_shared<ControlQueue>(control_queue_capacity);
   bool stop_requested_ = false;
-  bool done_ = false;
   bool read_loop_finished_ = true;
   size_t active_parsers_ = 0;
   uint64_t next_sub_id_ = 0;

--- a/plugins/zmq/builtins/from_zmq.cpp
+++ b/plugins/zmq/builtins/from_zmq.cpp
@@ -6,7 +6,7 @@
 // SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#include "transport.hpp"
+#include "zmq/transport.hpp"
 
 #include <tenzir/async.hpp>
 #include <tenzir/diagnostics.hpp>
@@ -18,14 +18,14 @@
 #include <tenzir/tql2/eval.hpp>
 #include <tenzir/tql2/plugin.hpp>
 
+#include <fmt/format.h>
+
 #include <chrono>
 #include <cstdint>
 #include <limits>
 #include <string>
 #include <utility>
 #include <variant>
-
-#include <fmt/format.h>
 
 using namespace std::chrono_literals;
 
@@ -79,16 +79,16 @@ public:
       prefix_ = *str;
     }
     if (auto err = socket_.set_subscription_prefix(prefix_); not err) {
-      startup_error_ = fmt::format(
-        "failed to configure ZeroMQ subscription for `{}`: {}", endpoint_,
-        render_socket_error(socket_, err.error()));
+      startup_error_
+        = fmt::format("failed to configure ZeroMQ subscription for `{}`: {}",
+                      endpoint_, render_socket_error(socket_, err.error()));
       request_stop();
       co_return;
     }
     if (auto err = socket_.open(Mode, endpoint_); not err) {
-      startup_error_ = fmt::format("failed to open ZeroMQ socket for `{}`: {}",
-                                   endpoint_,
-                                   render_socket_error(socket_, err.error()));
+      startup_error_
+        = fmt::format("failed to open ZeroMQ socket for `{}`: {}", endpoint_,
+                      render_socket_error(socket_, err.error()));
       request_stop();
       co_return;
     }
@@ -154,8 +154,8 @@ public:
       }
       co_return;
     }
-    TENZIR_ASSERT(next_sub_id_
-                  <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max()));
+    TENZIR_ASSERT(next_sub_id_ <= static_cast<uint64_t>(
+                    std::numeric_limits<int64_t>::max()));
     auto key = data{int64_t{static_cast<int64_t>(next_sub_id_++)}};
     co_await ctx.spawn_sub<chunk_ptr>(key, std::move(parser));
     auto sub = ctx.get_sub(make_view(key));
@@ -175,12 +175,13 @@ public:
     co_await sub_pipeline.close();
   }
 
-  auto process_sub(SubKeyView, table_slice slice, Push<table_slice>& push, OpCtx&)
-    -> Task<void> override {
+  auto process_sub(SubKeyView, table_slice slice, Push<table_slice>& push,
+                   OpCtx&) -> Task<void> override {
     co_await push(std::move(slice));
   }
 
-  auto finish_sub(SubKeyView, Push<table_slice>&, OpCtx&) -> Task<void> override {
+  auto finish_sub(SubKeyView, Push<table_slice>&, OpCtx&)
+    -> Task<void> override {
     TENZIR_ASSERT(active_parsers_ > 0);
     --active_parsers_;
     if (stop_requested_ and active_parsers_ == 0) {

--- a/plugins/zmq/builtins/from_zmq.cpp
+++ b/plugins/zmq/builtins/from_zmq.cpp
@@ -10,6 +10,8 @@
 
 #include <tenzir/async.hpp>
 #include <tenzir/async/blocking_executor.hpp>
+#include <tenzir/async/channel.hpp>
+#include <tenzir/atomic.hpp>
 #include <tenzir/co_match.hpp>
 #include <tenzir/diagnostics.hpp>
 #include <tenzir/error.hpp>
@@ -21,13 +23,14 @@
 #include <tenzir/tql2/plugin.hpp>
 
 #include <fmt/format.h>
-#include <folly/coro/BoundedQueue.h>
+#include <folly/coro/BlockingWait.h>
 
 #include <chrono>
 #include <cstdint>
 #include <limits>
 #include <memory>
 #include <string>
+#include <thread>
 #include <utility>
 #include <variant>
 
@@ -38,8 +41,8 @@ namespace tenzir::plugins::zmq {
 namespace {
 
 constexpr auto message_queue_capacity = uint32_t{16};
-constexpr auto control_queue_capacity = uint32_t{1};
 constexpr auto receive_timeout = 100ms;
+constexpr auto message_queue_retry_delay = 1ms;
 
 auto render_caf_error(const caf::error& err) -> std::string {
   return fmt::to_string(err);
@@ -60,26 +63,20 @@ struct SourceArgs {
   located<ir::pipeline> parser;
 };
 
-struct StartupError {
-  std::string message;
-};
-
 struct ReceiveError {
   std::string message;
 };
 
-struct ReadLoopFinished {};
-
-using SourceMessage = variant<StartupError, ReceiveError, ReadLoopFinished,
-                              chunk_ptr>;
-using MessageQueue = folly::coro::BoundedQueue<SourceMessage>;
-using ControlQueue = folly::coro::BoundedQueue<std::monostate>;
+using SourceMessage = variant<ReceiveError, chunk_ptr>;
+using MessageSender = Sender<SourceMessage>;
+using MessageReceiver = Receiver<SourceMessage>;
 
 struct Runtime {
   explicit Runtime(transport::Socket socket) : socket{std::move(socket)} {
   }
 
   transport::Socket socket;
+  Atomic<bool> stop_requested = false;
 };
 
 template <transport::ConnectionMode Mode>
@@ -98,50 +95,58 @@ public:
       }
       auto* str = try_as<std::string>(&*prefix);
       if (not str) {
-        co_await message_queue_->enqueue(
-          SourceMessage{StartupError{"`prefix` must be a constant string"}});
+        request_stop();
+        diagnostic::error("`prefix` must be a constant string")
+          .primary(args_.prefix->get_location())
+          .emit(ctx);
         co_return;
       }
       prefix_ = *str;
     }
+    auto [sender, receiver] = channel<SourceMessage>(message_queue_capacity);
+    message_receiver_ = std::make_shared<MessageReceiver>(std::move(receiver));
     auto runtime = std::make_shared<Runtime>(
       transport::Socket{transport::SocketRole::subscriber});
     if (auto err = runtime->socket.set_subscription_prefix(prefix_); not err) {
-      co_await message_queue_->enqueue(SourceMessage{StartupError{fmt::format(
-        "failed to configure ZeroMQ subscription for `{}`: {}", endpoint_,
-        render_socket_error(runtime->socket, err.error()))}});
+      request_stop();
+      diagnostic::error("failed to configure ZeroMQ subscription for `{}`: {}",
+                        endpoint_,
+                        render_socket_error(runtime->socket, err.error()))
+        .primary(args_.endpoint.source)
+        .emit(ctx);
       co_return;
     }
     if (auto err = runtime->socket.open(Mode, endpoint_); not err) {
-      co_await message_queue_->enqueue(SourceMessage{StartupError{fmt::format(
-        "failed to open ZeroMQ socket for `{}`: {}", endpoint_,
-        render_socket_error(runtime->socket, err.error()))}});
+      request_stop();
+      diagnostic::error("failed to open ZeroMQ socket for `{}`: {}", endpoint_,
+                        render_socket_error(runtime->socket, err.error()))
+        .primary(args_.endpoint.source)
+        .emit(ctx);
       co_return;
     }
+    runtime_ = runtime;
     read_loop_finished_ = false;
-    ctx.spawn_task(read_loop(runtime, message_queue_, control_queue_));
+    ctx.spawn_task(read_loop(runtime, std::move(sender)));
   }
 
   auto await_task(diagnostic_handler& dh) const -> Task<Any> override {
     TENZIR_UNUSED(dh);
-    co_return co_await message_queue_->dequeue();
+    TENZIR_ASSERT(message_receiver_);
+    co_return co_await message_receiver_->recv();
   }
 
   auto process_task(Any result, Push<table_slice>&, OpCtx& ctx)
     -> Task<void> override {
-    auto* message = result.try_as<SourceMessage>();
+    auto* message = result.try_as<Option<SourceMessage>>();
     if (not message) {
       co_return;
     }
+    if (message->is_none()) {
+      read_loop_finished_ = true;
+      co_return;
+    }
     co_await co_match(
-      std::move(*message),
-      [&](StartupError error) -> Task<void> {
-        request_stop();
-        diagnostic::error("{}", error.message)
-          .primary(args_.endpoint.source)
-          .emit(ctx);
-        co_return;
-      },
+      std::move(**message),
       [&](ReceiveError error) -> Task<void> {
         diagnostic::error("failed to receive ZeroMQ message")
           .primary(args_.endpoint.source)
@@ -150,12 +155,11 @@ public:
         request_stop();
         co_return;
       },
-      [&](ReadLoopFinished) -> Task<void> {
-        read_loop_finished_ = true;
-        co_return;
-      },
       [&](chunk_ptr payload) -> Task<void> {
         if (stop_requested_) {
+          // PUB/SUB gives us no delivery acknowledgements, so if shutdown
+          // starts before this payload enters the parser subpipeline we can
+          // safely drop it and behave as if it was never received.
           co_return;
         }
         if (not args_.keep_prefix and not prefix_.empty()) {
@@ -220,42 +224,57 @@ private:
       return;
     }
     stop_requested_ = true;
-    static_cast<void>(control_queue_->try_enqueue(std::monostate{}));
+    if (runtime_) {
+      runtime_->stop_requested.store(true, std::memory_order_release);
+    }
   }
 
   auto is_done() const -> bool {
     return stop_requested_ and active_parsers_ == 0 and read_loop_finished_;
   }
 
-  static auto read_loop(std::shared_ptr<Runtime> runtime,
-                        std::shared_ptr<MessageQueue> message_queue,
-                        std::shared_ptr<ControlQueue> control_queue)
+  static auto read_loop(std::shared_ptr<Runtime> runtime, MessageSender sender)
     -> Task<void> {
-    while (not control_queue->try_dequeue()) {
-      auto message = co_await spawn_blocking([runtime] {
-        return runtime->socket.receive(receive_timeout);
-      });
-      if (message) {
-        co_await message_queue->enqueue(SourceMessage{std::move(*message)});
-        continue;
+    auto enqueue = [runtime = std::weak_ptr{runtime}](
+                     MessageSender& sender, SourceMessage message) -> void {
+      auto current = runtime.lock();
+      TENZIR_ASSERT(current);
+      while (true) {
+        auto result = sender.try_send(std::move(message));
+        if (result.is_ok()) {
+          return;
+        }
+        message = std::move(result).unwrap_err();
+        if (current->stop_requested.load(std::memory_order_acquire)) {
+          return;
+        }
+        std::this_thread::sleep_for(message_queue_retry_delay);
       }
-      if (message == ec::timeout) {
-        continue;
+    };
+    co_await spawn_blocking([runtime = std::move(runtime),
+                             sender = std::move(sender),
+                             enqueue = std::move(enqueue)]() mutable {
+      while (not runtime->stop_requested.load(std::memory_order_acquire)) {
+        auto message = runtime->socket.receive(receive_timeout);
+        if (message) {
+          enqueue(sender, SourceMessage{std::move(*message)});
+          continue;
+        }
+        if (message == ec::timeout) {
+          continue;
+        }
+        enqueue(sender, SourceMessage{ReceiveError{render_socket_error(
+                          runtime->socket, message.error())}});
+        break;
       }
-      co_await message_queue->enqueue(SourceMessage{
-        ReceiveError{render_socket_error(runtime->socket, message.error())}});
-      break;
-    }
-    co_await message_queue->enqueue(SourceMessage{ReadLoopFinished{}});
+    });
   }
 
   SourceArgs args_;
   std::string endpoint_;
   std::string prefix_;
-  std::shared_ptr<MessageQueue> message_queue_
-    = std::make_shared<MessageQueue>(message_queue_capacity);
-  std::shared_ptr<ControlQueue> control_queue_
-    = std::make_shared<ControlQueue>(control_queue_capacity);
+  std::shared_ptr<Runtime> runtime_;
+  std::shared_ptr<MessageReceiver> message_receiver_;
   bool stop_requested_ = false;
   bool read_loop_finished_ = true;
   size_t active_parsers_ = 0;

--- a/plugins/zmq/builtins/from_zmq.cpp
+++ b/plugins/zmq/builtins/from_zmq.cpp
@@ -106,9 +106,10 @@ public:
     if (done_ or stop_requested_) {
       co_await wait_forever();
     }
-    if (auto message = socket_.receive(250ms)) {
+    if (auto message = socket_.receive(0ms)) {
       co_return SourceMessage{std::move(*message)};
     } else if (message == ec::timeout) {
+      co_await sleep_for(250ms);
       co_return SourceMessage{PollTimeout{}};
     } else {
       diagnostic::error("failed to receive ZeroMQ message")

--- a/plugins/zmq/builtins/from_zmq.cpp
+++ b/plugins/zmq/builtins/from_zmq.cpp
@@ -9,6 +9,7 @@
 #include "zmq/transport.hpp"
 
 #include <tenzir/async.hpp>
+#include <tenzir/co_match.hpp>
 #include <tenzir/diagnostics.hpp>
 #include <tenzir/error.hpp>
 #include <tenzir/ir.hpp>
@@ -52,9 +53,18 @@ struct SourceArgs {
   located<ir::pipeline> parser;
 };
 
+struct StartupError {
+  std::string message;
+};
+
+struct ReceiveError {
+  std::string message;
+};
+
 struct PollTimeout {};
 
-using SourceMessage = variant<PollTimeout, chunk_ptr>;
+using SourceMessage
+  = variant<StartupError, ReceiveError, PollTimeout, chunk_ptr>;
 
 template <transport::ConnectionMode Mode>
 class ZmqSource final : public Operator<void, table_slice> {
@@ -95,13 +105,9 @@ public:
   }
 
   auto await_task(diagnostic_handler& dh) const -> Task<Any> override {
+    TENZIR_UNUSED(dh);
     if (startup_error_) {
-      diagnostic::error("{}", *startup_error_)
-        .primary(args_.endpoint.source)
-        .emit(dh);
-      startup_error_ = None{};
-      done_ = true;
-      co_await wait_forever();
+      co_return SourceMessage{StartupError{*startup_error_}};
     }
     if (done_ or stop_requested_) {
       co_await wait_forever();
@@ -112,16 +118,8 @@ public:
       co_await sleep_for(250ms);
       co_return SourceMessage{PollTimeout{}};
     } else {
-      diagnostic::error("failed to receive ZeroMQ message")
-        .primary(args_.endpoint.source)
-        .note("{}", render_socket_error(socket_, message.error()))
-        .emit(dh);
-      request_stop();
-      if (active_parsers_ == 0) {
-        done_ = true;
-      }
-      co_await wait_forever();
-      co_return SourceMessage{PollTimeout{}};
+      co_return SourceMessage{
+        ReceiveError{render_socket_error(socket_, message.error())}};
     }
   }
 
@@ -131,48 +129,73 @@ public:
     if (not message) {
       co_return;
     }
-    if (is<PollTimeout>(*message) or stop_requested_) {
-      co_return;
-    }
-    auto payload = std::move(as<chunk_ptr>(*message));
-    if (not args_.keep_prefix and not prefix_.empty()) {
-      auto stripped = transport::strip_prefix(std::move(payload), prefix_);
-      if (not stripped) {
-        diagnostic::warning("failed to strip ZeroMQ prefix")
+    co_await co_match(
+      std::move(*message),
+      [&](StartupError error) -> Task<void> {
+        diagnostic::error("{}", error.message)
           .primary(args_.endpoint.source)
-          .note("{}", render(stripped.error()))
           .emit(ctx);
+        startup_error_ = None{};
+        done_ = true;
         co_return;
-      }
-      payload = std::move(*stripped);
-    }
-    auto parser = args_.parser.inner;
-    if (not parser.substitute(substitute_ctx{{ctx}, nullptr}, true)) {
-      request_stop();
-      if (active_parsers_ == 0) {
-        done_ = true;
-      }
-      co_return;
-    }
-    TENZIR_ASSERT(next_sub_id_ <= static_cast<uint64_t>(
-                    std::numeric_limits<int64_t>::max()));
-    auto key = data{int64_t{static_cast<int64_t>(next_sub_id_++)}};
-    co_await ctx.spawn_sub<chunk_ptr>(key, std::move(parser));
-    auto sub = ctx.get_sub(make_view(key));
-    if (not sub) {
-      request_stop();
-      if (active_parsers_ == 0) {
-        done_ = true;
-      }
-      co_return;
-    }
-    ++active_parsers_;
-    auto& sub_pipeline = as<SubHandle<chunk_ptr>>(*sub);
-    auto push_result = co_await sub_pipeline.push(std::move(payload));
-    if (push_result.is_err()) {
-      request_stop();
-    }
-    co_await sub_pipeline.close();
+      },
+      [&](ReceiveError error) -> Task<void> {
+        diagnostic::error("failed to receive ZeroMQ message")
+          .primary(args_.endpoint.source)
+          .note("{}", error.message)
+          .emit(ctx);
+        request_stop();
+        if (active_parsers_ == 0) {
+          done_ = true;
+        }
+        co_return;
+      },
+      [&](PollTimeout) -> Task<void> {
+        co_return;
+      },
+      [&](chunk_ptr payload) -> Task<void> {
+        if (stop_requested_) {
+          co_return;
+        }
+        if (not args_.keep_prefix and not prefix_.empty()) {
+          auto stripped = transport::strip_prefix(std::move(payload), prefix_);
+          if (not stripped) {
+            diagnostic::warning("failed to strip ZeroMQ prefix")
+              .primary(args_.endpoint.source)
+              .note("{}", render(stripped.error()))
+              .emit(ctx);
+            co_return;
+          }
+          payload = std::move(*stripped);
+        }
+        auto parser = args_.parser.inner;
+        if (not parser.substitute(substitute_ctx{{ctx}, nullptr}, true)) {
+          request_stop();
+          if (active_parsers_ == 0) {
+            done_ = true;
+          }
+          co_return;
+        }
+        TENZIR_ASSERT(next_sub_id_ <= static_cast<uint64_t>(
+                        std::numeric_limits<int64_t>::max()));
+        auto key = data{int64_t{static_cast<int64_t>(next_sub_id_++)}};
+        co_await ctx.spawn_sub<chunk_ptr>(key, std::move(parser));
+        auto sub = ctx.get_sub(make_view(key));
+        if (not sub) {
+          request_stop();
+          if (active_parsers_ == 0) {
+            done_ = true;
+          }
+          co_return;
+        }
+        ++active_parsers_;
+        auto& sub_pipeline = as<SubHandle<chunk_ptr>>(*sub);
+        auto push_result = co_await sub_pipeline.push(std::move(payload));
+        if (push_result.is_err()) {
+          request_stop();
+        }
+        co_await sub_pipeline.close();
+      });
   }
 
   auto process_sub(SubKeyView, table_slice slice, Push<table_slice>& push,
@@ -203,7 +226,7 @@ public:
   }
 
 private:
-  auto request_stop() const -> void {
+  auto request_stop() -> void {
     stop_requested_ = true;
   }
 
@@ -211,9 +234,9 @@ private:
   std::string endpoint_;
   std::string prefix_;
   mutable transport::Socket socket_{transport::SocketRole::subscriber};
-  mutable bool stop_requested_ = false;
-  mutable bool done_ = false;
-  mutable Option<std::string> startup_error_ = None{};
+  bool stop_requested_ = false;
+  bool done_ = false;
+  Option<std::string> startup_error_ = None{};
   size_t active_parsers_ = 0;
   uint64_t next_sub_id_ = 0;
 };

--- a/plugins/zmq/builtins/from_zmq.cpp
+++ b/plugins/zmq/builtins/from_zmq.cpp
@@ -1,0 +1,290 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "transport.hpp"
+
+#include <tenzir/async.hpp>
+#include <tenzir/diagnostics.hpp>
+#include <tenzir/error.hpp>
+#include <tenzir/ir.hpp>
+#include <tenzir/operator_plugin.hpp>
+#include <tenzir/plugin.hpp>
+#include <tenzir/substitute_ctx.hpp>
+#include <tenzir/tql2/eval.hpp>
+#include <tenzir/tql2/plugin.hpp>
+
+#include <chrono>
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <utility>
+#include <variant>
+
+#include <fmt/format.h>
+
+using namespace std::chrono_literals;
+
+namespace tenzir::plugins::zmq {
+
+namespace {
+
+auto render_caf_error(const caf::error& err) -> std::string {
+  return fmt::to_string(err);
+}
+
+auto render_socket_error(const transport::Socket& socket, const caf::error& err)
+  -> std::string {
+  if (not socket.last_error().empty()) {
+    return socket.last_error();
+  }
+  return render_caf_error(err);
+}
+
+struct SourceArgs {
+  located<std::string> endpoint;
+  Option<ast::expression> prefix;
+  bool keep_prefix = false;
+  located<ir::pipeline> parser;
+};
+
+struct PollTimeout {};
+
+using SourceMessage = variant<PollTimeout, chunk_ptr>;
+
+template <transport::ConnectionMode Mode>
+class ZmqSource final : public Operator<void, table_slice> {
+public:
+  explicit ZmqSource(SourceArgs args) : args_{std::move(args)} {
+  }
+
+  auto start(OpCtx& ctx) -> Task<void> override {
+    endpoint_ = transport::normalize_endpoint(args_.endpoint.inner);
+    if (args_.prefix) {
+      auto prefix = const_eval(*args_.prefix, ctx.dh());
+      if (not prefix) {
+        request_stop();
+        co_return;
+      }
+      auto* str = try_as<std::string>(&*prefix);
+      if (not str) {
+        startup_error_ = "`prefix` must be a constant string";
+        request_stop();
+        co_return;
+      }
+      prefix_ = *str;
+    }
+    if (auto err = socket_.set_subscription_prefix(prefix_); not err) {
+      startup_error_ = fmt::format(
+        "failed to configure ZeroMQ subscription for `{}`: {}", endpoint_,
+        render_socket_error(socket_, err.error()));
+      request_stop();
+      co_return;
+    }
+    if (auto err = socket_.open(Mode, endpoint_); not err) {
+      startup_error_ = fmt::format("failed to open ZeroMQ socket for `{}`: {}",
+                                   endpoint_,
+                                   render_socket_error(socket_, err.error()));
+      request_stop();
+      co_return;
+    }
+  }
+
+  auto await_task(diagnostic_handler& dh) const -> Task<Any> override {
+    if (startup_error_) {
+      diagnostic::error("{}", *startup_error_)
+        .primary(args_.endpoint.source)
+        .emit(dh);
+      startup_error_ = None{};
+      done_ = true;
+      co_await wait_forever();
+    }
+    if (done_ or stop_requested_) {
+      co_await wait_forever();
+    }
+    if (auto message = socket_.receive(250ms)) {
+      co_return SourceMessage{std::move(*message)};
+    } else if (message == ec::timeout) {
+      co_return SourceMessage{PollTimeout{}};
+    } else {
+      diagnostic::error("failed to receive ZeroMQ message")
+        .primary(args_.endpoint.source)
+        .note("{}", render_socket_error(socket_, message.error()))
+        .emit(dh);
+      request_stop();
+      if (active_parsers_ == 0) {
+        done_ = true;
+      }
+      co_await wait_forever();
+      co_return SourceMessage{PollTimeout{}};
+    }
+  }
+
+  auto process_task(Any result, Push<table_slice>&, OpCtx& ctx)
+    -> Task<void> override {
+    auto* message = result.try_as<SourceMessage>();
+    if (not message) {
+      co_return;
+    }
+    if (is<PollTimeout>(*message) or stop_requested_) {
+      co_return;
+    }
+    auto payload = std::move(as<chunk_ptr>(*message));
+    if (not args_.keep_prefix and not prefix_.empty()) {
+      auto stripped = transport::strip_prefix(std::move(payload), prefix_);
+      if (not stripped) {
+        diagnostic::warning("failed to strip ZeroMQ prefix")
+          .primary(args_.endpoint.source)
+          .note("{}", render(stripped.error()))
+          .emit(ctx);
+        co_return;
+      }
+      payload = std::move(*stripped);
+    }
+    auto parser = args_.parser.inner;
+    if (not parser.substitute(substitute_ctx{{ctx}, nullptr}, true)) {
+      request_stop();
+      if (active_parsers_ == 0) {
+        done_ = true;
+      }
+      co_return;
+    }
+    TENZIR_ASSERT(next_sub_id_
+                  <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max()));
+    auto key = data{int64_t{static_cast<int64_t>(next_sub_id_++)}};
+    co_await ctx.spawn_sub<chunk_ptr>(key, std::move(parser));
+    auto sub = ctx.get_sub(make_view(key));
+    if (not sub) {
+      request_stop();
+      if (active_parsers_ == 0) {
+        done_ = true;
+      }
+      co_return;
+    }
+    ++active_parsers_;
+    auto& sub_pipeline = as<SubHandle<chunk_ptr>>(*sub);
+    auto push_result = co_await sub_pipeline.push(std::move(payload));
+    if (push_result.is_err()) {
+      request_stop();
+    }
+    co_await sub_pipeline.close();
+  }
+
+  auto process_sub(SubKeyView, table_slice slice, Push<table_slice>& push, OpCtx&)
+    -> Task<void> override {
+    co_await push(std::move(slice));
+  }
+
+  auto finish_sub(SubKeyView, Push<table_slice>&, OpCtx&) -> Task<void> override {
+    TENZIR_ASSERT(active_parsers_ > 0);
+    --active_parsers_;
+    if (stop_requested_ and active_parsers_ == 0) {
+      done_ = true;
+    }
+    co_return;
+  }
+
+  auto stop(OpCtx&) -> Task<void> override {
+    request_stop();
+    if (active_parsers_ == 0) {
+      done_ = true;
+    }
+    co_return;
+  }
+
+  auto state() -> OperatorState override {
+    return done_ ? OperatorState::done : OperatorState::unspecified;
+  }
+
+private:
+  auto request_stop() const -> void {
+    stop_requested_ = true;
+  }
+
+  SourceArgs args_;
+  std::string endpoint_;
+  std::string prefix_;
+  mutable transport::Socket socket_{transport::SocketRole::subscriber};
+  mutable bool stop_requested_ = false;
+  mutable bool done_ = false;
+  mutable Option<std::string> startup_error_ = None{};
+  size_t active_parsers_ = 0;
+  uint64_t next_sub_id_ = 0;
+};
+
+template <transport::ConnectionMode Mode>
+class ZmqSourcePlugin : public virtual OperatorPlugin {
+public:
+  explicit ZmqSourcePlugin(std::string name) : name_{std::move(name)} {
+  }
+
+  auto name() const -> std::string override {
+    return name_;
+  }
+
+  auto describe() const -> Description override {
+    auto d = Describer<SourceArgs, ZmqSource<Mode>>{};
+    auto endpoint_arg = d.positional("endpoint", &SourceArgs::endpoint);
+    auto prefix_arg = d.named("prefix", &SourceArgs::prefix, "string");
+    auto keep_prefix_arg = d.named("keep_prefix", &SourceArgs::keep_prefix);
+    auto parser_arg = d.pipeline(&SourceArgs::parser);
+    d.validate([=](DescribeCtx& ctx) -> Empty {
+      TENZIR_UNUSED(keep_prefix_arg);
+      TRY(auto endpoint, ctx.get(endpoint_arg));
+      if (endpoint.inner.empty()) {
+        diagnostic::error("endpoint must not be empty")
+          .primary(endpoint.source)
+          .emit(ctx);
+      }
+      if (auto prefix = ctx.get(prefix_arg)) {
+        auto noop_dh = null_diagnostic_handler{};
+        auto value = const_eval(*prefix, noop_dh);
+        if (not value or not is<std::string>(*value)) {
+          diagnostic::error("`prefix` must be a constant string")
+            .primary(prefix->get_location())
+            .emit(ctx);
+        }
+      }
+      TRY(auto parser, ctx.get(parser_arg));
+      auto output = parser.inner.infer_type(tag_v<chunk_ptr>, ctx);
+      if (output.is_error()) {
+        return {};
+      }
+      if (not *output or (*output)->template is_not<table_slice>()) {
+        diagnostic::error("pipeline must return events")
+          .primary(parser.source.subloc(0, 1))
+          .emit(ctx);
+      }
+      return {};
+    });
+    return d.without_optimize();
+  }
+
+private:
+  std::string name_;
+};
+
+class FromZmqPlugin final
+  : public ZmqSourcePlugin<transport::ConnectionMode::connect> {
+public:
+  FromZmqPlugin() : ZmqSourcePlugin{"from_zmq"} {
+  }
+};
+
+class AcceptZmqPlugin final
+  : public ZmqSourcePlugin<transport::ConnectionMode::bind> {
+public:
+  AcceptZmqPlugin() : ZmqSourcePlugin{"accept_zmq"} {
+  }
+};
+
+} // namespace
+
+} // namespace tenzir::plugins::zmq
+
+TENZIR_REGISTER_PLUGIN(tenzir::plugins::zmq::FromZmqPlugin)
+TENZIR_REGISTER_PLUGIN(tenzir::plugins::zmq::AcceptZmqPlugin)

--- a/plugins/zmq/builtins/from_zmq.cpp
+++ b/plugins/zmq/builtins/from_zmq.cpp
@@ -9,6 +9,7 @@
 #include "zmq/transport.hpp"
 
 #include <tenzir/async.hpp>
+#include <tenzir/async/blocking_executor.hpp>
 #include <tenzir/co_match.hpp>
 #include <tenzir/diagnostics.hpp>
 #include <tenzir/error.hpp>
@@ -20,10 +21,12 @@
 #include <tenzir/tql2/plugin.hpp>
 
 #include <fmt/format.h>
+#include <folly/coro/BoundedQueue.h>
 
 #include <chrono>
 #include <cstdint>
 #include <limits>
+#include <memory>
 #include <string>
 #include <utility>
 #include <variant>
@@ -33,6 +36,10 @@ using namespace std::chrono_literals;
 namespace tenzir::plugins::zmq {
 
 namespace {
+
+constexpr auto message_queue_capacity = uint32_t{16};
+constexpr auto control_queue_capacity = uint32_t{1};
+constexpr auto receive_timeout = 100ms;
 
 auto render_caf_error(const caf::error& err) -> std::string {
   return fmt::to_string(err);
@@ -61,10 +68,19 @@ struct ReceiveError {
   std::string message;
 };
 
-struct PollTimeout {};
+struct ReadLoopFinished {};
 
-using SourceMessage
-  = variant<StartupError, ReceiveError, PollTimeout, chunk_ptr>;
+using SourceMessage = variant<StartupError, ReceiveError, ReadLoopFinished,
+                              chunk_ptr>;
+using MessageQueue = folly::coro::BoundedQueue<SourceMessage>;
+using ControlQueue = folly::coro::BoundedQueue<std::monostate>;
+
+struct Runtime {
+  explicit Runtime(transport::Socket socket) : socket{std::move(socket)} {
+  }
+
+  transport::Socket socket;
+};
 
 template <transport::ConnectionMode Mode>
 class ZmqSource final : public Operator<void, table_slice> {
@@ -78,49 +94,41 @@ public:
       auto prefix = const_eval(*args_.prefix, ctx.dh());
       if (not prefix) {
         request_stop();
+        done_ = true;
         co_return;
       }
       auto* str = try_as<std::string>(&*prefix);
       if (not str) {
-        startup_error_ = "`prefix` must be a constant string";
-        request_stop();
+        co_await message_queue_->enqueue(
+          SourceMessage{StartupError{"`prefix` must be a constant string"}});
         co_return;
       }
       prefix_ = *str;
     }
-    if (auto err = socket_.set_subscription_prefix(prefix_); not err) {
-      startup_error_
-        = fmt::format("failed to configure ZeroMQ subscription for `{}`: {}",
-                      endpoint_, render_socket_error(socket_, err.error()));
-      request_stop();
+    auto runtime = std::make_shared<Runtime>(
+      transport::Socket{transport::SocketRole::subscriber});
+    if (auto err = runtime->socket.set_subscription_prefix(prefix_); not err) {
+      co_await message_queue_->enqueue(SourceMessage{StartupError{fmt::format(
+        "failed to configure ZeroMQ subscription for `{}`: {}", endpoint_,
+        render_socket_error(runtime->socket, err.error()))}});
       co_return;
     }
-    if (auto err = socket_.open(Mode, endpoint_); not err) {
-      startup_error_
-        = fmt::format("failed to open ZeroMQ socket for `{}`: {}", endpoint_,
-                      render_socket_error(socket_, err.error()));
-      request_stop();
+    if (auto err = runtime->socket.open(Mode, endpoint_); not err) {
+      co_await message_queue_->enqueue(SourceMessage{StartupError{fmt::format(
+        "failed to open ZeroMQ socket for `{}`: {}", endpoint_,
+        render_socket_error(runtime->socket, err.error()))}});
       co_return;
     }
+    read_loop_finished_ = false;
+    ctx.spawn_task(read_loop(runtime, message_queue_, control_queue_));
   }
 
   auto await_task(diagnostic_handler& dh) const -> Task<Any> override {
     TENZIR_UNUSED(dh);
-    if (startup_error_) {
-      co_return SourceMessage{StartupError{*startup_error_}};
-    }
-    if (done_ or stop_requested_) {
+    if (done_) {
       co_await wait_forever();
     }
-    if (auto message = socket_.receive(0ms)) {
-      co_return SourceMessage{std::move(*message)};
-    } else if (message == ec::timeout) {
-      co_await sleep_for(250ms);
-      co_return SourceMessage{PollTimeout{}};
-    } else {
-      co_return SourceMessage{
-        ReceiveError{render_socket_error(socket_, message.error())}};
-    }
+    co_return co_await message_queue_->dequeue();
   }
 
   auto process_task(Any result, Push<table_slice>&, OpCtx& ctx)
@@ -135,7 +143,6 @@ public:
         diagnostic::error("{}", error.message)
           .primary(args_.endpoint.source)
           .emit(ctx);
-        startup_error_ = None{};
         done_ = true;
         co_return;
       },
@@ -145,12 +152,12 @@ public:
           .note("{}", error.message)
           .emit(ctx);
         request_stop();
-        if (active_parsers_ == 0) {
-          done_ = true;
-        }
+        maybe_finish();
         co_return;
       },
-      [&](PollTimeout) -> Task<void> {
+      [&](ReadLoopFinished) -> Task<void> {
+        read_loop_finished_ = true;
+        maybe_finish();
         co_return;
       },
       [&](chunk_ptr payload) -> Task<void> {
@@ -171,9 +178,7 @@ public:
         auto parser = args_.parser.inner;
         if (not parser.substitute(substitute_ctx{{ctx}, nullptr}, true)) {
           request_stop();
-          if (active_parsers_ == 0) {
-            done_ = true;
-          }
+          maybe_finish();
           co_return;
         }
         TENZIR_ASSERT(next_sub_id_ <= static_cast<uint64_t>(
@@ -183,9 +188,7 @@ public:
         auto sub = ctx.get_sub(make_view(key));
         if (not sub) {
           request_stop();
-          if (active_parsers_ == 0) {
-            done_ = true;
-          }
+          maybe_finish();
           co_return;
         }
         ++active_parsers_;
@@ -193,6 +196,7 @@ public:
         auto push_result = co_await sub_pipeline.push(std::move(payload));
         if (push_result.is_err()) {
           request_stop();
+          maybe_finish();
         }
         co_await sub_pipeline.close();
       });
@@ -207,17 +211,13 @@ public:
     -> Task<void> override {
     TENZIR_ASSERT(active_parsers_ > 0);
     --active_parsers_;
-    if (stop_requested_ and active_parsers_ == 0) {
-      done_ = true;
-    }
+    maybe_finish();
     co_return;
   }
 
   auto stop(OpCtx&) -> Task<void> override {
     request_stop();
-    if (active_parsers_ == 0) {
-      done_ = true;
-    }
+    maybe_finish();
     co_return;
   }
 
@@ -227,16 +227,51 @@ public:
 
 private:
   auto request_stop() -> void {
+    if (stop_requested_) {
+      return;
+    }
     stop_requested_ = true;
+    static_cast<void>(control_queue_->try_enqueue(std::monostate{}));
+  }
+
+  auto maybe_finish() -> void {
+    if (stop_requested_ and active_parsers_ == 0 and read_loop_finished_) {
+      done_ = true;
+    }
+  }
+
+  static auto read_loop(std::shared_ptr<Runtime> runtime,
+                        std::shared_ptr<MessageQueue> message_queue,
+                        std::shared_ptr<ControlQueue> control_queue)
+    -> Task<void> {
+    while (not control_queue->try_dequeue()) {
+      auto message = co_await spawn_blocking([runtime] {
+        return runtime->socket.receive(receive_timeout);
+      });
+      if (message) {
+        co_await message_queue->enqueue(SourceMessage{std::move(*message)});
+        continue;
+      }
+      if (message == ec::timeout) {
+        continue;
+      }
+      co_await message_queue->enqueue(SourceMessage{
+        ReceiveError{render_socket_error(runtime->socket, message.error())}});
+      break;
+    }
+    co_await message_queue->enqueue(SourceMessage{ReadLoopFinished{}});
   }
 
   SourceArgs args_;
   std::string endpoint_;
   std::string prefix_;
-  mutable transport::Socket socket_{transport::SocketRole::subscriber};
+  std::shared_ptr<MessageQueue> message_queue_
+    = std::make_shared<MessageQueue>(message_queue_capacity);
+  std::shared_ptr<ControlQueue> control_queue_
+    = std::make_shared<ControlQueue>(control_queue_capacity);
   bool stop_requested_ = false;
   bool done_ = false;
-  Option<std::string> startup_error_ = None{};
+  bool read_loop_finished_ = true;
   size_t active_parsers_ = 0;
   uint64_t next_sub_id_ = 0;
 };

--- a/plugins/zmq/builtins/to_zmq.cpp
+++ b/plugins/zmq/builtins/to_zmq.cpp
@@ -6,7 +6,7 @@
 // SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#include "transport.hpp"
+#include "zmq/transport.hpp"
 
 #include <tenzir/async/task.hpp>
 #include <tenzir/chunk.hpp>
@@ -77,7 +77,9 @@ auto evaluate_prefix(const ast::expression& expr, const table_slice& input,
   }
   if (auto strings = series->as<string_type>()) {
     if (strings->array->IsNull(0)) {
-      diagnostic::warning("expected `string`, got `null`").primary(expr).emit(dh);
+      diagnostic::warning("expected `string`, got `null`")
+        .primary(expr)
+        .emit(dh);
       return std::nullopt;
     }
     return std::string{strings->array->Value(0)};
@@ -150,7 +152,8 @@ public:
         if (not prefix) {
           continue;
         }
-        auto with_prefix = transport::prepend_prefix(std::move(framed), *prefix);
+        auto with_prefix
+          = transport::prepend_prefix(std::move(framed), *prefix);
         if (not with_prefix) {
           diagnostic::error("failed to prefix ZeroMQ message")
             .primary(args_.prefix->get_location())

--- a/plugins/zmq/builtins/to_zmq.cpp
+++ b/plugins/zmq/builtins/to_zmq.cpp
@@ -126,7 +126,6 @@ public:
           .primary(args_.endpoint.source)
           .note("{}", render(err.error()))
           .emit(ctx);
-        done_ = true;
         co_return;
       }
     }
@@ -135,7 +134,6 @@ public:
         .primary(args_.endpoint.source)
         .note("{}", render(err.error()))
         .emit(ctx);
-      done_ = true;
       co_return;
     }
   }
@@ -152,7 +150,6 @@ public:
           .primary(args_.encoding.source)
           .note("{}", render(payload.error()))
           .emit(ctx);
-        done_ = true;
         co_return;
       }
       auto framed = *payload;
@@ -168,7 +165,6 @@ public:
             .primary(args_.prefix->get_location())
             .note("{}", render(with_prefix.error()))
             .emit(ctx);
-          done_ = true;
           co_return;
         }
         framed = std::move(*with_prefix);
@@ -185,7 +181,6 @@ public:
             .primary(args_.endpoint.source)
             .note("`monitor=true` requires a connected peer before sending")
             .emit(ctx);
-          done_ = true;
           co_return;
         }
         co_await sleep_for(monitor_wait_poll_interval);
@@ -207,7 +202,6 @@ public:
         .primary(args_.endpoint.source)
         .note("{}", render(err))
         .emit(ctx);
-      done_ = true;
       co_return;
     }
   }

--- a/plugins/zmq/builtins/to_zmq.cpp
+++ b/plugins/zmq/builtins/to_zmq.cpp
@@ -1,0 +1,266 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "transport.hpp"
+
+#include <tenzir/chunk.hpp>
+#include <tenzir/concept/printable/tenzir/json2.hpp>
+#include <tenzir/diagnostics.hpp>
+#include <tenzir/error.hpp>
+#include <tenzir/ir.hpp>
+#include <tenzir/operator_plugin.hpp>
+#include <tenzir/plugin.hpp>
+#include <tenzir/table_slice.hpp>
+#include <tenzir/tql2/eval.hpp>
+#include <tenzir/tql2/plugin.hpp>
+#include <tenzir/view3.hpp>
+
+#include <chrono>
+#include <optional>
+#include <span>
+#include <string>
+#include <utility>
+
+using namespace std::chrono_literals;
+
+namespace tenzir::plugins::zmq {
+
+namespace {
+
+enum class Encoding {
+  json,
+  ndjson,
+};
+
+struct SinkArgs {
+  located<std::string> endpoint;
+  located<std::string> encoding;
+  Option<ast::expression> prefix;
+  bool monitor = false;
+};
+
+auto parse_encoding(std::string_view encoding) -> std::optional<Encoding> {
+  if (encoding == "json") {
+    return Encoding::json;
+  }
+  if (encoding == "ndjson") {
+    return Encoding::ndjson;
+  }
+  return std::nullopt;
+}
+
+auto make_json_printer(Encoding encoding) -> json_printer2 {
+  TENZIR_UNUSED(encoding);
+  return json_printer2{json_printer_options{
+    .style = no_style(),
+    .oneline = true,
+  }};
+}
+
+auto evaluate_prefix(const ast::expression& expr, const table_slice& input,
+                     diagnostic_handler& dh) -> std::optional<std::string> {
+  auto result = eval(expr, input, dh);
+  auto* series = [&]() -> const tenzir::series* {
+    for (const auto& item : result) {
+      return &item;
+    }
+    return nullptr;
+  }();
+  if (not series) {
+    return std::string{};
+  }
+  if (auto strings = series->as<string_type>()) {
+    if (strings->array->IsNull(0)) {
+      diagnostic::warning("expected `string`, got `null`").primary(expr).emit(dh);
+      return std::nullopt;
+    }
+    return std::string{strings->array->Value(0)};
+  }
+  diagnostic::warning("expected `string`, got `{}`", series->type.kind())
+    .primary(expr)
+    .emit(dh);
+  return std::nullopt;
+}
+
+auto serialize_row(json_printer2& printer, const table_slice& input)
+  -> caf::expected<chunk_ptr> {
+  for (auto row : values3(input)) {
+    printer.load_new(row);
+    auto bytes = printer.bytes();
+    return chunk::copy(bytes.data(), bytes.size());
+  }
+  return caf::make_error(ec::invalid_argument, "expected one event");
+}
+
+template <transport::ConnectionMode Mode>
+class ZmqSink final : public Operator<table_slice, void> {
+public:
+  explicit ZmqSink(SinkArgs args)
+    : args_{std::move(args)},
+      encoding_{*parse_encoding(args_.encoding.inner)},
+      printer_{make_json_printer(encoding_)} {
+  }
+
+  auto start(OpCtx& ctx) -> Task<void> override {
+    endpoint_ = transport::normalize_endpoint(args_.endpoint.inner);
+    if (args_.monitor) {
+      if (auto err = socket_.enable_peer_monitoring(); not err) {
+        diagnostic::error("failed to enable ZeroMQ peer monitoring")
+          .primary(args_.endpoint.source)
+          .note("{}", render(err.error()))
+          .emit(ctx);
+        done_ = true;
+        co_return;
+      }
+    }
+    if (auto err = socket_.open(Mode, endpoint_); not err) {
+      diagnostic::error("failed to open ZeroMQ socket")
+        .primary(args_.endpoint.source)
+        .note("{}", render(err.error()))
+        .emit(ctx);
+      done_ = true;
+      co_return;
+    }
+  }
+
+  auto process(table_slice input, OpCtx& ctx) -> Task<void> override {
+    if (done_) {
+      co_return;
+    }
+    for (size_t row = 0; row < input.rows(); ++row) {
+      auto row_slice = subslice(input, row, row + 1);
+      auto payload = serialize_row(printer_, row_slice);
+      if (not payload) {
+        diagnostic::error("failed to serialize ZeroMQ message")
+          .primary(args_.encoding.source)
+          .note("{}", render(payload.error()))
+          .emit(ctx);
+        done_ = true;
+        co_return;
+      }
+      auto framed = *payload;
+      if (args_.prefix) {
+        auto prefix = evaluate_prefix(*args_.prefix, row_slice, ctx.dh());
+        if (not prefix) {
+          continue;
+        }
+        auto with_prefix = transport::prepend_prefix(std::move(framed), *prefix);
+        if (not with_prefix) {
+          diagnostic::error("failed to prefix ZeroMQ message")
+            .primary(args_.prefix->get_location())
+            .note("{}", render(with_prefix.error()))
+            .emit(ctx);
+          done_ = true;
+          co_return;
+        }
+        framed = std::move(*with_prefix);
+      }
+      while (args_.monitor and socket_.num_peers() == 0 and not done_) {
+        socket_.poll_monitor(250ms);
+      }
+      socket_.poll_monitor(0ms);
+      auto err = socket_.send(framed, 250ms);
+      if (not err) {
+        continue;
+      }
+      diagnostic::error("failed to send ZeroMQ message")
+        .primary(args_.endpoint.source)
+        .note("{}", render(err))
+        .emit(ctx);
+      done_ = true;
+      co_return;
+    }
+  }
+
+  auto finalize(OpCtx&) -> Task<FinalizeBehavior> override {
+    done_ = true;
+    co_return FinalizeBehavior::done;
+  }
+
+  auto state() -> OperatorState override {
+    return done_ ? OperatorState::done : OperatorState::unspecified;
+  }
+
+private:
+  SinkArgs args_;
+  std::string endpoint_;
+  Encoding encoding_;
+  json_printer2 printer_;
+  transport::Socket socket_{transport::SocketRole::publisher};
+  bool done_ = false;
+};
+
+template <transport::ConnectionMode Mode>
+class ZmqSinkPlugin : public virtual OperatorPlugin {
+public:
+  explicit ZmqSinkPlugin(std::string name) : name_{std::move(name)} {
+  }
+
+  auto name() const -> std::string override {
+    return name_;
+  }
+
+  auto describe() const -> Description override {
+    auto d = Describer<SinkArgs, ZmqSink<Mode>>{};
+    auto endpoint_arg = d.positional("endpoint", &SinkArgs::endpoint);
+    auto encoding_arg = d.named("encoding", &SinkArgs::encoding);
+    auto prefix_arg = d.named("prefix", &SinkArgs::prefix, "string");
+    auto monitor_arg = d.named("monitor", &SinkArgs::monitor);
+    d.validate([=](DescribeCtx& ctx) -> Empty {
+      TRY(auto endpoint, ctx.get(endpoint_arg));
+      if (endpoint.inner.empty()) {
+        diagnostic::error("endpoint must not be empty")
+          .primary(endpoint.source)
+          .emit(ctx);
+      }
+      TRY(auto encoding, ctx.get(encoding_arg));
+      if (not parse_encoding(encoding.inner)) {
+        diagnostic::error("unsupported encoding `{}`", encoding.inner)
+          .primary(encoding.source)
+          .emit(ctx);
+      }
+      TRY(auto monitor, ctx.get(monitor_arg));
+      if (monitor
+          and not transport::is_tcp_endpoint(
+            transport::normalize_endpoint(endpoint.inner))) {
+        diagnostic::error("`monitor` requires a TCP endpoint")
+          .primary(ctx.get_location(monitor_arg).value_or(location::unknown))
+          .emit(ctx);
+      }
+      if (auto prefix = ctx.get(prefix_arg)) {
+        TENZIR_UNUSED(prefix);
+      }
+      return {};
+    });
+    return d.without_optimize();
+  }
+
+private:
+  std::string name_;
+};
+
+class ToZmqPlugin final
+  : public ZmqSinkPlugin<transport::ConnectionMode::connect> {
+public:
+  ToZmqPlugin() : ZmqSinkPlugin{"to_zmq"} {
+  }
+};
+
+class ServeZmqPlugin final
+  : public ZmqSinkPlugin<transport::ConnectionMode::bind> {
+public:
+  ServeZmqPlugin() : ZmqSinkPlugin{"serve_zmq"} {
+  }
+};
+
+} // namespace
+
+} // namespace tenzir::plugins::zmq
+
+TENZIR_REGISTER_PLUGIN(tenzir::plugins::zmq::ToZmqPlugin)
+TENZIR_REGISTER_PLUGIN(tenzir::plugins::zmq::ServeZmqPlugin)

--- a/plugins/zmq/builtins/to_zmq.cpp
+++ b/plugins/zmq/builtins/to_zmq.cpp
@@ -8,6 +8,7 @@
 
 #include "transport.hpp"
 
+#include <tenzir/async/task.hpp>
 #include <tenzir/chunk.hpp>
 #include <tenzir/concept/printable/tenzir/json2.hpp>
 #include <tenzir/diagnostics.hpp>
@@ -161,10 +162,21 @@ public:
         framed = std::move(*with_prefix);
       }
       while (args_.monitor and socket_.num_peers() == 0 and not done_) {
-        socket_.poll_monitor(250ms);
+        socket_.poll_monitor(0ms);
+        if (socket_.num_peers() == 0) {
+          co_await sleep_for(250ms);
+        }
       }
       socket_.poll_monitor(0ms);
-      auto err = socket_.send(framed, 250ms);
+      auto deadline = std::chrono::steady_clock::now() + 250ms;
+      auto err = socket_.send(framed, 0ms);
+      while (err == ec::timeout and not done_) {
+        if (std::chrono::steady_clock::now() >= deadline) {
+          break;
+        }
+        co_await sleep_for(10ms);
+        err = socket_.send(framed, 0ms);
+      }
       if (not err) {
         continue;
       }

--- a/plugins/zmq/builtins/to_zmq.cpp
+++ b/plugins/zmq/builtins/to_zmq.cpp
@@ -34,6 +34,9 @@ namespace tenzir::plugins::zmq {
 
 namespace {
 
+constexpr auto monitor_wait_poll_interval = 250ms;
+constexpr auto monitor_wait_timeout = 5s;
+
 enum class Encoding {
   json,
   ndjson,
@@ -170,11 +173,22 @@ public:
         }
         framed = std::move(*with_prefix);
       }
+      auto monitor_deadline
+        = std::chrono::steady_clock::now() + monitor_wait_timeout;
       while (args_.monitor and socket_.num_peers() == 0 and not done_) {
         socket_.poll_monitor(0ms);
-        if (socket_.num_peers() == 0) {
-          co_await sleep_for(250ms);
+        if (socket_.num_peers() != 0) {
+          break;
         }
+        if (std::chrono::steady_clock::now() >= monitor_deadline) {
+          diagnostic::error("timed out waiting for a ZeroMQ peer")
+            .primary(args_.endpoint.source)
+            .note("`monitor=true` requires a connected peer before sending")
+            .emit(ctx);
+          done_ = true;
+          co_return;
+        }
+        co_await sleep_for(monitor_wait_poll_interval);
       }
       socket_.poll_monitor(0ms);
       auto deadline = std::chrono::steady_clock::now() + 250ms;

--- a/plugins/zmq/builtins/to_zmq.cpp
+++ b/plugins/zmq/builtins/to_zmq.cpp
@@ -10,6 +10,7 @@
 
 #include <tenzir/async/task.hpp>
 #include <tenzir/chunk.hpp>
+#include <tenzir/concept/printable/tenzir/json.hpp>
 #include <tenzir/concept/printable/tenzir/json2.hpp>
 #include <tenzir/diagnostics.hpp>
 #include <tenzir/error.hpp>
@@ -55,14 +56,6 @@ auto parse_encoding(std::string_view encoding) -> std::optional<Encoding> {
   return std::nullopt;
 }
 
-auto make_json_printer(Encoding encoding) -> json_printer2 {
-  TENZIR_UNUSED(encoding);
-  return json_printer2{json_printer_options{
-    .style = no_style(),
-    .oneline = true,
-  }};
-}
-
 auto evaluate_prefix(const ast::expression& expr, const table_slice& input,
                      diagnostic_handler& dh) -> std::optional<std::string> {
   auto result = eval(expr, input, dh);
@@ -90,12 +83,27 @@ auto evaluate_prefix(const ast::expression& expr, const table_slice& input,
   return std::nullopt;
 }
 
-auto serialize_row(json_printer2& printer, const table_slice& input)
+auto serialize_row(Encoding encoding, const table_slice& input)
   -> caf::expected<chunk_ptr> {
   for (auto row : values3(input)) {
-    printer.load_new(row);
-    auto bytes = printer.bytes();
-    return chunk::copy(bytes.data(), bytes.size());
+    if (encoding == Encoding::ndjson) {
+      auto compact_printer = json_printer2{json_printer_options{
+        .style = no_style(),
+        .oneline = true,
+      }};
+      compact_printer.load_new(row);
+      auto bytes = compact_printer.bytes();
+      return chunk::copy(bytes.data(), bytes.size());
+    }
+    auto pretty_printer = json_printer{json_printer_options{
+      .style = no_style(),
+    }};
+    auto buffer = std::string{};
+    auto it = std::back_inserter(buffer);
+    if (not pretty_printer.print(it, row)) {
+      return caf::make_error(ec::invalid_argument, "failed to print JSON");
+    }
+    return chunk::copy(buffer.data(), buffer.size());
   }
   return caf::make_error(ec::invalid_argument, "expected one event");
 }
@@ -104,9 +112,7 @@ template <transport::ConnectionMode Mode>
 class ZmqSink final : public Operator<table_slice, void> {
 public:
   explicit ZmqSink(SinkArgs args)
-    : args_{std::move(args)},
-      encoding_{*parse_encoding(args_.encoding.inner)},
-      printer_{make_json_printer(encoding_)} {
+    : args_{std::move(args)}, encoding_{*parse_encoding(args_.encoding.inner)} {
   }
 
   auto start(OpCtx& ctx) -> Task<void> override {
@@ -137,7 +143,7 @@ public:
     }
     for (size_t row = 0; row < input.rows(); ++row) {
       auto row_slice = subslice(input, row, row + 1);
-      auto payload = serialize_row(printer_, row_slice);
+      auto payload = serialize_row(encoding_, row_slice);
       if (not payload) {
         diagnostic::error("failed to serialize ZeroMQ message")
           .primary(args_.encoding.source)
@@ -205,7 +211,6 @@ private:
   SinkArgs args_;
   std::string endpoint_;
   Encoding encoding_;
-  json_printer2 printer_;
   transport::Socket socket_{transport::SocketRole::publisher};
   bool done_ = false;
 };

--- a/plugins/zmq/include/context.hpp
+++ b/plugins/zmq/include/context.hpp
@@ -1,0 +1,24 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <zmq.hpp>
+
+namespace tenzir::plugins::zmq {
+
+/// This is the 0mq context singleton. There exists exactly one context per
+/// process so that inproc sockets can be used across pipelines within the same
+/// node. Since accessing a 0mq context instance is thread-safe, we can share it
+/// globally.
+inline auto global_context() -> ::zmq::context_t& {
+  static auto ctx = ::zmq::context_t{};
+  return ctx;
+}
+
+} // namespace tenzir::plugins::zmq

--- a/plugins/zmq/include/operator.hpp
+++ b/plugins/zmq/include/operator.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "context.hpp"
+
 #include <tenzir/chunk.hpp>
 #include <tenzir/pipeline.hpp>
 #include <tenzir/plugin.hpp>
@@ -23,15 +25,6 @@
 using namespace std::chrono_literals;
 
 namespace tenzir::plugins::zmq {
-
-/// This is the 0mq context singleton. There exists exactly one context per
-/// process so that inproc sockets can be used across pipelines within the same
-/// node. Since accessing a 0mq context instance is thread-safe, we can share it
-/// globally.
-inline auto global_context() -> ::zmq::context_t& {
-  static auto ctx = ::zmq::context_t{};
-  return ctx;
-}
 
 namespace {
 

--- a/plugins/zmq/include/operator.hpp
+++ b/plugins/zmq/include/operator.hpp
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include "context.hpp"
-
 #include <tenzir/chunk.hpp>
 #include <tenzir/pipeline.hpp>
 #include <tenzir/plugin.hpp>
@@ -21,6 +19,8 @@
 #include <string>
 #include <string_view>
 #include <zmq.hpp>
+
+#include "context.hpp"
 
 using namespace std::chrono_literals;
 

--- a/plugins/zmq/include/transport.hpp
+++ b/plugins/zmq/include/transport.hpp
@@ -79,8 +79,12 @@ public:
 
   auto num_peers() const -> size_t;
 
+  auto last_error() const -> const std::string&;
+
 private:
   class Monitor;
+
+  auto ensure_socket() -> caf::expected<void>;
 
   auto make_error(const ::zmq::error_t& error) const -> caf::error;
 
@@ -88,9 +92,11 @@ private:
 
   auto make_error() const -> caf::error;
 
-  ::zmq::socket_t socket_;
+  SocketRole role_;
+  std::optional<::zmq::socket_t> socket_;
   std::unique_ptr<Monitor> monitor_;
   size_t num_peers_ = 0;
+  mutable std::string last_error_;
 };
 
 } // namespace tenzir::plugins::zmq::transport

--- a/plugins/zmq/include/transport.hpp
+++ b/plugins/zmq/include/transport.hpp
@@ -1,0 +1,96 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <tenzir/chunk.hpp>
+#include <tenzir/error.hpp>
+
+#include <chrono>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include <caf/error.hpp>
+#include <caf/expected.hpp>
+#include <zmq.hpp>
+
+namespace tenzir::plugins::zmq::transport {
+
+enum class SocketRole {
+  publisher,
+  subscriber,
+};
+
+enum class ConnectionMode {
+  bind,
+  connect,
+};
+
+inline constexpr auto default_endpoint = std::string_view{"tcp://127.0.0.1:5555"};
+
+auto normalize_endpoint(std::string endpoint) -> std::string;
+
+auto is_tcp_endpoint(std::string_view endpoint) -> bool;
+
+auto render_monitor_event(uint16_t event) -> std::string_view;
+
+auto strip_prefix(chunk_ptr message, std::string_view prefix)
+  -> caf::expected<chunk_ptr>;
+
+auto prepend_prefix(chunk_ptr payload, std::string_view prefix)
+  -> caf::expected<chunk_ptr>;
+
+class Socket {
+public:
+  explicit Socket(SocketRole role);
+  ~Socket();
+
+  Socket(Socket const&) = delete;
+  auto operator=(Socket const&) -> Socket& = delete;
+  Socket(Socket&&) noexcept;
+  auto operator=(Socket&&) noexcept -> Socket&;
+
+  auto enable_peer_monitoring() -> caf::expected<void>;
+
+  auto open(ConnectionMode mode, std::string_view endpoint,
+            std::chrono::milliseconds reconnect_interval
+            = std::chrono::seconds{1}) -> caf::expected<void>;
+
+  auto set_subscription_prefix(std::string_view prefix) -> caf::expected<void>;
+
+  auto send(const chunk_ptr& chunk,
+            std::optional<std::chrono::milliseconds> timeout = {})
+    -> caf::error;
+
+  auto receive(std::optional<std::chrono::milliseconds> timeout = {})
+    -> caf::expected<chunk_ptr>;
+
+  auto poll_monitor(std::optional<std::chrono::milliseconds> timeout = {})
+    -> size_t;
+
+  auto monitored() const -> bool;
+
+  auto num_peers() const -> size_t;
+
+private:
+  class Monitor;
+
+  auto make_error(const ::zmq::error_t& error) const -> caf::error;
+
+  auto make_error(int error_number) const -> caf::error;
+
+  auto make_error() const -> caf::error;
+
+  ::zmq::socket_t socket_;
+  std::unique_ptr<Monitor> monitor_;
+  size_t num_peers_ = 0;
+};
+
+} // namespace tenzir::plugins::zmq::transport

--- a/plugins/zmq/include/zmq/transport.hpp
+++ b/plugins/zmq/include/zmq/transport.hpp
@@ -11,14 +11,14 @@
 #include <tenzir/chunk.hpp>
 #include <tenzir/error.hpp>
 
+#include <caf/error.hpp>
+#include <caf/expected.hpp>
+
 #include <chrono>
 #include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
-
-#include <caf/error.hpp>
-#include <caf/expected.hpp>
 #include <zmq.hpp>
 
 namespace tenzir::plugins::zmq::transport {
@@ -33,7 +33,8 @@ enum class ConnectionMode {
   connect,
 };
 
-inline constexpr auto default_endpoint = std::string_view{"tcp://127.0.0.1:5555"};
+inline constexpr auto default_endpoint
+  = std::string_view{"tcp://127.0.0.1:5555"};
 
 auto normalize_endpoint(std::string endpoint) -> std::string;
 

--- a/plugins/zmq/src/transport.cpp
+++ b/plugins/zmq/src/transport.cpp
@@ -6,8 +6,7 @@
 // SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#include "context.hpp"
-#include "transport.hpp"
+#include "zmq/transport.hpp"
 
 #include <tenzir/detail/narrow.hpp>
 #include <tenzir/uuid.hpp>
@@ -16,6 +15,8 @@
 #include <cstring>
 #include <utility>
 #include <vector>
+
+#include "context.hpp"
 
 using namespace std::chrono_literals;
 
@@ -53,11 +54,13 @@ public:
 
   explicit Monitor(::zmq::socket_t& socket) {
     auto endpoint = fmt::format("inproc://monitor-{}", uuid::random());
-    int rc = zmq_socket_monitor(socket.handle(), endpoint.c_str(), ZMQ_EVENT_ALL);
+    int rc
+      = zmq_socket_monitor(socket.handle(), endpoint.c_str(), ZMQ_EVENT_ALL);
     if (rc != 0) {
       throw ::zmq::error_t{};
     }
-    monitor_socket_ = ::zmq::socket_t{global_context(), ::zmq::socket_type::pair};
+    monitor_socket_
+      = ::zmq::socket_t{global_context(), ::zmq::socket_type::pair};
     monitor_socket_.connect(endpoint.c_str());
   }
 
@@ -147,9 +150,9 @@ auto strip_prefix(chunk_ptr message, std::string_view prefix)
     message->size(),
   };
   if (not view.starts_with(prefix)) {
-    return caf::make_error(ec::invalid_argument,
-                           fmt::format("message does not start with prefix `{}`",
-                                       prefix));
+    return caf::make_error(
+      ec::invalid_argument,
+      fmt::format("message does not start with prefix `{}`", prefix));
   }
   auto offset = prefix.size();
   return chunk::make(message->data() + offset, message->size() - offset,
@@ -166,7 +169,8 @@ auto prepend_prefix(chunk_ptr payload, std::string_view prefix)
   auto buffer = std::string{};
   buffer.reserve(prefix.size() + payload->size());
   buffer.append(prefix);
-  buffer.append(reinterpret_cast<char const*>(payload->data()), payload->size());
+  buffer.append(reinterpret_cast<char const*>(payload->data()),
+                payload->size());
   return chunk::make(std::move(buffer));
 }
 
@@ -304,8 +308,8 @@ auto Socket::ensure_socket() -> caf::expected<void> {
   }
   try {
     socket_.emplace(global_context(), role_ == SocketRole::publisher
-                                      ? ::zmq::socket_type::pub
-                                      : ::zmq::socket_type::sub);
+                                        ? ::zmq::socket_type::pub
+                                        : ::zmq::socket_type::sub);
     socket_->set(::zmq::sockopt::linger, 0);
     return {};
   } catch (const ::zmq::error_t& e) {

--- a/plugins/zmq/src/transport.cpp
+++ b/plugins/zmq/src/transport.cpp
@@ -1,0 +1,307 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "transport.hpp"
+
+#include <tenzir/detail/narrow.hpp>
+#include <tenzir/uuid.hpp>
+
+#include <array>
+#include <cstring>
+#include <utility>
+#include <vector>
+
+using namespace std::chrono_literals;
+
+namespace tenzir::plugins::zmq::transport {
+
+namespace {
+
+auto global_context() -> ::zmq::context_t& {
+  static auto ctx = ::zmq::context_t{};
+  return ctx;
+}
+
+auto poll(::zmq::socket_t& socket, short flags,
+          std::optional<std::chrono::milliseconds> timeout = {}) -> bool {
+  auto items = std::array<::zmq::pollitem_t, 1>{
+    {{socket.handle(), 0, flags, 0}},
+  };
+  auto infinite = std::chrono::milliseconds(-1);
+  auto ms = timeout ? *timeout : infinite;
+  auto num_events_signaled = ::zmq::poll(items.data(), items.size(), ms);
+  if (num_events_signaled == 0) {
+    return false;
+  }
+  TENZIR_ASSERT(num_events_signaled > 0);
+  TENZIR_ASSERT((items[0].revents & flags) != 0);
+  return true;
+}
+
+struct MonitorEvent {
+  uint16_t event = 0;
+  int32_t value = 0;
+  std::string address;
+};
+
+} // namespace
+
+class Socket::Monitor {
+public:
+  Monitor() = default;
+
+  explicit Monitor(::zmq::socket_t& socket) {
+    auto endpoint = fmt::format("inproc://monitor-{}", uuid::random());
+    int rc = zmq_socket_monitor(socket.handle(), endpoint.c_str(), ZMQ_EVENT_ALL);
+    if (rc != 0) {
+      throw ::zmq::error_t{};
+    }
+    monitor_socket_ = ::zmq::socket_t{global_context(), ::zmq::socket_type::pair};
+    monitor_socket_.connect(endpoint.c_str());
+  }
+
+  auto events(std::optional<std::chrono::milliseconds> timeout = {})
+    -> std::vector<MonitorEvent> {
+    auto result = std::vector<MonitorEvent>{};
+    if (not poll(monitor_socket_, ZMQ_POLLIN, timeout)) {
+      return result;
+    }
+    do {
+      auto event = MonitorEvent{};
+      auto event_msg = ::zmq::message_t{};
+      auto flags = ::zmq::recv_flags::none;
+      auto bytes = monitor_socket_.recv(event_msg, flags);
+      TENZIR_ASSERT(bytes);
+      auto* ptr = event_msg.data<char>();
+      std::memcpy(&event.event, ptr, sizeof(uint16_t));
+      std::memcpy(&event.value, ptr + sizeof(uint16_t), sizeof(int32_t));
+      auto addr_msg = ::zmq::message_t{};
+      bytes = monitor_socket_.recv(addr_msg, flags);
+      TENZIR_ASSERT(bytes);
+      event.address = addr_msg.to_string();
+      result.push_back(std::move(event));
+    } while (poll(monitor_socket_, ZMQ_POLLIN, 0ms));
+    return result;
+  }
+
+private:
+  ::zmq::socket_t monitor_socket_;
+};
+
+auto normalize_endpoint(std::string endpoint) -> std::string {
+  if (endpoint.find("://") == std::string::npos) {
+    endpoint = fmt::format("tcp://{}", endpoint);
+  }
+  return endpoint;
+}
+
+auto is_tcp_endpoint(std::string_view endpoint) -> bool {
+  return endpoint.starts_with("tcp://");
+}
+
+auto render_monitor_event(uint16_t event) -> std::string_view {
+  switch (event) {
+    default:
+      return "unknown ZMQ_EVENT";
+    case ZMQ_EVENT_CONNECTED:
+      return "ZMQ_EVENT_CONNECTED";
+    case ZMQ_EVENT_CONNECT_DELAYED:
+      return "ZMQ_EVENT_CONNECT_DELAYED";
+    case ZMQ_EVENT_CONNECT_RETRIED:
+      return "ZMQ_EVENT_CONNECT_RETRIED";
+    case ZMQ_EVENT_LISTENING:
+      return "ZMQ_EVENT_LISTENING";
+    case ZMQ_EVENT_BIND_FAILED:
+      return "ZMQ_EVENT_BIND_FAILED";
+    case ZMQ_EVENT_ACCEPTED:
+      return "ZMQ_EVENT_ACCEPTED";
+    case ZMQ_EVENT_ACCEPT_FAILED:
+      return "ZMQ_EVENT_ACCEPT_FAILED";
+    case ZMQ_EVENT_CLOSED:
+      return "ZMQ_EVENT_CLOSED";
+    case ZMQ_EVENT_CLOSE_FAILED:
+      return "ZMQ_EVENT_CLOSE_FAILED";
+    case ZMQ_EVENT_DISCONNECTED:
+      return "ZMQ_EVENT_DISCONNECTED";
+    case ZMQ_EVENT_MONITOR_STOPPED:
+      return "ZMQ_EVENT_MONITOR_STOPPED";
+    case ZMQ_EVENT_HANDSHAKE_FAILED_AUTH:
+      return "ZMQ_EVENT_HANDSHAKE_FAILED_AUTH";
+    case ZMQ_EVENT_HANDSHAKE_FAILED_PROTOCOL:
+      return "ZMQ_EVENT_HANDSHAKE_FAILED_PROTOCOL";
+    case ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL:
+      return "ZMQ_EVENT_HANDSHAKE_FAILED_NO_DETAIL";
+    case ZMQ_EVENT_HANDSHAKE_SUCCEEDED:
+      return "ZMQ_EVENT_HANDSHAKE_SUCCEEDED";
+  }
+}
+
+auto strip_prefix(chunk_ptr message, std::string_view prefix)
+  -> caf::expected<chunk_ptr> {
+  if (not message or prefix.empty()) {
+    return message;
+  }
+  auto view = std::string_view{
+    reinterpret_cast<char const*>(message->data()),
+    message->size(),
+  };
+  if (not view.starts_with(prefix)) {
+    return caf::make_error(ec::invalid_argument,
+                           fmt::format("message does not start with prefix `{}`",
+                                       prefix));
+  }
+  auto offset = prefix.size();
+  return chunk::make(message->data() + offset, message->size() - offset,
+                     [message = std::move(message)]() noexcept {
+                       static_cast<void>(message);
+                     });
+}
+
+auto prepend_prefix(chunk_ptr payload, std::string_view prefix)
+  -> caf::expected<chunk_ptr> {
+  if (not payload or prefix.empty()) {
+    return payload;
+  }
+  auto buffer = std::string{};
+  buffer.reserve(prefix.size() + payload->size());
+  buffer.append(prefix);
+  buffer.append(reinterpret_cast<char const*>(payload->data()), payload->size());
+  return chunk::make(std::move(buffer));
+}
+
+Socket::Socket(SocketRole role)
+  : socket_{global_context(), role == SocketRole::publisher
+                                ? ::zmq::socket_type::pub
+                                : ::zmq::socket_type::sub} {
+  socket_.set(::zmq::sockopt::linger, 0);
+}
+
+Socket::~Socket() = default;
+
+Socket::Socket(Socket&&) noexcept = default;
+
+auto Socket::operator=(Socket&&) noexcept -> Socket& = default;
+
+auto Socket::enable_peer_monitoring() -> caf::expected<void> {
+  try {
+    monitor_ = std::make_unique<Monitor>(socket_);
+    return {};
+  } catch (const ::zmq::error_t& e) {
+    return make_error(e);
+  }
+}
+
+auto Socket::open(ConnectionMode mode, std::string_view endpoint,
+                  std::chrono::milliseconds reconnect_interval)
+  -> caf::expected<void> {
+  try {
+    auto ms = detail::narrow_cast<int>(reconnect_interval.count());
+    auto endpoint_string = std::string{endpoint};
+    socket_.set(::zmq::sockopt::reconnect_ivl, ms);
+    if (mode == ConnectionMode::bind) {
+      socket_.bind(endpoint_string.c_str());
+    } else {
+      socket_.connect(endpoint_string.c_str());
+    }
+    return {};
+  } catch (const ::zmq::error_t& e) {
+    return make_error(e);
+  }
+}
+
+auto Socket::set_subscription_prefix(std::string_view prefix)
+  -> caf::expected<void> {
+  try {
+    socket_.set(::zmq::sockopt::subscribe, prefix);
+    return {};
+  } catch (const ::zmq::error_t& e) {
+    return make_error(e);
+  }
+}
+
+auto Socket::send(const chunk_ptr& chunk,
+                  std::optional<std::chrono::milliseconds> timeout)
+  -> caf::error {
+  try {
+    if (not poll(socket_, ZMQ_POLLOUT, timeout)) {
+      return caf::make_error(ec::timeout, "timed out while polling socket");
+    }
+    auto message = ::zmq::message_t{chunk->begin(), chunk->end()};
+    auto bytes = socket_.send(message, ::zmq::send_flags::none);
+    TENZIR_ASSERT(bytes);
+    return {};
+  } catch (const ::zmq::error_t& e) {
+    return make_error(e);
+  }
+}
+
+auto Socket::receive(std::optional<std::chrono::milliseconds> timeout)
+  -> caf::expected<chunk_ptr> {
+  try {
+    if (not poll(socket_, ZMQ_POLLIN, timeout)) {
+      return caf::make_error(ec::timeout, "timed out while polling socket");
+    }
+    auto message = std::make_shared<::zmq::message_t>();
+    auto bytes = socket_.recv(*message, ::zmq::recv_flags::none);
+    TENZIR_ASSERT(bytes);
+    auto* data = message->data();
+    auto size = message->size();
+    return chunk::make(data, size, [message = std::move(message)]() noexcept {
+      static_cast<void>(message);
+    });
+  } catch (const ::zmq::error_t& e) {
+    return make_error(e);
+  }
+}
+
+auto Socket::poll_monitor(std::optional<std::chrono::milliseconds> timeout)
+  -> size_t {
+  if (not monitor_) {
+    return 0;
+  }
+  auto num_events = size_t{0};
+  for (auto& event : monitor_->events(timeout)) {
+    ++num_events;
+    switch (event.event) {
+      default:
+        break;
+      case ZMQ_EVENT_HANDSHAKE_SUCCEEDED:
+        ++num_peers_;
+        break;
+      case ZMQ_EVENT_DISCONNECTED:
+        if (num_peers_ > 0) {
+          --num_peers_;
+        }
+        break;
+    }
+  }
+  return num_events;
+}
+
+auto Socket::monitored() const -> bool {
+  return monitor_ != nullptr;
+}
+
+auto Socket::num_peers() const -> size_t {
+  return num_peers_;
+}
+
+auto Socket::make_error(const ::zmq::error_t& error) const -> caf::error {
+  return caf::make_error(ec::unspecified,
+                         fmt::format("ZeroMQ: {}", error.what()));
+}
+
+auto Socket::make_error(int error_number) const -> caf::error {
+  return make_error(::zmq::error_t{error_number});
+}
+
+auto Socket::make_error() const -> caf::error {
+  return make_error(zmq_errno());
+}
+
+} // namespace tenzir::plugins::zmq::transport

--- a/plugins/zmq/src/transport.cpp
+++ b/plugins/zmq/src/transport.cpp
@@ -6,6 +6,7 @@
 // SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+#include "context.hpp"
 #include "transport.hpp"
 
 #include <tenzir/detail/narrow.hpp>
@@ -21,11 +22,6 @@ using namespace std::chrono_literals;
 namespace tenzir::plugins::zmq::transport {
 
 namespace {
-
-auto global_context() -> ::zmq::context_t& {
-  static auto ctx = ::zmq::context_t{};
-  return ctx;
-}
 
 auto poll(::zmq::socket_t& socket, short flags,
           std::optional<std::chrono::milliseconds> timeout = {}) -> bool {

--- a/plugins/zmq/src/transport.cpp
+++ b/plugins/zmq/src/transport.cpp
@@ -174,11 +174,7 @@ auto prepend_prefix(chunk_ptr payload, std::string_view prefix)
   return chunk::make(std::move(buffer));
 }
 
-Socket::Socket(SocketRole role)
-  : socket_{global_context(), role == SocketRole::publisher
-                                ? ::zmq::socket_type::pub
-                                : ::zmq::socket_type::sub} {
-  socket_.set(::zmq::sockopt::linger, 0);
+Socket::Socket(SocketRole role) : role_{role} {
 }
 
 Socket::~Socket() = default;
@@ -189,7 +185,10 @@ auto Socket::operator=(Socket&&) noexcept -> Socket& = default;
 
 auto Socket::enable_peer_monitoring() -> caf::expected<void> {
   try {
-    monitor_ = std::make_unique<Monitor>(socket_);
+    if (auto err = ensure_socket(); not err) {
+      return err;
+    }
+    monitor_ = std::make_unique<Monitor>(*socket_);
     return {};
   } catch (const ::zmq::error_t& e) {
     return make_error(e);
@@ -200,13 +199,16 @@ auto Socket::open(ConnectionMode mode, std::string_view endpoint,
                   std::chrono::milliseconds reconnect_interval)
   -> caf::expected<void> {
   try {
+    if (auto err = ensure_socket(); not err) {
+      return err;
+    }
     auto ms = detail::narrow_cast<int>(reconnect_interval.count());
     auto endpoint_string = std::string{endpoint};
-    socket_.set(::zmq::sockopt::reconnect_ivl, ms);
+    socket_->set(::zmq::sockopt::reconnect_ivl, ms);
     if (mode == ConnectionMode::bind) {
-      socket_.bind(endpoint_string.c_str());
+      socket_->bind(endpoint_string.c_str());
     } else {
-      socket_.connect(endpoint_string.c_str());
+      socket_->connect(endpoint_string.c_str());
     }
     return {};
   } catch (const ::zmq::error_t& e) {
@@ -217,7 +219,10 @@ auto Socket::open(ConnectionMode mode, std::string_view endpoint,
 auto Socket::set_subscription_prefix(std::string_view prefix)
   -> caf::expected<void> {
   try {
-    socket_.set(::zmq::sockopt::subscribe, prefix);
+    if (auto err = ensure_socket(); not err) {
+      return err;
+    }
+    socket_->set(::zmq::sockopt::subscribe, prefix);
     return {};
   } catch (const ::zmq::error_t& e) {
     return make_error(e);
@@ -228,11 +233,12 @@ auto Socket::send(const chunk_ptr& chunk,
                   std::optional<std::chrono::milliseconds> timeout)
   -> caf::error {
   try {
-    if (not poll(socket_, ZMQ_POLLOUT, timeout)) {
+    TENZIR_ASSERT(socket_);
+    if (not poll(*socket_, ZMQ_POLLOUT, timeout)) {
       return caf::make_error(ec::timeout, "timed out while polling socket");
     }
     auto message = ::zmq::message_t{chunk->begin(), chunk->end()};
-    auto bytes = socket_.send(message, ::zmq::send_flags::none);
+    auto bytes = socket_->send(message, ::zmq::send_flags::none);
     TENZIR_ASSERT(bytes);
     return {};
   } catch (const ::zmq::error_t& e) {
@@ -243,11 +249,12 @@ auto Socket::send(const chunk_ptr& chunk,
 auto Socket::receive(std::optional<std::chrono::milliseconds> timeout)
   -> caf::expected<chunk_ptr> {
   try {
-    if (not poll(socket_, ZMQ_POLLIN, timeout)) {
+    TENZIR_ASSERT(socket_);
+    if (not poll(*socket_, ZMQ_POLLIN, timeout)) {
       return caf::make_error(ec::timeout, "timed out while polling socket");
     }
     auto message = std::make_shared<::zmq::message_t>();
-    auto bytes = socket_.recv(*message, ::zmq::recv_flags::none);
+    auto bytes = socket_->recv(*message, ::zmq::recv_flags::none);
     TENZIR_ASSERT(bytes);
     auto* data = message->data();
     auto size = message->size();
@@ -291,7 +298,27 @@ auto Socket::num_peers() const -> size_t {
   return num_peers_;
 }
 
+auto Socket::last_error() const -> const std::string& {
+  return last_error_;
+}
+
+auto Socket::ensure_socket() -> caf::expected<void> {
+  if (socket_) {
+    return {};
+  }
+  try {
+    socket_.emplace(global_context(), role_ == SocketRole::publisher
+                                      ? ::zmq::socket_type::pub
+                                      : ::zmq::socket_type::sub);
+    socket_->set(::zmq::sockopt::linger, 0);
+    return {};
+  } catch (const ::zmq::error_t& e) {
+    return make_error(e);
+  }
+}
+
 auto Socket::make_error(const ::zmq::error_t& error) const -> caf::error {
+  last_error_ = error.what();
   return caf::make_error(ec::unspecified,
                          fmt::format("ZeroMQ: {}", error.what()));
 }

--- a/shell.nix
+++ b/shell.nix
@@ -37,6 +37,7 @@ pkgs.mkShell (
           pandas
           pip
           pyarrow
+          pyzmq
           python-box
         ]
       ))

--- a/test/fixtures/__init__.py
+++ b/test/fixtures/__init__.py
@@ -18,6 +18,7 @@ from . import http_request  # noqa: F401
 from . import http_paginate  # noqa: F401
 from . import http_server  # noqa: F401
 from . import tcp  # noqa: F401
+from . import zmq  # noqa: F401
 
 __all__ = [
     "abs",
@@ -35,4 +36,5 @@ __all__ = [
     "s3",
     "sentinelone",
     "tcp",
+    "zmq",
 ]

--- a/test/fixtures/tools/zmq_peer.py
+++ b/test/fixtures/tools/zmq_peer.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import argparse
+import signal
+import time
+from pathlib import Path
+
+import zmq
+
+_STARTUP_SETTLE_SECONDS = 0.25
+_RECV_POLL_TIMEOUT_MS = 100
+_running = True
+
+
+def _handle_stop(_: int, __: object) -> None:
+    global _running
+    _running = False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--role", choices=("publisher", "subscriber"), required=True)
+    parser.add_argument("--mode", choices=("bind", "connect"), required=True)
+    parser.add_argument("--endpoint", required=True)
+    parser.add_argument("--ready-file", required=True)
+    parser.add_argument("--capture-file", required=True)
+    parser.add_argument("--payload", default="")
+    parser.add_argument("--subscribe-prefix", default="")
+    parser.add_argument("--send-interval-ms", type=int, default=50)
+    args = parser.parse_args()
+
+    signal.signal(signal.SIGTERM, _handle_stop)
+    signal.signal(signal.SIGINT, _handle_stop)
+
+    context = zmq.Context()
+    socket_type = zmq.PUB if args.role == "publisher" else zmq.SUB
+    socket = context.socket(socket_type)
+    socket.setsockopt(zmq.LINGER, 0)
+    if args.role == "subscriber":
+        socket.setsockopt_string(zmq.SUBSCRIBE, args.subscribe_prefix)
+    if args.mode == "bind":
+        socket.bind(args.endpoint)
+    else:
+        socket.connect(args.endpoint)
+    Path(args.ready_file).touch()
+    time.sleep(_STARTUP_SETTLE_SECONDS)
+    try:
+        if args.role == "publisher":
+            payload = args.payload.encode()
+            interval = args.send_interval_ms / 1000.0
+            while _running:
+                socket.send(payload)
+                time.sleep(interval)
+        else:
+            poller = zmq.Poller()
+            poller.register(socket, zmq.POLLIN)
+            capture_path = Path(args.capture_file)
+            while _running:
+                if socket not in dict(poller.poll(_RECV_POLL_TIMEOUT_MS)):
+                    continue
+                payload = socket.recv()
+                with capture_path.open("ab") as capture:
+                    capture.write(payload)
+                    capture.write(b"\n")
+    finally:
+        socket.close()
+        context.term()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/fixtures/zmq.py
+++ b/test/fixtures/zmq.py
@@ -50,6 +50,7 @@ def zmq() -> FixtureHandle:
     endpoint = f"tcp://{_HOST}:{find_free_port()}"
     ready_fd, ready_path = tempfile.mkstemp(prefix="zmq-ready-", suffix=".flag")
     os.close(ready_fd)
+    os.unlink(ready_path)
     capture_fd, capture_path = tempfile.mkstemp(prefix="zmq-capture-", suffix=".log")
     os.close(capture_fd)
     helper_log_fd, helper_log_path = tempfile.mkstemp(

--- a/test/fixtures/zmq.py
+++ b/test/fixtures/zmq.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 import tempfile
 import time
 from dataclasses import dataclass
@@ -19,7 +20,6 @@ _STARTUP_POLL_INTERVAL = 0.05
 _ASSERTION_WAIT_TIMEOUT = 2.0
 _ASSERTION_WAIT_INTERVAL = 0.01
 _HELPER = Path(__file__).resolve().parent / "tools" / "zmq_peer.py"
-_REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 @dataclass(frozen=True)
@@ -59,11 +59,7 @@ def zmq() -> FixtureHandle:
     os.close(helper_log_fd)
     helper_stdout = open(helper_log_path, "wb")
     cmd = [
-        "nix",
-        "develop",
-        ".",
-        "-c",
-        "python3",
+        sys.executable,
         str(_HELPER),
         "--role",
         opts.role,
@@ -84,7 +80,6 @@ def zmq() -> FixtureHandle:
     ]
     proc = subprocess.Popen(
         cmd,
-        cwd=_REPO_ROOT,
         stdout=helper_stdout,
         stderr=subprocess.STDOUT,
         close_fds=True,

--- a/test/fixtures/zmq.py
+++ b/test/fixtures/zmq.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 import subprocess
-import sys
 import tempfile
 import time
 from dataclasses import dataclass
@@ -20,6 +19,7 @@ _STARTUP_POLL_INTERVAL = 0.05
 _ASSERTION_WAIT_TIMEOUT = 2.0
 _ASSERTION_WAIT_INTERVAL = 0.01
 _HELPER = Path(__file__).resolve().parent / "tools" / "zmq_peer.py"
+_REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 @dataclass(frozen=True)
@@ -58,7 +58,11 @@ def zmq() -> FixtureHandle:
     os.close(helper_log_fd)
     helper_stdout = open(helper_log_path, "wb")
     cmd = [
-        sys.executable,
+        "nix",
+        "develop",
+        ".",
+        "-c",
+        "python3",
         str(_HELPER),
         "--role",
         opts.role,
@@ -79,6 +83,7 @@ def zmq() -> FixtureHandle:
     ]
     proc = subprocess.Popen(
         cmd,
+        cwd=_REPO_ROOT,
         stdout=helper_stdout,
         stderr=subprocess.STDOUT,
         close_fds=True,

--- a/test/fixtures/zmq.py
+++ b/test/fixtures/zmq.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from tenzir_test import FixtureHandle, fixture
+from tenzir_test.fixtures import current_options
+
+from ._utils import find_free_port
+
+_HOST = "127.0.0.1"
+_STARTUP_TIMEOUT = 20.0
+_STARTUP_POLL_INTERVAL = 0.05
+_ASSERTION_WAIT_TIMEOUT = 2.0
+_ASSERTION_WAIT_INTERVAL = 0.01
+_HELPER = Path(__file__).resolve().parent / "tools" / "zmq_peer.py"
+
+
+@dataclass(frozen=True)
+class ZmqOptions:
+    role: str = "publisher"  # publisher sends payload, subscriber receives
+    mode: str = "bind"  # bind or connect
+    payload: str = '{"line":"foo"}'
+    subscribe_prefix: str = ""
+    send_interval_ms: int = 50
+
+
+@dataclass(frozen=True)
+class ZmqAssertions:
+    received_contains: str | None = None
+
+
+@fixture(options=ZmqOptions, assertions=ZmqAssertions)
+def zmq() -> FixtureHandle:
+    opts = current_options("zmq")
+    if opts.role not in {"publisher", "subscriber"}:
+        raise RuntimeError(
+            "zmq fixture option `role` must be one of: publisher, subscriber"
+        )
+    if opts.mode not in {"bind", "connect"}:
+        raise RuntimeError("zmq fixture option `mode` must be one of: bind, connect")
+    if opts.send_interval_ms <= 0:
+        raise RuntimeError("zmq fixture option `send_interval_ms` must be > 0")
+    endpoint = f"tcp://{_HOST}:{find_free_port()}"
+    ready_fd, ready_path = tempfile.mkstemp(prefix="zmq-ready-", suffix=".flag")
+    os.close(ready_fd)
+    capture_fd, capture_path = tempfile.mkstemp(prefix="zmq-capture-", suffix=".log")
+    os.close(capture_fd)
+    helper_log_fd, helper_log_path = tempfile.mkstemp(
+        prefix="zmq-helper-", suffix=".log"
+    )
+    os.close(helper_log_fd)
+    helper_stdout = open(helper_log_path, "wb")
+    cmd = [
+        sys.executable,
+        str(_HELPER),
+        "--role",
+        opts.role,
+        "--mode",
+        opts.mode,
+        "--endpoint",
+        endpoint,
+        "--ready-file",
+        ready_path,
+        "--capture-file",
+        capture_path,
+        "--send-interval-ms",
+        str(opts.send_interval_ms),
+        "--payload",
+        opts.payload,
+        "--subscribe-prefix",
+        opts.subscribe_prefix,
+    ]
+    proc = subprocess.Popen(
+        cmd,
+        stdout=helper_stdout,
+        stderr=subprocess.STDOUT,
+        close_fds=True,
+    )
+    deadline = time.monotonic() + _STARTUP_TIMEOUT
+    while not os.path.exists(ready_path):
+        if proc.poll() is not None:
+            helper_stdout.close()
+            log = Path(helper_log_path).read_text(errors="replace")
+            raise RuntimeError(
+                f"zmq fixture helper exited with code {proc.returncode}: {log}"
+            )
+        if time.monotonic() >= deadline:
+            proc.terminate()
+            proc.wait(timeout=2)
+            helper_stdout.close()
+            log = Path(helper_log_path).read_text(errors="replace")
+            raise RuntimeError(f"zmq fixture helper did not become ready: {log}")
+        time.sleep(_STARTUP_POLL_INTERVAL)
+
+    env = {
+        "ZMQ_ENDPOINT": endpoint,
+        "ZMQ_FILE": capture_path,
+    }
+
+    def _assert_test(
+        *,
+        test: Path,
+        assertions: ZmqAssertions | dict[str, Any],
+        **_: Any,
+    ) -> None:
+        if isinstance(assertions, dict):
+            assertions = ZmqAssertions(**assertions)
+        if assertions.received_contains is None:
+            return
+        deadline = time.monotonic() + _ASSERTION_WAIT_TIMEOUT
+        while True:
+            received = Path(capture_path).read_text(errors="replace")
+            if assertions.received_contains in received:
+                return
+            if time.monotonic() >= deadline:
+                raise AssertionError(
+                    f"{test.name}: expected fixture capture to contain "
+                    f"{assertions.received_contains!r}, got {received!r}"
+                )
+            time.sleep(_ASSERTION_WAIT_INTERVAL)
+
+    def _teardown() -> None:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=5)
+        helper_stdout.close()
+        for path in (ready_path, capture_path, helper_log_path):
+            if os.path.exists(path):
+                os.remove(path)
+
+    return FixtureHandle(
+        env=env,
+        teardown=_teardown,
+        hooks={"assert_test": _assert_test},
+    )

--- a/test/fixtures/zmq.py
+++ b/test/fixtures/zmq.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.util
 import os
 import subprocess
 import sys
@@ -10,7 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from tenzir_test import FixtureHandle, fixture
-from tenzir_test.fixtures import current_options
+from tenzir_test.fixtures import FixtureUnavailable, current_options
 
 from ._utils import find_free_port
 
@@ -38,6 +39,8 @@ class ZmqAssertions:
 
 @fixture(options=ZmqOptions, assertions=ZmqAssertions)
 def zmq() -> FixtureHandle:
+    if importlib.util.find_spec("zmq") is None:
+        raise FixtureUnavailable("pyzmq package not installed")
     opts = current_options("zmq")
     if opts.role not in {"publisher", "subscriber"}:
         raise RuntimeError(

--- a/test/tests/operators/accept_zmq/keep_prefix_read_all.tql
+++ b/test/tests/operators/accept_zmq/keep_prefix_read_all.tql
@@ -1,0 +1,13 @@
+---
+fixtures:
+  - zmq:
+      role: publisher
+      mode: connect
+      payload: 'alerts/hello-from-accept-zmq-prefix'
+timeout: 60
+---
+
+accept_zmq env("ZMQ_ENDPOINT"), prefix="alerts/", keep_prefix=true {
+  read_all
+}
+head 1

--- a/test/tests/operators/accept_zmq/keep_prefix_read_all.tql
+++ b/test/tests/operators/accept_zmq/keep_prefix_read_all.tql
@@ -3,11 +3,11 @@ fixtures:
   - zmq:
       role: publisher
       mode: connect
-      payload: 'alerts/hello-from-accept-zmq-prefix'
+      payload: 'alerts/hello-from-accept-zmq-prefix\n'
 timeout: 60
 ---
 
 accept_zmq env("ZMQ_ENDPOINT"), prefix="alerts/", keep_prefix=true {
-  read_all
+  read_lines
 }
 head 1

--- a/test/tests/operators/accept_zmq/keep_prefix_read_all.tql
+++ b/test/tests/operators/accept_zmq/keep_prefix_read_all.tql
@@ -4,6 +4,8 @@ fixtures:
       role: publisher
       mode: connect
       payload: 'alerts/hello-from-accept-zmq-prefix\n'
+skip:
+  on: fixture-unavailable
 timeout: 60
 ---
 

--- a/test/tests/operators/accept_zmq/keep_prefix_read_all.txt
+++ b/test/tests/operators/accept_zmq/keep_prefix_read_all.txt
@@ -1,3 +1,3 @@
 {
-  data: "alerts/hello-from-accept-zmq-prefix",
+  line: "alerts/hello-from-accept-zmq-prefix\\n",
 }

--- a/test/tests/operators/accept_zmq/keep_prefix_read_all.txt
+++ b/test/tests/operators/accept_zmq/keep_prefix_read_all.txt
@@ -1,0 +1,3 @@
+{
+  data: "alerts/hello-from-accept-zmq-prefix",
+}

--- a/test/tests/operators/accept_zmq/plain_read_json.tql
+++ b/test/tests/operators/accept_zmq/plain_read_json.tql
@@ -4,6 +4,8 @@ fixtures:
       role: publisher
       mode: connect
       payload: '{"line":"hello-from-accept-zmq"}'
+skip:
+  on: fixture-unavailable
 timeout: 60
 ---
 

--- a/test/tests/operators/accept_zmq/plain_read_json.tql
+++ b/test/tests/operators/accept_zmq/plain_read_json.tql
@@ -1,0 +1,13 @@
+---
+fixtures:
+  - zmq:
+      role: publisher
+      mode: connect
+      payload: '{"line":"hello-from-accept-zmq"}'
+timeout: 60
+---
+
+accept_zmq env("ZMQ_ENDPOINT") {
+  read_json
+}
+head 1

--- a/test/tests/operators/accept_zmq/plain_read_json.txt
+++ b/test/tests/operators/accept_zmq/plain_read_json.txt
@@ -1,0 +1,3 @@
+{
+  line: "hello-from-accept-zmq",
+}

--- a/test/tests/operators/accept_zmq/test.yaml
+++ b/test/tests/operators/accept_zmq/test.yaml
@@ -1,0 +1,3 @@
+timeout: 60
+skip:
+  on: fixture-unavailable

--- a/test/tests/operators/accept_zmq/test.yaml
+++ b/test/tests/operators/accept_zmq/test.yaml
@@ -1,3 +1,0 @@
-timeout: 60
-skip:
-  on: fixture-unavailable

--- a/test/tests/operators/from_zmq/plain_read_json.tql
+++ b/test/tests/operators/from_zmq/plain_read_json.tql
@@ -4,6 +4,8 @@ fixtures:
       role: publisher
       mode: bind
       payload: '{"line":"hello-from-zmq"}'
+skip:
+  on: fixture-unavailable
 timeout: 60
 ---
 

--- a/test/tests/operators/from_zmq/plain_read_json.tql
+++ b/test/tests/operators/from_zmq/plain_read_json.tql
@@ -1,0 +1,13 @@
+---
+fixtures:
+  - zmq:
+      role: publisher
+      mode: bind
+      payload: '{"line":"hello-from-zmq"}'
+timeout: 60
+---
+
+from_zmq env("ZMQ_ENDPOINT") {
+  read_json
+}
+head 1

--- a/test/tests/operators/from_zmq/plain_read_json.txt
+++ b/test/tests/operators/from_zmq/plain_read_json.txt
@@ -1,0 +1,3 @@
+{
+  line: "hello-from-zmq",
+}

--- a/test/tests/operators/from_zmq/prefix_read_json.tql
+++ b/test/tests/operators/from_zmq/prefix_read_json.tql
@@ -4,6 +4,8 @@ fixtures:
       role: publisher
       mode: bind
       payload: 'alerts/{"line":"hello-from-zmq-prefix"}'
+skip:
+  on: fixture-unavailable
 timeout: 60
 ---
 

--- a/test/tests/operators/from_zmq/prefix_read_json.tql
+++ b/test/tests/operators/from_zmq/prefix_read_json.tql
@@ -1,0 +1,13 @@
+---
+fixtures:
+  - zmq:
+      role: publisher
+      mode: bind
+      payload: 'alerts/{"line":"hello-from-zmq-prefix"}'
+timeout: 60
+---
+
+from_zmq env("ZMQ_ENDPOINT"), prefix="alerts/" {
+  read_json
+}
+head 1

--- a/test/tests/operators/from_zmq/prefix_read_json.txt
+++ b/test/tests/operators/from_zmq/prefix_read_json.txt
@@ -1,0 +1,3 @@
+{
+  line: "hello-from-zmq-prefix",
+}

--- a/test/tests/operators/from_zmq/test.yaml
+++ b/test/tests/operators/from_zmq/test.yaml
@@ -1,0 +1,3 @@
+timeout: 60
+skip:
+  on: fixture-unavailable

--- a/test/tests/operators/from_zmq/test.yaml
+++ b/test/tests/operators/from_zmq/test.yaml
@@ -1,3 +1,0 @@
-timeout: 60
-skip:
-  on: fixture-unavailable

--- a/test/tests/operators/from_zmq/validation/error_prefix_must_be_constant.tql
+++ b/test/tests/operators/from_zmq/validation/error_prefix_must_be_constant.tql
@@ -1,0 +1,3 @@
+from_zmq "127.0.0.1:31337", prefix=message {
+  read_json
+}

--- a/test/tests/operators/from_zmq/validation/error_prefix_must_be_constant.tql
+++ b/test/tests/operators/from_zmq/validation/error_prefix_must_be_constant.tql
@@ -1,3 +1,7 @@
+---
+error: true
+---
+
 from_zmq "127.0.0.1:31337", prefix=message {
   read_json
 }

--- a/test/tests/operators/from_zmq/validation/error_prefix_must_be_constant.txt
+++ b/test/tests/operators/from_zmq/validation/error_prefix_must_be_constant.txt
@@ -1,6 +1,6 @@
 error: `prefix` must be a constant string
- --> tests/operators/from_zmq/validation/error_prefix_must_be_constant.tql:1:36
+ --> tests/operators/from_zmq/validation/error_prefix_must_be_constant.tql:5:36
   |
-1 | from_zmq "127.0.0.1:31337", prefix=message {
-  |                                    ^^^^^^^
+5 | from_zmq "127.0.0.1:31337", prefix=message {
+  |                                    ^^^^^^^ 
   |

--- a/test/tests/operators/from_zmq/validation/error_prefix_must_be_constant.txt
+++ b/test/tests/operators/from_zmq/validation/error_prefix_must_be_constant.txt
@@ -1,0 +1,6 @@
+error: `prefix` must be a constant string
+ --> tests/operators/from_zmq/validation/error_prefix_must_be_constant.tql:1:36
+  |
+1 | from_zmq "127.0.0.1:31337", prefix=message {
+  |                                    ^^^^^^^
+  |

--- a/test/tests/operators/serve_zmq/plain_write_ndjson.tql
+++ b/test/tests/operators/serve_zmq/plain_write_ndjson.tql
@@ -13,4 +13,4 @@ timeout: 60
 from {
   line: "hello-from-serve_zmq",
 }
-serve_zmq env("ZMQ_ENDPOINT"), encoding="ndjson"
+serve_zmq env("ZMQ_ENDPOINT"), encoding="ndjson", monitor=true

--- a/test/tests/operators/serve_zmq/plain_write_ndjson.tql
+++ b/test/tests/operators/serve_zmq/plain_write_ndjson.tql
@@ -1,0 +1,16 @@
+---
+fixtures:
+  - zmq:
+      role: subscriber
+      mode: connect
+assertions:
+  fixtures:
+    zmq:
+      received_contains: '"line":"hello-from-serve_zmq"'
+timeout: 60
+---
+
+from {
+  line: "hello-from-serve_zmq",
+}
+serve_zmq env("ZMQ_ENDPOINT"), encoding="ndjson"

--- a/test/tests/operators/serve_zmq/plain_write_ndjson.tql
+++ b/test/tests/operators/serve_zmq/plain_write_ndjson.tql
@@ -3,6 +3,8 @@ fixtures:
   - zmq:
       role: subscriber
       mode: connect
+skip:
+  on: fixture-unavailable
 assertions:
   fixtures:
     zmq:

--- a/test/tests/operators/serve_zmq/test.yaml
+++ b/test/tests/operators/serve_zmq/test.yaml
@@ -1,0 +1,3 @@
+timeout: 60
+skip:
+  on: fixture-unavailable

--- a/test/tests/operators/serve_zmq/test.yaml
+++ b/test/tests/operators/serve_zmq/test.yaml
@@ -1,3 +1,0 @@
-timeout: 60
-skip:
-  on: fixture-unavailable

--- a/test/tests/operators/to_zmq/plain_write_json.tql
+++ b/test/tests/operators/to_zmq/plain_write_json.tql
@@ -3,6 +3,8 @@ fixtures:
   - zmq:
       role: subscriber
       mode: bind
+skip:
+  on: fixture-unavailable
 assertions:
   fixtures:
     zmq:

--- a/test/tests/operators/to_zmq/plain_write_json.tql
+++ b/test/tests/operators/to_zmq/plain_write_json.tql
@@ -1,0 +1,16 @@
+---
+fixtures:
+  - zmq:
+      role: subscriber
+      mode: bind
+assertions:
+  fixtures:
+    zmq:
+      received_contains: '"line":"hello-from-to_zmq"'
+timeout: 60
+---
+
+from {
+  line: "hello-from-to_zmq",
+}
+to_zmq env("ZMQ_ENDPOINT"), encoding="json"

--- a/test/tests/operators/to_zmq/plain_write_json.tql
+++ b/test/tests/operators/to_zmq/plain_write_json.tql
@@ -12,5 +12,32 @@ timeout: 60
 
 from {
   line: "hello-from-to_zmq",
+},
+{
+  line: "hello-from-to_zmq",
+},
+{
+  line: "hello-from-to_zmq",
+},
+{
+  line: "hello-from-to_zmq",
+},
+{
+  line: "hello-from-to_zmq",
+},
+{
+  line: "hello-from-to_zmq",
+},
+{
+  line: "hello-from-to_zmq",
+},
+{
+  line: "hello-from-to_zmq",
+},
+{
+  line: "hello-from-to_zmq",
+},
+{
+  line: "hello-from-to_zmq",
 }
-to_zmq env("ZMQ_ENDPOINT"), encoding="json"
+to_zmq env("ZMQ_ENDPOINT"), encoding="json", monitor=true

--- a/test/tests/operators/to_zmq/plain_write_json.tql
+++ b/test/tests/operators/to_zmq/plain_write_json.tql
@@ -8,7 +8,7 @@ skip:
 assertions:
   fixtures:
     zmq:
-      received_contains: '"line":"hello-from-to_zmq"'
+      received_contains: "{\n  \"line\": \"hello-from-to_zmq\"\n}"
 timeout: 60
 ---
 

--- a/test/tests/operators/to_zmq/prefix_from_field.tql
+++ b/test/tests/operators/to_zmq/prefix_from_field.tql
@@ -1,0 +1,17 @@
+---
+fixtures:
+  - zmq:
+      role: subscriber
+      mode: bind
+assertions:
+  fixtures:
+    zmq:
+      received_contains: 'alerts/{"channel":"alerts/","line":"hello-from-to_zmq-prefix"}'
+timeout: 60
+---
+
+from {
+  channel: "alerts/",
+  line: "hello-from-to_zmq-prefix",
+}
+to_zmq env("ZMQ_ENDPOINT"), encoding="json", prefix=channel

--- a/test/tests/operators/to_zmq/prefix_from_field.tql
+++ b/test/tests/operators/to_zmq/prefix_from_field.tql
@@ -8,7 +8,7 @@ skip:
 assertions:
   fixtures:
     zmq:
-      received_contains: 'alerts/{"channel":"alerts/","line":"hello-from-to_zmq-prefix"}'
+      received_contains: "alerts/{\n  \"channel\": \"alerts/\",\n  \"line\": \"hello-from-to_zmq-prefix\"\n}"
 timeout: 60
 ---
 

--- a/test/tests/operators/to_zmq/prefix_from_field.tql
+++ b/test/tests/operators/to_zmq/prefix_from_field.tql
@@ -3,6 +3,8 @@ fixtures:
   - zmq:
       role: subscriber
       mode: bind
+skip:
+  on: fixture-unavailable
 assertions:
   fixtures:
     zmq:

--- a/test/tests/operators/to_zmq/prefix_from_field.tql
+++ b/test/tests/operators/to_zmq/prefix_from_field.tql
@@ -13,5 +13,13 @@ timeout: 60
 from {
   channel: "alerts/",
   line: "hello-from-to_zmq-prefix",
+},
+{
+  channel: "alerts/",
+  line: "hello-from-to_zmq-prefix",
+},
+{
+  channel: "alerts/",
+  line: "hello-from-to_zmq-prefix",
 }
-to_zmq env("ZMQ_ENDPOINT"), encoding="json", prefix=channel
+to_zmq env("ZMQ_ENDPOINT"), encoding="json", prefix=channel, monitor=true

--- a/test/tests/operators/to_zmq/test.yaml
+++ b/test/tests/operators/to_zmq/test.yaml
@@ -1,0 +1,3 @@
+timeout: 60
+skip:
+  on: fixture-unavailable

--- a/test/tests/operators/to_zmq/test.yaml
+++ b/test/tests/operators/to_zmq/test.yaml
@@ -1,3 +1,0 @@
-timeout: 60
-skip:
-  on: fixture-unavailable

--- a/test/tests/operators/to_zmq/validation/error_encoding_invalid.tql
+++ b/test/tests/operators/to_zmq/validation/error_encoding_invalid.tql
@@ -1,0 +1,1 @@
+to_zmq "127.0.0.1:31337", encoding="csv"

--- a/test/tests/operators/to_zmq/validation/error_encoding_invalid.tql
+++ b/test/tests/operators/to_zmq/validation/error_encoding_invalid.tql
@@ -1,1 +1,5 @@
+---
+error: true
+---
+
 to_zmq "127.0.0.1:31337", encoding="csv"

--- a/test/tests/operators/to_zmq/validation/error_encoding_invalid.txt
+++ b/test/tests/operators/to_zmq/validation/error_encoding_invalid.txt
@@ -1,0 +1,6 @@
+error: unsupported encoding `csv`
+ --> tests/operators/to_zmq/validation/error_encoding_invalid.tql:1:36
+  |
+1 | to_zmq "127.0.0.1:31337", encoding="csv"
+  |                                    ^^^^^
+  |

--- a/test/tests/operators/to_zmq/validation/error_encoding_invalid.txt
+++ b/test/tests/operators/to_zmq/validation/error_encoding_invalid.txt
@@ -1,6 +1,6 @@
 error: unsupported encoding `csv`
- --> tests/operators/to_zmq/validation/error_encoding_invalid.tql:1:36
+ --> tests/operators/to_zmq/validation/error_encoding_invalid.tql:5:36
   |
-1 | to_zmq "127.0.0.1:31337", encoding="csv"
-  |                                    ^^^^^
+5 | to_zmq "127.0.0.1:31337", encoding="csv"
+  |                                    ^^^^^ 
   |

--- a/test/tests/operators/to_zmq/validation/error_monitor_non_tcp.tql
+++ b/test/tests/operators/to_zmq/validation/error_monitor_non_tcp.tql
@@ -1,1 +1,5 @@
+---
+error: true
+---
+
 to_zmq "inproc://test", encoding="json", monitor=true

--- a/test/tests/operators/to_zmq/validation/error_monitor_non_tcp.tql
+++ b/test/tests/operators/to_zmq/validation/error_monitor_non_tcp.tql
@@ -1,0 +1,1 @@
+to_zmq "inproc://test", encoding="json", monitor=true

--- a/test/tests/operators/to_zmq/validation/error_monitor_non_tcp.txt
+++ b/test/tests/operators/to_zmq/validation/error_monitor_non_tcp.txt
@@ -1,0 +1,6 @@
+error: `monitor` requires a TCP endpoint
+ --> tests/operators/to_zmq/validation/error_monitor_non_tcp.tql:1:43
+  |
+1 | to_zmq "inproc://test", encoding="json", monitor=true
+  |                                           ^^^^^^^^^^^^
+  |

--- a/test/tests/operators/to_zmq/validation/error_monitor_non_tcp.txt
+++ b/test/tests/operators/to_zmq/validation/error_monitor_non_tcp.txt
@@ -1,6 +1,6 @@
 error: `monitor` requires a TCP endpoint
- --> tests/operators/to_zmq/validation/error_monitor_non_tcp.tql:1:43
+ --> tests/operators/to_zmq/validation/error_monitor_non_tcp.tql:5:50
   |
-1 | to_zmq "inproc://test", encoding="json", monitor=true
-  |                                           ^^^^^^^^^^^^
+5 | to_zmq "inproc://test", encoding="json", monitor=true
+  |                                                  ^^^^ 
   |


### PR DESCRIPTION
## 🔍 Problem

The ZeroMQ plugin only had the legacy `load_zmq` and `save_zmq` operators, which are byte-oriented and tied to the legacy executor. For the new executor, we need event-oriented operators that model ZeroMQ PUB/SUB usage without treating ZeroMQ topics as a first-class protocol concept.

## 🛠️ Solution

- Add neo-only `from_zmq` / `accept_zmq` sources that consume ZeroMQ messages and parse each message with a nested `read_*` pipeline.
- Add neo-only `to_zmq` / `serve_zmq` sinks that publish one event per ZeroMQ message with `encoding="json"` or `encoding="ndjson"`.
- Support raw `prefix` filtering on reads, optional prefix stripping via `keep_prefix`, dynamic write-side prefixes, and publisher-side `monitor=true`.
- Add ZeroMQ integration fixtures and tests, including Nix wiring for `pyzmq`.

Note: this PR targets `main` because the implementation branch is based on `main`. Targeting `topic/new-executor` currently pulls in unrelated branch history.

## 💬 Review

- Check the read-side message-boundary behavior: every ZeroMQ message runs through its own parser subpipeline.
- Check the write-side invariant: every input event becomes one ZeroMQ message.
- Check the PUB/SUB startup synchronization in the fixture and publisher-side `monitor` behavior.

## Documentation PR

- https://github.com/tenzir/docs/pull/256

Closes TNZ-67.
Closes TNZ-68.