### PR TITLE
Port sigma to the new executor

### DIFF
--- a/plugins/sigma/src/plugin.cpp
+++ b/plugins/sigma/src/plugin.cpp
@@ -20,6 +20,7 @@
 #include <tenzir/data.hpp>
 #include <tenzir/error.hpp>
 #include <tenzir/io/read.hpp>
+#include <tenzir/operator_plugin.hpp>
 #include <tenzir/pipeline.hpp>
 #include <tenzir/plugin.hpp>
 #include <tenzir/series_builder.hpp>
@@ -30,9 +31,118 @@
 #include <caf/typed_event_based_actor.hpp>
 #include <fmt/format.h>
 
+#include <chrono>
+#include <filesystem>
 #include <string_view>
+#include <unordered_map>
+#include <utility>
 
 namespace tenzir::plugins::sigma {
+
+namespace {
+
+struct RuleEntry {
+  data yaml;
+  expression rule;
+};
+
+using RuleMap = std::unordered_map<std::string, RuleEntry>;
+
+auto load_rules(const std::filesystem::path& path, RuleMap& rules,
+                diagnostic_handler& dh) -> void {
+  if (std::filesystem::is_directory(path)) {
+    for (const auto& entry : std::filesystem::directory_iterator(path)) {
+      load_rules(entry.path(), rules, dh);
+    }
+    return;
+  }
+  if (path.extension() != ".yml" and path.extension() != ".yaml") {
+    // We silently ignore non-yaml files.
+    return;
+  }
+  auto query = tenzir::io::read(path);
+  if (not query) {
+    diagnostic::warning("sigma operator ignores rule '{}'", path.string())
+      .note("failed to read file: {}", query.error())
+      .emit(dh);
+    return;
+  }
+  auto query_str = std::string_view{
+    reinterpret_cast<const char*>(query->data()),
+    reinterpret_cast<const char*>(query->data() + query->size())}; // NOLINT
+  auto yaml = from_yaml(query_str);
+  if (not yaml) {
+    diagnostic::warning("sigma operator ignores rule '{}'", path.string())
+      .note("failed to parse yaml: {}", yaml.error())
+      .emit(dh);
+    return;
+  }
+  if (not is<record>(*yaml)) {
+    diagnostic::warning("sigma operator ignores rule '{}'", path.string())
+      .note("rule is not a YAML dictionary")
+      .emit(dh);
+    return;
+  }
+  auto rule = parse_rule(*yaml);
+  if (not rule) {
+    diagnostic::warning("sigma operator ignores rule '{}'", path.string())
+      .note("failed to parse sigma rule: {}", rule.error())
+      .emit(dh);
+    return;
+  }
+  rules[path.string()] = {std::move(*yaml), std::move(*rule)};
+}
+
+auto update_rules(const std::filesystem::path& path, RuleMap& rules,
+                  diagnostic_handler& dh) -> void {
+  auto old_rules = std::exchange(rules, {});
+  load_rules(path, rules, dh);
+  for (const auto& [rule_path, rule] : rules) {
+    const auto old_rule = old_rules.find(rule_path);
+    if (old_rule == old_rules.end()) {
+      TENZIR_VERBOSE("added Sigma rule {}", rule_path);
+    } else if (old_rule->second.yaml != rule.yaml
+               or old_rule->second.rule != rule.rule) {
+      TENZIR_VERBOSE("updated Sigma rule {}", rule_path);
+    }
+  }
+  for (const auto& [rule_path, _] : old_rules) {
+    if (not rules.contains(rule_path)) {
+      TENZIR_VERBOSE("removed Sigma rule {}", rule_path);
+    }
+  }
+}
+
+auto make_sigma_slice(const table_slice& input, const data& yaml,
+                      const expression& rule) -> std::optional<table_slice> {
+  auto expr = tailor(rule, input.schema());
+  if (not expr) {
+    return std::nullopt;
+  }
+  auto event = filter(input, *expr);
+  if (not event) {
+    return std::nullopt;
+  }
+  auto [event_schema, event_array] = offset{}.get(*event);
+  auto [rule_schema, rule_array] = [&] {
+    auto rule_builder = series_builder{};
+    for (auto i = size_t{0}; i < event->rows(); ++i) {
+      rule_builder.data(yaml);
+    }
+    return rule_builder.finish_assert_one_array();
+  }();
+  const auto result_schema = type{
+    "tenzir.sigma",
+    record_type{
+      {"event", event_schema},
+      {"rule", rule_schema},
+    },
+  };
+  auto batch
+    = arrow::RecordBatch::Make(result_schema.to_arrow_schema(), event->rows(),
+                               {std::move(event_array), std::move(rule_array)});
+  return table_slice{batch, result_schema};
+}
 
 class sigma_operator final : public crtp_operator<sigma_operator> {
 public:
@@ -42,81 +152,12 @@ public:
     : refresh_interval_{refresh_interval}, path_{std::move(path)} {
   }
 
-  struct monitor_state {
-    auto update(const std::filesystem::path& path, operator_control_plane& ctrl)
-      -> void {
-      auto old_rules = std::exchange(rules, {});
-      load_rules(path, ctrl);
-      for (const auto& [rule_path, rule] : rules) {
-        const auto old_rule = old_rules.find(rule_path);
-        if (old_rule == old_rules.end()) {
-          TENZIR_VERBOSE("added Sigma rule {}", rule_path);
-        } else if (old_rule->second != rule) {
-          TENZIR_VERBOSE("updated Sigma rule {}", rule_path);
-        }
-      }
-      for (const auto& [rule_path, _] : old_rules) {
-        if (not rules.contains(rule_path)) {
-          TENZIR_VERBOSE("removed Sigma rule {}", rule_path);
-        }
-      }
-    }
-
-    auto load_rules(const std::filesystem::path& path,
-                    operator_control_plane& ctrl) -> void {
-      if (std::filesystem::is_directory(path)) {
-        for (const auto& entry : std::filesystem::directory_iterator(path)) {
-          load_rules(entry.path(), ctrl);
-        }
-        return;
-      }
-      if (path.extension() != ".yml" and path.extension() != ".yaml") {
-        // We silently ignore non-yaml files.
-        return;
-      }
-      auto query = tenzir::io::read(path);
-      if (not query) {
-        diagnostic::warning("sigma operator ignores rule '{}'", path.string())
-          .note("failed to read file: {}", query.error())
-          .emit(ctrl.diagnostics());
-        return;
-      }
-      auto query_str = std::string_view{
-        reinterpret_cast<const char*>(query->data()),
-        reinterpret_cast<const char*>(query->data() + query->size())}; // NOLINT
-      auto yaml = from_yaml(query_str);
-      if (not yaml) {
-        diagnostic::warning("sigma operator ignores rule '{}'", path.string())
-          .note("failed to parse yaml: {}", yaml.error())
-          .emit(ctrl.diagnostics());
-        return;
-      }
-      if (not is<record>(*yaml)) {
-        diagnostic::warning("sigma operator ignores rule '{}'", path.string())
-          .note("rule is not a YAML dictionary")
-          .emit(ctrl.diagnostics());
-        return;
-      }
-      auto rule = parse_rule(*yaml);
-      if (not rule) {
-        diagnostic::warning("sigma operator ignores rule '{}'", path.string())
-          .note("failed to parse sigma rule: {}", rule.error())
-          .emit(ctrl.diagnostics());
-        return;
-      }
-      rules[path.string()] = {std::move(*yaml), std::move(*rule)};
-    }
-
-    std::filesystem::path path;
-    std::unordered_map<std::string, std::pair<data, expression>> rules = {};
-  };
-
   auto
   operator()(generator<table_slice> input, operator_control_plane& ctrl) const
     -> generator<table_slice> {
-    auto state = monitor_state{};
-    state.path = path_;
-    state.update(state.path, ctrl);
+    auto rules = RuleMap{};
+    auto path = std::filesystem::path{path_};
+    update_rules(path, rules, ctrl.diagnostics());
     auto last_update = std::chrono::steady_clock::now();
     co_yield {}; // signal that we're done initializing
     for (auto&& slice : input) {
@@ -124,37 +165,14 @@ public:
         co_yield {};
         continue;
       }
-      if (last_update + refresh_interval_ < std::chrono::steady_clock::now()) {
-        state.update(state.path, ctrl);
-        last_update = std::chrono::steady_clock::now();
+      auto now = std::chrono::steady_clock::now();
+      if (now - last_update > refresh_interval_) {
+        update_rules(path, rules, ctrl.diagnostics());
+        last_update = now;
       }
-      for (const auto& [path, entry] : state.rules) {
-        const auto& [yaml, rule] = entry;
-        auto expr = tailor(rule, slice.schema());
-        if (not expr) {
-          continue;
-        }
-        if (auto event = filter(slice, *expr)) {
-          auto [event_schema, event_array] = offset{}.get(*event);
-          auto [rule_schema, rule_array] = [&] {
-            auto rule_builder = series_builder{};
-            for (size_t i = 0; i < event->rows(); ++i) {
-              rule_builder.data(yaml);
-            }
-            return rule_builder.finish_assert_one_array();
-          }();
-          const auto result_schema = type{
-            "tenzir.sigma",
-            record_type{
-              {"event", event_schema},
-              {"rule", rule_schema},
-            },
-          };
-          auto batch = arrow::RecordBatch::Make(
-            result_schema.to_arrow_schema(),
-            detail::narrow_cast<int64_t>(event->rows()),
-            {std::move(event_array), std::move(rule_array)});
-          co_yield table_slice{batch, result_schema};
+      for (const auto& [_, entry] : rules) {
+        if (auto result = make_sigma_slice(slice, entry.yaml, entry.rule)) {
+          co_yield std::move(*result);
         }
       }
     }
@@ -172,8 +190,7 @@ public:
 
   auto optimize(expression const& filter, event_order order) const
     -> optimize_result override {
-    (void)order;
-    (void)filter;
+    TENZIR_UNUSED(filter, order);
     return do_not_optimize(*this);
   }
 
@@ -189,8 +206,53 @@ private:
   std::string path_ = {};
 };
 
+struct SigmaArgs {
+  std::string path;
+  duration refresh_interval = std::chrono::seconds{5};
+};
+
+class Sigma final : public Operator<table_slice, table_slice> {
+public:
+  explicit Sigma(SigmaArgs args) : args_{std::move(args)}, path_{args_.path} {
+  }
+
+  auto start(OpCtx& ctx) -> Task<void> override {
+    update_rules(path_, rules_, ctx.dh());
+    last_update_ = std::chrono::steady_clock::now();
+    co_return;
+  }
+
+  auto process(table_slice input, Push<table_slice>& push, OpCtx& ctx)
+    -> Task<void> override {
+    auto now = std::chrono::steady_clock::now();
+    if (now - last_update_ > args_.refresh_interval) {
+      update_rules(path_, rules_, ctx.dh());
+      last_update_ = now;
+    }
+    for (const auto& [_, entry] : rules_) {
+      if (auto result = make_sigma_slice(input, entry.yaml, entry.rule)) {
+        co_await push(std::move(*result));
+      }
+    }
+  }
+
+  auto snapshot(Serde& serde) -> void override {
+    TENZIR_UNUSED(serde);
+    // Rules are reloaded from disk in `start()`, and `steady_clock`
+    // timestamps are not portable across restarts.
+  }
+
+private:
+  SigmaArgs args_;
+  std::filesystem::path path_;
+  RuleMap rules_;
+  std::chrono::steady_clock::time_point last_update_ = {};
+};
+
 class plugin final : public virtual operator_plugin<sigma_operator>,
-                     public virtual operator_factory_plugin {
+                     public virtual operator_factory_plugin,
+                     public virtual OperatorPlugin {
+public:
   auto signature() const -> operator_signature override {
     return {.transformation = true};
   }
@@ -204,21 +266,37 @@ class plugin final : public virtual operator_plugin<sigma_operator>,
       .named("refresh_interval", refresh_interval)
       .parse(inv, ctx)
       .ignore();
-    if (not refresh_interval) {
-      refresh_interval->inner = std::chrono::seconds(5);
-    } else if (refresh_interval->inner.count() < 0) {
-      diagnostic::error("refresh_interval must be greater than 0")
+    auto interval
+      = refresh_interval ? refresh_interval->inner : std::chrono::seconds{5};
+    if (refresh_interval and interval <= duration::zero()) {
+      diagnostic::error("`refresh_interval` must be a positive duration")
         .primary(refresh_interval.value())
         .emit(ctx);
       return failure::promise();
     }
-    return std::make_unique<sigma_operator>(refresh_interval->inner,
-                                            std::move(path));
+    return std::make_unique<sigma_operator>(interval, std::move(path));
+  }
+
+  auto describe() const -> Description override {
+    auto d = Describer<SigmaArgs, Sigma>{};
+    d.positional("path", &SigmaArgs::path);
+    auto refresh_interval
+      = d.named_optional("refresh_interval", &SigmaArgs::refresh_interval);
+    d.validate([refresh_interval](DescribeCtx& ctx) -> Empty {
+      if (auto value = ctx.get(refresh_interval);
+          value and *value <= duration::zero()) {
+        diagnostic::error("`refresh_interval` must be a positive duration")
+          .primary(ctx.get_location(refresh_interval).value())
+          .emit(ctx);
+      }
+      return {};
+    });
+    return d.without_optimize();
   }
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
     auto parser = argument_parser{"sigma", "https://docs.tenzir.com/"
-                                           "operators/batch"};
+                                           "reference/operators"};
     auto refresh_interval = duration{std::chrono::seconds{5}};
     auto refresh_interval_arg = std::optional<located<std::string>>{};
     auto path = std::string{};
@@ -233,10 +311,17 @@ class plugin final : public virtual operator_plugin<sigma_operator>,
           .primary(refresh_interval_arg->source)
           .throw_();
       }
+      if (refresh_interval <= duration::zero()) {
+        diagnostic::error("`refresh_interval` must be a positive duration")
+          .primary(refresh_interval_arg->source)
+          .throw_();
+      }
     }
     return std::make_unique<sigma_operator>(refresh_interval, std::move(path));
   }
 };
+
+} // namespace
 
 } // namespace tenzir::plugins::sigma
 

