### PR TITLE
Port catalog inspection to new executor

### DIFF
--- a/libtenzir/builtins/operators/fields.cpp
+++ b/libtenzir/builtins/operators/fields.cpp
@@ -7,10 +7,12 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include <tenzir/argument_parser.hpp>
+#include <tenzir/async/fetch_node.hpp>
+#include <tenzir/async/mail.hpp>
 #include <tenzir/catalog.hpp>
+#include <tenzir/operator_plugin.hpp>
 #include <tenzir/pipeline.hpp>
 #include <tenzir/plugin.hpp>
-#include <tenzir/series_builder.hpp>
 #include <tenzir/tql2/plugin.hpp>
 
 #include <caf/actor_registry.hpp>
@@ -18,138 +20,6 @@
 namespace tenzir::plugins::fields {
 
 namespace {
-
-auto field_type() -> type {
-  return type{
-    "tenzir.field",
-    record_type{
-      {"schema", string_type{}},
-      {"schema_id", string_type{}},
-      {"field", string_type{}},
-      {"path", list_type{string_type{}}},
-      {"index", list_type{uint64_type{}}},
-      {"type",
-       record_type{
-         {"kind", string_type{}},
-         {"category", string_type{}},
-         {"lists", uint64_type()},
-         {"name", string_type{}},
-         {"attributes", list_type{record_type{
-                          {"key", string_type{}},
-                          {"value", string_type{}},
-                        }}},
-       }},
-    },
-  };
-}
-
-struct field_context {
-  std::string name{};
-  std::vector<std::string> path{};
-  offset index{};
-};
-
-struct type_context {
-  type_kind kind{};
-  std::string category;
-  size_t lists{0};
-  std::string name{};
-  std::vector<std::pair<std::string, std::string>> attributes{};
-};
-
-struct schema_context {
-  field_context field;
-  type_context type;
-};
-
-/// Yields all fields from a record type, with listness being a separate
-/// attribute.
-auto traverse(type t) -> generator<schema_context> {
-  schema_context result;
-  // Unpack lists. Note that we lose type metadata of lists.
-  while (const auto* list = try_as<list_type>(&t)) {
-    ++result.type.lists;
-    t = list->value_type();
-  }
-  result.type.name = t.name();
-  for (auto [key, value] : t.attributes()) {
-    result.type.attributes.emplace_back(key, value);
-  }
-  result.type.kind = t.kind();
-  // TODO: This categorization is somewhat arbitrary, and we probably want to
-  // think about this more.
-  if (result.type.kind.is<record_type>()) {
-    result.type.category = "container";
-  } else {
-    result.type.category = "atomic";
-  }
-  TENZIR_ASSERT(not is<list_type>(t));
-  TENZIR_ASSERT(not is<map_type>(t));
-  if (const auto* record = try_as<record_type>(&t)) {
-    auto i = size_t{0};
-    for (const auto& field : record->fields()) {
-      result.field.name = field.name;
-      result.field.path.emplace_back(field.name);
-      result.field.index.emplace_back(i);
-      for (const auto& inner : traverse(field.type)) {
-        result.type = inner.type;
-        auto nested = not inner.field.name.empty();
-        if (nested) {
-          result.field.name = inner.field.name;
-          for (const auto& p : inner.field.path) {
-            result.field.path.push_back(p);
-          }
-          for (const auto& i : inner.field.index) {
-            result.field.index.push_back(i);
-          }
-        }
-        co_yield result;
-        if (nested) {
-          auto delta = inner.field.path.size();
-          result.field.path.resize(result.field.path.size() - delta);
-          delta = inner.field.index.size();
-          result.field.index.resize(result.field.index.size() - delta);
-        }
-      }
-      result.field.index.pop_back();
-      result.field.path.pop_back();
-      ++i;
-    }
-  } else {
-    co_yield result;
-  }
-}
-
-// TODO: this feels like it should be a generic function that works on any
-// inspectable type.
-/// Adds a schema (= named record type) to a builder, with one row per field.
-auto add_field(builder_ref builder, const type& t) {
-  for (const auto& ctx : traverse(t)) {
-    auto row = builder.record();
-    row.field("schema").data(t.name());
-    row.field("schema_id").data(t.make_fingerprint());
-    row.field("field").data(ctx.field.name);
-    auto path = row.field("path").list();
-    for (const auto& p : ctx.field.path) {
-      path.data(p);
-    }
-    auto index = row.field("index").list();
-    for (auto i : ctx.field.index) {
-      index.data(uint64_t{i});
-    }
-    auto type = row.field("type").record();
-    type.field("kind").data(to_string(ctx.type.kind));
-    type.field("category").data(ctx.type.category);
-    type.field("lists").data(ctx.type.lists);
-    type.field("name").data(ctx.type.name);
-    auto attrs = type.field("attributes").list();
-    for (const auto& [key, value] : ctx.type.attributes) {
-      auto attr = attrs.record();
-      attr.field("key").data(key);
-      attr.field("value").data(value);
-    }
-  }
-}
 
 class fields_operator final : public crtp_operator<fields_operator> {
 public:
@@ -161,30 +31,22 @@ public:
       = ctrl.self().system().registry().get<catalog_actor>("tenzir.catalog");
     TENZIR_ASSERT(catalog);
     ctrl.set_waiting(true);
-    auto synopses = std::vector<partition_synopsis_pair>{};
+    auto slices = std::vector<table_slice>{};
     ctrl.self()
-      .mail(atom::get_v)
+      .mail(atom::get_v, std::string{"fields"})
       .request(catalog, caf::infinite)
       .then(
-        [&](std::vector<partition_synopsis_pair>& result) {
-          synopses = std::move(result);
+        [&](std::vector<table_slice>& result) {
+          slices = std::move(result);
           ctrl.set_waiting(false);
         },
         [&ctrl](const caf::error& err) {
           diagnostic::error(err)
-            .note("failed to get partitions")
+            .note("failed to get fields")
             .emit(ctrl.diagnostics());
         });
     co_yield {};
-    auto fields = std::set<type>{};
-    for (const auto& synopsis : synopses) {
-      fields.insert(synopsis.synopsis->schema);
-    }
-    auto builder = series_builder{field_type()};
-    for (const auto& schema : fields) {
-      add_field(builder, schema);
-    }
-    for (auto&& slice : builder.finish_as_table_slice()) {
+    for (auto&& slice : slices) {
       co_yield std::move(slice);
     }
   }
@@ -213,8 +75,66 @@ public:
   }
 };
 
+struct FieldsArgs {
+  location operator_location = location::unknown;
+};
+
+class Fields final : public Operator<void, table_slice> {
+public:
+  explicit Fields(FieldsArgs args) : args_{std::move(args)} {
+  }
+
+  auto start(OpCtx& ctx) -> Task<void> override {
+    auto catalog_result = co_await fetch_actor_from_node<catalog_actor>(
+      "catalog", args_.operator_location, ctx.actor_system(), ctx);
+    if (not catalog_result) {
+      done_ = true;
+      co_return;
+    }
+    catalog_ = std::move(*catalog_result);
+    co_return;
+  }
+
+  auto await_task(diagnostic_handler& dh) const -> Task<Any> override {
+    TENZIR_UNUSED(dh);
+    TENZIR_ASSERT(not done_);
+    co_return co_await async_mail(atom::get_v, std::string{"fields"})
+      .request(catalog_);
+  }
+
+  auto process_task(Any result, Push<table_slice>& push, OpCtx& ctx)
+    -> Task<void> override {
+    done_ = true;
+    auto& slices_result = result.as<caf::expected<std::vector<table_slice>>>();
+    if (not slices_result) {
+      diagnostic::error(slices_result.error())
+        .primary(args_.operator_location)
+        .note("failed to get fields")
+        .emit(ctx);
+      co_return;
+    }
+    for (auto&& slice : *slices_result) {
+      co_await push(std::move(slice));
+    }
+  }
+
+  auto state() -> OperatorState override {
+    return done_ ? OperatorState::done : OperatorState::unspecified;
+  }
+
+  auto snapshot(Serde& serde) -> void override {
+    serde("done", done_);
+  }
+
+private:
+  FieldsArgs args_;
+  catalog_actor catalog_ = {};
+  bool done_ = false;
+};
+
 class plugin final : public virtual operator_plugin<fields_operator>,
-                     operator_factory_plugin {
+                     public virtual operator_factory_plugin,
+                     public virtual OperatorPlugin {
 public:
   auto signature() const -> operator_signature override {
     return {.source = true};
@@ -231,6 +151,12 @@ public:
     -> failure_or<operator_ptr> override {
     argument_parser2::operator_("fields").parse(inv, ctx).ignore();
     return std::make_unique<fields_operator>();
+  }
+
+  auto describe() const -> Description override {
+    auto d = Describer<FieldsArgs, Fields>{};
+    d.operator_location(&FieldsArgs::operator_location);
+    return d.without_optimize();
   }
 };
 

--- a/libtenzir/builtins/operators/partitions.cpp
+++ b/libtenzir/builtins/operators/partitions.cpp
@@ -8,10 +8,13 @@
 
 #include <tenzir/actors.hpp>
 #include <tenzir/argument_parser.hpp>
+#include <tenzir/async/fetch_node.hpp>
+#include <tenzir/async/mail.hpp>
 #include <tenzir/catalog.hpp>
 #include <tenzir/double_synopsis.hpp>
 #include <tenzir/duration_synopsis.hpp>
 #include <tenzir/int64_synopsis.hpp>
+#include <tenzir/operator_plugin.hpp>
 #include <tenzir/partition_synopsis.hpp>
 #include <tenzir/pipeline.hpp>
 #include <tenzir/plugin.hpp>
@@ -171,8 +174,73 @@ private:
   bool experimental_include_ranges_ = {};
 };
 
+struct PartitionsArgs {
+  Option<ast::expression> predicate;
+  location operator_location = location::unknown;
+};
+
+class Partitions final : public Operator<void, table_slice> {
+public:
+  explicit Partitions(PartitionsArgs args) : args_{std::move(args)} {
+  }
+
+  auto start(OpCtx& ctx) -> Task<void> override {
+    auto catalog_result = co_await fetch_actor_from_node<catalog_actor>(
+      "catalog", args_.operator_location, ctx.actor_system(), ctx);
+    if (not catalog_result) {
+      done_ = true;
+      co_return;
+    }
+    catalog_ = std::move(*catalog_result);
+    if (args_.predicate) {
+      auto [legacy, _] = split_legacy_expression(*args_.predicate);
+      filter_ = std::move(legacy);
+    }
+    co_return;
+  }
+
+  auto await_task(diagnostic_handler& dh) const -> Task<Any> override {
+    TENZIR_UNUSED(dh);
+    TENZIR_ASSERT(not done_);
+    co_return co_await async_mail(atom::get_v, std::string{"partitions"},
+                                  filter_)
+      .request(catalog_);
+  }
+
+  auto process_task(Any result, Push<table_slice>& push, OpCtx& ctx)
+    -> Task<void> override {
+    done_ = true;
+    auto& slices_result = result.as<caf::expected<std::vector<table_slice>>>();
+    if (not slices_result) {
+      diagnostic::error(slices_result.error())
+        .primary(args_.operator_location)
+        .note("failed to perform catalog lookup")
+        .emit(ctx);
+      co_return;
+    }
+    for (auto&& slice : *slices_result) {
+      co_await push(std::move(slice));
+    }
+  }
+
+  auto state() -> OperatorState override {
+    return done_ ? OperatorState::done : OperatorState::unspecified;
+  }
+
+  auto snapshot(Serde& serde) -> void override {
+    serde("done", done_);
+  }
+
+private:
+  PartitionsArgs args_;
+  catalog_actor catalog_ = {};
+  expression filter_ = trivially_true_expression();
+  bool done_ = false;
+};
+
 class plugin final : public virtual operator_plugin<partitions_operator>,
-                     public virtual operator_factory_plugin {
+                     public virtual operator_factory_plugin,
+                     public virtual OperatorPlugin {
 public:
   auto signature() const -> operator_signature override {
     return {
@@ -225,11 +293,40 @@ public:
       if (not expr) {
         return trivially_true_expression();
       }
-      auto [legacy, _] = split_legacy_expression(*expr);
+      auto [legacy, remainder] = split_legacy_expression(*expr);
+      if (not is_true_literal(remainder)) {
+        diagnostic::warning("`partitions` only supports the legacy subset of "
+                            "this predicate")
+          .note("the used predicate will be wider than the given one")
+          .primary(expr->get_location())
+          .emit(ctx);
+      }
       return std::move(legacy);
     }();
     return std::make_unique<partitions_operator>(
       std::move(legacy_expr), experimental_include_ranges.has_value());
+  }
+
+  auto describe() const -> Description override {
+    auto d = Describer<PartitionsArgs, Partitions>{};
+    auto predicate
+      = d.positional("predicate", &PartitionsArgs::predicate, "bool");
+    d.operator_location(&PartitionsArgs::operator_location);
+    d.validate([predicate](DescribeCtx& ctx) -> Empty {
+      if (auto expr = ctx.get(predicate)) {
+        auto [legacy, remainder] = split_legacy_expression(*expr);
+        TENZIR_UNUSED(legacy);
+        if (not is_true_literal(remainder)) {
+          diagnostic::warning("`partitions` only supports the legacy subset "
+                              "of this predicate")
+            .note("the used predicate will be wider than the given one")
+            .primary(expr->get_location())
+            .emit(ctx);
+        }
+      }
+      return {};
+    });
+    return d.without_optimize();
   }
 };
 

--- a/libtenzir/builtins/operators/schemas.cpp
+++ b/libtenzir/builtins/operators/schemas.cpp
@@ -7,10 +7,12 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include <tenzir/argument_parser.hpp>
+#include <tenzir/async/fetch_node.hpp>
+#include <tenzir/async/mail.hpp>
 #include <tenzir/catalog.hpp>
+#include <tenzir/operator_plugin.hpp>
 #include <tenzir/pipeline.hpp>
 #include <tenzir/plugin.hpp>
-#include <tenzir/series_builder.hpp>
 #include <tenzir/tql2/plugin.hpp>
 
 #include <caf/actor_registry.hpp>
@@ -29,30 +31,23 @@ public:
       = ctrl.self().system().registry().get<catalog_actor>("tenzir.catalog");
     TENZIR_ASSERT(catalog);
     ctrl.set_waiting(true);
-    auto schemas = std::unordered_set<type>{};
+    auto slices = std::vector<table_slice>{};
     ctrl.self()
-      .mail(atom::get_v)
+      .mail(atom::get_v, std::string{"schemas"})
       .request(catalog, caf::infinite)
       .then(
-        [&](std::vector<partition_synopsis_pair>& synopses) {
-          for (const auto& [id, synopsis] : synopses) {
-            TENZIR_ASSERT(synopsis);
-            TENZIR_ASSERT(synopsis->schema);
-            schemas.insert(synopsis->schema);
-          }
+        [&](std::vector<table_slice>& result) {
+          slices = std::move(result);
           ctrl.set_waiting(false);
         },
         [&ctrl](const caf::error& err) {
           diagnostic::error(err)
-            .note("failed to get partitions")
+            .note("failed to get schemas")
             .emit(ctrl.diagnostics());
         });
     co_yield {};
-    auto builder = series_builder{};
-    for (const auto& schema : schemas) {
-      builder.data(schema.to_definition());
-      co_yield builder.finish_assert_one_slice(
-        fmt::format("tenzir.schema.{}", schema.make_fingerprint()));
+    for (auto&& slice : slices) {
+      co_yield std::move(slice);
     }
   }
 
@@ -80,8 +75,66 @@ public:
   }
 };
 
+struct SchemasArgs {
+  location operator_location = location::unknown;
+};
+
+class Schemas final : public Operator<void, table_slice> {
+public:
+  explicit Schemas(SchemasArgs args) : args_{std::move(args)} {
+  }
+
+  auto start(OpCtx& ctx) -> Task<void> override {
+    auto catalog_result = co_await fetch_actor_from_node<catalog_actor>(
+      "catalog", args_.operator_location, ctx.actor_system(), ctx);
+    if (not catalog_result) {
+      done_ = true;
+      co_return;
+    }
+    catalog_ = std::move(*catalog_result);
+    co_return;
+  }
+
+  auto await_task(diagnostic_handler& dh) const -> Task<Any> override {
+    TENZIR_UNUSED(dh);
+    TENZIR_ASSERT(not done_);
+    co_return co_await async_mail(atom::get_v, std::string{"schemas"})
+      .request(catalog_);
+  }
+
+  auto process_task(Any result, Push<table_slice>& push, OpCtx& ctx)
+    -> Task<void> override {
+    done_ = true;
+    auto& slices_result = result.as<caf::expected<std::vector<table_slice>>>();
+    if (not slices_result) {
+      diagnostic::error(slices_result.error())
+        .primary(args_.operator_location)
+        .note("failed to get schemas")
+        .emit(ctx);
+      co_return;
+    }
+    for (auto&& slice : *slices_result) {
+      co_await push(std::move(slice));
+    }
+  }
+
+  auto state() -> OperatorState override {
+    return done_ ? OperatorState::done : OperatorState::unspecified;
+  }
+
+  auto snapshot(Serde& serde) -> void override {
+    serde("done", done_);
+  }
+
+private:
+  SchemasArgs args_;
+  catalog_actor catalog_ = {};
+  bool done_ = false;
+};
+
 class plugin final : public virtual operator_plugin<schemas_operator>,
-                     operator_factory_plugin {
+                     public virtual operator_factory_plugin,
+                     public virtual OperatorPlugin {
 public:
   auto signature() const -> operator_signature override {
     return {.source = true};
@@ -98,6 +151,12 @@ public:
     -> failure_or<operator_ptr> override {
     argument_parser2::operator_("schemas").parse(inv, ctx).ignore();
     return std::make_unique<schemas_operator>();
+  }
+
+  auto describe() const -> Description override {
+    auto d = Describer<SchemasArgs, Schemas>{};
+    d.operator_location(&SchemasArgs::operator_location);
+    return d.without_optimize();
   }
 };
 

--- a/libtenzir/include/tenzir/actors.hpp
+++ b/libtenzir/include/tenzir/actors.hpp
@@ -160,6 +160,8 @@ using catalog_actor = typed_actor_fwd<
   // should instead be moved inside of the catalog itself.
   auto(atom::get)->caf::result<std::vector<partition_synopsis_pair>>,
   auto(atom::get, expression)->caf::result<std::vector<partition_synopsis_pair>>,
+  auto(atom::get, std::string)->caf::result<std::vector<table_slice>>,
+  auto(atom::get, std::string, expression)->caf::result<std::vector<table_slice>>,
   // Erase a single partition synopsis.
   auto(atom::erase, uuid)->caf::result<atom::ok>,
   // Atomatically replace a set of partititon synopses with another.

--- a/libtenzir/include/tenzir/async/mail.hpp
+++ b/libtenzir/include/tenzir/async/mail.hpp
@@ -30,8 +30,8 @@
 namespace tenzir {
 
 template <class Result, class Handle, class F, class... Ts>
-void mail_with_callback(Handle receiver, std::source_location location, F f,
-                        Ts&&... xs) {
+void mail_with_callback(Handle receiver, caf::timespan timeout,
+                        std::source_location location, F f, Ts&&... xs) {
   struct state_t {
     explicit state_t(F fn) : callback{std::move(fn)} {
     }
@@ -55,8 +55,8 @@ void mail_with_callback(Handle receiver, std::source_location location, F f,
   }
   auto state = std::make_shared<state_t>(std::move(f));
   receiver->home_system().template spawn<caf::hidden>(
-    [receiver = std::move(receiver), location, state = std::move(state),
-     args = std::make_tuple(std::forward<Ts>(xs)...)](
+    [receiver = std::move(receiver), timeout, location,
+     state = std::move(state), args = std::make_tuple(std::forward<Ts>(xs)...)](
       caf::event_based_actor* self) mutable -> caf::behavior {
       self->attach_functor([location, state] {
         state->finish(caf::expected<Result>{
@@ -67,10 +67,10 @@ void mail_with_callback(Handle receiver, std::source_location location, F f,
                                       location.file_name(), location.line()))});
       });
       std::apply(
-        [self, &receiver, &state](auto&&... ys) mutable {
+        [self, &receiver, &state, timeout](auto&&... ys) mutable {
           if constexpr (std::is_void_v<Result>) {
             self->mail(std::move(ys)...)
-              .request(receiver, caf::infinite)
+              .request(receiver, timeout)
               .then(
                 [self, state]() mutable {
                   state->finish(caf::expected<void>{});
@@ -82,7 +82,7 @@ void mail_with_callback(Handle receiver, std::source_location location, F f,
                 });
           } else {
             self->mail(std::move(ys)...)
-              .request(receiver, caf::infinite)
+              .request(receiver, timeout)
               .then(
                 [self, state](Result result) mutable {
                   state->finish(caf::expected<Result>{std::move(result)});
@@ -111,14 +111,14 @@ public:
 
   template <class Handle, class Result = AsyncMailResult<Handle, Args...>>
   auto
-  request(Handle receiver,
+  request(Handle receiver, caf::timespan timeout = caf::infinite,
           std::source_location location
           = std::source_location::current()) and -> folly::SemiFuture<Result> {
     auto [promise, future] = folly::makePromiseContract<Result>();
     std::apply(
       [&](auto&&... xs) mutable {
         mail_with_callback<typename Result::value_type>(
-          receiver, location,
+          receiver, timeout, location,
           [promise = std::move(promise)](Result result) mutable {
             promise.setValue(std::move(result));
           },

--- a/libtenzir/src/catalog.cpp
+++ b/libtenzir/src/catalog.cpp
@@ -15,9 +15,12 @@
 #include "tenzir/detail/set_operations.hpp"
 #include "tenzir/detail/tracepoint.hpp"
 #include "tenzir/detail/weak_run_delayed.hpp"
+#include "tenzir/double_synopsis.hpp"
+#include "tenzir/duration_synopsis.hpp"
 #include "tenzir/error.hpp"
 #include "tenzir/expression.hpp"
 #include "tenzir/instrumentation.hpp"
+#include "tenzir/int64_synopsis.hpp"
 #include "tenzir/io/read.hpp"
 #include "tenzir/io/save.hpp"
 #include "tenzir/logger.hpp"
@@ -25,19 +28,264 @@
 #include "tenzir/partition_synopsis.hpp"
 #include "tenzir/pipeline.hpp"
 #include "tenzir/query_context.hpp"
+#include "tenzir/series_builder.hpp"
 #include "tenzir/status.hpp"
 #include "tenzir/synopsis.hpp"
 #include "tenzir/taxonomies.hpp"
 #include "tenzir/time_synopsis.hpp"
+#include "tenzir/uint64_synopsis.hpp"
 
 #include <caf/binary_serializer.hpp>
 #include <caf/detail/set_thread_name.hpp>
 #include <caf/expected.hpp>
 
 #include <ranges>
+#include <set>
 #include <string_view>
+#include <unordered_set>
 
 namespace tenzir {
+
+namespace {
+
+TENZIR_ENUM(catalog_slice_selector, fields, schemas, partitions);
+
+auto collect_synopses(const catalog_state& state)
+  -> std::vector<partition_synopsis_pair> {
+  auto result = std::vector<partition_synopsis_pair>{};
+  result.reserve(state.synopses_per_type.size());
+  for (const auto& [schema, id_synopsis_map] : state.synopses_per_type) {
+    for (const auto& [id, synopsis] : id_synopsis_map) {
+      result.push_back({id, synopsis});
+    }
+  }
+  return result;
+}
+
+auto collect_synopses(const catalog_state& state, const expression& filter)
+  -> caf::expected<std::vector<partition_synopsis_pair>> {
+  auto result = std::vector<partition_synopsis_pair>{};
+  const auto candidates = state.lookup(filter);
+  if (not candidates) {
+    return candidates.error();
+  }
+  for (const auto& [schema, candidate] : candidates->candidate_infos) {
+    const auto& partition_synopses = state.synopses_per_type.find(schema);
+    TENZIR_ASSERT(partition_synopses != state.synopses_per_type.end());
+    for (const auto& partition : candidate.partition_infos) {
+      const auto& synopsis = partition_synopses->second.find(partition.uuid);
+      if (synopsis == partition_synopses->second.end()) {
+        continue;
+      }
+      result.push_back({synopsis->first, synopsis->second});
+    }
+  }
+  return result;
+}
+
+auto field_type() -> type {
+  return type{
+    "tenzir.field",
+    record_type{
+      {"schema", string_type{}},
+      {"schema_id", string_type{}},
+      {"field", string_type{}},
+      {"path", list_type{string_type{}}},
+      {"index", list_type{uint64_type{}}},
+      {"type",
+       record_type{
+         {"kind", string_type{}},
+         {"category", string_type{}},
+         {"lists", uint64_type()},
+         {"name", string_type{}},
+         {"attributes", list_type{record_type{
+                          {"key", string_type{}},
+                          {"value", string_type{}},
+                        }}},
+       }},
+    },
+  };
+}
+
+struct field_context {
+  std::string name{};
+  std::vector<std::string> path{};
+  offset index{};
+};
+
+struct type_context {
+  type_kind kind{};
+  std::string category;
+  size_t lists{0};
+  std::string name{};
+  std::vector<std::pair<std::string, std::string>> attributes{};
+};
+
+struct schema_context {
+  field_context field;
+  type_context type;
+};
+
+auto traverse(type t) -> generator<schema_context> {
+  schema_context result;
+  while (const auto* list = try_as<list_type>(&t)) {
+    ++result.type.lists;
+    t = list->value_type();
+  }
+  result.type.name = t.name();
+  for (auto [key, value] : t.attributes()) {
+    result.type.attributes.emplace_back(key, value);
+  }
+  result.type.kind = t.kind();
+  if (result.type.kind.is<record_type>()) {
+    result.type.category = "container";
+  } else {
+    result.type.category = "atomic";
+  }
+  TENZIR_ASSERT(not is<list_type>(t));
+  TENZIR_ASSERT(not is<map_type>(t));
+  if (const auto* record = try_as<record_type>(&t)) {
+    auto i = size_t{0};
+    for (const auto& field : record->fields()) {
+      result.field.name = field.name;
+      result.field.path.emplace_back(field.name);
+      result.field.index.emplace_back(i);
+      for (const auto& inner : traverse(field.type)) {
+        result.type = inner.type;
+        auto nested = not inner.field.name.empty();
+        if (nested) {
+          result.field.name = inner.field.name;
+          for (const auto& path : inner.field.path) {
+            result.field.path.push_back(path);
+          }
+          for (const auto& index : inner.field.index) {
+            result.field.index.push_back(index);
+          }
+        }
+        co_yield result;
+        if (nested) {
+          auto delta = inner.field.path.size();
+          result.field.path.resize(result.field.path.size() - delta);
+          delta = inner.field.index.size();
+          result.field.index.resize(result.field.index.size() - delta);
+        }
+      }
+      result.field.index.pop_back();
+      result.field.path.pop_back();
+      ++i;
+    }
+  } else {
+    co_yield result;
+  }
+}
+
+auto add_field(builder_ref builder, const type& t) -> void {
+  for (const auto& ctx : traverse(t)) {
+    auto row = builder.record();
+    row.field("schema").data(t.name());
+    row.field("schema_id").data(t.make_fingerprint());
+    row.field("field").data(ctx.field.name);
+    auto path = row.field("path").list();
+    for (const auto& part : ctx.field.path) {
+      path.data(part);
+    }
+    auto index = row.field("index").list();
+    for (auto i : ctx.field.index) {
+      index.data(uint64_t{i});
+    }
+    auto type = row.field("type").record();
+    type.field("kind").data(to_string(ctx.type.kind));
+    type.field("category").data(ctx.type.category);
+    type.field("lists").data(ctx.type.lists);
+    type.field("name").data(ctx.type.name);
+    auto attrs = type.field("attributes").list();
+    for (const auto& [key, value] : ctx.type.attributes) {
+      auto attr = attrs.record();
+      attr.field("key").data(key);
+      attr.field("value").data(value);
+    }
+  }
+}
+
+auto build_field_slices(const std::vector<partition_synopsis_pair>& synopses)
+  -> std::vector<table_slice> {
+  auto fields = std::set<type>{};
+  for (const auto& synopsis : synopses) {
+    fields.insert(synopsis.synopsis->schema);
+  }
+  auto builder = series_builder{field_type()};
+  for (const auto& schema : fields) {
+    add_field(builder, schema);
+  }
+  return builder.finish_as_table_slice();
+}
+
+auto build_schema_slices(const std::vector<partition_synopsis_pair>& synopses)
+  -> std::vector<table_slice> {
+  auto schemas = std::unordered_set<type>{};
+  for (const auto& [id, synopsis] : synopses) {
+    TENZIR_UNUSED(id);
+    TENZIR_ASSERT(synopsis);
+    TENZIR_ASSERT(synopsis->schema);
+    schemas.insert(synopsis->schema);
+  }
+  auto builder = series_builder{};
+  auto result = std::vector<table_slice>{};
+  result.reserve(schemas.size());
+  for (const auto& schema : schemas) {
+    builder.data(schema.to_definition());
+    result.push_back(builder.finish_assert_one_slice(
+      fmt::format("tenzir.schema.{}", schema.make_fingerprint())));
+  }
+  return result;
+}
+
+auto build_partition_slices(const std::vector<partition_synopsis_pair>& synopses)
+  -> std::vector<table_slice> {
+  auto builder = series_builder{};
+  for (const auto& synopsis : synopses) {
+    auto event = builder.record();
+    event.field("uuid").data(fmt::to_string(synopsis.uuid));
+    event.field("memusage").data(synopsis.synopsis->memusage());
+    event.field("diskusage")
+      .data(synopsis.synopsis->store_file.size
+            + synopsis.synopsis->indexes_file.size
+            + synopsis.synopsis->sketches_file.size);
+    event.field("events").data(synopsis.synopsis->events);
+    event.field("min_import_time").data(synopsis.synopsis->min_import_time);
+    event.field("max_import_time").data(synopsis.synopsis->max_import_time);
+    event.field("version").data(synopsis.synopsis->version);
+    event.field("schema").data(synopsis.synopsis->schema.name());
+    event.field("schema_id").data(synopsis.synopsis->schema.make_fingerprint());
+    event.field("internal")
+      .data(synopsis.synopsis->schema.attribute("internal").has_value());
+    auto add_resource = [&](std::string_view key, const resource& value) {
+      auto x = event.field(key).record();
+      x.field("url").data(value.url);
+      x.field("size").data(value.size);
+    };
+    add_resource("store", synopsis.synopsis->store_file);
+    add_resource("indexes", synopsis.synopsis->indexes_file);
+    add_resource("sketches", synopsis.synopsis->sketches_file);
+  }
+  return builder.finish_as_table_slice("tenzir.partition");
+}
+
+auto build_catalog_slices(catalog_slice_selector selector,
+                          const std::vector<partition_synopsis_pair>& synopses)
+  -> std::vector<table_slice> {
+  switch (selector) {
+    case catalog_slice_selector::fields:
+      return build_field_slices(synopses);
+    case catalog_slice_selector::schemas:
+      return build_schema_slices(synopses);
+    case catalog_slice_selector::partitions:
+      return build_partition_slices(synopses);
+  }
+  TENZIR_UNREACHABLE();
+}
+
+} // namespace
 
 auto catalog_lookup_result::size() const noexcept -> size_t {
   return std::accumulate(candidate_infos.begin(), candidate_infos.end(),
@@ -486,41 +734,46 @@ auto catalog(catalog_actor::stateful_pointer<catalog_state> self)
       // if (self->state().mail_cache) {
       //   return self->state().stash<std::vector<partition_synopsis_pair>>();
       // }
-      std::vector<partition_synopsis_pair> result;
-      result.reserve(self->state().synopses_per_type.size());
-      for (const auto& [type, id_synopsis_map] :
-           self->state().synopses_per_type) {
-        for (const auto& [id, synopsis] : id_synopsis_map) {
-          result.push_back({id, synopsis});
-        }
-      }
-      return result;
+      return collect_synopses(self->state());
     },
     [self](atom::get, const expression& filter)
       -> caf::result<std::vector<partition_synopsis_pair>> {
       // if (self->state().mail_cache) {
       //   return self->state().stash<std::vector<partition_synopsis_pair>>();
       // }
-      auto result = std::vector<partition_synopsis_pair>{};
-      const auto candidates = self->state().lookup(filter);
-      if (not candidates) {
-        return candidates.error();
+      return collect_synopses(self->state(), filter);
+    },
+    [self](atom::get, const std::string& selector)
+      -> caf::result<std::vector<table_slice>> {
+      const auto parsed = from_string<catalog_slice_selector>(selector);
+      if (not parsed) {
+        return caf::make_error(ec::invalid_argument,
+                               fmt::format("unsupported catalog get selector: "
+                                           "{}",
+                                           selector));
       }
-      for (const auto& [schema, candidate] : candidates->candidate_infos) {
-        const auto& partition_synopses
-          = self->state().synopses_per_type.find(schema);
-        TENZIR_ASSERT(partition_synopses
-                      != self->state().synopses_per_type.end());
-        for (const auto& partition : candidate.partition_infos) {
-          const auto& synopsis
-            = partition_synopses->second.find(partition.uuid);
-          if (synopsis == partition_synopses->second.end()) {
-            continue;
-          }
-          result.push_back({synopsis->first, synopsis->second});
-        }
+      return build_catalog_slices(*parsed, collect_synopses(self->state()));
+    },
+    [self](atom::get, const std::string& selector,
+           const expression& filter) -> caf::result<std::vector<table_slice>> {
+      const auto parsed = from_string<catalog_slice_selector>(selector);
+      if (not parsed) {
+        return caf::make_error(ec::invalid_argument,
+                               fmt::format("unsupported catalog get selector: "
+                                           "{}",
+                                           selector));
       }
-      return result;
+      if (*parsed != catalog_slice_selector::partitions) {
+        return caf::make_error(ec::invalid_argument,
+                               fmt::format("filtered catalog get is only "
+                                           "supported for partitions, got {}",
+                                           selector));
+      }
+      const auto synopses = collect_synopses(self->state(), filter);
+      if (not synopses) {
+        return synopses.error();
+      }
+      return build_catalog_slices(*parsed, *synopses);
     },
     [self](atom::erase, uuid partition) -> caf::result<atom::ok> {
       if (self->state().cache) {

--- a/test/tests/node/storage/partitions/01_seed.tql
+++ b/test/tests/node/storage/partitions/01_seed.tql
@@ -1,0 +1,5 @@
+from {}
+repeat 100
+enumerate index
+@name = "count." + ("small" if index < 10 else "large")
+import

--- a/test/tests/node/storage/partitions/02_partitions.tql
+++ b/test/tests/node/storage/partitions/02_partitions.tql
@@ -1,0 +1,4 @@
+partitions
+where not internal
+select schema, events
+sort schema

--- a/test/tests/node/storage/partitions/02_partitions.txt
+++ b/test/tests/node/storage/partitions/02_partitions.txt
@@ -1,0 +1,8 @@
+{
+  schema: "count.large",
+  events: 90,
+}
+{
+  schema: "count.small",
+  events: 10,
+}

--- a/test/tests/node/storage/partitions/test.yaml
+++ b/test/tests/node/storage/partitions/test.yaml
@@ -1,0 +1,4 @@
+suite: partitions
+runner: neo
+fixtures: [node]
+timeout: 60


### PR DESCRIPTION
This ports the `fields`, `schemas` and `partitions` operators to the new
executor.

For this, the catalog API is expanded to directly support the operations
these operators previously did themselves, as the synopsis_ptr's returned
by the old interface cannot be transferred across a process boundary. The
old interface stays in place, as its still used by the old operators as
well as the index.

Closes
- TNZ-120
- TNZ-121
- TNZ-122
