### PR TITLE
Port load_balance to the new executor

### DIFF
--- a/libtenzir/builtins/operators/from_to_2.cpp
+++ b/libtenzir/builtins/operators/from_to_2.cpp
@@ -172,9 +172,7 @@ public:
   auto infer_type(element_type_tag input, diagnostic_handler& dh) const
     -> failure_or<std::optional<element_type_tag>> override {
     if (input.is_not<void>()) {
-      diagnostic::error("expected void, got {}", input)
-        .primary(self_)
-        .emit(dh);
+      diagnostic::error("expected void, got {}", input).primary(self_).emit(dh);
       return failure::promise();
     }
     return tag_v<table_slice>;

--- a/libtenzir/builtins/operators/from_to_2.cpp
+++ b/libtenzir/builtins/operators/from_to_2.cpp
@@ -147,8 +147,8 @@ class from_ir final : public ir::Operator {
 public:
   from_ir() = default;
 
-  explicit from_ir(std::vector<ast::expression> events)
-    : events_{std::move(events)} {
+  from_ir(std::vector<ast::expression> events, location self)
+    : events_{std::move(events)}, self_{self} {
   }
 
   auto name() const -> std::string override {
@@ -171,18 +171,23 @@ public:
 
   auto infer_type(element_type_tag input, diagnostic_handler& dh) const
     -> failure_or<std::optional<element_type_tag>> override {
-    TENZIR_UNUSED(dh);
-    // FIXME
-    TENZIR_ASSERT(input.is<void>());
+    if (input.is_not<void>()) {
+      diagnostic::error("expected void, got {}", input)
+        .primary(self_)
+        .emit(dh);
+      return failure::promise();
+    }
     return tag_v<table_slice>;
   }
 
   friend auto inspect(auto& f, from_ir& x) -> bool {
-    return f.apply(x.events_);
+    return f.object(x).fields(f.field("events", x.events_),
+                              f.field("self", x.self_));
   }
 
 private:
   std::vector<ast::expression> events_;
+  location self_;
 };
 
 class from_plugin2 final : public virtual operator_factory_plugin,
@@ -258,7 +263,7 @@ public:
     for (auto& arg : inv.args) {
       TRY(arg.bind(ctx));
     }
-    return from_ir{std::move(inv.args)};
+    return from_ir{std::move(inv.args), inv.op.get_location()};
   }
 };
 

--- a/libtenzir/builtins/operators/load_balance.cpp
+++ b/libtenzir/builtins/operators/load_balance.cpp
@@ -7,15 +7,13 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "tenzir/async.hpp"
-#include "tenzir/compile_ctx.hpp"
 #include "tenzir/detail/narrow.hpp"
-#include "tenzir/ir.hpp"
+#include "tenzir/operator_plugin.hpp"
 #include "tenzir/option.hpp"
 #include "tenzir/pipeline.hpp"
 #include "tenzir/pipeline_executor.hpp"
 #include "tenzir/scope_linked.hpp"
 #include "tenzir/substitute_ctx.hpp"
-#include "tenzir/tql2/eval.hpp"
 #include "tenzir/tql2/exec.hpp"
 #include "tenzir/view.hpp"
 
@@ -198,7 +196,9 @@ auto as_constant_kind(data const& value) -> ast::constant::kind {
 }
 
 struct LoadBalanceArgs {
-  std::vector<ir::pipeline> pipes;
+  located<list> over;
+  located<ir::pipeline> pipe;
+  let_id over_id;
 };
 
 class LoadBalance final : public Operator<table_slice, void> {
@@ -211,11 +211,18 @@ public:
       co_return;
     }
     started_ = true;
-    workers_.assign(args_.pipes.size(), Worker{});
+    workers_.assign(args_.over.inner.size(), Worker{});
     active_workers_ = workers_.size();
-    for (auto i = size_t{0}; i < args_.pipes.size(); ++i) {
+    for (auto i = size_t{0}; i < args_.over.inner.size(); ++i) {
+      auto pipe = args_.pipe.inner;
+      auto env = substitute_ctx::env_t{};
+      env[args_.over_id] = as_constant_kind(args_.over.inner[i]);
+      if (not pipe.substitute(substitute_ctx{ctx, &env}, true)) {
+        done_ = true;
+        co_return;
+      }
       co_await ctx.spawn_sub<table_slice>(data{detail::narrow<int64_t>(i)},
-                                          std::move(args_.pipes[i]));
+                                          std::move(pipe));
     }
   }
 
@@ -310,127 +317,6 @@ private:
   size_t active_workers_ = 0;
   bool started_ = false;
   bool done_ = false;
