### PR TITLE
Fix single-file nix fmt with the plugin submodule

### DIFF
--- a/libtenzir/include/tenzir/allocator.hpp
+++ b/libtenzir/include/tenzir/allocator.hpp
@@ -457,9 +457,8 @@ public:
 
   auto note_reallocation(const detail::allocation_tag& tag,
                          std::int64_t old_size, std::int64_t new_size) -> void {
-    [[maybe_unused]] auto success
-      = try_note_impl(tag, &stats::note_reallocation, false, old_size,
-                      new_size);
+    [[maybe_unused]] auto success = try_note_impl(
+      tag, &stats::note_reallocation, false, old_size, new_size);
     TENZIR_ALLOCATOR_ASSERT(success and "unexpected unknown reallocation");
   }
 

--- a/nix/format.nix
+++ b/nix/format.nix
@@ -11,37 +11,115 @@ pkgs.writeShellScriptBin "format" ''
   submodule_prefix=contrib/tenzir-plugins
   submodule_root="$PWD/$submodule_prefix"
 
-  "$treefmt" \
-    --config-file="$config_file" \
-    --tree-root-file=${treefmtEval.config.projectRootFile} \
-    "$@"
+  path_count=0
+  submodule_path_count=0
+  submodule_args=()
 
-  if [ -f "$submodule_prefix/README.md" ]; then
-    submodule_args=()
+  add_path_arg() {
+    local arg="$1"
 
-    for arg in "$@"; do
-      case "$arg" in
-        "$submodule_root"|"$submodule_root"/)
-          submodule_args+=(.)
-          ;;
-        "$submodule_root"/*)
-          submodule_args+=("''${arg#"$submodule_root"/}")
-          ;;
-        "$submodule_prefix"|"$submodule_prefix"/)
-          submodule_args+=(.)
-          ;;
-        "$submodule_prefix"/*)
-          submodule_args+=("''${arg#"$submodule_prefix"/}")
-          ;;
-      esac
-    done
+    path_count=$((path_count + 1))
+    case "$arg" in
+      "$submodule_root"|"$submodule_root"/)
+        submodule_args+=(.)
+        submodule_path_count=$((submodule_path_count + 1))
+        ;;
+      "$submodule_root"/*)
+        submodule_args+=("''${arg#"$submodule_root"/}")
+        submodule_path_count=$((submodule_path_count + 1))
+        ;;
+      "$submodule_prefix"|"$submodule_prefix"/|"./$submodule_prefix"|"./$submodule_prefix"/)
+        submodule_args+=(.)
+        submodule_path_count=$((submodule_path_count + 1))
+        ;;
+      "$submodule_prefix"/*)
+        submodule_args+=("''${arg#"$submodule_prefix"/}")
+        submodule_path_count=$((submodule_path_count + 1))
+        ;;
+      "./$submodule_prefix"/*)
+        submodule_args+=("''${arg#"./$submodule_prefix"/}")
+        submodule_path_count=$((submodule_path_count + 1))
+        ;;
+      *)
+        submodule_args+=("$arg")
+        ;;
+    esac
+  }
 
-    if [ "$#" -eq 0 ] || [ "''${#submodule_args[@]}" -gt 0 ]; then
+  consume_option_value=false
+  paths_only=false
+  for arg in "$@"; do
+    if $consume_option_value; then
+      submodule_args+=("$arg")
+      consume_option_value=false
+      continue
+    fi
+
+    if $paths_only; then
+      add_path_arg "$arg"
+      continue
+    fi
+
+    case "$arg" in
+      --)
+        submodule_args+=("$arg")
+        paths_only=true
+        ;;
+      --completion|--config-file|--cpu-profile|--excludes|--formatters|--on-unmatched|--tree-root|--tree-root-cmd|--tree-root-file|--walk|--working-dir)
+        submodule_args+=("$arg")
+        consume_option_value=true
+        ;;
+      --completion=*|--config-file=*|--cpu-profile=*|--excludes=*|--formatters=*|--on-unmatched=*|--tree-root=*|--tree-root-cmd=*|--tree-root-file=*|--walk=*|--working-dir=*)
+        submodule_args+=("$arg")
+        ;;
+      -f|-u|-C)
+        submodule_args+=("$arg")
+        consume_option_value=true
+        ;;
+      -f?*|-u?*|-C?*)
+        submodule_args+=("$arg")
+        ;;
+      -*)
+        submodule_args+=("$arg")
+        ;;
+      *)
+        add_path_arg "$arg"
+        ;;
+    esac
+  done
+
+  if [ "$path_count" -gt 0 ]; then
+    if [ "$submodule_path_count" -eq "$path_count" ]; then
+      if [ ! -f "$submodule_prefix/README.md" ]; then
+        echo "error: cannot format $submodule_prefix because the submodule is not checked out" >&2
+        exit 1
+      fi
       "$treefmt" \
         --config-file="$config_file" \
         --working-dir="$submodule_prefix" \
         --tree-root-file=README.md \
         "''${submodule_args[@]}"
+    elif [ "$submodule_path_count" -gt 0 ]; then
+      echo "error: cannot format main repository and $submodule_prefix paths in one invocation" >&2
+      exit 1
+    else
+      "$treefmt" \
+        --config-file="$config_file" \
+        --tree-root-file=${treefmtEval.config.projectRootFile} \
+        "$@"
+    fi
+  else
+    "$treefmt" \
+      --config-file="$config_file" \
+      --tree-root-file=${treefmtEval.config.projectRootFile} \
+      "$@"
+
+    if [ -f "$submodule_prefix/README.md" ]; then
+      "$treefmt" \
+        --config-file="$config_file" \
+        --working-dir="$submodule_prefix" \
+        --tree-root-file=README.md \
+        "$@"
     fi
   fi
 ''

--- a/nix/format.nix
+++ b/nix/format.nix
@@ -21,13 +21,13 @@ pkgs.writeShellScriptBin "format" ''
 
     for arg in "$@"; do
       case "$arg" in
-        "$submodule_root")
+        "$submodule_root"|"$submodule_root"/)
           submodule_args+=(.)
           ;;
         "$submodule_root"/*)
           submodule_args+=("''${arg#"$submodule_root"/}")
           ;;
-        "$submodule_prefix")
+        "$submodule_prefix"|"$submodule_prefix"/)
           submodule_args+=(.)
           ;;
         "$submodule_prefix"/*)

--- a/nix/format.nix
+++ b/nix/format.nix
@@ -8,17 +8,40 @@ pkgs.writeShellScriptBin "format" ''
 
   treefmt=${treefmtEval.config.package}/bin/treefmt
   config_file=${treefmtEval.config.build.configFile}
+  submodule_prefix=contrib/tenzir-plugins
+  submodule_root="$PWD/$submodule_prefix"
 
   "$treefmt" \
     --config-file="$config_file" \
     --tree-root-file=${treefmtEval.config.projectRootFile} \
     "$@"
 
-  if [ -f contrib/tenzir-plugins/README.md ]; then
-    "$treefmt" \
-      --config-file="$config_file" \
-      --working-dir=contrib/tenzir-plugins \
-      --tree-root-file=README.md \
-      "$@"
+  if [ -f "$submodule_prefix/README.md" ]; then
+    submodule_args=()
+
+    for arg in "$@"; do
+      case "$arg" in
+        "$submodule_root")
+          submodule_args+=(.)
+          ;;
+        "$submodule_root"/*)
+          submodule_args+=("''${arg#"$submodule_root"/}")
+          ;;
+        "$submodule_prefix")
+          submodule_args+=(.)
+          ;;
+        "$submodule_prefix"/*)
+          submodule_args+=("''${arg#"$submodule_prefix"/}")
+          ;;
+      esac
+    done
+
+    if [ "$#" -eq 0 ] || [ "''${#submodule_args[@]}" -gt 0 ]; then
+      "$treefmt" \
+        --config-file="$config_file" \
+        --working-dir="$submodule_prefix" \
+        --tree-root-file=README.md \
+        "''${submodule_args[@]}"
+    fi
   fi
 ''


### PR DESCRIPTION
## 🔍 Problem

- `nix fmt -- <path>` replays the same path list against the repo root and `contrib/tenzir-plugins`.
- Root files such as `version.json` fail in the second pass because the wrapper looks for them under `contrib/tenzir-plugins/`.
- Targeted formatting of submodule files also relies on paths that are only valid from the repo root.

## 🛠️ Solution

- Keep the repo-root `treefmt` invocation unchanged.
- Derive a second argument list for the plugin submodule by keeping only paths that point into `contrib/tenzir-plugins`.
- Strip the `contrib/tenzir-plugins/` prefix, with support for both relative and absolute paths, before running the submodule-local `treefmt` pass.
- Skip the submodule pass entirely when a targeted invocation does not touch the submodule.

## 💬 Review

- Focus on the path partitioning in `nix/format.nix`.
- Validated with:
  - `nix fmt -- version.json`
  - `nix fmt -- contrib/tenzir-plugins/README.md`
  - `nix fmt -- "$PWD/contrib/tenzir-plugins/README.md"`
