### PR TITLE
Use Google DNS in Docker CI builds to fix intermittent DNS failures

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -126,6 +126,11 @@ jobs:
           rm -rf ~/.cargo ~/go ~/.cache
           cd /opt
           find . -maxdepth 1 -mindepth 1 '!' -path ./containerd '!' -path ./actionarchivecache '!' -path ./runner '!' -path ./runner-cache -exec rm -rf '{}' ';'
+      - name: Configure Google DNS
+        run: |
+          # Work around intermittent DNS resolution failures in CI by
+          # prepending Google's public DNS servers to resolv.conf.
+          sudo sed -i '1s/^/nameserver 8.8.8.8\nnameserver 8.8.4.4\n/' /etc/resolv.conf
       - name: Build Docker Images
         id: build-images
         env:
@@ -148,6 +153,8 @@ jobs:
               --build-arg "TENZIR_BUILD_OPTIONS=${cmake_version_args}" \
               --cache-from "${CACHE_REF}" \
               --cache-to "${CACHE_REF}" \
+              --dns 8.8.8.8 \
+              --dns 8.8.4.4 \
               --tag "img"
             image="${registry}/tenzir/${name}:${source_tag}-${{ inputs.arch }}"
             buildah push img "${image}"


### PR DESCRIPTION
## Summary
- Adds a "Configure Google DNS" step before Docker image builds that prepends Google's public DNS servers (8.8.8.8, 8.8.4.4) to `/etc/resolv.conf` on the CI runner host
- Passes `--dns 8.8.8.8 --dns 8.8.4.4` to `buildah build` so container build stages also use reliable DNS
- Works around intermittent DNS resolution failures that have been causing CI build failures

## Test plan
- [x] Verify Docker CI builds pass without DNS-related failures
- [x] Confirm `apt-get update` and dependency downloads inside container builds resolve correctly
- [x] Confirm `buildah push` and cache operations to `ghcr.io` succeed reliably

https://claude.ai/code/session_01XNTZ2hEPTUEpbxLM16o3v5