### PR TITLE
Use `raw=true` in Route53 benchmark

### DIFF
--- a/bench/benchmarks/from_file_route53_ocsf/bench.yaml
+++ b/bench/benchmarks/from_file_route53_ocsf/bench.yaml
@@ -10,7 +10,7 @@ tags:
 inputs:
   main:
     path: cloudwatch/route53.ndjson
-    repetitions: 10
+    repetitions: 30
     source:
       url: https://datasets.tenzir.tools/CloudWatch/route53.ndjson
       num_events: 2586

--- a/bench/benchmarks/from_file_route53_ocsf/legacy.tql
+++ b/bench/benchmarks/from_file_route53_ocsf/legacy.tql
@@ -5,7 +5,7 @@ bench:
   min_version: "5.20.0"
 ---
 from_file env("BENCHMARK_INPUT_PATH") {
-  read_ndjson
+  read_ndjson raw=true
 }
 
 let $rcode_id = {

--- a/bench/benchmarks/from_file_route53_ocsf/neo.tql
+++ b/bench/benchmarks/from_file_route53_ocsf/neo.tql
@@ -7,7 +7,7 @@ bench:
     - --neo
 ---
 from_file env("BENCHMARK_INPUT_PATH") {
-  read_ndjson
+  read_ndjson raw=true
 }
 
 let $rcode_id = {


### PR DESCRIPTION
Due to the testing data mixing both IPs and strings, we otherwise run into a bad edge case for both neo and legacy executor where way too many batches are emitted. The difference in runtime is mostly because the legacy executor contains an additional rebatching pass. However, this just hides a problem that is already caused upstream. By using `raw=true`, we get proper batching, which makes this a more fair comparison.