### PR TITLE
Only save ccache after compilation starts

### DIFF
--- a/.github/workflows/tenzir.yaml
+++ b/.github/workflows/tenzir.yaml
@@ -961,6 +961,7 @@ jobs:
           echo "PACKAGE_NAME=$PACKAGE_NAME" >> $GITHUB_ENV
           echo "PUBLISH_NAME=$PUBLISH_NAME" >> $GITHUB_ENV
       - name: Fetch ccache Cache
+        id: ccache_restore
         uses: actions/cache/restore@v4
         with:
           # Note that the `path` is implicitly part of the key when looking up cache hits:
@@ -996,20 +997,22 @@ jobs:
             -DTENZIR_VERSION_BUILD_METADATA:STRING="${{ needs.configure.outputs.tenzir-version-build-metadata }}" \
             ${{ matrix.tenzir.cmake-extra-flags }}
       - name: Compile All Targets
+        id: compile_all_targets
         run: |
           cmake --build "$BUILD_DIR" --target all --parallel --verbose
       - name: Show ccache Statistics
+        if: ${{ always() && steps.compile_all_targets.outcome != 'skipped' }}
         run: |
           # Print statistics counter IDs and corresponding values.
           ccache --show-stats
           # Print statistics about cache compression.
           ccache --show-compression
       - name: Save ccache Cache
-        if: always()
+        if: ${{ always() && steps.compile_all_targets.outcome != 'skipped' && steps.ccache_restore.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
         with:
           path: ${{ env.CCACHE_DIR }}
-          key: ${{ github.workflow }}-${{ matrix.tenzir.name }}-${{ matrix.tenzir.compiler }}-${{ needs.configure.outputs.ref-slug }}-${{ github.sha }}
+          key: ${{ steps.ccache_restore.outputs.cache-primary-key }}
           enableCrossOsArchive: true
       - name: Run Unit Tests
         env:


### PR DESCRIPTION
## 🔍 Problem

- `Save ccache Cache` currently uses `if: always()`, so macOS CI saves a new SHA-keyed cache even when the job is cancelled or fails before compilation starts.
- On PRs, `cancel-in-progress` makes that case common: a run can be cancelled during dependency setup or configure, never produce new object files, and still publish a cache entry.
- That entry is not warmer than the previously restored cache, but it can still become the newest branch-prefix candidate and consumes part of the 10 GB GitHub Actions cache budget.

**Key benefit:** keep the useful partial caches from failed or cancelled compiles, while stopping pre-compile cancellations and setup/configure failures from publishing low-value ccache entries.

| Scenario | Today (`if: always()`) | This PR | Why this is better |
| --- | --- | --- | --- |
| Job is cancelled during setup/dependency install | Saves cache anyway | Does not save | No compile happened, so the cache is not warmer than before. |
| Configure step fails before compile | Saves cache anyway | Does not save | Avoids publishing a new SHA cache with no new object files. |
| Compile starts, then fails halfway | Saves cache | Saves cache | Keeps the useful partial-build case. |
| Compile starts, then job is cancelled mid-build | Saves cache | Saves cache | Preserves warmed objects from the partial compile. |
| Compile succeeds | Saves cache | Saves cache | No regression. |
| Exact cache hit for same SHA | Tries to save again | Skips save | Avoids a pointless save step. |

## 🛠️ Solution

- Give the restore and compile steps IDs so later steps can distinguish "compile ran" from "compile never started".
- Gate `Show ccache Statistics` and `Save ccache Cache` on `steps.compile_all_targets.outcome != 'skipped'`.
- Keep `always()` so successful, failed, and mid-compile cancelled builds still save their partial ccache state.
- Reuse `steps.ccache_restore.outputs.cache-primary-key` and skip saving on an exact cache hit.

## 💬 Review

- Focus on whether `outcome != 'skipped'` matches the intended policy boundary: save after any compile attempt, but not after pre-compile cancellation or setup/configure failure.
- This PR intentionally does not change the cache key shape or workflow concurrency. It only improves which runs are allowed to publish a cache.
- No changelog entry: this is an internal CI behavior fix without user-facing changes.

<sub>
📎 Related: tenzir/tenzir#6065
</sub>
