### PR TITLE
Add `accept_http` operator alias for the old executor

### DIFF
--- a/changelog/unreleased/add-accept-http-operator.md
+++ b/changelog/unreleased/add-accept-http-operator.md
@@ -1,0 +1,14 @@
+---
+title: Add `accept_http` operator for receiving HTTP requests
+type: change
+authors:
+  - lava
+created: 2026-04-15T00:00:00.000000Z
+---
+
+We added a new operator to accept data from incoming HTTP connections.
+
+The `server` option of the `from_http` operator is now deprecated.
+Going forward, it should only be used for client-mode HTTP operations,
+and the new `accept_http` operator should be used for server-mode
+operations.

--- a/libtenzir/builtins/operators/http.cpp
+++ b/libtenzir/builtins/operators/http.cpp
@@ -1804,6 +1804,12 @@ struct from_http final : public virtual operator_factory_plugin {
     TRY(args.paginate, validate_paginate(std::move(args.paginate_expr), ctx));
     TRY(args.validate(ctx));
     warn_deprecated_payload(inv, ctx);
+    if (args.server) {
+      diagnostic::warning("`server` option is deprecated")
+        .primary(*args.server)
+        .hint("use `accept_http` instead of `from_http server=true`")
+        .emit(ctx);
+    }
     // Check if the subpipeline is a sink
     bool subpipeline_is_sink = false;
     if (args.parse) {
@@ -1838,6 +1844,62 @@ struct from_http final : public virtual operator_factory_plugin {
   auto load_properties() const -> load_properties_t override {
     return {
       .schemes = {"http", "https"},
+      .default_format = plugins::find<operator_factory_plugin>("read_json"),
+      .accepts_pipeline = true,
+      .events = true,
+    };
+  }
+};
+
+struct accept_http final : public virtual operator_factory_plugin {
+  auto name() const -> std::string override {
+    return "tql2.accept_http";
+  }
+
+  auto make(operator_factory_invocation inv, session ctx) const
+    -> failure_or<operator_ptr> override {
+    auto args = from_http_args{};
+    args.op = inv.self.get_location();
+    auto p = argument_parser2::operator_(name());
+    // Register only server-relevant arguments. The `server` flag itself is
+    // not exposed because `accept_http` implies server mode.
+    p.positional("url", args.url);
+    p.named("metadata_field", args.metadata_field);
+    p.named("responses", args.responses);
+    p.named("max_request_size", args.max_request_size);
+    p.named("max_connections", args.max_connections);
+    args.ssl.add_tls_options(p);
+    p.positional("{ … }", args.parse);
+    TRY(p.parse(inv, ctx));
+    // Force server mode.
+    args.server = inv.self.get_location();
+    TRY(args.validate(ctx));
+    // Check if the subpipeline is a sink
+    bool subpipeline_is_sink = false;
+    if (args.parse) {
+      auto ty = args.parse->inner.infer_type(tag_v<chunk_ptr>);
+      if (ty and ty->is<void>()) {
+        subpipeline_is_sink = true;
+      }
+    }
+    auto op = operator_ptr{};
+    op = std::make_unique<from_http_server_operator>(std::move(args));
+    if (subpipeline_is_sink) {
+      auto pipe = std::make_unique<pipeline>();
+      pipe->append(std::move(op));
+      const auto* discard_plugin
+        = plugins::find<operator_factory_plugin>("discard");
+      TENZIR_ASSERT(discard_plugin);
+      TRY(auto discard_op, discard_plugin->make({inv.self, {}}, ctx));
+      pipe->append(std::move(discard_op));
+      return pipe;
+    }
+    return op;
+  }
+
+  auto load_properties() const -> load_properties_t override {
+    return {
+      .schemes = {},
       .default_format = plugins::find<operator_factory_plugin>("read_json"),
       .accepts_pipeline = true,
       .events = true,
@@ -2588,6 +2650,7 @@ using from_http_server = operator_inspection_plugin<from_http_server_operator>;
 } // namespace tenzir::plugins::http
 
 TENZIR_REGISTER_PLUGIN(tenzir::plugins::http::from_http)
+TENZIR_REGISTER_PLUGIN(tenzir::plugins::http::accept_http)
 TENZIR_REGISTER_PLUGIN(tenzir::plugins::http::from_http_client)
 TENZIR_REGISTER_PLUGIN(tenzir::plugins::http::from_http_server)
 TENZIR_REGISTER_PLUGIN(tenzir::plugins::http::http_plugin)


### PR DESCRIPTION
## Description

This change introduces a new `accept_http` operator that serves as a dedicated replacement for the server mode of `from_http` in the old executor. A new deprecation warning pushes users away from the `server` option.

This allows users to gradually make the switch from old to new executor, by having a pipeline that works in both modes before making the update.

https://claude.ai/code/session_01Wf7mLACddTNJPwfKTfR5yF