### PR TITLE
Fix Arc with incomplete inner types

### DIFF
--- a/libtenzir/include/tenzir/arc.hpp
+++ b/libtenzir/include/tenzir/arc.hpp
@@ -62,9 +62,9 @@ public:
   /// Constructs an arc by converting `U` into `T`. This is not selected for
   /// types that are pointer-convertible to prevent slicing.
   template <class U>
-    requires(not std::convertible_to<std::shared_ptr<U>, std::shared_ptr<T>>)
+    requires(not detail::is_arc_v<std::remove_cvref_t<U>>)
+            and (not std::convertible_to<std::shared_ptr<U>, std::shared_ptr<T>>)
             and std::constructible_from<T, U>
-            and (not detail::is_arc_v<std::remove_cvref_t<U>>)
   explicit(false) Arc(U x) : ptr_{std::make_shared<T>(std::move(x))} {
   }
 


### PR DESCRIPTION
## 🔍 Problem

- `cmake --build --preset macos-xcode-release` failed in `Subprocess`
  because `Arc` evaluated converting-constructor constraints for `Arc`
  inputs.
- That instantiated `std::constructible_from<T, U>` for incomplete inner
  types such as `Subprocess::SharedState` and caused hard compile errors.

## 🛠️ Solution

- Reorder the converting-constructor constraints in `Arc` to reject `Arc`
  inputs before checking `std::constructible_from<T, U>`.
- This keeps copy and move construction on the dedicated `Arc` overloads
  and avoids constraint instantiation on incomplete types.
- Verified with `cmake --build --preset macos-xcode-release`.

## 💬 Review

- Focus on whether the constraint ordering is the right minimal fix for
  incomplete inner types.
- No user-facing behavior changes; I did not add a changelog entry.
