### PR TITLE
Tweak summarize behavior around finalize

### DIFF
--- a/libtenzir/builtins/operators/summarize.cpp
+++ b/libtenzir/builtins/operators/summarize.cpp
@@ -882,7 +882,6 @@ public:
   auto finalize(Push<table_slice>& push, OpCtx& ctx)
     -> Task<FinalizeBehavior> override {
     TENZIR_UNUSED(ctx);
-    co_await flush_until(steady_clock::now(), push);
     for (auto& slice : impl_->finish(provider_->as_session())) {
       co_await push(std::move(slice));
     }

--- a/test/tests/operators/summarize/frequency-anchor-first-input.tql
+++ b/test/tests/operators/summarize/frequency-anchor-first-input.tql
@@ -3,6 +3,6 @@
 // implementation anchored the schedule too early and emitted an extra periodic
 // result between the two delayed rows.
 from {ts: 400ms.from_epoch(), x: 1},
-     {ts: 650ms.from_epoch(), x: 1}
+     {ts: 900ms.from_epoch(), x: 1}
 delay ts, start=0ms.from_epoch()
-summarize count=count(), options={frequency: 300ms, mode: "cumulative"}
+summarize count=count(), options={frequency: 1000ms, mode: "cumulative"}


### PR DESCRIPTION
Stop summarize from emitting overdue periodic results during
finalization. Periodic frequency outputs now only happen while
the pipeline is still running, which fixes the extra emission in
frequency-anchor-first-input.

This PR also tweaks that test to increase time intervals, so flakes
are less likely.