### PR TITLE
Add `mmap` option to `from_file`

### DIFF
--- a/libtenzir/builtins/operators/from_file.cpp
+++ b/libtenzir/builtins/operators/from_file.cpp
@@ -19,7 +19,9 @@ namespace tenzir::plugins::from_file {
 
 namespace {
 
-struct FromFileArgs : ArrowFsArgs {};
+struct FromFileArgs : ArrowFsArgs {
+  Option<location> mmap;
+};
 
 class FromFileOperator final : public ArrowFsOperator {
 public:
@@ -38,6 +40,9 @@ protected:
       co_return failure::promise();
     }
     auto expanded = expand_home(std::move(resolved));
+    if (not std::filesystem::path{expanded}.is_absolute()) {
+      expanded = "./" + expanded;
+    }
     expanded = std::filesystem::weakly_canonical(expanded);
     auto uri = arrow::util::Uri{};
     auto status = uri.Parse(fmt::format("file://{}", expanded));
@@ -53,8 +58,10 @@ protected:
 
   auto make_filesystem(arrow::util::Uri const& uri, diagnostic_handler&)
     -> Task<failure_or<MakeFilesystemResult>> override {
+    auto opts = arrow::fs::LocalFileSystemOptions::Defaults();
+    opts.use_mmap = args_.mmap.is_some();
     co_return MakeFilesystemResult{
-      std::make_shared<arrow::fs::LocalFileSystem>(),
+      std::make_shared<arrow::fs::LocalFileSystem>(opts),
       uri.path(),
     };
   }
@@ -85,6 +92,7 @@ public:
   auto describe() const -> Description override {
     auto d = Describer<FromFileArgs, FromFileOperator>{};
     ArrowFsArgs::describe_to(d);
+    d.named("mmap", &FromFileArgs::mmap);
     return d.without_optimize();
   }
 };

--- a/test/tests/operators/from_file/mmap.input
+++ b/test/tests/operators/from_file/mmap.input
@@ -1,0 +1,3 @@
+alpha
+beta
+gamma

--- a/test/tests/operators/from_file/mmap.tql
+++ b/test/tests/operators/from_file/mmap.tql
@@ -1,0 +1,3 @@
+from_file env("TENZIR_INPUT"), mmap=true {
+  read_lines
+}

--- a/test/tests/operators/from_file/mmap.txt
+++ b/test/tests/operators/from_file/mmap.txt
@@ -1,0 +1,9 @@
+{
+  line: "alpha",
+}
+{
+  line: "beta",
+}
+{
+  line: "gamma",
+}


### PR DESCRIPTION
Pass `mmap=true` to make Arrow's `LocalFileSystem` memory-map files instead of using regular reads. Delegates to `LocalFileSystemOptions::use_mmap`, so the existing `ReadAsync` path works transparently over the mapped region.

<sub>
🔗 Documentation PR: https://github.com/tenzir/docs/pull/263
</sub>