--- a/plugins/sigma/src/plugin.cpp
+++ b/plugins/sigma/src/plugin.cpp
@@ -18,6 +18,7 @@
 #include <tenzir/concept/parseable/tenzir/pipeline.hpp>
 #include <tenzir/concept/parseable/to.hpp>
 #include <tenzir/data.hpp>
+#include <tenzir/detail/narrow.hpp>
 #include <tenzir/error.hpp>
 #include <tenzir/io/read.hpp>
 #include <tenzir/operator_plugin.hpp>
@@ -139,7 +140,8 @@ auto make_sigma_slice(const table_slice& input, const data& yaml,
     },
   };
   auto batch
-    = arrow::RecordBatch::Make(result_schema.to_arrow_schema(), event->rows(),
+    = arrow::RecordBatch::Make(result_schema.to_arrow_schema(),
+                               detail::narrow<int64_t>(event->rows()),
                                {std::move(event_array), std::move(rule_array)});
   return table_slice{batch, result_schema};
 }

--- a/plugins/sigma/src/plugin.cpp
+++ b/plugins/sigma/src/plugin.cpp
@@ -238,16 +238,12 @@ public:
     }
   }
 
-  auto snapshot(Serde& serde) -> void override {
-    TENZIR_UNUSED(serde);
-    // Rules are reloaded from disk in `start()`, and `steady_clock`
-    // timestamps are not portable across restarts.
-  }
-
 private:
   SigmaArgs args_;
   std::filesystem::path path_;
   RuleMap rules_;