-};
-
-class LoadBalanceIr final : public ir::Operator {
-public:
-  LoadBalanceIr() = default;
-
-  LoadBalanceIr(location self, ast::dollar_var var, location pipe_location,
-                ir::pipeline pipe)
-    : self_{self},
-      var_{std::move(var)},
-      pipe_location_{pipe_location},
-      pipe_{std::move(pipe)} {
-  }
-
-  auto name() const -> std::string override {
-    return "load_balance-ir";
-  }
-
-  auto substitute(substitute_ctx ctx, bool instantiate)
-    -> failure_or<void> override {
-    if (not instantiate) {
-      if (not ctx.get(var_.let)) {
-        return {};
-      }
-    }
-    if (not pipes_.empty()) {
-      if (instantiate and not pipes_instantiated_) {
-        for (auto& pipe : pipes_) {
-          TRY(pipe.substitute(ctx, true));
-        }
-        pipes_instantiated_ = true;
-      }
-      return {};
-    }
-    auto original = ctx.get(var_.let);
-    if (not original) {
-      diagnostic::error("expected a constant list").primary(var_).emit(ctx);
-      return failure::promise();
-    }
-    auto* entries = try_as<list>(*original);
-    if (not entries) {
-      auto got = original->match([]<class T>(T const&) {
-        return type_kind::of<data_to_type_t<T>>;
-      });
-      diagnostic::error("expected a list, got `{}`", got)
-        .primary(var_)
-        .emit(ctx);
-      return failure::promise();
-    }
-    if (entries->empty()) {
-      diagnostic::error("expected list to not be empty").primary(var_).emit(ctx);
-      return failure::promise();
-    }
-    auto pipes = std::vector<ir::pipeline>{};
-    pipes.reserve(entries->size());
-    for (auto const& entry : *entries) {
-      auto env = ctx.env();
-      env.insert_or_assign(var_.let, as_constant_kind(entry));
-      auto pipe = pipe_;
-      TRY(pipe.substitute(ctx.with_env(&env), instantiate));
-      pipes.push_back(std::move(pipe));
-    }
-    pipes_ = std::move(pipes);
-    pipes_instantiated_ = instantiate;
-    return {};
-  }
-
-  auto infer_type(element_type_tag input, diagnostic_handler& dh) const
-    -> failure_or<std::optional<element_type_tag>> override {
-    if (input.is_not<table_slice>()) {
-      diagnostic::error("operator expects events").primary(self_).emit(dh);
-      return failure::promise();
-    }
-    for (auto const& pipe : pipes_) {
-      TRY(auto output, pipe.infer_type(input, dh));
-      if (not output) {
-        return std::nullopt;
-      }
-      if (output->is_not<void>()) {
-        diagnostic::error("pipeline must currently end with a sink")
-          .primary(pipe_location_)
-          .emit(dh);
-        return failure::promise();
-      }
-    }
-    return tag_v<void>;
-  }
-
-  auto optimize(ir::optimize_filter filter,
-                event_order order) && -> ir::optimize_result override {
-    TENZIR_UNUSED(filter, order);
-    auto replacement = ir::pipeline{};
-    replacement.operators.push_back(LoadBalanceIr{std::move(*this)});
-    return {ir::optimize_filter{}, event_order::unordered,
-            std::move(replacement)};
-  }
-
-  auto spawn(element_type_tag input) && -> AnyOperator override {
-    TENZIR_ASSERT(input.is<table_slice>());
-    return LoadBalance{LoadBalanceArgs{std::move(pipes_)}};
-  }
-
-  auto main_location() const -> location override {
-    return self_;
-  }
-
-  friend auto inspect(auto& f, LoadBalanceIr& x) -> bool {
-    return f.object(x).fields(
-      f.field("self", x.self_), f.field("var", x.var_),
-      f.field("pipe_location", x.pipe_location_), f.field("pipe", x.pipe_),
-      f.field("pipes", x.pipes_),
-      f.field("pipes_instantiated", x.pipes_instantiated_));
-  }
-
-private:
-  location self_;
-  ast::dollar_var var_;
-  location pipe_location_;
-  ir::pipeline pipe_;
-  std::vector<ir::pipeline> pipes_;
-  bool pipes_instantiated_ = false;
 };
 
 auto make_load_balancer(
@@ -619,7 +505,7 @@ private:
 };
 
 class plugin final : public virtual operator_plugin2<load_balance>,
