### PR TITLE
Fix partition rebuild shutdown

### DIFF
--- a/changelog/unreleased/partition-rebuild-completion.md
+++ b/changelog/unreleased/partition-rebuild-completion.md
@@ -1,0 +1,11 @@
+---
+title: Partition rebuild completion
+type: bugfix
+authors:
+  - tobim
+  - codex
+pr: 6057
+created: 2026-04-20T13:38:16.55446Z
+---
+
+Partition rebuilds now finish after persisting rebuilt partitions. Previously, rebuild jobs could remain stuck indefinitely even though the replacement partitions were written successfully.

--- a/libtenzir/src/store.cpp
+++ b/libtenzir/src/store.cpp
@@ -293,6 +293,11 @@ default_active_store_actor::behavior_type default_active_store(
         {"store-type", self->state().store_type},
       };
     },
+    [self](const caf::exit_msg& msg) {
+      TENZIR_TRACE("{} received EXIT from {} with reason: {}", *self,
+                   msg.source, msg.reason);
+      self->quit(msg.reason);
+    },
   };
 }
 


### PR DESCRIPTION
## 🔍 Problem

- Partition rebuilds could hang after a store persisted successfully.
- The rebuild waited for the store builder to terminate, but normal exit messages did not stop the active store builder.

## 🛠️ Solution

- Handle exit messages explicitly in active store builders.
- Preserve normal shutdown semantics while allowing the rebuild monitor to observe completion.

## 💬 Review

- Focus on actor shutdown behavior for active store builders.
- Verified with a minimal explicit `rebuild start --all` repro that previously timed out.

Fixes TNZ-503.