+  // Rules are reloaded from disk in `start()`, and `last_update_` uses
+  // `steady_clock`, so the default no-op snapshot behavior is sufficient.
   std::chrono::steady_clock::time_point last_update_ = {};
 };
 

--- a/test/inputs/sigma/basic-rule.yaml
+++ b/test/inputs/sigma/basic-rule.yaml
@@ -1,0 +1,5 @@
+title: basic sigma rule
+detection:
+  selection:
+    foo: needle
+  condition: selection

--- a/test/inputs/sigma/directory/alpha.yml
+++ b/test/inputs/sigma/directory/alpha.yml
@@ -1,0 +1,5 @@
+title: alpha sigma rule
+detection:
+  selection:
+    foo: needle
+  condition: selection

--- a/test/inputs/sigma/directory/nested/bravo.yaml
+++ b/test/inputs/sigma/directory/nested/bravo.yaml
@@ -1,0 +1,5 @@
+title: bravo sigma rule
+detection:
+  selection:
+    foo: needle
+  condition: selection

--- a/test/tests/operators/sigma/basic.tql
+++ b/test/tests/operators/sigma/basic.tql
@@ -1,0 +1,2 @@
+from {foo: "needle"}
+sigma f"{env("TENZIR_INPUTS")}/sigma/basic-rule.yaml"

