### PR TITLE
Fix no-op build stamp handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -677,17 +677,34 @@ option(TENZIR_ENABLE_BUNDLED_DEPENDENCIES
 
 # -- schemas -------------------------------------------------------------------
 
+file(GLOB_RECURSE tenzir_bundled_schema_files CONFIGURE_DEPENDS
+     "${CMAKE_CURRENT_SOURCE_DIR}/schema/*")
+list(SORT tenzir_bundled_schema_files)
+set(_tenzir_schema_manifest
+    "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/tenzir-schema-manifest.txt")
+list(JOIN tenzir_bundled_schema_files "\n" _tenzir_schema_manifest_contents)
+file(CONFIGURE OUTPUT "${_tenzir_schema_manifest}" CONTENT
+     "${_tenzir_schema_manifest_contents}\n" @ONLY)
+
 option(TENZIR_ENABLE_BUNDLED_SCHEMAS "Install bundled schemas with Tenzir" ON)
 if (TENZIR_ENABLE_RELOCATABLE_INSTALLATIONS)
-  add_custom_target(
-    tenzir-schema
+  set(_tenzir_schema_stamp
+      "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/tenzir-schema.stamp")
+  add_custom_command(
+    OUTPUT "${_tenzir_schema_stamp}"
     COMMAND ${CMAKE_COMMAND} -E remove_directory
             "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_DATADIR}/tenzir/schema/"
     COMMAND
       ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/schema"
       "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_DATADIR}/tenzir/schema/"
+    COMMAND ${CMAKE_COMMAND} -E touch "${_tenzir_schema_stamp}"
+    DEPENDS "${_tenzir_schema_manifest}" ${tenzir_bundled_schema_files}
     COMMENT "Copying schema directory")
+  add_custom_target(tenzir-schema DEPENDS "${_tenzir_schema_stamp}")
+  unset(_tenzir_schema_stamp)
 endif ()
+unset(_tenzir_schema_manifest)
+unset(_tenzir_schema_manifest_contents)
 
 if (TENZIR_ENABLE_BUNDLED_SCHEMAS)
   install(
@@ -891,6 +908,31 @@ if (NOT TENZIR_ENABLE_BUNDLED_FACEBOOK_LIBS)
 else ()
   add_definitions(-DGLOG_USE_GLOG_EXPORT)
   add_subdirectory(libtenzir/aux/facebook)
+  # Proxygen declares StatsWrapper.h as a generated file in the build tree, but
+  # the bundled generator writes it to the source tree. Materialize the build
+  # tree copy via a dedicated target so normal rebuilds refresh it when the
+  # tracked generator inputs change.
+  set(_tenzir_proxygen_generated_root
+      "${CMAKE_CURRENT_BINARY_DIR}/libtenzir/aux/facebook/proxygen/generated")
+  set(_tenzir_proxygen_stats_wrapper
+      "${_tenzir_proxygen_generated_root}/proxygen/lib/stats/StatsWrapper.h")
+  add_custom_target(
+    tenzir-proxygen-stats-wrapper
+    COMMAND ${CMAKE_COMMAND} -E make_directory
+            "${_tenzir_proxygen_generated_root}/proxygen/lib/stats"
+    COMMAND ${CMAKE_COMMAND} -E rm -f "${_tenzir_proxygen_stats_wrapper}"
+    COMMAND
+      "${CMAKE_CURRENT_SOURCE_DIR}/libtenzir/aux/facebook/proxygen/proxygen/lib/stats/gen_StatsWrapper.sh"
+      "${_tenzir_proxygen_generated_root}"
+    DEPENDS
+      "${CMAKE_CURRENT_SOURCE_DIR}/libtenzir/aux/facebook/proxygen/proxygen/lib/stats/gen_StatsWrapper.sh"
+      "${CMAKE_CURRENT_SOURCE_DIR}/libtenzir/aux/facebook/proxygen/proxygen/lib/stats/BaseStats.h"
+    COMMENT "Generating StatsWrapper.h in the Proxygen build tree")
+  if (TARGET proxygen-generated)
+    add_dependencies(proxygen-generated tenzir-proxygen-stats-wrapper)
+  endif ()
+  unset(_tenzir_proxygen_generated_root)
+  unset(_tenzir_proxygen_stats_wrapper)
 endif ()
 
 if (TENZIR_ENABLE_RELOCATABLE_INSTALLATIONS

--- a/cmake/TenzirRegisterPlugin.cmake
+++ b/cmake/TenzirRegisterPlugin.cmake
@@ -480,6 +480,14 @@ function (TenzirExportCompileCommands)
       ON
       PARENT_SCOPE)
 
+  if (NOT "${CMAKE_GENERATOR}" MATCHES "(Ninja|Makefiles)")
+    message(
+      STATUS
+        "Skipping compilation database export for ${ARGV0}: generator ${CMAKE_GENERATOR} does not support CMAKE_EXPORT_COMPILE_COMMANDS"
+    )
+    return()
+  endif ()
+
   # Link once when configuring the build to make the compilation database
   # immediately available.
   execute_process(
@@ -488,9 +496,12 @@ function (TenzirExportCompileCommands)
       "${CMAKE_BINARY_DIR}/compile_commands.json"
       "${CMAKE_SOURCE_DIR}/compile_commands.json")
 
-  # Link again when building the specified target. This ensures the file is
-  # available even after the user ran `git-clean` or similar and triggered
-  # another build.
+  # Link again when building the specified target. Keep this as a custom target
+  # instead of an output-based command so each build directory can relink the
+  # shared source-tree symlink even when another build directory updated it.
+  # Do not depend on the build-tree compilation database directly: after a
+  # `git clean -fdx` or similar, the symlink recreation should still succeed
+  # without forcing an explicit reconfigure first.
   add_custom_target(
     compilation-database
     BYPRODUCTS "${CMAKE_SOURCE_DIR}/compile_commands.json"

--- a/libtenzir/CMakeLists.txt
+++ b/libtenzir/CMakeLists.txt
@@ -27,13 +27,16 @@ if (NOT tsl-robin-map_FOUND)
     EXPORT tsl-robin-mapTargets
     FILE tsl-robin-mapTargets.cmake
     NAMESPACE tsl::)
-  add_custom_target(
-    tsl-robin-map-targets-link
+  add_custom_command(
+    OUTPUT "${CMAKE_BINARY_DIR}/tsl-robin-mapTargets.cmake"
     COMMAND
       ${CMAKE_COMMAND} -E create_symlink
       "${CMAKE_CURRENT_BINARY_DIR}/tsl-robin-mapTargets.cmake"
       "${CMAKE_BINARY_DIR}/tsl-robin-mapTargets.cmake"
+    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/tsl-robin-mapTargets.cmake"
     COMMENT "Linking tsl-robin-map targets")
+  add_custom_target(tsl-robin-map-targets-link
+                    DEPENDS "${CMAKE_BINARY_DIR}/tsl-robin-mapTargets.cmake")
   install(
     EXPORT tsl-robin-mapTargets
     DESTINATION "${TENZIR_INSTALL_CMAKEDIR}/tenzir"
@@ -447,14 +450,21 @@ if (NOT simdjson_FOUND)
       ON
       CACHE BOOL "")
   add_subdirectory(aux/simdjson)
+  export(
+    EXPORT simdjsonTargets
+    FILE simdjsonTargets.cmake
+    NAMESPACE simdjson::)
   set(_tenzir_bundled_simdjson "simdjson")
-  add_custom_target(
-    simdjson-targets-link
+  add_custom_command(
+    OUTPUT "${CMAKE_BINARY_DIR}/simdjsonTargets.cmake"
     COMMAND
       "${CMAKE_COMMAND}" -E create_symlink
       "${CMAKE_CURRENT_BINARY_DIR}/simdjsonTargets.cmake"
       "${CMAKE_BINARY_DIR}/simdjsonTargets.cmake"
+    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/simdjsonTargets.cmake"
     COMMENT "Linking simdjson targets")
+  add_custom_target(simdjson-targets-link
+                    DEPENDS "${CMAKE_BINARY_DIR}/simdjsonTargets.cmake")
   TenzirSystemizeTarget(simdjson)
   add_dependencies(simdjson simdjson-targets-link)
   dependency_summary("simdjson" "${CMAKE_CURRENT_SOURCE_DIR}/aux/simdjson"
@@ -729,14 +739,17 @@ file(
 
 unset(set_tenzir_version_build_metadata)
 
-# We generate config.cpp as a byproduct of a custom target so we can re-generate
-# the version string and build tree hash on every build. Note that this must not
-# be added to the ALL target. The dependency is inferred from the byproduct
-# automatically.
+# Re-run the version generation script on every build so git-derived build
+# metadata, including the dirty suffix, stays current. The configure_file() in
+# update-config.cmake only updates config.cpp when the contents actually change.
 add_custom_target(
   libtenzir_update_config
   BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/src/config.cpp"
-  COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_BINARY_DIR}/update-config.cmake")
+  COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_BINARY_DIR}/update-config.cmake"
+  DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/update-config.cmake"
+          "${CMAKE_CURRENT_SOURCE_DIR}/src/config.cpp.in"
+          "${CMAKE_CURRENT_SOURCE_DIR}/../cmake/TenzirVersion.cmake"
+          "${CMAKE_CURRENT_SOURCE_DIR}/../version.json")
 
 target_sources(
   libtenzir
@@ -744,6 +757,7 @@ target_sources(
           "${CMAKE_CURRENT_BINARY_DIR}/include/tenzir/allocator_config.hpp"
           "${CMAKE_CURRENT_BINARY_DIR}/src/config.cpp"
           "${CMAKE_CURRENT_BINARY_DIR}/src/detail/installdirs.cpp")
+add_dependencies(libtenzir libtenzir_update_config)
 
 tenzirconfigurepchreuse(
   libtenzir

--- a/plugins/clickhouse/CMakeLists.txt
+++ b/plugins/clickhouse/CMakeLists.txt
@@ -66,6 +66,10 @@ else ()
       ON
       CACHE BOOL "")
 
+  set(DEBUG_DEPENDENCIES
+      OFF
+      CACHE BOOL "Disable bundled clickhouse-cpp debug helper targets"
+      FORCE)
   set(_build_shared_libs_before "${BUILD_SHARED_LIBS}")
   set(BUILD_SHARED_LIBS OFF)
   add_subdirectory(aux/clickhouse-cpp)

--- a/tenzir/CMakeLists.txt
+++ b/tenzir/CMakeLists.txt
@@ -483,16 +483,16 @@ target_compile_definitions(
 # deterministic builds.
 string(TIMESTAMP TENZIR_LAST_COMMIT_DATE)
 if (TENZIR_ENABLE_MANPAGES)
-  add_custom_target(
-    tenzir-manpage
+  add_custom_command(
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/tenzir.1"
     DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/tenzir.1.md"
     COMMAND
       "${PANDOC}" -s -f gfm -t man -V date:${TENZIR_LAST_COMMIT_DATE}
       "${CMAKE_CURRENT_SOURCE_DIR}/tenzir.1.md" -o
       "${CMAKE_CURRENT_BINARY_DIR}/tenzir.1"
-    BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/tenzir.1"
     COMMENT "Generating tenzir.1"
     VERBATIM)
+  add_custom_target(tenzir-manpage DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/tenzir.1")
   add_dependencies(tenzir tenzir-manpage)
   install(
     FILES "${CMAKE_CURRENT_BINARY_DIR}/tenzir.1"


### PR DESCRIPTION
## 🔍 Problem

- Incremental builds still did unnecessary work because several generated artifacts were modeled as side-effecting custom targets instead of build outputs.
- Tightening those rules exposed a few places where the invalidation semantics are intentionally different:
  - schema deletions could leave stale copied files in the build tree
  - `compile_commands.json` is one shared source-tree symlink, so multiple build dirs can race on it
  - `config.cpp` must keep tracking `git describe --dirty`
  - bundled Proxygen declares `StatsWrapper.h` in the build tree, but its generator writes it to the source tree

## 🛠️ Solution

- Keep stable generated artifacts on output-based rules where that matches the actual build semantics.
- Make bundled schema copying invalidate on deletions via a manifest.
- Keep `libtenzir` config generation as an always-run target so Git-derived version metadata stays current.
- Keep compilation database relinking as a custom target so each build dir can refresh the shared source-tree symlink.
- Materialize Proxygen's `StatsWrapper.h` in Tenzir's build tree via a dependency-tracked target.
- Disable bundled `clickhouse-cpp` debug helper targets.

## 💬 Review

- Focus on the places where this PR intentionally does **not** use plain output-based rules: `libtenzir_update_config`, `compilation-database`, and the Proxygen `StatsWrapper.h` workaround.
- No changelog entry: this is an internal build-system-only change.
- Verified locally with repeated configure/build cycles and after CI-driven fixes for clean-checkout and subproject cases.