-                     public virtual operator_compiler_plugin {
+                     public virtual OperatorPlugin {
 public:
   auto make(operator_factory_invocation inv, session ctx) const
     -> failure_or<operator_ptr> override {
@@ -646,56 +532,37 @@ public:
     return std::make_unique<load_balance>(std::move(pipes));
   }
 
-  auto compile(ast::invocation inv, compile_ctx ctx) const
-    -> failure_or<ir::CompileResult> override {
-    auto const* docs = "https://docs.tenzir.com/tql2/operators/load_balance";
-    auto const* usage = "load_balance over:list { … }";
-    auto emit = [&](diagnostic_builder d) {
-      std::move(d).docs(docs).usage(usage).emit(ctx);
-    };
-    if (inv.args.empty()) {
-      emit(
-        diagnostic::error("expected two positional arguments").primary(inv.op));
-      return failure::promise();
-    }
-    auto* var = try_as<ast::dollar_var>(inv.args[0]);
-    if (not var) {
-      emit(diagnostic::error("expected a `$`-variable").primary(inv.args[0]));
-      return failure::promise();
-    }
-    TRY(inv.args[0].bind(ctx));
-    var = try_as<ast::dollar_var>(inv.args[0]);
-    TENZIR_ASSERT(var);
-    if (inv.args.size() < 2) {
-      emit(diagnostic::error("expected a pipeline afterwards").primary(*var));
-      return failure::promise();
-    }
-    auto* pipe = try_as<ast::pipeline_expr>(inv.args[1]);
-    if (not pipe) {
-      emit(diagnostic::error("expected a pipeline expression")
-             .primary(inv.args[1]));
-      return failure::promise();
-    }
-    if (inv.args.size() > 2) {
-      emit(diagnostic::error("expected exactly two arguments, got {}",
-                             inv.args.size())
-             .primary(inv.args[2]));
-      return failure::promise();
-    }
-    auto self = inv.op.get_location();
-    auto pipe_location = pipe->get_location();
-    TRY(auto pipe_ir, std::move(pipe->inner).compile(ctx));
-    return LoadBalanceIr{self, *var, pipe_location, std::move(pipe_ir)};
+  auto describe() const -> Description override {
+    auto d = Describer<LoadBalanceArgs, LoadBalance>{};
+    auto over = d.positional("over", &LoadBalanceArgs::over, "list");
+    auto pipe = d.pipeline(&LoadBalanceArgs::pipe,
+                           {{"over", &LoadBalanceArgs::over_id}});
+    d.validate([over, pipe](DescribeCtx& ctx) -> Empty {
+      if (auto entries = ctx.get(over); entries and entries->inner.empty()) {
+        diagnostic::error("expected list to not be empty")
+          .primary(entries->source)
+          .emit(ctx);
+      }
+      TRY(auto p, ctx.get(pipe));
+      auto output = p.inner.infer_type(tag_v<table_slice>, ctx);
+      if (output.is_error() or not output->has_value()) {
+        return {};
+      }
+      if (output->value().is_not<void>()) {
+        diagnostic::error("pipeline must currently end with a sink")
+          .primary(p.source)
+          .emit(ctx);
+      }
+      return {};
+    });
+    return d.without_optimize();
   }
 };
-
-using load_balance_ir_plugin = inspection_plugin<ir::Operator, LoadBalanceIr>;
 
 } // namespace
 
 } // namespace tenzir::plugins::load_balance
 
 TENZIR_REGISTER_PLUGIN(tenzir::plugins::load_balance::plugin)
-TENZIR_REGISTER_PLUGIN(tenzir::plugins::load_balance::load_balance_ir_plugin)
 TENZIR_REGISTER_PLUGIN(tenzir::operator_inspection_plugin<
                        tenzir::plugins::load_balance::load_balance_source>)

--- a/libtenzir/builtins/operators/load_balance.cpp
+++ b/libtenzir/builtins/operators/load_balance.cpp
@@ -6,16 +6,25 @@
 // SPDX-FileCopyrightText: (c) 2024 The Tenzir Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+#include "tenzir/async.hpp"
+#include "tenzir/compile_ctx.hpp"
+#include "tenzir/detail/narrow.hpp"
+#include "tenzir/ir.hpp"
+#include "tenzir/option.hpp"
 #include "tenzir/pipeline.hpp"
 #include "tenzir/pipeline_executor.hpp"
 #include "tenzir/scope_linked.hpp"
+#include "tenzir/substitute_ctx.hpp"
+#include "tenzir/tql2/eval.hpp"
 #include "tenzir/tql2/exec.hpp"
+#include "tenzir/view.hpp"
 
 #include <tenzir/plugin/register.hpp>
 #include <tenzir/tql2/plugin.hpp>
 
 #include <caf/anon_mail.hpp>
 