--- a/test/tests/operators/sigma/basic.txt
+++ b/test/tests/operators/sigma/basic.txt
@@ -1,0 +1,14 @@
+{
+  event: {
+    foo: "needle",
+  },
+  rule: {
+    title: "basic sigma rule",
+    detection: {
+      selection: {
+        foo: "needle",
+      },
+      condition: "selection",
+    },
+  },
+}

--- a/test/tests/operators/sigma/directory.tql
+++ b/test/tests/operators/sigma/directory.tql
@@ -1,0 +1,3 @@
+from {foo: "needle"}
+sigma f"{env("TENZIR_INPUTS")}/sigma/directory"
+sort rule.title

--- a/test/tests/operators/sigma/directory.txt
+++ b/test/tests/operators/sigma/directory.txt
@@ -1,0 +1,28 @@
+{
+  event: {
+    foo: "needle",
+  },
+  rule: {
+    title: "alpha sigma rule",
+    detection: {
+      selection: {
+        foo: "needle",
+      },
+      condition: "selection",
+    },
+  },
+}
+{
+  event: {
+    foo: "needle",
+  },
+  rule: {
+    title: "bravo sigma rule",
+    detection: {
+      selection: {
+        foo: "needle",
+      },
+      condition: "selection",
+    },
+  },
+}

