### PR TITLE
TNZ-495: Add `$file` let-binding to `ArrowFsOperator` subpipelines

### DIFF
--- a/libtenzir/include/tenzir/arrow_fs.hpp
+++ b/libtenzir/include/tenzir/arrow_fs.hpp
@@ -13,6 +13,7 @@
 #include "tenzir/glob.hpp"
 #include "tenzir/hash/hash.hpp"
 #include "tenzir/ir.hpp"
+#include "tenzir/let_id.hpp"
 #include "tenzir/operator_plugin.hpp"
 #include "tenzir/secret.hpp"
 #include "tenzir/tql2/ast.hpp"
@@ -40,6 +41,7 @@ struct ArrowFsArgs {
   Option<ast::lambda_expr> rename;
   Option<duration> max_age;
   located<ir::pipeline> pipe;
+  let_id file_info;
 
   /// Registers the common ArrowFsArgs fields on a Describer.
   template <class Args, class... Impls>
@@ -52,7 +54,8 @@ struct ArrowFsArgs {
       = d.template named<ast::lambda_expr>("rename", &ArrowFsArgs::rename);
     auto max_age_arg
       = d.template named<duration>("max_age", &ArrowFsArgs::max_age);
-    auto pipe_arg = d.pipeline(&ArrowFsArgs::pipe);
+    auto pipe_arg
+      = d.pipeline(&ArrowFsArgs::pipe, {{"file", &ArrowFsArgs::file_info}});
     d.validate([=](DescribeCtx& ctx) -> Empty {
       auto remove_loc = ctx.get_location(remove_arg);
       auto rename_loc = ctx.get_location(rename_arg);
@@ -95,7 +98,8 @@ struct ArrowFsArgs {
       = d.template named<ast::lambda_expr>("rename", &ArrowFsArgs::rename);
     auto max_age_arg
       = d.template named<duration>("max_age", &ArrowFsArgs::max_age);
-    auto pipe_arg = d.pipeline(&ArrowFsArgs::pipe);
+    auto pipe_arg
+      = d.pipeline(&ArrowFsArgs::pipe, {{"file", &ArrowFsArgs::file_info}});
     d.validate([=](DescribeCtx& ctx) -> Empty {
       auto remove_loc = ctx.get_location(remove_arg);
       auto rename_loc = ctx.get_location(rename_arg);
@@ -152,7 +156,7 @@ inline auto arrow_future_to_task(arrow::Future<arrow::internal::Empty> future)
 /// Persisted state for a file that is pending or being actively processed.
 struct TrackedFile {
   std::string path;
-  int64_t mtime_ns = 0;
+  Option<time> mtime;
   int64_t offset = 0;
   uint64_t job_id = 0;
   std::shared_ptr<arrow::io::RandomAccessFile> file;
@@ -160,7 +164,7 @@ struct TrackedFile {
   friend auto inspect(auto& f, TrackedFile& x) -> bool {
     return f.object(x).fields(f.field("path", x.path),
                               f.field("offset", x.offset),
-                              f.field("mtime_ns", x.mtime_ns),
+                              f.field("mtime", x.mtime),
                               f.field("job_id", x.job_id));
   }
 };
@@ -195,17 +199,26 @@ using FileSystemPtr = std::shared_ptr<arrow::fs::FileSystem>;
 auto split_at_first_slash(std::string_view path)
   -> std::pair<std::string, std::string>;
 
+/// Converts an Arrow filesystem TimePoint to an Option<time>.
+/// Returns None for Arrow's kNoTime sentinel.
+inline auto to_option_time(arrow::fs::TimePoint tp) -> Option<time> {
+  if (tp == arrow::fs::kNoTime) {
+    return {};
+  }
+  return tp;
+}
+
 /// Serializable representation of a previously seen file.
 struct SeenFile {
   std::string path;
-  int64_t mtime_ns = 0;
+  Option<time> mtime;
   int64_t size = 0;
 
   SeenFile() = default;
 
   SeenFile(arrow::fs::FileInfo const& file)
     : path{file.path()},
-      mtime_ns{file.mtime().time_since_epoch().count()},
+      mtime{to_option_time(file.mtime())},
       size{file.size()} {
   }
 
@@ -213,14 +226,14 @@ struct SeenFile {
 
   friend auto inspect(auto& f, SeenFile& x) -> bool {
     return f.object(x).fields(f.field("path", x.path),
-                              f.field("mtime_ns", x.mtime_ns),
+                              f.field("mtime", x.mtime),
                               f.field("size", x.size));
   }
 };
 
 struct SeenFileHasher {
   auto operator()(SeenFile const& file) const -> size_t {
-    return hash(file.path, file.mtime_ns, file.size);
+    return hash(file.path, data{file.mtime}, file.size);
   }
 };
 

--- a/libtenzir/include/tenzir/data.hpp
+++ b/libtenzir/include/tenzir/data.hpp
@@ -16,6 +16,7 @@
 #include "tenzir/defaults.hpp"
 #include "tenzir/detail/debug_writer.hpp"
 #include "tenzir/detail/operators.hpp"
+#include "tenzir/option.hpp"
 #include "tenzir/detail/string.hpp"
 #include "tenzir/detail/type_list.hpp"
 #include "tenzir/detail/type_traits.hpp"
@@ -138,6 +139,14 @@ public:
   /// @param x The optional data instance.
   template <class T>
   data(std::optional<T> x) : data{x ? std::move(*x) : data{}} {
+    // nop
+  }
+
+  /// Constructs data from an Option, mapping None to null.
+  template <class T>
+    requires(!std::is_reference_v<T>
+             && !std::same_as<to_data_type<T>, detail::invalid_data_type>)
+  data(Option<T> x) : data{x ? data{std::move(*x)} : data{}} {
     // nop
   }
 

--- a/libtenzir/src/arrow_fs.cpp
+++ b/libtenzir/src/arrow_fs.cpp
@@ -15,6 +15,7 @@
 #include "tenzir/detail/enumerate.hpp"
 #include "tenzir/diagnostics.hpp"
 #include "tenzir/glob.hpp"
+#include "tenzir/substitute_ctx.hpp"
 #include "tenzir/tql2/eval.hpp"
 
 #include <arrow/filesystem/filesystem.h>
@@ -98,7 +99,7 @@ auto ArrowFsOperator::process_task(Any result, Push<table_slice>&, OpCtx& ctx)
         }
         pending_.push_back(TrackedFile{
           .path = file.path(),
-          .mtime_ns = file.mtime().time_since_epoch().count(),
+          .mtime = to_option_time(file.mtime()),
           .file = nullptr,
         });
       }
@@ -134,7 +135,23 @@ auto ArrowFsOperator::process_task(Any result, Push<table_slice>&, OpCtx& ctx)
         co_return;
       }
       file_state.file = open.file.MoveValueUnsafe();
-      co_await ctx.spawn_sub<chunk_ptr>(open.job_id, base_args_.pipe.inner);
+      auto pipe = base_args_.pipe.inner;
+      auto env = substitute_ctx::env_t{
+        {
+          base_args_.file_info,
+          record{
+            {"path", file_state.path},
+            {"mtime", file_state.mtime},
+          },
+        },
+      };
+      auto sub_result = pipe.substitute({ctx, &env}, true);
+      if (not sub_result) {
+        processing_[*slot].reset();
+        start_job_in_slot(*slot, ctx);
+        co_return;
+      }
+      co_await ctx.spawn_sub<chunk_ptr>(open.job_id, std::move(pipe));
       // Queue the first read.
       enqueue_task(
         ctx,
@@ -326,20 +343,20 @@ auto ArrowFsOperator::restore(OpCtx& ctx) -> Task<void> {
       continue;
     }
     auto& file_info = info[0];
-    auto file_mtime_ns = file_info.mtime().time_since_epoch().count();
-    if (file_mtime_ns != state.mtime_ns) {
+    auto file_mtime = to_option_time(file_info.mtime());
+    if (file_mtime != state.mtime) {
       diagnostic::warning("file `{}` was modified since last checkpoint",
                           state.path)
         .primary(base_args_.url)
         .emit(ctx);
       if (state.offset < file_info.size()) {
         // Assume the file was appended to.
-        state.mtime_ns = file_mtime_ns;
+        state.mtime = file_mtime;
       } else {
         if (base_args_.watch) {
           pending_.push_back(TrackedFile{
             .path = state.path,
-            .mtime_ns = file_mtime_ns,
+            .mtime = file_mtime,
             .file = nullptr,
           });
         }
@@ -484,14 +501,13 @@ auto ArrowFsOperator::start_job_in_slot(size_t slot, OpCtx& ctx) -> void {
   processing_[slot] = std::move(pending_.front());
   processing_[slot]->job_id = ++next_job_id_;
   pending_.pop_front();
-  enqueue_task(
-    ctx,
-    [this, job_id = processing_[slot]->job_id,
-     path = processing_[slot]->path] mutable -> Task<AwaitResult> {
-      auto result
-        = co_await arrow_future_to_task(fs_->OpenInputFileAsync(path));
-      co_return FileOpen{job_id, std::move(result)};
-    });
+  enqueue_task(ctx,
+               [this, job_id = processing_[slot]->job_id,
+                path = processing_[slot]->path] mutable -> Task<AwaitResult> {
+                 auto result = co_await arrow_future_to_task(
+                   fs_->OpenInputFileAsync(path));
+                 co_return FileOpen{job_id, std::move(result)};
+               });
 }
 
 auto ArrowFsOperator::find_free_slot() const -> Option<size_t> {
@@ -503,7 +519,8 @@ auto ArrowFsOperator::find_free_slot() const -> Option<size_t> {
   return std::nullopt;
 }
 
-auto ArrowFsOperator::find_slot_by_job(uint64_t job_id) const -> Option<size_t> {
+auto ArrowFsOperator::find_slot_by_job(uint64_t job_id) const
+  -> Option<size_t> {
   for (auto i = size_t{0}; i < max_jobs; ++i) {
     if (processing_[i] and processing_[i]->job_id == job_id) {
       return i;

--- a/libtenzir/src/compile_ctx.cpp
+++ b/libtenzir/src/compile_ctx.cpp
@@ -49,8 +49,7 @@ auto compile_ctx::scope::let(std::string name) & -> let_id {
   TENZIR_ASSERT(env_);
   root_.last_let_id_ += 1;
   auto id = let_id{root_.last_let_id_};
-  auto inserted = env_->try_emplace(std::move(name), id).second;
-  TENZIR_ASSERT(inserted);
+  env_->insert_or_assign(std::move(name), id);
   return id;
 }
 

--- a/test/fixtures/local_files.py
+++ b/test/fixtures/local_files.py
@@ -108,7 +108,9 @@ def _verify_post_test(root: Path, assertions: LocalFilesAssertions) -> None:
 @fixture(assertions=LocalFilesAssertions)
 def local_files() -> FixtureHandle:
     """Create temporary test files and return fixture handle with assertions."""
-    root = Path(tempfile.mkdtemp(prefix="tenzir-test-local-files-"))
+    # Resolve symlinks so that FILE_ROOT matches the canonical paths returned
+    # by the Arrow filesystem. On macOS, /tmp is a symlink to /private/tmp.
+    root = Path(tempfile.mkdtemp(prefix="tenzir-test-local-files-")).resolve()
 
     try:
         _setup_files(root)

--- a/test/tests/operators/from_file/let_mtime.tql
+++ b/test/tests/operators/from_file/let_mtime.tql
@@ -1,0 +1,5 @@
+from_file env("FILE_ROOT") + "/single/data.json" {
+  read_json
+  has_mtime = $file.mtime != null
+}
+select has_mtime

--- a/test/tests/operators/from_file/let_mtime.txt
+++ b/test/tests/operators/from_file/let_mtime.txt
@@ -1,0 +1,3 @@
+{
+  has_mtime: true,
+}

--- a/test/tests/operators/from_file/let_path.tql
+++ b/test/tests/operators/from_file/let_path.tql
@@ -1,0 +1,6 @@
+from_file env("FILE_ROOT") + "/single/data.json" {
+  read_json
+  source_path = $file.path
+}
+select source_path
+source_path = source_path.replace(env("FILE_ROOT"), "<ROOT>")

--- a/test/tests/operators/from_file/let_path.txt
+++ b/test/tests/operators/from_file/let_path.txt
@@ -1,0 +1,3 @@
+{
+  source_path: "<ROOT>/single/data.json",
+}

--- a/test/tests/operators/from_file/let_path_glob.tql
+++ b/test/tests/operators/from_file/let_path_glob.tql
@@ -1,0 +1,7 @@
+from_file env("FILE_ROOT") + "/multi/*.json" {
+  read_json
+  source_path = $file.path
+}
+select source_path
+source_path = source_path.replace(env("FILE_ROOT"), "<ROOT>")
+sort source_path

--- a/test/tests/operators/from_file/let_path_glob.txt
+++ b/test/tests/operators/from_file/let_path_glob.txt
@@ -1,0 +1,6 @@
+{
+  source_path: "<ROOT>/multi/data-001.json",
+}
+{
+  source_path: "<ROOT>/multi/data-002.json",
+}

--- a/test/tests/operators/from_file/let_redefine.tql
+++ b/test/tests/operators/from_file/let_redefine.tql
@@ -1,0 +1,5 @@
+let $file = "shadowed"
+from_file env("FILE_ROOT") + "/single/data.json" {
+  let $file = "redefined"
+  read_json
+}

--- a/test/tests/operators/from_file/let_redefine.txt
+++ b/test/tests/operators/from_file/let_redefine.txt
@@ -1,0 +1,3 @@
+{
+  filename: "single/data.json",
+}


### PR DESCRIPTION
Subpipelines spawned by `ArrowFsOperator` now receive a `$file`
record with `path` (`string`) and `mtime` (`time` or `null`).

Replaces raw `int64_t mtime_ns` in `TrackedFile` and `SeenFile` with
`Option<time>`. Adds a constrained `data(Option<T>)` constructor.