+#include <algorithm>
 #include <deque>
 
 namespace tenzir::plugins::load_balance {
@@ -177,6 +186,260 @@ auto get_or_compute(Map& map, Key&& key, F&& f) -> decltype(auto) {
     .try_emplace(std::forward<Key>(key), implicit_caller(std::forward<F>(f)))
     .first->second;
 }
+
+auto as_constant_kind(data const& value) -> ast::constant::kind {
+  return match(
+    value,
+    []<class T>(T const& x) -> ast::constant::kind {
+      if constexpr (std::same_as<T, pattern>) {
+        TENZIR_UNREACHABLE();
+      } else {
+        return x;
+      }
+    });
+}
+
+struct LoadBalanceArgs {
+  std::vector<ir::pipeline> pipes;
+};
+
+class LoadBalance final : public Operator<table_slice, void> {
+public:
+  explicit LoadBalance(LoadBalanceArgs args) : args_{std::move(args)} {
+  }
+
+  auto start(OpCtx& ctx) -> Task<void> override {
+    if (started_) {
+      co_return;
+    }
+    started_ = true;
+    workers_.assign(args_.pipes.size(), Worker{});
+    active_workers_ = workers_.size();
+    for (auto i = size_t{0}; i < args_.pipes.size(); ++i) {
+      co_await ctx.spawn_sub<table_slice>(
+        data{detail::narrow<int64_t>(i)}, std::move(args_.pipes[i]));
+    }
+  }
+
+  auto process(table_slice input, OpCtx& ctx) -> Task<void> override {
+    if (input.rows() == 0) {
+      co_return;
+    }
+    auto const rows = input.rows();
+    while (active_workers_ > 0) {
+      auto worker = select_worker();
+      TENZIR_ASSERT(worker);
+      auto sub = ctx.get_sub(detail::narrow<int64_t>(*worker));
+      if (not sub) {
+        mark_inactive(*worker);
+        continue;
+      }
+      auto& pipe = as<SubHandle<table_slice>>(*sub);
+      auto result = co_await pipe.push(std::move(input));
+      if (result.is_ok()) {
+        workers_[*worker].rows_assigned += rows;
+        co_return;
+      }
+      input = std::move(result).unwrap_err();
+      mark_inactive(*worker);
+    }
+    done_ = true;
+  }
+
+  auto finish_sub(SubKeyView key, OpCtx& ctx) -> Task<void> override {
+    TENZIR_UNUSED(ctx);
+    auto key_data = materialize(key);
+    auto* index = try_as<int64_t>(key_data);
+    TENZIR_ASSERT(index);
+    mark_inactive(detail::narrow<size_t>(*index));
+    co_return;
+  }
+
+  auto finalize(OpCtx& ctx) -> Task<FinalizeBehavior> override {
+    for (auto i = size_t{0}; i < workers_.size(); ++i) {
+      if (not workers_[i].active) {
+        continue;
+      }
+      if (auto sub = ctx.get_sub(detail::narrow<int64_t>(i))) {
+        auto& pipe = as<SubHandle<table_slice>>(*sub);
+        co_await pipe.close();
+      }
+      mark_inactive(i);
+    }
+    done_ = true;
+    co_return FinalizeBehavior::done;
+  }
+
+  auto state() -> OperatorState override {
+    return done_ ? OperatorState::done : OperatorState::unspecified;
+  }
+
+private:
+  struct Worker {
+    uint64_t rows_assigned = 0;
+    bool active = true;
+  };
+
+  auto select_worker() const -> Option<size_t> {
+    auto result = Option<size_t>{None{}};
+    for (auto i = size_t{0}; i < workers_.size(); ++i) {
+      if (not workers_[i].active) {
+        continue;
+      }
+      if (not result
+          or workers_[i].rows_assigned < workers_[*result].rows_assigned) {
+        result = i;
+      }
+    }
+    return result;
+  }
+
+  auto mark_inactive(size_t index) -> void {
+    TENZIR_ASSERT(index < workers_.size());
+    if (not workers_[index].active) {
+      return;
+    }
+    workers_[index].active = false;
+    TENZIR_ASSERT(active_workers_ > 0);
+    --active_workers_;
+    if (active_workers_ == 0) {
+      done_ = true;
+    }
+  }
+
+  LoadBalanceArgs args_;
+  std::vector<Worker> workers_;
+  size_t active_workers_ = 0;
+  bool started_ = false;
+  bool done_ = false;
+};
+
+class LoadBalanceIr final : public ir::Operator {
+public:
+  LoadBalanceIr() = default;
+
+  LoadBalanceIr(location self, ast::dollar_var var, location pipe_location,
+                ir::pipeline pipe)
+    : self_{self},
+      var_{std::move(var)},
+      pipe_location_{pipe_location},
+      pipe_{std::move(pipe)} {
+  }
+
+  auto name() const -> std::string override {
+    return "load_balance-ir";
+  }
+
+  auto substitute(substitute_ctx ctx, bool instantiate)
+    -> failure_or<void> override {
+    if (not instantiate) {
+      if (not ctx.get(var_.let)) {
+        return {};
+      }
+    }
+    if (not pipes_.empty()) {
+      if (instantiate and not pipes_instantiated_) {
+        for (auto& pipe : pipes_) {
+          TRY(pipe.substitute(ctx, true));
+        }
+        pipes_instantiated_ = true;
+      }
+      return {};
+    }
+    auto original = ctx.get(var_.let);
+    if (not original) {
+      diagnostic::error("expected a constant list")
+        .primary(var_)
+        .emit(ctx);
+      return failure::promise();
+    }
+    auto* entries = try_as<list>(*original);
+    if (not entries) {
+      auto got = original->match([]<class T>(T const&) {
+        return type_kind::of<data_to_type_t<T>>;
+      });
+      diagnostic::error("expected a list, got `{}`", got)
+        .primary(var_)
+        .emit(ctx);
+      return failure::promise();
+    }
+    if (entries->empty()) {
+      diagnostic::error("expected list to not be empty")
+        .primary(var_)
+        .emit(ctx);
+      return failure::promise();
+    }
+    auto pipes = std::vector<ir::pipeline>{};
+    pipes.reserve(entries->size());
+    for (auto const& entry : *entries) {
+      auto env = ctx.env();
+      env.insert_or_assign(var_.let, as_constant_kind(entry));
+      auto pipe = pipe_;
+      TRY(pipe.substitute(ctx.with_env(&env), instantiate));
+      pipes.push_back(std::move(pipe));
+    }
+    pipes_ = std::move(pipes);
+    pipes_instantiated_ = instantiate;
+    return {};
+  }
+
+  auto infer_type(element_type_tag input, diagnostic_handler& dh) const
+    -> failure_or<std::optional<element_type_tag>> override {
+    if (input.is_not<table_slice>()) {
+      diagnostic::error("operator expects events").primary(self_).emit(dh);
+      return failure::promise();
+    }
+    for (auto const& pipe : pipes_) {
+      TRY(auto output, pipe.infer_type(input, dh));
+      if (not output) {
+        return std::nullopt;
+      }
+      if (output->is_not<void>()) {
+        diagnostic::error("pipeline must currently end with a sink")
+          .primary(pipe_location_)
+          .emit(dh);
+        return failure::promise();
+      }
+    }
+    return tag_v<void>;
+  }
+
+  auto optimize(ir::optimize_filter filter,
+                event_order order) && -> ir::optimize_result override {
+    TENZIR_UNUSED(filter, order);
+    auto replacement = ir::pipeline{};
+    replacement.operators.push_back(LoadBalanceIr{std::move(*this)});
+    return {ir::optimize_filter{}, event_order::unordered,
+            std::move(replacement)};
+  }
+
+  auto spawn(element_type_tag input) && -> AnyOperator override {
+    TENZIR_ASSERT(input.is<table_slice>());
+    return LoadBalance{LoadBalanceArgs{std::move(pipes_)}};
+  }
+
+  auto main_location() const -> location override {
+    return self_;
+  }
+
+  friend auto inspect(auto& f, LoadBalanceIr& x) -> bool {
+    return f.object(x).fields(f.field("self", x.self_),
+                              f.field("var", x.var_),
+                              f.field("pipe_location", x.pipe_location_),
+                              f.field("pipe", x.pipe_),
+                              f.field("pipes", x.pipes_),
+                              f.field("pipes_instantiated",
+                                      x.pipes_instantiated_));
+  }
+
+private:
+  location self_;
+  ast::dollar_var var_;
+  location pipe_location_;
+  ir::pipeline pipe_;
+  std::vector<ir::pipeline> pipes_;
+  bool pipes_instantiated_ = false;
+};
 
 auto make_load_balancer(
   load_balancer_actor::stateful_pointer<load_balancer_state> self,
@@ -363,7 +626,8 @@ private:
   std::vector<pipeline> pipes_;
 };
 
-class plugin final : public virtual operator_plugin2<load_balance> {
+class plugin final : public virtual operator_plugin2<load_balance>,
+                     public virtual operator_compiler_plugin {
 public:
   auto make(operator_factory_invocation inv, session ctx) const
     -> failure_or<operator_ptr> override {
@@ -371,7 +635,7 @@ public:
     for (auto& arg : inv.args) {
       auto pipe = std::get_if<ast::pipeline_expr>(&*arg.kind);
       TENZIR_ASSERT(pipe);
-      TRY(auto compiled, compile(std::move(pipe->inner), ctx));
+      TRY(auto compiled, tenzir::compile(std::move(pipe->inner), ctx));
       auto output = compiled.infer_type<table_slice>();
       if (not output) {
         diagnostic::error("pipeline must take events as input")
@@ -389,12 +653,58 @@ public:
     }
     return std::make_unique<load_balance>(std::move(pipes));
   }
+
+  auto compile(ast::invocation inv, compile_ctx ctx) const
+    -> failure_or<ir::CompileResult> override {
+    auto const* docs = "https://docs.tenzir.com/tql2/operators/load_balance";
+    auto const* usage = "load_balance over:list { … }";
+    auto emit = [&](diagnostic_builder d) {
+      std::move(d).docs(docs).usage(usage).emit(ctx);
+    };
+    if (inv.args.empty()) {
+      emit(diagnostic::error("expected two positional arguments")
+             .primary(inv.op));
+      return failure::promise();
+    }
+    auto* var = try_as<ast::dollar_var>(inv.args[0]);
+    if (not var) {
+      emit(diagnostic::error("expected a `$`-variable").primary(inv.args[0]));
+      return failure::promise();
+    }
+    TRY(inv.args[0].bind(ctx));
+    var = try_as<ast::dollar_var>(inv.args[0]);
+    TENZIR_ASSERT(var);
+    if (inv.args.size() < 2) {
+      emit(diagnostic::error("expected a pipeline afterwards").primary(*var));
+      return failure::promise();
+    }
+    auto* pipe = try_as<ast::pipeline_expr>(inv.args[1]);
+    if (not pipe) {
+      emit(diagnostic::error("expected a pipeline expression")
+             .primary(inv.args[1]));
+      return failure::promise();
+    }
+    if (inv.args.size() > 2) {
+      emit(diagnostic::error("expected exactly two arguments, got {}",
+                             inv.args.size())
+             .primary(inv.args[2]));
+      return failure::promise();
+    }
+    auto self = inv.op.get_location();
+    auto pipe_location = pipe->get_location();
+    TRY(auto pipe_ir, std::move(pipe->inner).compile(ctx));
+    return LoadBalanceIr{self, *var, pipe_location, std::move(pipe_ir)};
+  }
 };
+
+using load_balance_ir_plugin
+  = inspection_plugin<ir::Operator, LoadBalanceIr>;
 
 } // namespace
 
 } // namespace tenzir::plugins::load_balance
 
 TENZIR_REGISTER_PLUGIN(tenzir::plugins::load_balance::plugin)
+TENZIR_REGISTER_PLUGIN(tenzir::plugins::load_balance::load_balance_ir_plugin)
 TENZIR_REGISTER_PLUGIN(tenzir::operator_inspection_plugin<
                        tenzir::plugins::load_balance::load_balance_source>)

--- a/libtenzir/builtins/operators/load_balance.cpp
+++ b/libtenzir/builtins/operators/load_balance.cpp
@@ -188,15 +188,13 @@ auto get_or_compute(Map& map, Key&& key, F&& f) -> decltype(auto) {
 }
 
 auto as_constant_kind(data const& value) -> ast::constant::kind {
-  return match(
-    value,
-    []<class T>(T const& x) -> ast::constant::kind {
-      if constexpr (std::same_as<T, pattern>) {
-        TENZIR_UNREACHABLE();
-      } else {
-        return x;
-      }
-    });
+  return match(value, []<class T>(T const& x) -> ast::constant::kind {
+    if constexpr (std::same_as<T, pattern>) {
+      TENZIR_UNREACHABLE();
+    } else {
+      return x;
+    }
+  });
 }
 
 struct LoadBalanceArgs {
@@ -216,8 +214,8 @@ public:
     workers_.assign(args_.pipes.size(), Worker{});
     active_workers_ = workers_.size();
     for (auto i = size_t{0}; i < args_.pipes.size(); ++i) {
-      co_await ctx.spawn_sub<table_slice>(
-        data{detail::narrow<int64_t>(i)}, std::move(args_.pipes[i]));
+      co_await ctx.spawn_sub<table_slice>(data{detail::narrow<int64_t>(i)},
+                                          std::move(args_.pipes[i]));
     }
   }
 
@@ -348,9 +346,7 @@ public:
     }
     auto original = ctx.get(var_.let);
     if (not original) {
-      diagnostic::error("expected a constant list")
-        .primary(var_)
-        .emit(ctx);
+      diagnostic::error("expected a constant list").primary(var_).emit(ctx);
       return failure::promise();
     }
     auto* entries = try_as<list>(*original);