--- a/test/tests/operators/sigma/refresh_interval_zero.tql
+++ b/test/tests/operators/sigma/refresh_interval_zero.tql
@@ -1,0 +1,6 @@
+---
+error: true
+---
+
+from {foo: "needle"}
+sigma f"{env("TENZIR_INPUTS")}/sigma/basic-rule.yaml", refresh_interval=0s

--- a/test/tests/operators/sigma/refresh_interval_zero.txt
+++ b/test/tests/operators/sigma/refresh_interval_zero.txt
@@ -1,0 +1,6 @@
+error: `refresh_interval` must be a positive duration
+ --> tests/operators/sigma/refresh_interval_zero.tql:6:73
+  |
+6 | sigma f"{env("TENZIR_INPUTS")}/sigma/basic-rule.yaml", refresh_interval=0s
+  |                                                                         ^^ 
+  |


### PR DESCRIPTION
## 🔍 Problem

- `sigma` still used the legacy executor path.
- That left the operator unavailable in neo mode and untested there.

## 🛠️ Solution

- add a new-executor `Operator<table_slice, table_slice>` implementation
- keep the legacy operator path in place while wiring the new IR/plugin path
- add neo integration tests for basic matching, invalid `refresh_interval`, and directory recursion
- use checked narrowing when building Arrow record batches

## 💬 Review

- Focus on the new executor flow in `plugins/sigma/src/plugin.cpp`.
- The directory test sorts by `rule.title` to keep the assertion deterministic.

<sub>resolves TNZ-151</sub>
