### PR TITLE
Disable treefmt checks in CI and restore regular style checks

### DIFF
--- a/.github/workflows/style-check.yaml
+++ b/.github/workflows/style-check.yaml
@@ -63,7 +63,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          fetch-depth: 1
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -86,7 +86,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          fetch-depth: 1
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -185,7 +185,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          fetch-depth: 1
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/flake.nix
+++ b/flake.nix
@@ -108,7 +108,8 @@
         devShells.default = import ./shell.nix { inherit pkgs package; };
         formatter = self.packages.${system}.format;
         checks = {
-          formatting = treefmtEval.config.build.check self;
+          # Disabled until the custom Style Check workflow is aligned.
+          #formatting = treefmtEval.config.build.check self;
         };
       }
     );


### PR DESCRIPTION
`treefmt-nix` is setup to use `ruff format`, which does not agree with `black` in some cases.
We'll switch to `ruff format` when the time is right.