### PR TITLE
Check for cancellation in JoinSet

### DIFF
--- a/libtenzir/include/tenzir/async/join_set.hpp
+++ b/libtenzir/include/tenzir/async/join_set.hpp
@@ -73,9 +73,13 @@ public:
     while (running_ > 0) {
       auto item = co_await queue_.dequeue();
       running_ -= 1;
-      // A cancelled task does not return a result.
+      // A cancelled task does not return a result, but we still need to check
+      // whether we were cancelled ourselves as we catch cancellation to produce
+      // nothing and at the same time, `.dequeue()` doesn't check itself.
       if (item) {
         co_return item;
+      } else {
+        co_await folly::coro::co_safe_point;
       }
     }
     co_return None{};


### PR DESCRIPTION
## 🔍 Problem

- `read_csv schema_only=true` reports the expected user-facing schema error.
- The diagnostic cancels the pipeline while `JoinSet` is still draining cancelled child tasks.
- Without a cancellation check in that drain path, callers can mistake cancellation for a normal shutdown path and hit unrelated executor assertions under parallel load.

## 🛠️ Solution

- Check for cancellation in `JoinSet::next()` when a child task completed as cancelled.
- Let the cancellation propagate before continuing to drain the set.

## 💬 Review

- Focus on whether `JoinSet::next()` is the right place to re-raise cancellation after `catch_cancellation()` turned it into an empty completion.
- I verified the original flaky repro with repeated parallel direct runs of `error_csv_schema_only_missing_schema.tql` and repeated `operators/xsv/` suite runs.
