### PR TITLE
Fix allocator unused-variable warnings

### DIFF
--- a/libtenzir/include/tenzir/allocator.hpp
+++ b/libtenzir/include/tenzir/allocator.hpp
@@ -457,14 +457,16 @@ public:
 
   auto note_reallocation(const detail::allocation_tag& tag,
                          std::int64_t old_size, std::int64_t new_size) -> void {
-    const auto success = try_note_impl(tag, &stats::note_reallocation, false,
-                                       old_size, new_size);
+    [[maybe_unused]] auto success
+      = try_note_impl(tag, &stats::note_reallocation, false, old_size,
+                      new_size);
     TENZIR_ALLOCATOR_ASSERT(success and "unexpected unknown reallocation");
   }
 
   auto note_deallocation(const detail::allocation_tag& tag, std::int64_t size)
     -> void {
-    const auto success = try_note_impl(tag, &stats::note_deallocation, size);
+    [[maybe_unused]] auto success
+      = try_note_impl(tag, &stats::note_deallocation, size);
     TENZIR_ALLOCATOR_ASSERT(success and "unexpected unknown deallocation");
   }
 

--- a/libtenzir/src/async/executor.cpp
+++ b/libtenzir/src/async/executor.cpp
@@ -823,8 +823,9 @@ private:
 
   auto io_executor() -> folly::Executor::KeepAlive<folly::IOExecutor> override {
     if (not io_executor_) {
+      auto& op = base_op();
       io_executor_
-        = exec_ctx_.make_io_executor(id_, demangle_op_type(typeid(base_op())));
+        = exec_ctx_.make_io_executor(id_, demangle_op_type(typeid(op)));
     }
     return io_executor_;
   }


### PR DESCRIPTION
## 🔍 Problem
- Release builds emit `-Wunused-variable` warnings in `allocator.hpp`.
- The variables are only used by allocator assertions, which compile out when assertions are disabled.

## 🛠️ Solution
- Mark the assertion-only `success` locals as `[[maybe_unused]]`.
- Preserve the existing assertion checks in assertion-enabled builds.

## 💬 Review
- Focus on whether `[[maybe_unused]]` is the right fix for this warning pattern.
- No changelog entry: this is internal warning cleanup with no user-facing impact.