@@ -364,9 +360,7 @@ public:
       return failure::promise();
     }
     if (entries->empty()) {
-      diagnostic::error("expected list to not be empty")
-        .primary(var_)
-        .emit(ctx);
+      diagnostic::error("expected list to not be empty").primary(var_).emit(ctx);
       return failure::promise();
     }
     auto pipes = std::vector<ir::pipeline>{};
@@ -423,13 +417,11 @@ public:
   }
 
   friend auto inspect(auto& f, LoadBalanceIr& x) -> bool {
-    return f.object(x).fields(f.field("self", x.self_),
-                              f.field("var", x.var_),
-                              f.field("pipe_location", x.pipe_location_),
-                              f.field("pipe", x.pipe_),
-                              f.field("pipes", x.pipes_),
-                              f.field("pipes_instantiated",
-                                      x.pipes_instantiated_));
+    return f.object(x).fields(
+      f.field("self", x.self_), f.field("var", x.var_),
+      f.field("pipe_location", x.pipe_location_), f.field("pipe", x.pipe_),
+      f.field("pipes", x.pipes_),
+      f.field("pipes_instantiated", x.pipes_instantiated_));
   }
 
 private:
@@ -662,8 +654,8 @@ public:
       std::move(d).docs(docs).usage(usage).emit(ctx);
     };
     if (inv.args.empty()) {
-      emit(diagnostic::error("expected two positional arguments")
-             .primary(inv.op));
+      emit(
+        diagnostic::error("expected two positional arguments").primary(inv.op));
       return failure::promise();
     }
     auto* var = try_as<ast::dollar_var>(inv.args[0]);
