### PR TITLE
Fix memory growth in `context::enrich`

### DIFF
--- a/changelog/unreleased/stable-memory-usage-for-contextenrich.md
+++ b/changelog/unreleased/stable-memory-usage-for-contextenrich.md
@@ -1,0 +1,10 @@
+---
+title: Fixed unbounded memory growth `context::enrich`
+type: bugfix
+authors:
+  - IyeOnline
+created: 2026-04-23T16:27:15.809496Z
+---
+
+We fixed an issue in the `context::enrich` operator that did cause unbounded
+memory growth.


### PR DESCRIPTION
This fixes an unbounded memory growth when doing a `context::enrich`
seemingly caused by some issue with coroutine suspension.

Submodule PR: https://github.com/tenzir/tenzir-plugins/pull/519

Resolves TNZ-347
