### PR TITLE
Skip unreadable directories in recursive files traversal

### DIFF
--- a/changelog/unreleased/recursive-files-traversal-of-unreadable-directories.md
+++ b/changelog/unreleased/recursive-files-traversal-of-unreadable-directories.md
@@ -1,0 +1,10 @@
+---
+title: Recursive files traversal of unreadable directories
+type: bugfix
+authors:
+  - mavam
+  - codex
+created: 2026-04-24T07:09:11.344154Z
+---
+
+The `files` operator now skips unreadable child directories during recursive traversal, emits a warning for each skipped directory, and continues listing accessible siblings. The initial directory still must be readable unless `skip_permission_denied=true` is set.

--- a/changelog/unreleased/recursive-files-traversal-of-unreadable-directories.md
+++ b/changelog/unreleased/recursive-files-traversal-of-unreadable-directories.md
@@ -7,4 +7,4 @@ authors:
 created: 2026-04-24T07:09:11.344154Z
 ---
 
-The `files` operator now skips unreadable child directories during recursive traversal, emits a warning for each skipped directory, and continues listing accessible siblings. The initial directory still must be readable unless `skip_permission_denied=true` is set.
+The `files` operator now skips unreadable child directories during recursive traversal, emits a warning for each skipped directory by default, and continues listing accessible siblings. Set `skip_permission_denied=true` to ignore permission-denied paths silently: this suppresses warnings for skipped child directories and still makes an unreadable initial directory produce no events instead of an error. Non-permission filesystem errors continue to fail the pipeline.

--- a/libtenzir/builtins/operators/files.cpp
+++ b/libtenzir/builtins/operators/files.cpp
@@ -18,6 +18,7 @@
 #include <filesystem>
 #include <grp.h>
 #include <pwd.h>
+#include <vector>
 #include <unistd.h>
 
 namespace tenzir::plugins::files {
@@ -38,6 +39,128 @@ struct files_args {
       f.field("skip_permission_denied", x.skip_permission_denied));
   }
 };