@@ -697,8 +689,7 @@ public:
   }
 };
 
-using load_balance_ir_plugin
-  = inspection_plugin<ir::Operator, LoadBalanceIr>;
+using load_balance_ir_plugin = inspection_plugin<ir::Operator, LoadBalanceIr>;
 
 } // namespace
 

--- a/test/tests/operators/load_balance/basic.tql
+++ b/test/tests/operators/load_balance/basic.tql
@@ -1,0 +1,7 @@
+let $worker = ["alpha"]
+from {x: 1}, {x: 2}
+load_balance $worker {
+  worker = $worker
+  write_tql
+  save_stdout
+}

--- a/test/tests/operators/load_balance/basic.tql
+++ b/test/tests/operators/load_balance/basic.tql
@@ -1,7 +1,8 @@
-let $worker = ["alpha"]
+let $over = ["alpha"]
 from {x: 1}, {x: 2}
-load_balance $worker {
-  worker = $worker
-  write_tql
-  save_stdout
+load_balance $over {
+  worker = $over
+  to_stdout {
+    write_tql
+  }
 }

--- a/test/tests/operators/load_balance/basic.txt
+++ b/test/tests/operators/load_balance/basic.txt
@@ -1,0 +1,8 @@
+{
+  x: 1,
+  worker: "alpha",
+}
+{
+  x: 2,
+  worker: "alpha",
+}

--- a/test/tests/operators/load_balance/error_bytes_output.tql
+++ b/test/tests/operators/load_balance/error_bytes_output.tql
@@ -2,8 +2,8 @@
 error: true
 ---
 
-let $worker = ["alpha"]
+let $over = ["alpha"]
 from {x: 1}
-load_balance $worker {
+load_balance $over {
   write_tql
 }

--- a/test/tests/operators/load_balance/error_bytes_output.tql
+++ b/test/tests/operators/load_balance/error_bytes_output.tql
@@ -1,0 +1,9 @@
+---
+error: true
+---
+
+let $worker = ["alpha"]
+from {x: 1}
+load_balance $worker {
+  write_tql
+}

--- a/test/tests/operators/load_balance/error_bytes_output.txt
+++ b/test/tests/operators/load_balance/error_bytes_output.txt
@@ -1,0 +1,6 @@
+error: pipeline must currently end with a sink
+ --> tests/operators/load_balance/error_bytes_output.tql:7:22
+  |
+7 | load_balance $worker {
+  |                      ^^^^^^^^^^^^^^^ 
+  |

--- a/test/tests/operators/load_balance/error_bytes_output.txt
+++ b/test/tests/operators/load_balance/error_bytes_output.txt
@@ -1,6 +1,6 @@
 error: pipeline must currently end with a sink
- --> tests/operators/load_balance/error_bytes_output.tql:7:22
+ --> tests/operators/load_balance/error_bytes_output.tql:7:20
   |
-7 | load_balance $worker {
-  |                      ^^^^^^^^^^^^^^^ 
+7 | load_balance $over {
+  |                    ^^^^^^^^^^^^^^^ 
   |

--- a/test/tests/operators/load_balance/error_empty_list.tql
+++ b/test/tests/operators/load_balance/error_empty_list.tql
@@ -2,8 +2,8 @@
 error: true
 ---
 
-let $worker = []
+let $over = []
 from {x: 1}
-load_balance $worker {
+load_balance $over {
   discard
 }

--- a/test/tests/operators/load_balance/error_empty_list.tql
+++ b/test/tests/operators/load_balance/error_empty_list.tql
@@ -1,0 +1,9 @@
+---
+error: true
+---
+
+let $worker = []
+from {x: 1}
+load_balance $worker {
+  discard
+}

--- a/test/tests/operators/load_balance/error_empty_list.txt
+++ b/test/tests/operators/load_balance/error_empty_list.txt
@@ -1,0 +1,6 @@
+error: expected list to not be empty
+ --> tests/operators/load_balance/error_empty_list.tql:7:14
+  |
+7 | load_balance $worker {
+  |              ^^^^^^^ 
+  |

--- a/test/tests/operators/load_balance/error_empty_list.txt
+++ b/test/tests/operators/load_balance/error_empty_list.txt
@@ -1,6 +1,6 @@
 error: expected list to not be empty
  --> tests/operators/load_balance/error_empty_list.tql:7:14
   |
-7 | load_balance $worker {
-  |              ^^^^^^^ 
+7 | load_balance $over {
+  |              ^^^^^ 
   |

--- a/test/tests/operators/load_balance/error_events_input.tql
+++ b/test/tests/operators/load_balance/error_events_input.tql
@@ -2,9 +2,9 @@
 error: true
 ---
 
-let $worker = ["alpha"]
+let $over = ["alpha"]
 from {x: 1}
-load_balance $worker {
+load_balance $over {
   from {y: 1}
   discard
 }

--- a/test/tests/operators/load_balance/error_events_input.tql
+++ b/test/tests/operators/load_balance/error_events_input.tql
@@ -1,0 +1,10 @@
+---
+error: true
+---
+
+let $worker = ["alpha"]
+from {x: 1}
+load_balance $worker {
+  from {y: 1}
+  discard
+}

--- a/test/tests/operators/load_balance/error_events_input.txt
+++ b/test/tests/operators/load_balance/error_events_input.txt
@@ -1,0 +1,6 @@
+error: expected void, got events
+ --> tests/operators/load_balance/error_events_input.tql:8:3
+  |
+8 |   from {y: 1}
+  |   ^^^^ 
+  |

--- a/test/tests/operators/load_balance/error_events_output.tql
+++ b/test/tests/operators/load_balance/error_events_output.tql
@@ -2,8 +2,8 @@
 error: true
 ---
 
-let $worker = ["alpha"]
+let $over = ["alpha"]
 from {x: 1}
-load_balance $worker {
+load_balance $over {
   pass
 }

--- a/test/tests/operators/load_balance/error_events_output.tql
+++ b/test/tests/operators/load_balance/error_events_output.tql
@@ -1,0 +1,9 @@
+---
+error: true
+---
+
+let $worker = ["alpha"]
+from {x: 1}
+load_balance $worker {
+  pass
+}

--- a/test/tests/operators/load_balance/error_events_output.txt
+++ b/test/tests/operators/load_balance/error_events_output.txt
@@ -1,0 +1,6 @@
+error: pipeline must currently end with a sink
+ --> tests/operators/load_balance/error_events_output.tql:7:22
+  |
+7 | load_balance $worker {
+  |                      ^^^^^^^^^^ 
+  |

--- a/test/tests/operators/load_balance/error_events_output.txt
+++ b/test/tests/operators/load_balance/error_events_output.txt
@@ -1,6 +1,6 @@
 error: pipeline must currently end with a sink
- --> tests/operators/load_balance/error_events_output.tql:7:22
+ --> tests/operators/load_balance/error_events_output.tql:7:20
   |
-7 | load_balance $worker {
-  |                      ^^^^^^^^^^ 
+7 | load_balance $over {
+  |                    ^^^^^^^^^^ 
   |

--- a/test/tests/operators/load_balance/error_expected_variable.tql
+++ b/test/tests/operators/load_balance/error_expected_variable.tql
@@ -1,0 +1,9 @@
+---
+error: true
+---
+
+let $worker = ["alpha"]
+from {x: 1}
+load_balance "alpha" {
+  discard
+}

--- a/test/tests/operators/load_balance/error_expected_variable.txt
+++ b/test/tests/operators/load_balance/error_expected_variable.txt
@@ -1,0 +1,8 @@
+error: expected a `$`-variable
+ --> tests/operators/load_balance/error_expected_variable.tql:7:14
+  |
+7 | load_balance "alpha" {
+  |              ^^^^^^^ 
+  |
+  = docs: https://docs.tenzir.com/tql2/operators/load_balance
+  = usage: load_balance over:list { … }

--- a/test/tests/operators/load_balance/error_expected_variable.txt
+++ b/test/tests/operators/load_balance/error_expected_variable.txt
@@ -1,8 +1,6 @@
-error: expected a `$`-variable
+error: expected argument of type `list`, but got `string`
  --> tests/operators/load_balance/error_expected_variable.tql:7:14
   |
 7 | load_balance "alpha" {
   |              ^^^^^^^ 
   |
-  = docs: https://docs.tenzir.com/tql2/operators/load_balance
-  = usage: load_balance over:list { … }

--- a/test/tests/operators/load_balance/error_non_list.tql
+++ b/test/tests/operators/load_balance/error_non_list.tql
@@ -1,0 +1,9 @@
+---
+error: true
+---
+
+let $worker = "alpha"
+from {x: 1}
+load_balance $worker {
+  discard
+}

--- a/test/tests/operators/load_balance/error_non_list.tql
+++ b/test/tests/operators/load_balance/error_non_list.tql
@@ -2,8 +2,8 @@
 error: true
 ---
 
-let $worker = "alpha"
+let $over = "alpha"
 from {x: 1}
-load_balance $worker {
+load_balance $over {
   discard
 }

--- a/test/tests/operators/load_balance/error_non_list.txt
+++ b/test/tests/operators/load_balance/error_non_list.txt
@@ -1,6 +1,6 @@
-error: expected a list, got `string`
+error: expected argument of type `list`, but got `string`
  --> tests/operators/load_balance/error_non_list.tql:7:14
   |
-7 | load_balance $worker {
-  |              ^^^^^^^ 
+7 | load_balance $over {
+  |              ^^^^^ 
   |

--- a/test/tests/operators/load_balance/error_non_list.txt
+++ b/test/tests/operators/load_balance/error_non_list.txt
@@ -1,0 +1,6 @@
+error: expected a list, got `string`
+ --> tests/operators/load_balance/error_non_list.tql:7:14
+  |
+7 | load_balance $worker {
+  |              ^^^^^^^ 
+  |

--- a/test/tests/operators/load_balance/multi_worker_sink.tql
+++ b/test/tests/operators/load_balance/multi_worker_sink.tql
@@ -1,9 +1,10 @@
-let $worker = ["alpha", "beta", "gamma"]
+let $over = ["alpha", "beta", "gamma"]
 from {x: 1}, {x: 2}, {x: 3}, {x: 4}, {x: 5}, {x: 6}
 batch 1
-load_balance $worker {
-  where $worker == "alpha"
-  worker = $worker
-  write_tql
-  save_stdout
+load_balance $over {
+  where $over == "alpha"
+  worker = $over
+  to_stdout {
+    write_tql
+  }
 }

--- a/test/tests/operators/load_balance/multi_worker_sink.tql
+++ b/test/tests/operators/load_balance/multi_worker_sink.tql
@@ -1,0 +1,9 @@
+let $worker = ["alpha", "beta", "gamma"]
+from {x: 1}, {x: 2}, {x: 3}, {x: 4}, {x: 5}, {x: 6}
+batch 1
+load_balance $worker {
+  where $worker == "alpha"
+  worker = $worker
+  write_tql
+  save_stdout
+}

--- a/test/tests/operators/load_balance/multi_worker_sink.txt
+++ b/test/tests/operators/load_balance/multi_worker_sink.txt
@@ -1,0 +1,8 @@
+{
+  x: 1,
+  worker: "alpha",
+}
+{
+  x: 4,
+  worker: "alpha",
+}

--- a/test/tests/operators/load_balance/nested_parallel.tql
+++ b/test/tests/operators/load_balance/nested_parallel.tql
@@ -1,0 +1,9 @@
+let $worker = ["alpha"]
+from {x: 1}, {x: 2}
+parallel 1 {
+  load_balance $worker {
+    worker = $worker
+    write_tql
+    save_stdout
+  }
+}

--- a/test/tests/operators/load_balance/nested_parallel.tql
+++ b/test/tests/operators/load_balance/nested_parallel.tql
@@ -1,9 +1,10 @@
-let $worker = ["alpha"]
+let $over = ["alpha"]
 from {x: 1}, {x: 2}
 parallel 1 {
-  load_balance $worker {
-    worker = $worker
-    write_tql
-    save_stdout
+  load_balance $over {
+    worker = $over
+    to_stdout {
+      write_tql
+    }
   }
 }

--- a/test/tests/operators/load_balance/nested_parallel.txt
+++ b/test/tests/operators/load_balance/nested_parallel.txt
@@ -1,0 +1,8 @@
+{
+  x: 1,
+  worker: "alpha",
+}
+{
+  x: 2,
+  worker: "alpha",
+}


### PR DESCRIPTION
## 🔍 Problem

- `load_balance` still only had a legacy executor implementation.
- The neo compiler also needed to preserve the operator-specific `$` list expansion semantics.

## 🛠️ Solution

- Add a custom IR path that expands the worker list into sink subpipelines.
- Implement whole-slice dispatch to the least-loaded active worker, with runtime-only scheduling counters.
- Add neo integration coverage and turn invalid source subpipelines into type diagnostics instead of assertions.

## 💬 Review

- Focus on subpipeline shutdown/finalization and the decision to avoid snapshotting scheduler hints.
- Distribution is intentionally whole-slice least-loaded, not the legacy demand-based handoff.

<sub>
✅ Closes TNZ-46
</sub>