### PR TITLE
Check for cancellation in `JoinSet`

### DIFF
--- a/libtenzir/include/tenzir/async/join_set.hpp
+++ b/libtenzir/include/tenzir/async/join_set.hpp
@@ -73,9 +73,13 @@ public:
     while (running_ > 0) {
       auto item = co_await queue_.dequeue();
       running_ -= 1;
-      // A cancelled task does not return a result.
+      // A cancelled task does not return a result, but we still need to check
+      // whether we were cancelled ourselves as we catch cancellation to produce
+      // nothing and at the same time, `.dequeue()` doesn't check itself.
       if (item) {
         co_return item;
+      } else {
+        co_await folly::coro::co_safe_point;
       }
     }
     co_return None{};


### PR DESCRIPTION
The `JoinSet` catches cancellation of it's inner tasks, but does not check for cancellation itself on the fast path where its queue is non-empty. As a result, when everything is cancelled and results are put into the queue before `.next()` is called, the call immediately produces `None` which can be quite surprising.