+
+auto is_permission_error(std::error_code ec) -> bool {
+  return ec == std::errc::permission_denied
+         or ec == std::errc::operation_not_permitted;
+}
+
+auto directory_options(files_args const& args)
+  -> std::filesystem::directory_options {
+  auto result = std::filesystem::directory_options::none;
+  if (args.follow_directory_symlink) {
+    result |= std::filesystem::directory_options::follow_directory_symlink;
+  }
+  return result;
+}
+
+auto emit_filesystem_error(const std::filesystem::path& path,
+                           std::error_code ec, diagnostic_handler& dh) -> void {
+  diagnostic::error("{}",
+                    std::filesystem::filesystem_error{
+                      "failed to list directory", path, ec}.what())
+    .emit(dh);
+}
+
+auto emit_skipped_directory_warning(const std::filesystem::path& path,
+                                    std::error_code ec,
+                                    diagnostic_handler& dh) -> void {
+  diagnostic::warning("skipping unreadable directory `{}`: {}", path,
+                      ec.message())
+    .emit(dh);
+}
+
+auto should_recurse_into(const std::filesystem::directory_entry& entry,
+                         std::filesystem::directory_options options,
+                         diagnostic_handler& dh) -> bool {
+  auto ec = std::error_code{};
+  const auto follow_symlinks
+    = (options & std::filesystem::directory_options::follow_directory_symlink)
+      != std::filesystem::directory_options::none;
+  const auto status
+    = follow_symlinks ? entry.status(ec) : entry.symlink_status(ec);
+  if (ec) {
+    diagnostic::warning("failed to inspect `{}`: {}", entry.path(),
+                        ec.message())
+      .emit(dh);
+    return false;
+  }
+  return status.type() == std::filesystem::file_type::directory;
+}
+
+auto list_directory(const std::filesystem::path& path,
+                    std::filesystem::directory_options options,
+                    bool skip_permission_denied,
+                    diagnostic_handler& dh)
+  -> generator<std::filesystem::directory_entry> {
+  auto ec = std::error_code{};
+  auto iterator = std::filesystem::directory_iterator{path, options, ec};
+  if (ec) {
+    if (skip_permission_denied and is_permission_error(ec)) {
+      co_return;
+    }
+    emit_filesystem_error(path, ec, dh);
+    co_return;
+  }
+  const auto end = std::filesystem::directory_iterator{};
+  while (iterator != end) {
+    co_yield *iterator;
+    ec.clear();
+    iterator.increment(ec);
+    if (ec) {
+      emit_filesystem_error(path, ec, dh);
+      co_return;
+    }
+  }
+}
+
+auto list_directory_recursive(const std::filesystem::path& path,
+                              std::filesystem::directory_options options,
+                              bool skip_permission_denied,
+                              diagnostic_handler& dh)
+  -> generator<std::filesystem::directory_entry> {
+  auto ec = std::error_code{};
+  auto stack = std::vector<std::filesystem::directory_iterator>{};
+  auto root = std::filesystem::directory_iterator{path, options, ec};
+  if (ec) {
+    if (skip_permission_denied and is_permission_error(ec)) {
+      co_return;
+    }
+    emit_filesystem_error(path, ec, dh);
+    co_return;
+  }
+  stack.push_back(std::move(root));
+  const auto end = std::filesystem::directory_iterator{};
+  while (not stack.empty()) {
+    auto& current = stack.back();
+    if (current == end) {
+      stack.pop_back();
+      continue;
+    }
+    auto entry = *current;
+    ec.clear();
+    current.increment(ec);
+    if (ec) {
+      emit_filesystem_error(entry.path(), ec, dh);
+      co_return;
+    }
+    co_yield entry;
+    if (not should_recurse_into(entry, options, dh)) {
+      continue;
+    }
+    ec.clear();
+    auto child = std::filesystem::directory_iterator{entry.path(), options, ec};
+    if (ec) {
+      if (is_permission_error(ec)) {
+        emit_skipped_directory_warning(entry.path(), ec, dh);
+        continue;
+      }
+      emit_filesystem_error(entry.path(), ec, dh);
+      co_return;
+    }
+    stack.push_back(std::move(child));
+  }
+}
 
 class files_operator final : public crtp_operator<files_operator> {
 public:
@@ -84,11 +207,16 @@ public:
     };
     auto builder = series_builder{schema};
     for (const auto& entry : std::move(listing)) {
+      auto status_ec = std::error_code{};
+      const auto status = entry.status(status_ec);
       auto event = builder.record();
       event.field("path", entry.path().string());
       event.field("type", [&]() -> data_view2 {
+        if (status_ec) {
+          return {};
+        }
         using std::filesystem::file_type;
-        switch (entry.status().type()) {
+        switch (status.type()) {
           case file_type::regular:
             return "regular";
           case file_type::directory:
@@ -114,7 +242,7 @@ public:
       {
         using std::filesystem::perms;
         auto permissions = event.field("permissions").record();
-        auto has_perm = [perms = entry.status().permissions()](auto perm) {
+        auto has_perm = [perms = status.permissions()](auto perm) {
           return perms::none != (perms & perm);
         };
 #define X(name)                                                                \
@@ -166,27 +294,19 @@ public:
     try {
       const auto path = args_.path ? std::filesystem::path{*args_.path}
                                    : std::filesystem::current_path();
-      const auto options = [&] {
-        auto result = std::filesystem::directory_options::none;
-        if (args_.follow_directory_symlink) {
-          result
-            |= std::filesystem::directory_options::follow_directory_symlink;
-        }
-        if (args_.skip_permission_denied) {
-          result |= std::filesystem::directory_options::skip_permission_denied;
-        }
-        return result;
-      }();
-      auto builder = series_builder{};
+      const auto options = directory_options(args_);
       if (args_.recurse_directories) {
-        auto gen = make_generator(
-          std::filesystem::recursive_directory_iterator{path, options});
+        auto gen
+          = make_generator(list_directory_recursive(path, options,
+                                                    args_.skip_permission_denied,
+                                                    ctrl.diagnostics()));
         for (auto&& result : std::move(gen)) {
           co_yield std::move(result);
         }
       } else {
-        auto gen
-          = make_generator(std::filesystem::directory_iterator{path, options});
+        auto gen = make_generator(
+          list_directory(path, options, args_.skip_permission_denied,
+                         ctrl.diagnostics()));
         for (auto&& result : std::move(gen)) {
           co_yield std::move(result);
         }

--- a/libtenzir/builtins/operators/files.cpp
+++ b/libtenzir/builtins/operators/files.cpp
@@ -271,7 +271,7 @@ auto make_file_events(auto listing) -> generator<table_slice> {
           return {};
       }
     }());
-    {
+    if (not status_ec) {
       using std::filesystem::perms;
       auto permissions = event.field("permissions").record();
       auto has_perm = [perms = status.permissions()](auto perm) {

--- a/libtenzir/builtins/operators/files.cpp
+++ b/libtenzir/builtins/operators/files.cpp
@@ -96,7 +96,8 @@ auto emit_skipped_directory_warning(const std::filesystem::path& path,
 
 auto should_recurse_into(const std::filesystem::directory_entry& entry,
                          std::filesystem::directory_options options,
-                         diagnostic_handler& dh) -> bool {
+                         bool skip_permission_denied, diagnostic_handler& dh)
+  -> bool {
   auto ec = std::error_code{};
   const auto follow_symlinks
     = (options & std::filesystem::directory_options::follow_directory_symlink)
@@ -104,6 +105,9 @@ auto should_recurse_into(const std::filesystem::directory_entry& entry,
   const auto status
     = follow_symlinks ? entry.status(ec) : entry.symlink_status(ec);
   if (ec) {
+    if (skip_permission_denied and is_permission_error(ec)) {
+      return false;
+    }
     diagnostic::warning("failed to inspect `{}`: {}", entry.path(),
                         ec.message())
       .emit(dh);
@@ -131,6 +135,9 @@ auto list_directory(const std::filesystem::path& path,
     ec.clear();
     iterator.increment(ec);
     if (ec) {
+      if (skip_permission_denied and is_permission_error(ec)) {
+        co_return;
+      }
       emit_filesystem_error(path, ec, dh);
       co_return;
     }
@@ -164,18 +171,24 @@ auto list_directory_recursive(const std::filesystem::path& path,
     ec.clear();
     current.increment(ec);
     if (ec) {
+      if (skip_permission_denied and is_permission_error(ec)) {
+        stack.pop_back();
+        continue;
+      }
       emit_filesystem_error(entry.path(), ec, dh);
       co_return;
     }
     co_yield entry;
-    if (not should_recurse_into(entry, options, dh)) {
+    if (not should_recurse_into(entry, options, skip_permission_denied, dh)) {
       continue;
     }
     ec.clear();
     auto child = std::filesystem::directory_iterator{entry.path(), options, ec};
     if (ec) {
       if (is_permission_error(ec)) {
-        emit_skipped_directory_warning(entry.path(), ec, dh);
+        if (not skip_permission_denied) {
+          emit_skipped_directory_warning(entry.path(), ec, dh);
+        }
         continue;
       }
       emit_filesystem_error(entry.path(), ec, dh);

--- a/libtenzir/builtins/operators/files.cpp
+++ b/libtenzir/builtins/operators/files.cpp
@@ -7,6 +7,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include <tenzir/argument_parser.hpp>
+#include <tenzir/async/blocking_executor.hpp>
+#include <tenzir/operator_plugin.hpp>
 #include <tenzir/pipeline.hpp>
 #include <tenzir/plugin.hpp>
 #include <tenzir/series_builder.hpp>
@@ -18,8 +20,8 @@
 #include <filesystem>
 #include <grp.h>
 #include <pwd.h>
-#include <vector>
 #include <unistd.h>
+#include <vector>
 
 namespace tenzir::plugins::files {
 
@@ -40,6 +42,27 @@ struct files_args {
   }
 };
 
+struct FilesArgs {
+  Option<std::string> path = {};
+  bool recurse_directories = {};
+  bool follow_directory_symlink = {};
+  bool skip_permission_denied = {};
+};
+
+struct FileListingResult {
+  std::vector<table_slice> slices = {};
+  std::vector<diagnostic> diagnostics = {};
+};
+
+auto to_legacy_args(const FilesArgs& args) -> files_args {
+  return {
+    .path = args.path ? std::optional<std::string>{*args.path} : std::nullopt,
+    .recurse_directories = args.recurse_directories,
+    .follow_directory_symlink = args.follow_directory_symlink,
+    .skip_permission_denied = args.skip_permission_denied,
+  };
+}
+
 auto is_permission_error(std::error_code ec) -> bool {
   return ec == std::errc::permission_denied
          or ec == std::errc::operation_not_permitted;
@@ -56,15 +79,16 @@ auto directory_options(files_args const& args)
 
 auto emit_filesystem_error(const std::filesystem::path& path,
                            std::error_code ec, diagnostic_handler& dh) -> void {
-  diagnostic::error("{}",
-                    std::filesystem::filesystem_error{
-                      "failed to list directory", path, ec}.what())
+  diagnostic::error(
+    "{}",
+    std::filesystem::filesystem_error{"failed to list directory", path, ec}
+      .what())
     .emit(dh);
 }
 
 auto emit_skipped_directory_warning(const std::filesystem::path& path,
-                                    std::error_code ec,
-                                    diagnostic_handler& dh) -> void {
+                                    std::error_code ec, diagnostic_handler& dh)
+  -> void {
   diagnostic::warning("skipping unreadable directory `{}`: {}", path,
                       ec.message())
     .emit(dh);
@@ -90,8 +114,7 @@ auto should_recurse_into(const std::filesystem::directory_entry& entry,
 
 auto list_directory(const std::filesystem::path& path,
                     std::filesystem::directory_options options,
-                    bool skip_permission_denied,
-                    diagnostic_handler& dh)
+                    bool skip_permission_denied, diagnostic_handler& dh)
   -> generator<std::filesystem::directory_entry> {
   auto ec = std::error_code{};
   auto iterator = std::filesystem::directory_iterator{path, options, ec};
@@ -162,89 +185,82 @@ auto list_directory_recursive(const std::filesystem::path& path,
   }
 }
 
-class files_operator final : public crtp_operator<files_operator> {
-public:
-  files_operator() = default;
-
-  files_operator(files_args args) : args_{std::move(args)} {
-  }
-
-  auto make_generator(auto listing) const -> generator<table_slice> {
-    auto identity = [](auto x) {
-      return x;
-    };
-    auto get_time = [](auto x) {
-      return std::chrono::time_point_cast<duration>(
-        std::chrono::file_clock::to_sys(x));
-    };
-    static constexpr auto max_length
-      = detail::narrow_cast<int64_t>(defaults::import::table_slice_size);
-    const auto file_permissions_type = type{
-      "tenzir.file_permissions",
-      record_type{
-        {"read", bool_type{}},
-        {"write", bool_type{}},
-        {"execute", bool_type{}},
-      },
-    };
-    const auto schema = type{
-      "tenzir.file",
-      record_type{
-        {"path", string_type{}},
-        {"type", string_type{}},
-        {"permissions",
-         record_type{
-           {"owner", file_permissions_type},
-           {"group", file_permissions_type},
-           {"others", file_permissions_type},
-         }},
-        {"owner", string_type{}},
-        {"group", string_type{}},
-        {"file_size", uint64_type{}},
-        {"hard_link_count", uint64_type{}},
-        {"last_write_time", time_type{}},
-      },
-    };
-    auto builder = series_builder{schema};
-    for (const auto& entry : std::move(listing)) {
-      auto status_ec = std::error_code{};
-      const auto status = entry.status(status_ec);
-      auto event = builder.record();
-      event.field("path", entry.path().string());
-      event.field("type", [&]() -> data_view2 {
-        if (status_ec) {
+auto make_file_events(auto listing) -> generator<table_slice> {
+  auto identity = [](auto x) {
+    return x;
+  };
+  auto get_time = [](auto x) {
+    return std::chrono::time_point_cast<duration>(
+      std::chrono::file_clock::to_sys(x));
+  };
+  static constexpr auto max_length
+    = detail::narrow_cast<int64_t>(defaults::import::table_slice_size);
+  const auto file_permissions_type = type{
+    "tenzir.file_permissions",
+    record_type{
+      {"read", bool_type{}},
+      {"write", bool_type{}},
+      {"execute", bool_type{}},
+    },
+  };
+  const auto schema = type{
+    "tenzir.file",
+    record_type{
+      {"path", string_type{}},
+      {"type", string_type{}},
+      {"permissions",
+       record_type{
+         {"owner", file_permissions_type},
+         {"group", file_permissions_type},
+         {"others", file_permissions_type},
+       }},
+      {"owner", string_type{}},
+      {"group", string_type{}},
+      {"file_size", uint64_type{}},
+      {"hard_link_count", uint64_type{}},
+      {"last_write_time", time_type{}},
+    },
+  };
+  auto builder = series_builder{schema};
+  for (const auto& entry : std::move(listing)) {
+    auto status_ec = std::error_code{};
+    const auto status = entry.status(status_ec);
+    auto event = builder.record();
+    event.field("path", entry.path().string());
+    event.field("type", [&]() -> data_view2 {
+      if (status_ec) {
+        return {};
+      }
+      using std::filesystem::file_type;
+      switch (status.type()) {
+        case file_type::regular:
+          return "regular";
+        case file_type::directory:
+          return "directory";
+        case file_type::symlink:
+          return "symlink";
+        case file_type::block:
+          return "block";
+        case file_type::character:
+          return "character";
+        case file_type::fifo:
+          return "fifo";
+        case file_type::socket:
+          return "socket";
+        case file_type::unknown:
+          return "unknown";
+        case file_type::not_found:
+          return "not_found";
+        default:
           return {};
-        }
-        using std::filesystem::file_type;
-        switch (status.type()) {
-          case file_type::regular:
-            return "regular";
-          case file_type::directory:
-            return "directory";
-          case file_type::symlink:
-            return "symlink";
-          case file_type::block:
-            return "block";
-          case file_type::character:
-            return "character";
-          case file_type::fifo:
-            return "fifo";
-          case file_type::socket:
-            return "socket";
-          case file_type::unknown:
-            return "unknown";
-          case file_type::not_found:
-            return "not_found";
-          default:
-            return {};
-        }
-      }());
-      {
-        using std::filesystem::perms;
-        auto permissions = event.field("permissions").record();
-        auto has_perm = [perms = status.permissions()](auto perm) {
-          return perms::none != (perms & perm);
-        };
+      }
+    }());
+    {
+      using std::filesystem::perms;
+      auto permissions = event.field("permissions").record();
+      auto has_perm = [perms = status.permissions()](auto perm) {
+        return perms::none != (perms & perm);
+      };
 #define X(name)                                                                \
   do {                                                                         \
     auto name = permissions.field(#name).record();                             \
@@ -252,23 +268,23 @@ public:
     name.field("write", has_perm(perms::name##_write));                        \
     name.field("execute", has_perm(perms::name##_exec));                       \
   } while (0)
-        X(owner);
-        X(group);
-        X(others);
+      X(owner);
+      X(group);
+      X(others);
 #undef X
-      }
-      {
-        struct ::stat stat_buf = {};
-        const auto stat_result = ::stat(entry.path().c_str(), &stat_buf);
-        if (stat_result == 0) {
-          if (const auto* pwuid = getpwuid(stat_buf.st_uid)) {
-            event.field("owner", pwuid->pw_name);
-          }
-          if (const auto* grgid = getgrgid(stat_buf.st_gid)) {
-            event.field("group", grgid->gr_name);
-          }
+    }
+    {
+      struct ::stat stat_buf = {};
+      const auto stat_result = ::stat(entry.path().c_str(), &stat_buf);
+      if (stat_result == 0) {
+        if (const auto* pwuid = getpwuid(stat_buf.st_uid)) {
+          event.field("owner", pwuid->pw_name);
+        }
+        if (const auto* grgid = getgrgid(stat_buf.st_gid)) {
+          event.field("group", grgid->gr_name);
         }
       }
+    }
 #define X(builder, name, transformation)                                       \
   do {                                                                         \
     auto ec = std::error_code{};                                               \
@@ -277,15 +293,62 @@ public:
       builder.field(#name, transformation(name));                              \
     }                                                                          \
   } while (0)
-      X(event, file_size, identity);
-      X(event, hard_link_count, identity);
-      X(event, last_write_time, get_time);
+    X(event, file_size, identity);
+    X(event, hard_link_count, identity);
+    X(event, last_write_time, get_time);
 #undef X
-      if (builder.length() >= max_length) {
-        co_yield builder.finish_assert_one_slice();
+    if (builder.length() >= max_length) {
+      co_yield builder.finish_assert_one_slice();
+    }
+  }
+  co_yield builder.finish_assert_one_slice();
+}
+
+auto make_file_listing(files_args args) -> FileListingResult {
+  auto result = FileListingResult{};
+  auto dh = collecting_diagnostic_handler{};
+  try {
+    auto ec = std::error_code{};
+    const auto path = args.path ? std::filesystem::path{*args.path}
+                                : std::filesystem::current_path(ec);
+    if (ec) {
+      diagnostic::error("{}",
+                        std::filesystem::filesystem_error{
+                          "failed to determine current directory", ec}
+                          .what())
+        .emit(dh);
+      result.diagnostics = std::move(dh).collect();
+      return result;
+    }
+    const auto options = directory_options(args);
+    auto gen = args.recurse_directories
+                 ? make_file_events(list_directory_recursive(
+                     path, options, args.skip_permission_denied, dh))
+                 : make_file_events(list_directory(
+                     path, options, args.skip_permission_denied, dh));
+    for (auto&& slice : std::move(gen)) {
+      if (slice.rows() > 0) {
+        result.slices.push_back(std::move(slice));
       }
     }
-    co_yield builder.finish_assert_one_slice();
+  } catch (const std::filesystem::filesystem_error& err) {
+    diagnostic::error("{}", err.what()).emit(dh);
+  }
+  result.diagnostics = std::move(dh).collect();
+  return result;
+}
+
+class files_operator final : public crtp_operator<files_operator> {
+public:
+  files_operator() = default;
+
+  files_operator(files_args args) : args_{std::move(args)} {
+  }
+
+  auto make_generator(auto listing) const -> generator<table_slice> {
+    for (auto&& slice : make_file_events(std::move(listing))) {
+      co_yield std::move(slice);
+    }
   }
 
   auto operator()(operator_control_plane& ctrl) const
@@ -296,17 +359,14 @@ public:
                                    : std::filesystem::current_path();
       const auto options = directory_options(args_);
       if (args_.recurse_directories) {
-        auto gen
-          = make_generator(list_directory_recursive(path, options,
-                                                    args_.skip_permission_denied,
-                                                    ctrl.diagnostics()));
+        auto gen = make_generator(list_directory_recursive(
+          path, options, args_.skip_permission_denied, ctrl.diagnostics()));
         for (auto&& result : std::move(gen)) {
           co_yield std::move(result);
         }
       } else {
-        auto gen = make_generator(
-          list_directory(path, options, args_.skip_permission_denied,
-                         ctrl.diagnostics()));
+        auto gen = make_generator(list_directory(
+          path, options, args_.skip_permission_denied, ctrl.diagnostics()));
         for (auto&& result : std::move(gen)) {
           co_yield std::move(result);
         }
@@ -337,8 +397,55 @@ private:
   files_args args_ = {};
 };
 
+class Files final : public Operator<void, table_slice> {
+public:
+  explicit Files(FilesArgs args) : args_{std::move(args)} {
+  }
+
+  auto start(OpCtx&) -> Task<void> override {
+    co_return;
+  }
+
+  auto await_task(diagnostic_handler& dh) const -> Task<Any> override {
+    TENZIR_UNUSED(dh);
+    if (done_) {
+      co_await wait_forever();
+      TENZIR_UNREACHABLE();
+    }
+    auto args = to_legacy_args(args_);
+    co_return co_await spawn_blocking([args = std::move(args)]() mutable {
+      return make_file_listing(std::move(args));
+    });
+  }
+
+  auto process_task(Any result, Push<table_slice>& push, OpCtx& ctx)
+    -> Task<void> override {
+    auto listing = std::move(result).as<FileListingResult>();
+    for (auto& slice : listing.slices) {
+      co_await push(std::move(slice));
+    }
+    for (auto& diag : listing.diagnostics) {
+      ctx.dh().emit(std::move(diag));
+    }
+    done_ = true;
+  }
+
+  auto state() -> OperatorState override {
+    return done_ ? OperatorState::done : OperatorState::unspecified;
+  }
+
+  auto snapshot(Serde& serde) -> void override {
+    serde("done", done_);
+  }
+
+private:
+  FilesArgs args_ = {};
+  bool done_ = false;
+};
+
 class plugin final : public virtual operator_plugin<files_operator>,
-                     public virtual operator_factory_plugin {
+                     public virtual operator_factory_plugin,
+                     public virtual OperatorPlugin {
 public:
   auto signature() const -> operator_signature override {
     return {.source = true};
@@ -366,6 +473,16 @@ public:
     parser.add("--skip-permission-denied", args.skip_permission_denied);
     parser.parse(p);
     return std::make_unique<files_operator>(std::move(args));
+  }
+
+  auto describe() const -> Description override {
+    auto d = Describer<FilesArgs, Files>{"https://docs.tenzir.com/operators/"
+                                         "files"};
+    d.positional("dir", &FilesArgs::path);
+    d.named("recurse", &FilesArgs::recurse_directories);
+    d.named("follow_symlinks", &FilesArgs::follow_directory_symlink);
+    d.named("skip_permission_denied", &FilesArgs::skip_permission_denied);
+    return d.without_optimize();
   }
 };
 

--- a/libtenzir/builtins/operators/files.cpp
+++ b/libtenzir/builtins/operators/files.cpp
@@ -20,9 +20,9 @@
 
 #include <filesystem>
 #include <grp.h>
+#include <optional>
 #include <pwd.h>
 #include <unistd.h>
-#include <optional>
 #include <vector>
 
 namespace tenzir::plugins::files {

--- a/libtenzir/builtins/operators/files.cpp
+++ b/libtenzir/builtins/operators/files.cpp
@@ -6,6 +6,7 @@
 // SPDX-FileCopyrightText: (c) 2024 The Tenzir Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+#include <tenzir/arc.hpp>
 #include <tenzir/argument_parser.hpp>
 #include <tenzir/async/blocking_executor.hpp>
 #include <tenzir/operator_plugin.hpp>
@@ -21,6 +22,7 @@
 #include <grp.h>
 #include <pwd.h>
 #include <unistd.h>
+#include <optional>
 #include <vector>
 
 namespace tenzir::plugins::files {
@@ -49,9 +51,10 @@ struct FilesArgs {
   bool skip_permission_denied = {};
 };
 
-struct FileListingResult {
-  std::vector<table_slice> slices = {};
+struct FileListingItem {
+  table_slice slice = {};
   std::vector<diagnostic> diagnostics = {};
+  bool done = false;
 };
 
 auto to_legacy_args(const FilesArgs& args) -> files_args {
@@ -116,7 +119,7 @@ auto should_recurse_into(const std::filesystem::directory_entry& entry,
   return status.type() == std::filesystem::file_type::directory;
 }
 
-auto list_directory(const std::filesystem::path& path,
+auto list_directory(std::filesystem::path path,
                     std::filesystem::directory_options options,
                     bool skip_permission_denied, diagnostic_handler& dh)
   -> generator<std::filesystem::directory_entry> {
@@ -144,7 +147,7 @@ auto list_directory(const std::filesystem::path& path,
   }
 }
 
-auto list_directory_recursive(const std::filesystem::path& path,
+auto list_directory_recursive(std::filesystem::path path,
                               std::filesystem::directory_options options,
                               bool skip_permission_denied,
                               diagnostic_handler& dh)
@@ -317,39 +320,70 @@ auto make_file_events(auto listing) -> generator<table_slice> {
   co_yield builder.finish_assert_one_slice();
 }
 
-auto make_file_listing(files_args args) -> FileListingResult {
-  auto result = FileListingResult{};
-  auto dh = collecting_diagnostic_handler{};
-  try {
+class FileListing {
+public:
+  explicit FileListing(files_args args) : args_{std::move(args)} {
+  }
+
+  auto next() -> FileListingItem {
+    auto result = FileListingItem{};
+    if (done_) {
+      result.done = true;
+      return result;
+    }
+    try {
+      if (not initialized_) {
+        initialize();
+      }
+      if (not done_) {
+        while (auto slice = slices_.next()) {
+          if (slice->rows() == 0) {
+            continue;
+          }
+          result.slice = std::move(*slice);
+          return result;
+        }
+      }
+    } catch (const std::filesystem::filesystem_error& err) {
+      diagnostic::error("{}", err.what()).emit(diagnostics_);
+    }
+    done_ = true;
+    result.done = true;
+    result.diagnostics = std::move(diagnostics_).collect();
+    return result;
+  }
+
+private:
+  auto initialize() -> void {
+    initialized_ = true;
     auto ec = std::error_code{};
-    const auto path = args.path ? std::filesystem::path{*args.path}
-                                : std::filesystem::current_path(ec);
+    auto path = args_.path ? std::filesystem::path{*args_.path}
+                           : std::filesystem::current_path(ec);
     if (ec) {
       diagnostic::error("{}",
                         std::filesystem::filesystem_error{
                           "failed to determine current directory", ec}
                           .what())
-        .emit(dh);
-      result.diagnostics = std::move(dh).collect();
-      return result;
+        .emit(diagnostics_);
+      done_ = true;
+      return;
     }
-    const auto options = directory_options(args);
-    auto gen = args.recurse_directories
-                 ? make_file_events(list_directory_recursive(
-                     path, options, args.skip_permission_denied, dh))
-                 : make_file_events(list_directory(
-                     path, options, args.skip_permission_denied, dh));
-    for (auto&& slice : std::move(gen)) {
-      if (slice.rows() > 0) {
-        result.slices.push_back(std::move(slice));
-      }
+    const auto options = directory_options(args_);
+    if (args_.recurse_directories) {
+      slices_ = make_file_events(list_directory_recursive(
+        std::move(path), options, args_.skip_permission_denied, diagnostics_));
+    } else {
+      slices_ = make_file_events(list_directory(
+        std::move(path), options, args_.skip_permission_denied, diagnostics_));
     }
-  } catch (const std::filesystem::filesystem_error& err) {
-    diagnostic::error("{}", err.what()).emit(dh);
   }
-  result.diagnostics = std::move(dh).collect();
-  return result;
-}
+
+  files_args args_ = {};
+  bool initialized_ = false;
+  bool done_ = false;
+  collecting_diagnostic_handler diagnostics_ = {};
+  generator<table_slice> slices_ = {};
+};
 
 class files_operator final : public crtp_operator<files_operator> {
 public:
@@ -412,7 +446,8 @@ private:
 
 class Files final : public Operator<void, table_slice> {
 public:
-  explicit Files(FilesArgs args) : args_{std::move(args)} {
+  explicit Files(FilesArgs args)
+    : listing_{std::in_place, to_legacy_args(args)} {
   }
 
   auto start(OpCtx&) -> Task<void> override {
@@ -425,22 +460,21 @@ public:
       co_await wait_forever();
       TENZIR_UNREACHABLE();
     }
-    auto args = to_legacy_args(args_);
-    co_return co_await spawn_blocking([args = std::move(args)]() mutable {
-      return make_file_listing(std::move(args));
+    co_return co_await spawn_blocking([listing = listing_]() mutable {
+      return listing->next();
     });
   }
 
   auto process_task(Any result, Push<table_slice>& push, OpCtx& ctx)
     -> Task<void> override {
-    auto listing = std::move(result).as<FileListingResult>();
-    for (auto& slice : listing.slices) {
-      co_await push(std::move(slice));
+    auto item = std::move(result).as<FileListingItem>();
+    if (item.slice.rows() > 0) {
+      co_await push(std::move(item.slice));
     }
-    for (auto& diag : listing.diagnostics) {
+    for (auto& diag : item.diagnostics) {
       ctx.dh().emit(std::move(diag));
     }
-    done_ = true;
+    done_ = item.done;
   }
 
   auto state() -> OperatorState override {
@@ -452,7 +486,7 @@ public:
   }
 
 private:
-  FilesArgs args_ = {};
+  Arc<FileListing> listing_;
   bool done_ = false;
 };
 

--- a/libtenzir/builtins/operators/files.cpp
+++ b/libtenzir/builtins/operators/files.cpp
@@ -51,12 +51,6 @@ struct FilesArgs {
   bool skip_permission_denied = {};
 };
 
-struct FileListingItem {
-  table_slice slice = {};
-  std::vector<diagnostic> diagnostics = {};
-  bool done = false;
-};
-
 auto to_legacy_args(const FilesArgs& args) -> files_args {
   return {
     .path = args.path ? std::optional<std::string>{*args.path} : std::nullopt,
@@ -320,70 +314,38 @@ auto make_file_events(auto listing) -> generator<table_slice> {
   co_yield builder.finish_assert_one_slice();
 }
 
-class FileListing {
-public:
-  explicit FileListing(files_args args) : args_{std::move(args)} {
-  }
-
-  auto next() -> FileListingItem {
-    auto result = FileListingItem{};
-    if (done_) {
-      result.done = true;
-      return result;
-    }
-    try {
-      if (not initialized_) {
-        initialize();
-      }
-      if (not done_) {
-        while (auto slice = slices_.next()) {
-          if (slice->rows() == 0) {
-            continue;
-          }
-          result.slice = std::move(*slice);
-          return result;
-        }
-      }
-    } catch (const std::filesystem::filesystem_error& err) {
-      diagnostic::error("{}", err.what()).emit(diagnostics_);
-    }
-    done_ = true;
-    result.done = true;
-    result.diagnostics = std::move(diagnostics_).collect();
-    return result;
-  }
-
-private:
-  auto initialize() -> void {
-    initialized_ = true;
+auto make_file_listing(files_args args, diagnostic_handler& dh)
+  -> generator<Option<table_slice>> {
+  try {
     auto ec = std::error_code{};
-    auto path = args_.path ? std::filesystem::path{*args_.path}
-                           : std::filesystem::current_path(ec);
+    auto path = args.path ? std::filesystem::path{*args.path}
+                          : std::filesystem::current_path(ec);
     if (ec) {
       diagnostic::error("{}",
                         std::filesystem::filesystem_error{
                           "failed to determine current directory", ec}
                           .what())
-        .emit(diagnostics_);
-      done_ = true;
-      return;
+        .emit(dh);
+      co_yield None{};
+      co_return;
     }
-    const auto options = directory_options(args_);
-    if (args_.recurse_directories) {
-      slices_ = make_file_events(list_directory_recursive(
-        std::move(path), options, args_.skip_permission_denied, diagnostics_));
-    } else {
-      slices_ = make_file_events(list_directory(
-        std::move(path), options, args_.skip_permission_denied, diagnostics_));
+    const auto options = directory_options(args);
+    auto slices
+      = args.recurse_directories
+          ? make_file_events(list_directory_recursive(
+              std::move(path), options, args.skip_permission_denied, dh))
+          : make_file_events(list_directory(std::move(path), options,
+                                            args.skip_permission_denied, dh));
+    for (auto&& slice : std::move(slices)) {
+      if (slice.rows() > 0) {
+        co_yield std::move(slice);
+      }
     }
+  } catch (const std::filesystem::filesystem_error& err) {
+    diagnostic::error("{}", err.what()).emit(dh);
   }
-
-  files_args args_ = {};
-  bool initialized_ = false;
-  bool done_ = false;
-  collecting_diagnostic_handler diagnostics_ = {};
-  generator<table_slice> slices_ = {};
-};
+  co_yield None{};
+}
 
 class files_operator final : public crtp_operator<files_operator> {
 public:
@@ -446,8 +408,7 @@ private:
 
 class Files final : public Operator<void, table_slice> {
 public:
-  explicit Files(FilesArgs args)
-    : listing_{std::in_place, to_legacy_args(args)} {
+  explicit Files(FilesArgs args) : args_{to_legacy_args(args)} {
   }
 
   auto start(OpCtx&) -> Task<void> override {
@@ -455,26 +416,29 @@ public:
   }
 
   auto await_task(diagnostic_handler& dh) const -> Task<Any> override {
-    TENZIR_UNUSED(dh);
     if (done_) {
       co_await wait_forever();
       TENZIR_UNREACHABLE();
     }
-    co_return co_await spawn_blocking([listing = listing_]() mutable {
-      return listing->next();
+    if (not listing_) {
+      listing_.emplace(std::in_place, make_file_listing(args_, dh));
+    }
+    auto listing = *listing_;
+    co_return co_await spawn_blocking([listing = std::move(listing)]() mutable {
+      auto result = listing->next();
+      return result ? std::move(*result) : Option<table_slice>{};
     });
   }
 
   auto process_task(Any result, Push<table_slice>& push, OpCtx& ctx)
     -> Task<void> override {
-    auto item = std::move(result).as<FileListingItem>();
-    if (item.slice.rows() > 0) {
-      co_await push(std::move(item.slice));
+    TENZIR_UNUSED(ctx);
+    auto slice = std::move(result).as<Option<table_slice>>();
+    if (slice) {
+      co_await push(std::move(*slice));
+    } else {
+      done_ = true;
     }
-    for (auto& diag : item.diagnostics) {
-      ctx.dh().emit(std::move(diag));
-    }
-    done_ = item.done;
   }
 
   auto state() -> OperatorState override {
@@ -486,7 +450,8 @@ public:
   }
 
 private:
-  Arc<FileListing> listing_;
+  files_args args_ = {};
+  mutable Option<Arc<generator<Option<table_slice>>>> listing_ = {};
   bool done_ = false;
 };
 
@@ -523,8 +488,7 @@ public:
   }
 
   auto describe() const -> Description override {
-    auto d = Describer<FilesArgs, Files>{"https://docs.tenzir.com/operators/"
-                                         "files"};
+    auto d = Describer<FilesArgs, Files>{};
     d.positional("dir", &FilesArgs::path);
     d.named("recurse", &FilesArgs::recurse_directories);
     d.named("follow_symlinks", &FilesArgs::follow_directory_symlink);

--- a/test/fixtures/__init__.py
+++ b/test/fixtures/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 # Import modules so their decorators register fixtures on import.
 from . import abs  # noqa: F401
 from . import clickhouse  # noqa: F401
+from . import files_permission_tree  # noqa: F401
 from . import gcs  # noqa: F401
 from . import google_cloud_logging  # noqa: F401
 from . import google_secops  # noqa: F401
@@ -23,6 +24,7 @@ from . import tcp  # noqa: F401
 __all__ = [
     "abs",
     "clickhouse",
+    "files_permission_tree",
     "gcs",
     "google_cloud_logging",
     "google_secops",

--- a/test/fixtures/files_permission_tree.py
+++ b/test/fixtures/files_permission_tree.py
@@ -1,4 +1,4 @@
-"""Local filesystem fixture with an unreadable child directory."""
+"""Local filesystem fixture with unreadable and dangling entries."""
 
 from __future__ import annotations
 
@@ -31,6 +31,11 @@ def files_permission_tree() -> FixtureHandle:
     (root / "ok").mkdir()
     (root / "after" / "data.json").write_text("{}\n")
     (root / "ok" / "data.json").write_text("{}\n")
+    try:
+        (root / "dangling").symlink_to("missing-target")
+    except OSError as err:
+        shutil.rmtree(root, ignore_errors=True)
+        raise FixtureUnavailable(f"symlink creation failed: {err}") from err
     blocked.mkdir()
     blocked.chmod(0)
 

--- a/test/fixtures/files_permission_tree.py
+++ b/test/fixtures/files_permission_tree.py
@@ -1,0 +1,44 @@
+"""Local filesystem fixture with an unreadable child directory."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+from tenzir_test import FixtureHandle, fixture
+from tenzir_test.fixtures import FixtureUnavailable
+
+RELATIVE_ROOT = Path("tests/operators/files/permission-root")
+
+
+def _make_writable(path: Path) -> None:
+    if path.exists():
+        path.chmod(0o700)
+
+
+@fixture
+def files_permission_tree() -> FixtureHandle:
+    """Create a deterministic local tree for recursive `files` tests."""
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        raise FixtureUnavailable("root can traverse chmod 000 directories")
+    test_root = Path(__file__).resolve().parents[1]
+    root = test_root / RELATIVE_ROOT
+    blocked = root / "blocked"
+    _make_writable(blocked)
+    shutil.rmtree(root, ignore_errors=True)
+    (root / "after").mkdir(parents=True)
+    (root / "ok").mkdir()
+    (root / "after" / "data.json").write_text("{}\n")
+    (root / "ok" / "data.json").write_text("{}\n")
+    blocked.mkdir()
+    blocked.chmod(0)
+
+    def _teardown() -> None:
+        _make_writable(blocked)
+        shutil.rmtree(root, ignore_errors=True)
+
+    return FixtureHandle(
+        env={"FILES_PERMISSION_ROOT": str(RELATIVE_ROOT)},
+        teardown=_teardown,
+    )

--- a/test/tests/operators/files/dangling_symlink_permissions.tql
+++ b/test/tests/operators/files/dangling_symlink_permissions.tql
@@ -1,0 +1,4 @@
+files env("FILES_PERMISSION_ROOT")
+path = path.replace(env("FILES_PERMISSION_ROOT"), "<ROOT>")
+where path == "<ROOT>/dangling"
+select path, type, permissions

--- a/test/tests/operators/files/dangling_symlink_permissions.txt
+++ b/test/tests/operators/files/dangling_symlink_permissions.txt
@@ -1,0 +1,5 @@
+{
+  path: "<ROOT>/dangling",
+  type: null,
+  permissions: null,
+}

--- a/test/tests/operators/files/recurse_permission_denied.tql
+++ b/test/tests/operators/files/recurse_permission_denied.tql
@@ -1,0 +1,4 @@
+files env("FILES_PERMISSION_ROOT"), recurse=true
+path = path.replace(env("FILES_PERMISSION_ROOT"), "<ROOT>")
+select path, type
+sort path

--- a/test/tests/operators/files/recurse_permission_denied.txt
+++ b/test/tests/operators/files/recurse_permission_denied.txt
@@ -1,0 +1,21 @@
+{
+  path: "<ROOT>/after",
+  type: "directory",
+}
+{
+  path: "<ROOT>/after/data.json",
+  type: "regular",
+}
+{
+  path: "<ROOT>/blocked",
+  type: "directory",
+}
+{
+  path: "<ROOT>/ok",
+  type: "directory",
+}
+{
+  path: "<ROOT>/ok/data.json",
+  type: "regular",
+}
+warning: skipping unreadable directory `tests/operators/files/permission-root/blocked`: Permission denied

--- a/test/tests/operators/files/recurse_permission_denied.txt
+++ b/test/tests/operators/files/recurse_permission_denied.txt
@@ -11,6 +11,10 @@
   type: "directory",
 }
 {
+  path: "<ROOT>/dangling",
+  type: null,
+}
+{
   path: "<ROOT>/ok",
   type: "directory",
 }

--- a/test/tests/operators/files/recurse_permission_denied_skip.tql
+++ b/test/tests/operators/files/recurse_permission_denied_skip.tql
@@ -1,0 +1,4 @@
+files env("FILES_PERMISSION_ROOT"), recurse=true, skip_permission_denied=true
+path = path.replace(env("FILES_PERMISSION_ROOT"), "<ROOT>")
+select path, type
+sort path

--- a/test/tests/operators/files/recurse_permission_denied_skip.txt
+++ b/test/tests/operators/files/recurse_permission_denied_skip.txt
@@ -11,6 +11,10 @@
   type: "directory",
 }
 {
+  path: "<ROOT>/dangling",
+  type: null,
+}
+{
   path: "<ROOT>/ok",
   type: "directory",
 }

--- a/test/tests/operators/files/recurse_permission_denied_skip.txt
+++ b/test/tests/operators/files/recurse_permission_denied_skip.txt
@@ -1,0 +1,20 @@
+{
+  path: "<ROOT>/after",
+  type: "directory",
+}
+{
+  path: "<ROOT>/after/data.json",
+  type: "regular",
+}
+{
+  path: "<ROOT>/blocked",
+  type: "directory",
+}
+{
+  path: "<ROOT>/ok",
+  type: "directory",
+}
+{
+  path: "<ROOT>/ok/data.json",
+  type: "regular",
+}

--- a/test/tests/operators/files/test.yaml
+++ b/test/tests/operators/files/test.yaml
@@ -1,5 +1,4 @@
 suite: files
-runner: tenzir
 fixtures: [files_permission_tree]
 timeout: 30
 skip:

--- a/test/tests/operators/files/test.yaml
+++ b/test/tests/operators/files/test.yaml
@@ -1,0 +1,6 @@
+suite: files
+runner: tenzir
+fixtures: [files_permission_tree]
+timeout: 30
+skip:
+  on: fixture-unavailable


### PR DESCRIPTION
## 🔍 Problem

- `files <dir>, recurse=true` failed when traversal encountered an unreadable child directory.
- The operator was still missing from the neo executor path.
- Follow-up review found that the neo source buffered the full traversal and that failed status lookups could produce bogus permission metadata.

## 🛠️ Solution

- Skip unreadable child directories during recursive traversal, emit a warning by default, and continue with accessible siblings.
- Treat `skip_permission_denied=true` as ignoring permission-denied paths silently: unreadable initial directories produce no events, and recursive child-directory warnings are suppressed.
- Add a neo `files` source implementation that reuses the same traversal and event-building helpers, offloads filesystem work to the blocking executor, and emits slices incrementally.
- Leave `type` and `permissions` null when filesystem status lookup fails, instead of deriving permissions from an unknown status.

## 💬 Review

- The `files` test now runs with the default neo runner.
- The legacy path still exists for compatibility and shares the same traversal helpers.
- The fixture covers both unreadable child directories and dangling symlinks.

<sub>
📚 Docs PR: tenzir/docs#277<br>
✅ Closes TNZ-516, TNZ-520
</sub>