### PR TITLE
Port `from_velociraptor` to the new executor

### DIFF
--- a/libtenzir/include/tenzir/operator_plugin.hpp
+++ b/libtenzir/include/tenzir/operator_plugin.hpp
@@ -311,11 +311,13 @@ class DescribeCtx {
 public:
   DescribeCtx(std::span<const Arg> args, std::span<const NamedArg> named_args,
               std::optional<const PipelineArg> pipeline,
-              const Description& desc, diagnostic_handler& dh)
+              const Description& desc, location operator_location,
+              diagnostic_handler& dh)
     : args_{args},
       named_args_{named_args},
       pipeline_{std::move(pipeline)},
       desc_{&desc},
+      operator_location_{operator_location},
       dh_{&dh} {
   }
 
@@ -461,6 +463,10 @@ public:
     return result;
   }
 
+  auto operator_location() const -> location {
+    return operator_location_;
+  }
+
   explicit(false) operator diagnostic_handler&() {
     return *dh_;
   }
@@ -512,6 +518,7 @@ private:
   std::span<const NamedArg> named_args_;
   std::optional<const PipelineArg> pipeline_;
   const Description* desc_;
+  location operator_location_;
   diagnostic_handler* dh_;
 };
 

--- a/libtenzir/src/operator_plugin.cpp
+++ b/libtenzir/src/operator_plugin.cpp
@@ -332,7 +332,8 @@ public:
   auto infer_type(element_type_tag input, diagnostic_handler& dh) const
     -> failure_or<std::optional<element_type_tag>> override {
     if (desc_->spawner) {
-      auto ctx = DescribeCtx{args_, named_args_, pipeline_, *desc_, dh};
+      auto ctx = DescribeCtx{args_,  named_args_,     pipeline_,
+                             *desc_, main_location(), dh};
       TRY(auto spawn, (*desc_->spawner)(input, ctx));
       if (spawn) {
         return match(*spawn,
@@ -369,7 +370,8 @@ public:
     auto spawner = std::optional<AnySpawn>{};
     if (desc_->spawner) {
       auto noop_dh = null_diagnostic_handler{};
-      auto ctx = DescribeCtx{args_, named_args_, pipeline_, *desc_, noop_dh};
+      auto ctx = DescribeCtx{args_,  named_args_,     pipeline_,
+                             *desc_, main_location(), noop_dh};
       auto result = (*desc_->spawner)(input, ctx);
       TENZIR_ASSERT(result);
       if (*result) {
@@ -585,8 +587,8 @@ public:
     // Run custom validation if provided.
     if (desc_->validator) {
       auto error_tracker = error_tracking_handler{ctx};
-      auto validate_ctx
-        = DescribeCtx{args_, named_args_, pipeline_, *desc_, error_tracker};
+      auto validate_ctx = DescribeCtx{args_,  named_args_,     pipeline_,
+                                      *desc_, main_location(), error_tracker};
       (*desc_->validator)(validate_ctx);
       if (error_tracker.had_error()) {
         return failure::promise();

--- a/plugins/from_velociraptor/CMakeLists.txt
+++ b/plugins/from_velociraptor/CMakeLists.txt
@@ -12,6 +12,8 @@ find_package(Tenzir REQUIRED)
 TenzirRegisterPlugin(
   TARGET from_velociraptor
   ENTRYPOINT src/plugin.cpp
+  INCLUDE_DIRECTORIES include
+  BUILTINS GLOB "${CMAKE_CURRENT_SOURCE_DIR}/builtins/*.cpp"
   SOURCES GLOB "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
 
 find_package(protobuf CONFIG)

--- a/plugins/from_velociraptor/builtins/from_velociraptor.cpp
+++ b/plugins/from_velociraptor/builtins/from_velociraptor.cpp
@@ -1,0 +1,454 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "from_velociraptor/common.hpp"
+
+#include <tenzir/arc.hpp>
+#include <tenzir/async.hpp>
+#include <tenzir/box.hpp>
+#include <tenzir/co_match.hpp>
+#include <tenzir/operator_plugin.hpp>
+#include <tenzir/plugin/register.hpp>
+#include <tenzir/tql2/plugin.hpp>
+#include <tenzir/variant.hpp>
+
+#include <fmt/ranges.h>
+#include <folly/coro/BlockingWait.h>
+#include <folly/coro/BoundedQueue.h>
+#include <grpcpp/channel.h>
+#include <grpcpp/client_context.h>
+#include <grpcpp/create_channel.h>
+#include <grpcpp/security/credentials.h>
+#include <grpcpp/support/client_callback.h>
+
+#include <atomic>
+#include <future>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "velociraptor.grpc.pb.h"
+
+namespace tenzir::plugins::velociraptor {
+
+using namespace std::chrono_literals;
+
+namespace {
+
+constexpr auto message_queue_capacity = uint32_t{1024};
+constexpr auto reactor_queue_overflow_error
+  = "Velociraptor reactor queue overflow";
+constexpr auto grpc_request_failed_error = "Velociraptor gRPC request failed";
+
+struct FromVelociraptorArgs {
+  record plugin_config;
+  Option<located<std::string>> request_name;
+  Option<located<std::string>> org_id;
+  Option<located<uint64_t>> max_rows;
+  Option<located<std::string>> subscribe;
+  Option<located<duration>> max_wait;
+  Option<located<std::string>> query;
+  Option<located<std::string>> profile;
+  location operator_location;
+};
+
+struct Response {
+  proto::VQLResponse response;
+};
+
+struct StreamFinished {
+  Option<std::string> error;
+};
+
+using Message = variant<Response, StreamFinished>;
+using MessageQueue = folly::coro::BoundedQueue<Message>;
+
+auto normalize_args(FromVelociraptorArgs const& args, diagnostic_handler& dh)
+  -> failure_or<operator_args> {
+  auto result = operator_args{
+    .max_rows = args.max_rows ? args.max_rows->inner : default_max_rows,
+    .max_wait
+    = args.max_wait
+        ? std::chrono::duration_cast<std::chrono::seconds>(args.max_wait->inner)
+        : default_max_wait,
+    .org_id = args.org_id ? args.org_id->inner : default_org_id,
+    .requests = {},
+  };
+  if (args.query) {
+    result.requests.push_back(request{
+      .name = args.request_name ? args.request_name->inner
+                                : fmt::to_string(uuid::random()),
+      .vql = args.query->inner,
+    });
+  }
+  if (args.subscribe) {
+    result.requests.push_back(request{
+      .name = args.request_name ? args.request_name->inner
+                                : fmt::to_string(uuid::random()),
+      .vql = make_subscribe_query(args.subscribe->inner),
+    });
+  }
+  if (result.max_wait < std::chrono::seconds{1}) {
+    auto diag = diagnostic::error("`max_wait` too low");
+    if (args.max_wait) {
+      std::move(diag).primary(args.max_wait->source).emit(dh);
+    } else {
+      std::move(diag).primary(args.operator_location).emit(dh);
+    }
+    return failure::promise();
+  }
+  if (result.requests.empty()) {
+    diagnostic::error("no artifact subscription or VQL expression provided")
+      .primary(args.operator_location)
+      .hint("specify `subscribe=<artifact>` for a subscription")
+      .hint("specify `query=<vql>` to run a VQL expression")
+      .emit(dh);
+    return failure::promise();
+  }
+  return result;
+}
+
+auto select_client_config(FromVelociraptorArgs const& args,
+                          diagnostic_handler& dh)
+  -> failure_or<GrpcClientConfig> {
+  auto profiles = available_profiles(args.plugin_config);
+  if (args.profile) {
+    if (profiles.empty()) {
+      diagnostic::error("no profiles configured")
+        .primary(args.profile->source)
+        .emit(dh);
+      return failure::promise();
+    }
+    auto profile_config = try_get_only<record>(
+      args.plugin_config, fmt::format("profiles.{}", args.profile->inner));
+    if (not profile_config) {
+      diagnostic::error("profile `{}` is invalid: {}", args.profile->inner,
+                        profile_config.error())
+        .primary(args.profile->source)
+        .emit(dh);
+      return failure::promise();
+    }
+    if (not *profile_config) {
+      diagnostic::error("profile `{}` does not exist", args.profile->inner)
+        .primary(args.profile->source)
+        .emit(dh);
+      return failure::promise();
+    }
+    return make_client_config(**profile_config, dh, args.operator_location);
+  }
+  if (not profiles.empty()) {
+    auto const& implicit_profile = profiles.front();
+    auto profile_config = try_get_only<record>(
+      args.plugin_config, fmt::format("profiles.{}", implicit_profile));
+    if (not profile_config) {
+      diagnostic::error("profile `{}` is invalid: {}", implicit_profile,
+                        profile_config.error())
+        .primary(args.operator_location)
+        .note("implicitly used the first configured profile")
+        .emit(dh);
+      return failure::promise();
+    }
+    if (not *profile_config) {
+      diagnostic::error("profile `{}` does not exist", implicit_profile)
+        .primary(args.operator_location)
+        .note("implicitly used the first configured profile")
+        .emit(dh);
+      return failure::promise();
+    }
+    return make_client_config(**profile_config, dh, args.operator_location);
+  }
+  return make_client_config(args.plugin_config, dh, args.operator_location);
+}
+
+class VelociraptorReadReactor final
+  : public grpc::ClientReadReactor<proto::VQLResponse> {
+public:
+  VelociraptorReadReactor(proto::API::Stub& stub,
+                          proto::VQLCollectorArgs request,
+                          Arc<MessageQueue> message_queue)
+    : request_{std::move(request)},
+      message_queue_{std::move(message_queue)},
+      done_future_{done_promise_.get_future().share()} {
+    auto* async = stub.async();
+    TENZIR_ASSERT(async);
+    async->Query(&context_, &request_, this);
+    StartCall();
+    StartRead(&read_buffer_);
+  }
+
+  VelociraptorReadReactor(VelociraptorReadReactor const&) = delete;
+  VelociraptorReadReactor(VelociraptorReadReactor&&) = delete;
+  auto operator=(VelociraptorReadReactor const&)
+    -> VelociraptorReadReactor& = delete;
+  auto operator=(VelociraptorReadReactor&&)
+    -> VelociraptorReadReactor& = delete;
+
+  ~VelociraptorReadReactor() noexcept override {
+    request_shutdown();
+    std::ignore = done_future_.wait_for(std::chrono::seconds{5});
+  }
+
+  auto request_shutdown() -> void {
+    local_shutdown_requested_.store(true, std::memory_order_release);
+    context_.TryCancel();
+  }
+
+  void OnReadDone(bool ok) override {
+    if (not ok) {
+      return;
+    }
+    if (not message_queue_->try_enqueue(Message{Response{read_buffer_}})) {
+      queue_overflow_.store(true, std::memory_order_release);
+      request_shutdown();
+      return;
+    }
+    StartRead(&read_buffer_);
+  }
+
+  void OnDone(grpc::Status const& status) override {
+    auto error = Option<std::string>{};
+    if (queue_overflow_.load(std::memory_order_acquire)) {
+      error = std::string{reactor_queue_overflow_error};
+    } else if (not status.ok()) {
+      auto const is_local_cancel
+        = status.error_code() == grpc::StatusCode::CANCELLED
+          and local_shutdown_requested_.load(std::memory_order_acquire);
+      if (not is_local_cancel) {
+        auto message = status.error_message();
+        if (message.empty()) {
+          message = grpc_request_failed_error;
+        }
+        error = std::move(message);
+      }
+    }
+    folly::coro::blocking_wait(
+      message_queue_->enqueue(Message{StreamFinished{std::move(error)}}));
+    done_promise_.set_value();
+  }
+
+private:
+  grpc::ClientContext context_;
+  proto::VQLCollectorArgs request_;
+  Arc<MessageQueue> message_queue_;
+  proto::VQLResponse read_buffer_;
+  std::promise<void> done_promise_;
+  std::shared_future<void> done_future_;
+  std::atomic<bool> local_shutdown_requested_{false};
+  std::atomic<bool> queue_overflow_{false};
+};
+
+class FromVelociraptor final : public Operator<void, table_slice> {
+public:
+  explicit FromVelociraptor(FromVelociraptorArgs args)
+    : args_{std::move(args)} {
+  }
+
+  auto start(OpCtx& ctx) -> Task<void> override {
+    auto normalized = normalize_args(args_, ctx.dh());
+    if (not normalized) {
+      done_ = true;
+      co_return;
+    }
+    auto config = select_client_config(args_, ctx.dh());
+    if (not config) {
+      done_ = true;
+      co_return;
+    }
+    auto credentials = grpc::SslCredentials({
+      .pem_root_certs = config->ca_certificate,
+      .pem_private_key = config->client_private_key,
+      .pem_cert_chain = config->client_cert,
+    });
+    auto channel_args = grpc::ChannelArguments{};
+    channel_args.SetSslTargetNameOverride("VelociraptorServer");
+    auto channel = grpc::CreateCustomChannel(config->api_connection_string,
+                                             credentials, channel_args);
+    auto stub = proto::API::NewStub(channel);
+    reactor_.emplace(std::in_place, *stub, make_collector_args(*normalized),
+                     message_queue_);
+    co_return;
+  }
+
+  auto await_task(diagnostic_handler&) const -> Task<Any> override {
+    if (done_) {
+      co_await wait_forever();
+      TENZIR_UNREACHABLE();
+    }
+    TENZIR_ASSERT(reactor_);
+    co_return co_await message_queue_->dequeue();
+  }
+
+  auto process_task(Any result, Push<table_slice>& push, OpCtx& ctx)
+    -> Task<void> override {
+    auto responses = std::vector<proto::VQLResponse>{};
+    auto terminal_error = Option<std::string>{};
+    auto saw_terminal = false;
+    auto collect_message = [&](Message message) -> void {
+      if (auto* response = try_as<Response>(&message)) {
+        responses.push_back(std::move(response->response));
+        return;
+      }
+      auto finished = as<StreamFinished>(std::move(message));
+      terminal_error = std::move(finished.error);
+      saw_terminal = true;
+    };
+    collect_message(std::move(result).as<Message>());
+    while (auto next = message_queue_->try_dequeue()) {
+      collect_message(std::move(*next));
+    }
+    for (auto& response : responses) {
+      if (auto slices = parse(response)) {
+        for (auto& slice : *slices) {
+          co_await push(std::move(slice));
+        }
+      } else {
+        emit_parse_warning(response, ctx.dh(), slices.error(),
+                           args_.operator_location);
+      }
+    }
+    if (saw_terminal and message_queue_->empty()) {
+      if (terminal_error) {
+        diagnostic::error(grpc_request_failed_error)
+          .primary(args_.operator_location)
+          .note("{}", *terminal_error)
+          .emit(ctx);
+      }
+      done_ = true;
+    }
+  }
+
+  auto finalize(Push<table_slice>& push, OpCtx& ctx)
+    -> Task<FinalizeBehavior> override {
+    TENZIR_UNUSED(push, ctx);
+    if (reactor_) {
+      (*reactor_)->request_shutdown();
+    }
+    done_ = true;
+    co_return FinalizeBehavior::done;
+  }
+
+  auto stop(OpCtx& ctx) -> Task<void> override {
+    co_await OperatorBase::stop(ctx);
+    if (reactor_) {
+      (*reactor_)->request_shutdown();
+    }
+    done_ = true;
+    co_return;
+  }
+
+  auto state() -> OperatorState override {
+    return done_ ? OperatorState::done : OperatorState::unspecified;
+  }
+
+private:
+  FromVelociraptorArgs args_;
+  mutable Arc<MessageQueue> message_queue_{std::in_place,
+                                           message_queue_capacity};
+  Option<Box<VelociraptorReadReactor>> reactor_;
+  bool done_ = false;
+};
+
+class from_velociraptor_builtin_plugin final : public virtual OperatorPlugin {
+public:
+  auto initialize(const record& unused_plugin_config,
+                  const record& global_config) -> caf::error override {
+    if (not unused_plugin_config.empty()) {
+      return diagnostic::error("`{}.yaml` is unused; Use `velociraptor.yaml` "
+                               "instead",
+                               this->name())
+        .primary(location::unknown)
+        .to_error();
+    }
+    auto c
+      = try_get_only<tenzir::record>(global_config, "plugins.velociraptor");
+    if (not c) {
+      return c.error();
+    }
+    if (*c) {
+      config_ = **c;
+    }
+    return caf::none;
+  }
+
+  auto name() const -> std::string override {
+    return "tql2.from_velociraptor";
+  }
+
+  auto describe() const -> Description override {
+    auto initial = FromVelociraptorArgs{};
+    initial.plugin_config = config_;
+    auto d
+      = Describer<FromVelociraptorArgs, FromVelociraptor>{std::move(initial)};
+    auto request_name
+      = d.named("request_name", &FromVelociraptorArgs::request_name);
+    auto org_id = d.named("org_id", &FromVelociraptorArgs::org_id);
+    auto query = d.named("query", &FromVelociraptorArgs::query);
+    auto max_rows = d.named("max_rows", &FromVelociraptorArgs::max_rows);
+    auto subscribe = d.named("subscribe", &FromVelociraptorArgs::subscribe);
+    auto max_wait = d.named("max_wait", &FromVelociraptorArgs::max_wait);
+    auto profile = d.named("profile", &FromVelociraptorArgs::profile);
+    d.named_optional("_config", &FromVelociraptorArgs::plugin_config);
+    d.operator_location(&FromVelociraptorArgs::operator_location);
+    d.validate([request_name, org_id, query, max_rows, subscribe, max_wait,
+                profile, this](DescribeCtx& ctx) -> Empty {
+      TENZIR_UNUSED(request_name, org_id, max_rows, profile);
+      auto args = FromVelociraptorArgs{};
+      args.plugin_config = config_;
+      args.operator_location = ctx.operator_location();
+      if (auto value = ctx.get(request_name)) {
+        args.request_name = *value;
+      }
+      if (auto value = ctx.get(org_id)) {
+        args.org_id = *value;
+      }
+      if (auto value = ctx.get(query)) {
+        args.query = *value;
+      }
+      if (auto value = ctx.get(max_rows)) {
+        args.max_rows = *value;
+      }
+      if (auto value = ctx.get(subscribe)) {
+        args.subscribe = *value;
+      }
+      if (auto value = ctx.get(max_wait)) {
+        args.max_wait = *value;
+      }
+      if (auto value = ctx.get(profile)) {
+        args.profile = *value;
+      }
+      if (auto wait = ctx.get(max_wait); wait and wait->inner < 1s) {
+        diagnostic::error("`max_wait` too low")
+          .primary(wait->source)
+          .hint("value must be great than 1s")
+          .emit(ctx);
+      }
+      if (not ctx.get(query) and not ctx.get(subscribe)) {
+        diagnostic::error("no artifact subscription or VQL expression provided")
+          .primary(ctx.operator_location())
+          .hint("specify `subscribe=<artifact>` for a subscription")
+          .hint("specify `query=<vql>` to run a VQL expression")
+          .emit(ctx);
+      }
+      std::ignore = select_client_config(args, ctx);
+      return {};
+    });
+    return d.without_optimize();
+  }
+
+private:
+  record config_;
+};
+
+} // namespace
+
+} // namespace tenzir::plugins::velociraptor
+
+TENZIR_REGISTER_PLUGIN(
+  tenzir::plugins::velociraptor::from_velociraptor_builtin_plugin)

--- a/plugins/from_velociraptor/builtins/from_velociraptor.cpp
+++ b/plugins/from_velociraptor/builtins/from_velociraptor.cpp
@@ -251,16 +251,10 @@ public:
   }
 
   auto start(OpCtx& ctx) -> Task<void> override {
-    auto normalized = normalize_args(args_, ctx.dh());
-    if (not normalized) {
-      done_ = true;
-      co_return;
-    }
+    auto normalized = normalize_args(args_, ctx);
+    TENZIR_ASSERT(normalized);
     auto config = select_client_config(args_, ctx.dh());
-    if (not config) {
-      done_ = true;
-      co_return;
-    }
+    TENZIR_ASSERT(config);
     auto credentials = grpc::SslCredentials({
       .pem_root_certs = config->ca_certificate,
       .pem_private_key = config->client_private_key,
@@ -277,10 +271,6 @@ public:
   }
 
   auto await_task(diagnostic_handler&) const -> Task<Any> override {
-    if (done_) {
-      co_await wait_forever();
-      TENZIR_UNREACHABLE();
-    }
     TENZIR_ASSERT(reactor_);
     co_return co_await message_queue_->dequeue();
   }
@@ -289,15 +279,14 @@ public:
     -> Task<void> override {
     auto responses = std::vector<proto::VQLResponse>{};
     auto terminal_error = Option<std::string>{};
-    auto saw_terminal = false;
     auto collect_message = [&](Message message) -> void {
       if (auto* response = try_as<Response>(&message)) {
         responses.push_back(std::move(response->response));
         return;
       }
-      auto finished = as<StreamFinished>(std::move(message));
-      terminal_error = std::move(finished.error);
-      saw_terminal = true;
+      auto finish_message = as<StreamFinished>(std::move(message));
+      terminal_error = std::move(finish_message.error);
+      stream_finished_ = true;
     };
     collect_message(std::move(result).as<Message>());
     while (auto next = message_queue_->try_dequeue()) {
@@ -313,38 +302,23 @@ public:
                            args_.operator_location);
       }
     }
-    if (saw_terminal and message_queue_->empty()) {
-      if (terminal_error) {
-        diagnostic::error(grpc_request_failed_error)
-          .primary(args_.operator_location)
-          .note("{}", *terminal_error)
-          .emit(ctx);
-      }
-      done_ = true;
+    TENZIR_ASSERT(not stream_finished_ or message_queue_->empty());
+    if (terminal_error) {
+      diagnostic::error(grpc_request_failed_error)
+        .primary(args_.operator_location)
+        .note("{}", *terminal_error)
+        .emit(ctx);
     }
-  }
-
-  auto finalize(Push<table_slice>& push, OpCtx& ctx)
-    -> Task<FinalizeBehavior> override {
-    TENZIR_UNUSED(push, ctx);
-    if (reactor_) {
-      (*reactor_)->request_shutdown();
-    }
-    done_ = true;
-    co_return FinalizeBehavior::done;
   }
 
   auto stop(OpCtx& ctx) -> Task<void> override {
-    co_await OperatorBase::stop(ctx);
-    if (reactor_) {
-      (*reactor_)->request_shutdown();
-    }
-    done_ = true;
+    TENZIR_ASSERT(reactor_);
+    (*reactor_)->request_shutdown();
     co_return;
   }
 
   auto state() -> OperatorState override {
-    return done_ ? OperatorState::done : OperatorState::unspecified;
+    return stream_finished_ ? OperatorState::done : OperatorState::unspecified;
   }
 
 private:
@@ -352,10 +326,10 @@ private:
   mutable Arc<MessageQueue> message_queue_{std::in_place,
                                            message_queue_capacity};
   Option<Box<VelociraptorReadReactor>> reactor_;
-  bool done_ = false;
+  bool stream_finished_ = false;
 };
 
-class from_velociraptor_builtin_plugin final : public virtual OperatorPlugin {
+class FromVelociraptorPlugin final : public virtual OperatorPlugin {
 public:
   auto initialize(const record& unused_plugin_config,
                   const record& global_config) -> caf::error override {
@@ -423,19 +397,7 @@ public:
       if (auto value = ctx.get(profile)) {
         args.profile = *value;
       }
-      if (auto wait = ctx.get(max_wait); wait and wait->inner < 1s) {
-        diagnostic::error("`max_wait` too low")
-          .primary(wait->source)
-          .hint("value must be great than 1s")
-          .emit(ctx);
-      }
-      if (not ctx.get(query) and not ctx.get(subscribe)) {
-        diagnostic::error("no artifact subscription or VQL expression provided")
-          .primary(ctx.operator_location())
-          .hint("specify `subscribe=<artifact>` for a subscription")
-          .hint("specify `query=<vql>` to run a VQL expression")
-          .emit(ctx);
-      }
+      std::ignore = normalize_args(args, ctx);
       std::ignore = select_client_config(args, ctx);
       return {};
     });
@@ -450,5 +412,4 @@ private:
 
 } // namespace tenzir::plugins::velociraptor
 
-TENZIR_REGISTER_PLUGIN(
-  tenzir::plugins::velociraptor::from_velociraptor_builtin_plugin)
+TENZIR_REGISTER_PLUGIN(tenzir::plugins::velociraptor::FromVelociraptorPlugin)

--- a/plugins/from_velociraptor/include/from_velociraptor/common.hpp
+++ b/plugins/from_velociraptor/include/from_velociraptor/common.hpp
@@ -1,0 +1,268 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <tenzir/data.hpp>
+#include <tenzir/diagnostics.hpp>
+#include <tenzir/error.hpp>
+#include <tenzir/logger.hpp>
+#include <tenzir/series_builder.hpp>
+#include <tenzir/uuid.hpp>
+#include <tenzir/view.hpp>
+
+#include <fmt/format.h>
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "velociraptor.pb.h"
+
+namespace tenzir::plugins::velociraptor {
+
+/// The ID of an Organization.
+constexpr auto default_org_id = "root";
+
+/// The maximum number of rows per response.
+constexpr auto default_max_rows = uint64_t{1'000};
+
+/// The number of seconds to wait on responses.
+constexpr auto default_max_wait = std::chrono::seconds{1};
+
+/// A VQL request.
+struct request {
+  std::string name;
+  std::string vql;
+
+  friend auto inspect(auto& f, request& x) -> bool {
+    return f.object(x).pretty_name("request").fields(f.field("name", x.name),
+                                                     f.field("vql", x.vql));
+  }
+};
+
+/// The arguments passed to the operator.
+struct operator_args {
+  uint64_t max_rows;
+  std::chrono::seconds max_wait;
+  std::string org_id;
+  std::vector<request> requests;
+
+  friend auto inspect(auto& f, operator_args& x) -> bool {
+    return f.object(x)
+      .pretty_name("operator_args")
+      .fields(f.field("max_rows", x.max_rows), f.field("max_wait", x.max_wait),
+              f.field("org_id", x.org_id), f.field("requests", x.requests));
+  }
+};
+
+struct GrpcClientConfig {
+  std::string ca_certificate;
+  std::string client_private_key;
+  std::string client_cert;
+  std::string api_connection_string;
+};
+
+/// Christoph Lobmeyer (https://github.com/lo-chr) devised this query and
+/// provided the use case to subscribe to a specific set of artifacts from
+/// multiple clients.
+constexpr auto subscribe_artifact_vql = R"__(
+LET subscribe_artifact = "{}"
+
+LET completions = SELECT *
+                  FROM watch_monitoring(artifact="System.Flow.Completion")
+                  WHERE Flow.artifacts_with_results =~ subscribe_artifact
+
+SELECT *
+FROM foreach(
+  row=completions,
+  query={{
+     SELECT *
+     FROM foreach(
+       row=Flow.artifacts_with_results,
+       query={{
+         SELECT *
+         FROM if(
+          condition=(_value =~ subscribe_artifact),
+          then={{
+             SELECT
+               {{
+                 SELECT *
+                 FROM source(
+                   client_id=ClientId,
+                   flow_id=Flow.session_id,
+                   artifact=_value)
+               }} AS HuntResult,
+               _value AS Artifact,
+               client_info(client_id=ClientId).os_info.hostname AS Hostname,
+               timestamp(epoch=now()) AS timestamp,
+               ClientId,
+               Flow.session_id AS FlowId
+             FROM source(
+               client_id=ClientId,
+               flow_id=Flow.session_id,
+               artifact=_value)
+             GROUP BY
+               artifact
+          }})
+        }})
+  }})
+)__";
+
+inline auto make_subscribe_query(std::string_view artifact) -> std::string {
+  return fmt::format(subscribe_artifact_vql, artifact);
+}
+
+/// Parses a response as table slice.
+inline auto parse(const proto::VQLResponse& response)
+  -> caf::expected<std::vector<table_slice>> {
+  auto builder = series_builder{};
+  auto us = std::chrono::microseconds(response.timestamp());
+  auto timestamp = time{std::chrono::duration_cast<duration>(us)};
+  // Velociraptor sends a stream of responses that consists of "control"
+  // and "data" messages. If the response payload is empty, then we have a
+  // control message, otherwise we have a data message.
+  if (not response.response().empty()) {
+    TENZIR_DEBUG("got a data message");
+    // There's an opportunity for improvement here, as we are not (yet)
+    // making use of the additional types provided in the response. We
+    // should synthesize a schema from that and provide that as hint to
+    // the series builder.
+    auto json = from_json(response.response());
+    if (not json) {
+      return caf::make_error(ec::parse_error,
+                             "Velociraptor response not in JSON format");
+    }
+    const auto* objects = try_as<list>(&*json);
+    if (objects == nullptr) {
+      return caf::make_error(ec::parse_error,
+                             "expected JSON array in Velociraptor response");
+    }
+    for (const auto& object : *objects) {
+      const auto* rec = try_as<record>(&object);
+      if (rec == nullptr) {
+        return caf::make_error(ec::parse_error,
+                               "expected objects in Velociraptor response");
+      }
+      auto row = builder.record();
+      row.field("timestamp").data(timestamp);
+      row.field("query_id").data(response.query_id());
+      row.field("query").data(record{
+        {"name", response.query().name()},
+        {"vql", response.query().vql()},
+      });
+      row.field("part").data(response.part());
+      auto resp = row.field("response").record();
+      for (const auto& [field, value] : *rec) {
+        resp.field(field).data(make_view(value));
+      }
+    }
+    return builder.finish_as_table_slice("velociraptor.response");
+  }
+  if (not response.log().empty()) {
+    TENZIR_DEBUG("got a control message");
+    auto row = builder.record();
+    row.field("timestamp").data(timestamp);
+    row.field("log").data(response.log());
+    return builder.finish_as_table_slice("velociraptor.log");
+  }
+  return caf::make_error(ec::unspecified, "empty Velociraptor response");
+}
+
+inline auto emit_parse_warning(proto::VQLResponse const& response,
+                               diagnostic_handler& dh, caf::error const& error,
+                               location const& operator_location
+                               = location::unknown) -> void {
+  diagnostic::warning("failed to parse Velociraptor gRPC response")
+    .primary(operator_location)
+    .note("{}", error)
+    .note("response: '{}'", response.response())
+    .note("query_id: '{}'", response.query_id())
+    .note("part: '{}'", response.part())
+    .note("query name: '{}'", response.query().name())
+    .note("query VQL: '{}'", response.query().vql())
+    .note("timestamp: '{}'", response.timestamp())
+    .note("total_rows: '{}'", response.total_rows())
+    .note("log: '{}'", response.log())
+    .emit(dh);
+}
+
+inline auto make_collector_args(operator_args const& args)
+  -> proto::VQLCollectorArgs {
+  auto result = proto::VQLCollectorArgs{};
+  for (auto const& request : args.requests) {
+    auto* query = result.add_query();
+    query->set_name(request.name);
+    query->set_vql(request.vql);
+  }
+  result.set_max_row(args.max_rows);
+  result.set_max_wait(args.max_wait.count());
+  result.set_org_id(args.org_id);
+  return result;
+}
+
+inline auto available_profiles(record const& config)
+  -> std::vector<std::string> {
+  auto const* profiles = get_if<record>(&config, "profiles");
+  if (not profiles) {
+    return {};
+  }
+  auto result = std::vector<std::string>{};
+  result.reserve(profiles->size());
+  for (auto const& [key, _] : *profiles) {
+    result.push_back(key);
+  }
+  return result;
+}
+
+inline auto
+make_client_config(record const& config, diagnostic_handler& dh,
+                   location const& operator_location = location::unknown)
+  -> failure_or<GrpcClientConfig> {
+  auto const* ca_certificate = get_if<std::string>(&config, "ca_certificate");
+  if (ca_certificate == nullptr) {
+    diagnostic::error("no 'ca_certificate' found in config file")
+      .primary(operator_location)
+      .emit(dh);
+    return failure::promise();
+  }
+  auto const* client_private_key
+    = get_if<std::string>(&config, "client_private_key");
+  if (client_private_key == nullptr) {
+    diagnostic::error("no 'client_private_key' found in config file")
+      .primary(operator_location)
+      .emit(dh);
+    return failure::promise();
+  }
+  auto const* client_cert = get_if<std::string>(&config, "client_cert");
+  if (client_cert == nullptr) {
+    diagnostic::error("no 'client_cert' found in config file")
+      .primary(operator_location)
+      .emit(dh);
+    return failure::promise();
+  }
+  auto const* api_connection_string
+    = get_if<std::string>(&config, "api_connection_string");
+  if (api_connection_string == nullptr) {
+    diagnostic::error("no 'api_connection_string' found in config file")
+      .primary(operator_location)
+      .emit(dh);
+    return failure::promise();
+  }
+  return GrpcClientConfig{
+    .ca_certificate = *ca_certificate,
+    .client_private_key = *client_private_key,
+    .client_cert = *client_cert,
+    .api_connection_string = *api_connection_string,
+  };
+}
+
+} // namespace tenzir::plugins::velociraptor

--- a/plugins/from_velociraptor/src/plugin.cpp
+++ b/plugins/from_velociraptor/src/plugin.cpp
@@ -6,28 +6,29 @@
 // SPDX-FileCopyrightText: (c) 2023 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+#include "from_velociraptor/common.hpp"
+
 #include <tenzir/argument_parser.hpp>
 #include <tenzir/detail/scope_guard.hpp>
 #include <tenzir/logger.hpp>
+#include <tenzir/operator_plugin.hpp>
 #include <tenzir/plugin.hpp>
-#include <tenzir/series_builder.hpp>
 #include <tenzir/tql2/plugin.hpp>
 #include <tenzir/uuid.hpp>
 
-#include <grpc/grpc.h>
+#include <fmt/ranges.h>
 #include <grpcpp/channel.h>
 #include <grpcpp/client_context.h>
+#include <grpcpp/completion_queue.h>
 #include <grpcpp/create_channel.h>
 #include <grpcpp/security/credentials.h>
 
 #include <chrono>
 #include <optional>
 #include <string>
-#include <string_view>
 #include <vector>
 
 #include "velociraptor.grpc.pb.h"
-#include "velociraptor.pb.h"
 
 // BEGIN Workaround https://github.com/abseil/abseil-cpp/issues/1747
 #include <absl/base/config.h>
@@ -70,147 +71,6 @@ using namespace std::chrono_literals;
 
 namespace {
 
-/// The ID of an Organization.
-constexpr auto default_org_id = "root";
-
-/// The maximum number of rows per response.
-constexpr auto default_max_rows = uint64_t{1'000};
-
-/// The number of seconds to wait on responses.
-constexpr auto default_max_wait = std::chrono::seconds{1};
-
-/// A VQL request.
-struct request {
-  std::string name;
-  std::string vql;
-
-  friend auto inspect(auto& f, request& x) -> bool {
-    return f.object(x).pretty_name("request").fields(f.field("name", x.name),
-                                                     f.field("vql", x.vql));
-  }
-};
-
-/// The arguments passed to the operator.
-struct operator_args {
-  uint64_t max_rows;
-  std::chrono::seconds max_wait;
-  std::string org_id;
-  std::vector<request> requests;
-
-  friend auto inspect(auto& f, operator_args& x) -> bool {
-    return f.object(x)
-      .pretty_name("operator_args")
-      .fields(f.field("max_rows", x.max_rows), f.field("max_wait", x.max_wait),
-              f.field("org_id", x.org_id), f.field("requests", x.requests));
-  }
-};
-
-/// Christoph Lobmeyer (https://github.com/lo-chr) devised this query and
-/// provided the use case to subscribe to a specific set of artifacts from
-/// multiple clients.
-constexpr auto subscribe_artifact_vql = R"__(
-LET subscribe_artifact = "{}"
-
-LET completions = SELECT *
-                  FROM watch_monitoring(artifact="System.Flow.Completion")
-                  WHERE Flow.artifacts_with_results =~ subscribe_artifact
-
-SELECT *
-FROM foreach(
-  row=completions,
-  query={{
-     SELECT *
-     FROM foreach(
-       row=Flow.artifacts_with_results,
-       query={{
-         SELECT *
-         FROM if(
-          condition=(_value =~ subscribe_artifact),
-          then={{
-             SELECT
-               {{
-                 SELECT *
-                 FROM source(
-                   client_id=ClientId,
-                   flow_id=Flow.session_id,
-                   artifact=_value)
-               }} AS HuntResult,
-               _value AS Artifact,
-               client_info(client_id=ClientId).os_info.hostname AS Hostname,
-               timestamp(epoch=now()) AS timestamp,
-               ClientId,
-               Flow.session_id AS FlowId
-             FROM source(
-               client_id=ClientId,
-               flow_id=Flow.session_id,
-               artifact=_value)
-             GROUP BY
-               artifact
-          }})
-        }})
-  }})
-)__";
-
-auto make_subscribe_query(std::string_view artifact) -> std::string {
-  return fmt::format(subscribe_artifact_vql, artifact);
-}
-
-/// Parses a response as table slice.
-auto parse(const proto::VQLResponse& response)
-  -> caf::expected<std::vector<table_slice>> {
-  auto builder = series_builder{};
-  auto us = std::chrono::microseconds(response.timestamp());
-  auto timestamp = time{std::chrono::duration_cast<duration>(us)};
-  // Velociraptor sends a stream of responses that consists of "control"
-  // and "data" messages. If the response payload is empty, then we have a
-  // control message, otherwise we have a data message.
-  if (not response.response().empty()) {
-    TENZIR_DEBUG("got a data message");
-    // There's an opportunity for improvement here, as we are not (yet)
-    // making use of the additional types provided in the response. We
-    // should synthesize a schema from that and provide that as hint to
-    // the series builder.
-    auto json = from_json(response.response());
-    if (not json) {
-      return caf::make_error(ec::parse_error,
-                             "Velociraptor response not in JSON format");
-    }
-    const auto* objects = try_as<list>(&*json);
-    if (objects == nullptr) {
-      return caf::make_error(ec::parse_error,
-                             "expected JSON array in Velociraptor response");
-    }
-    for (const auto& object : *objects) {
-      const auto* rec = try_as<record>(&object);
-      if (rec == nullptr) {
-        return caf::make_error(ec::parse_error,
-                               "expected objects in Velociraptor response");
-      }
-      auto row = builder.record();
-      row.field("timestamp").data(timestamp);
-      row.field("query_id").data(response.query_id());
-      row.field("query").data(record{
-        {"name", response.query().name()},
-        {"vql", response.query().vql()},
-      });
-      row.field("part").data(response.part());
-      auto resp = row.field("response").record();
-      for (const auto& [field, value] : *rec) {
-        resp.field(field).data(make_view(value));
-      }
-    }
-    return builder.finish_as_table_slice("velociraptor.response");
-  }
-  if (not response.log().empty()) {
-    TENZIR_DEBUG("got a control message");
-    auto row = builder.record();
-    row.field("timestamp").data(timestamp);
-    row.field("log").data(response.log());
-    return builder.finish_as_table_slice("velociraptor.log");
-  }
-  return caf::make_error(ec::unspecified, "empty Velociraptor response");
-}
-
 class velociraptor_operator final
   : public crtp_operator<velociraptor_operator> {
 public:
@@ -222,60 +82,28 @@ public:
 
   auto operator()(operator_control_plane& ctrl) const
     -> generator<table_slice> {
-    const auto* ca_certificate
-      = get_if<std::string>(&config_, "ca_certificate");
-    if (ca_certificate == nullptr) {
-      diagnostic::error("no 'ca_certificate' found in config file")
-        .hint("generate a valid config file `velociraptor config api_client`")
-        .emit(ctrl.diagnostics());
+    auto client_config = make_client_config(config_, ctrl.diagnostics());
+    if (not client_config) {
       co_return;
     }
-    const auto* client_private_key
-      = get_if<std::string>(&config_, "client_private_key");
-    if (client_private_key == nullptr) {
-      diagnostic::error("no 'client_private_key' found in config file")
-        .hint("generate a valid config file `velociraptor config api_client`")
-        .emit(ctrl.diagnostics());
-      co_return;
-    }
-    const auto* client_cert = get_if<std::string>(&config_, "client_cert");
-    if (client_private_key == nullptr) {
-      diagnostic::error("no 'client_cert' found in config file")
-        .hint("generate a valid config file `velociraptor config api_client`")
-        .emit(ctrl.diagnostics());
-      co_return;
-    }
-    const auto* api_connection_string
-      = get_if<std::string>(&config_, "api_connection_string");
-    if (api_connection_string == nullptr) {
-      diagnostic::error("no 'api_connection_string' found in config file")
-        .hint("generate a valid config file `velociraptor config api_client`")
-        .emit(ctrl.diagnostics());
-      co_return;
-    }
-    TENZIR_DEBUG("establishing gRPC channel to {}", *api_connection_string);
+    TENZIR_DEBUG("establishing gRPC channel to {}",
+                 client_config->api_connection_string);
     auto credentials = grpc::SslCredentials({
-      .pem_root_certs = *ca_certificate,
-      .pem_private_key = *client_private_key,
-      .pem_cert_chain = *client_cert,
+      .pem_root_certs = client_config->ca_certificate,
+      .pem_private_key = client_config->client_private_key,
+      .pem_cert_chain = client_config->client_cert,
     });
     auto channel_args = grpc::ChannelArguments{};
     // Overriding the target name is necessary to connect by IP address
     // because Velociraptor uses self-signed certs.
     channel_args.SetSslTargetNameOverride("VelociraptorServer");
-    auto channel = grpc::CreateCustomChannel(*api_connection_string,
-                                             credentials, channel_args);
+    auto channel = grpc::CreateCustomChannel(
+      client_config->api_connection_string, credentials, channel_args);
     auto stub = proto::API::NewStub(channel);
-    auto args = proto::VQLCollectorArgs{};
     for (const auto& request : args_.requests) {
       TENZIR_DEBUG("staging request {}: {}", request.name, request.vql);
-      auto* query = args.add_query();
-      query->set_name(request.name);
-      query->set_vql(request.vql);
     }
-    args.set_max_row(args_.max_rows);
-    args.set_max_wait(args_.max_wait.count());
-    args.set_org_id(args_.org_id);
+    auto args = make_collector_args(args_);
     TENZIR_DEBUG("submitting request: max_row = {}, max_wait = {}, org_id = "
                  "{}",
                  args_.max_rows, args_.max_wait, args_.org_id);
@@ -329,18 +157,8 @@ public:
                   co_yield slice;
                 }
               } else {
-                diagnostic::warning(
-                  "failed to parse Velociraptor gRPC response")
-                  .note("{}", slices.error())
-                  .note("response: '{}'", response.response())
-                  .note("query_id: '{}'", response.query_id())
-                  .note("part: '{}'", response.part())
-                  .note("query name: '{}'", response.query().name())
-                  .note("query VQL: '{}'", response.query().vql())
-                  .note("timestamp: '{}'", response.timestamp())
-                  .note("total_rows: '{}'", response.total_rows())
-                  .note("log: '{}'", response.log())
-                  .emit(ctrl.diagnostics());
+                emit_parse_warning(response, ctrl.diagnostics(),
+                                   slices.error());
               }
               read = true;
             }
@@ -469,20 +287,9 @@ public:
     args.max_rows = max_rows ? max_rows->inner : default_max_rows;
     args.max_wait = std::chrono::duration_cast<std::chrono::seconds>(
       max_wait ? max_wait->inner : default_max_wait);
-    const auto available_profiles = [&]() -> std::vector<std::string_view> {
-      const auto* profiles = get_if<record>(&config_, "profiles");
-      if (not profiles) {
-        return {};
-      }
-      auto result = std::vector<std::string_view>{};
-      result.reserve(profiles->size());
-      for (const auto& [key, _] : *profiles) {
-        result.push_back(key);
-      }
-      return result;
-    }();
+    auto profiles = available_profiles(config_);
     if (profile) {
-      if (available_profiles.empty()) {
+      if (profiles.empty()) {
         diagnostic::error("no profiles configured")
           .primary(profile->source)
           .emit(ctx);
@@ -494,29 +301,29 @@ public:
         diagnostic::error("profile `{}` is invalid: {}", profile->inner,
                           profile_config.error())
           .primary(profile->source)
-          .hint("available profiles: {}", fmt::join(available_profiles, ", "))
+          .hint("available profiles: {}", fmt::join(profiles, ", "))
           .emit(ctx);
         return failure::promise();
       }
       if (not *profile_config) {
         diagnostic::error("profile `{}` does not exist", profile->inner)
           .primary(profile->source)
-          .hint("available profiles: {}", fmt::join(available_profiles, ", "))
+          .hint("available profiles: {}", fmt::join(profiles, ", "))
           .emit(ctx);
         return failure::promise();
       }
       return std::make_unique<velociraptor_operator>(std::move(args),
                                                      **profile_config);
     }
-    if (available_profiles.empty()) {
+    if (profiles.empty()) {
       return std::make_unique<velociraptor_operator>(std::move(args), config_);
     }
     // If we have profiles configured but no --profile set, we default to the
     // first configured profile.
     auto profile_config = try_get_only<record>(
-      config_, fmt::format("profiles.{}", available_profiles.front()));
+      config_, fmt::format("profiles.{}", profiles.front()));
     if (not profile_config or not *profile_config) {
-      diagnostic::error("profile `{}` is invalid", available_profiles.front())
+      diagnostic::error("profile `{}` is invalid", profiles.front())
         .note("implicitly used the first configured profile")
         .emit(ctx);
       return failure::promise();
@@ -574,20 +381,9 @@ public:
     args.max_rows = max_rows ? max_rows->inner : default_max_rows;
     args.max_wait = std::chrono::duration_cast<std::chrono::seconds>(
       max_wait ? max_wait->inner : default_max_wait);
-    const auto available_profiles = [&]() -> std::vector<std::string_view> {
-      const auto* profiles = get_if<record>(&config_, "profiles");
-      if (not profiles) {
-        return {};
-      }
-      auto result = std::vector<std::string_view>{};
-      result.reserve(profiles->size());
-      for (const auto& [key, _] : *profiles) {
-        result.push_back(key);
-      }
-      return result;
-    }();
+    auto profiles = available_profiles(config_);
     if (profile) {
-      if (available_profiles.empty()) {
+      if (profiles.empty()) {
         diagnostic::error("no profiles configured")
           .primary(profile->source)
           .throw_();
@@ -598,27 +394,27 @@ public:
         diagnostic::error("profile `{}` is invalid: {}", profile->inner,
                           profile_config.error())
           .primary(profile->source)
-          .hint("available profiles: {}", fmt::join(available_profiles, ", "))
+          .hint("available profiles: {}", fmt::join(profiles, ", "))
           .throw_();
       }
       if (not *profile_config) {
         diagnostic::error("profile `{}` does not exist", profile->inner)
           .primary(profile->source)
-          .hint("available profiles: {}", fmt::join(available_profiles, ", "))
+          .hint("available profiles: {}", fmt::join(profiles, ", "))
           .throw_();
       }
       return std::make_unique<velociraptor_operator>(std::move(args),
                                                      **profile_config);
     }
-    if (available_profiles.empty()) {
+    if (profiles.empty()) {
       return std::make_unique<velociraptor_operator>(std::move(args), config_);
     }
     // If we have profiles configured but no --profile set, we default to the
     // first configured profile.
     auto profile_config = try_get_only<record>(
-      config_, fmt::format("profiles.{}", available_profiles.front()));
+      config_, fmt::format("profiles.{}", profiles.front()));
     if (not profile_config or not *profile_config) {
-      diagnostic::error("profile `{}` is invalid", available_profiles.front())
+      diagnostic::error("profile `{}` is invalid", profiles.front())
         .note("implicitly used the first configured profile")
         .throw_();
     }


### PR DESCRIPTION
The port extracts some common components from the old-executor implementation
into a shared header.

The new implementation does not rely on synchronous timeout-based pulls
from a queue, but rather reacts to new events properly.

I tested this locally.

<sub>
✅ Closes TNZ-79
</sub>
