### PR TITLE
Add OData pagination to from_http

### DIFF
--- a/changelog/unreleased/odata-pagination-for-from-http.md
+++ b/changelog/unreleased/odata-pagination-for-from-http.md
@@ -20,5 +20,5 @@ from_http "https://graph.microsoft.com/v1.0/users",
 ```
 
 This mode emits the objects from the response body's top-level `value` array
-and follows opaque top-level `@odata.nextLink` URLs until no next link is
-present.
+and follows top-level `@odata.nextLink` URLs until no next link is present. The
+next link can be absolute or relative to the current response URL.

--- a/changelog/unreleased/odata-pagination-for-from-http.md
+++ b/changelog/unreleased/odata-pagination-for-from-http.md
@@ -1,0 +1,24 @@
+---
+title: OData pagination for from_http
+type: feature
+authors:
+  - mavam
+  - codex
+created: 2026-04-24T15:28:40Z
+---
+
+The `from_http` operator now supports `paginate="odata"` for
+[OData](https://www.oasis-open.org/standard/odata-v4-01-os/) collection
+responses such as Microsoft Graph:
+
+```tql
+from_http "https://graph.microsoft.com/v1.0/users",
+  headers={"ConsistencyLevel": "eventual"},
+  paginate="odata" {
+  read_json
+}
+```
+
+This mode emits the objects from the response body's top-level `value` array
+and follows opaque top-level `@odata.nextLink` URLs until no next link is
+present.

--- a/libtenzir/builtins/operators/from_http.cpp
+++ b/libtenzir/builtins/operators/from_http.cpp
@@ -287,9 +287,14 @@ auto validate_paginate(Option<ast::expression> const& expr,
     });
 }
 
-auto resolve_paginate_url(std::string_view next_url,
-                          std::string const& base_url, location paginate_loc,
-                          diagnostic_handler& dh) -> Option<std::string> {
+enum class NextUrlSource {
+  paginate_lambda,
+  odata_next_link,
+};
+
+auto resolve_next_url(std::string_view next_url, std::string const& base_url,
+                      location paginate_loc, diagnostic_handler& dh,
+                      NextUrlSource source) -> Option<std::string> {
   auto base = boost::urls::parse_uri_reference(base_url);
   if (not base) {
     diagnostic::warning("failed to parse request URI for pagination: {}",
@@ -301,20 +306,43 @@ auto resolve_paginate_url(std::string_view next_url,
   }
   auto ref = boost::urls::parse_uri_reference(next_url);
   if (not ref) {
-    diagnostic::warning("invalid next URL from `paginate` lambda: {}",
-                        ref.error().message())
-      .primary(paginate_loc)
-      .note("stopping pagination")
-      .emit(dh);
+    switch (source) {
+      case NextUrlSource::paginate_lambda:
+        diagnostic::warning("invalid next URL from `paginate` lambda: {}",
+                            ref.error().message())
+          .primary(paginate_loc)
+          .note("stopping pagination")
+          .emit(dh);
+        break;
+      case NextUrlSource::odata_next_link:
+        diagnostic::warning("invalid OData `@odata.nextLink` URL: {}",
+                            ref.error().message())
+          .primary(paginate_loc)
+          .note("stopping pagination")
+          .emit(dh);
+        break;
+    }
     return None{};
   }
   auto resolved = boost::urls::url{};
   if (auto r = boost::urls::resolve(*base, *ref, resolved); not r) {
-    diagnostic::warning("failed to resolve next URL from `paginate` lambda: {}",
-                        r.error().message())
-      .primary(paginate_loc)
-      .note("stopping pagination")
-      .emit(dh);
+    switch (source) {
+      case NextUrlSource::paginate_lambda:
+        diagnostic::warning("failed to resolve next URL from `paginate` "
+                            "lambda: {}",
+                            r.error().message())
+          .primary(paginate_loc)
+          .note("stopping pagination")
+          .emit(dh);
+        break;
+      case NextUrlSource::odata_next_link:
+        diagnostic::warning("failed to resolve OData `@odata.nextLink` URL: {}",
+                            r.error().message())
+          .primary(paginate_loc)
+          .note("stopping pagination")
+          .emit(dh);
+        break;
+    }
     return None{};
   }
   return Option<std::string>{std::string{resolved.buffer()}};
@@ -345,7 +373,8 @@ auto next_url_from_lambda(Option<pagination_spec> const& paginate,
       return None{};
     },
     [&](std::string_view url) -> Option<std::string> {
-      return resolve_paginate_url(url, base_url, paginate->source, dh);
+      return resolve_next_url(url, base_url, paginate->source, dh,
+                              NextUrlSource::paginate_lambda);
     },
     [&](auto const&) -> Option<std::string> {
       diagnostic::error("expected `paginate` to be `string`, got `{}`",
@@ -763,7 +792,12 @@ public:
         co_return;
       }
       odata_envelope_seen_ = true;
-      pagination_.next_url = std::move(page->next_url);
+      pagination_.next_url
+        = page->next_url
+            ? resolve_next_url(*page->next_url, pagination_.current_url,
+                               paginate_->source, ctx.dh(),
+                               NextUrlSource::odata_next_link)
+            : None{};
       for (auto& event_slice : page->events) {
         co_await push(std::move(event_slice));
       }

--- a/libtenzir/builtins/operators/from_http.cpp
+++ b/libtenzir/builtins/operators/from_http.cpp
@@ -236,7 +236,11 @@ auto resolve_http_secrets(
   co_return {};
 }
 
-using pagination_spec = located<variant<ast::lambda_expr, std::string>>;
+using pagination_spec
+  = located<variant<ast::lambda_expr, http::PaginationMode>>;
+
+constexpr auto paginate_hint
+  = R"(`paginate` must be `"link"`, `"odata"`, or a lambda)";
 
 auto validate_paginate(Option<ast::expression> const& expr,
                        diagnostic_handler& dh)
@@ -253,7 +257,7 @@ auto validate_paginate(Option<ast::expression> const& expr,
       return failure::promise();
     }
     return Option<pagination_spec>{pagination_spec{
-      variant<ast::lambda_expr, std::string>{*lambda},
+      variant<ast::lambda_expr, http::PaginationMode>{*lambda},
       expr->get_location(),
     }};
   }
@@ -261,22 +265,23 @@ auto validate_paginate(Option<ast::expression> const& expr,
   return match(
     value,
     [&](std::string const& mode) -> failure_or<Option<pagination_spec>> {
-      if (mode != "link") {
+      auto pagination_mode = http::parse_pagination_mode(mode);
+      if (not pagination_mode) {
         diagnostic::error("unsupported pagination mode: `{}`", mode)
           .primary(*expr)
-          .hint("`paginate` must be `\"link\"` or a lambda")
+          .hint(paginate_hint)
           .emit(dh);
         return failure::promise();
       }
       return Option<pagination_spec>{pagination_spec{
-        variant<ast::lambda_expr, std::string>{mode},
+        variant<ast::lambda_expr, http::PaginationMode>{*pagination_mode},
         expr->get_location(),
       }};
     },
     [&](auto const&) -> failure_or<Option<pagination_spec>> {
       diagnostic::error("expected `paginate` to be `string` or `lambda`")
         .primary(*expr)
-        .hint("`paginate` must be `\"link\"` or a lambda")
+        .hint(paginate_hint)
         .emit(dh);
       return failure::promise();
     });
@@ -351,231 +356,16 @@ auto next_url_from_lambda(Option<pagination_spec> const& paginate,
     });
 }
 
-auto is_link_pagination(Option<pagination_spec> const& paginate) -> bool {
+auto builtin_pagination_mode(Option<pagination_spec> const& paginate)
+  -> Option<http::PaginationMode> {
   if (not paginate) {
-    return false;
+    return None{};
   }
-  auto const* mode = try_as<std::string>(&paginate->inner);
+  auto const* mode = try_as<http::PaginationMode>(&paginate->inner);
   if (not mode) {
-    return false;
-  }
-  TENZIR_ASSERT(*mode == "link");
-  return true;
-}
-
-// ---- RFC 8288 Link header parsing -----------------------------------------
-//
-// Ported from the legacy http.cpp implementation.
-
-// Splits a raw HTTP Link header value into individual link-value items at
-// top-level commas (not inside <...> or quoted strings).
-auto split_link_header(std::string_view value)
-  -> std::vector<std::string_view> {
-  auto result = std::vector<std::string_view>{};
-  auto start = size_t{0};
-  auto in_angle = false;
-  auto in_quotes = false;
-  auto escaped = false;
-  for (auto i = size_t{}; i < value.size(); ++i) {
-    const auto c = value[i];
-    if (escaped) {
-      escaped = false;
-      continue;
-    }
-    if (c == '\\' and in_quotes) {
-      escaped = true;
-      continue;
-    }
-    if (c == '"' and not in_angle) {
-      in_quotes = not in_quotes;
-      continue;
-    }
-    if (c == '<' and not in_quotes) {
-      in_angle = true;
-      continue;
-    }
-    if (c == '>' and not in_quotes) {
-      in_angle = false;
-      continue;
-    }
-    if (c == ',' and not in_quotes and not in_angle) {
-      auto item = detail::trim(value.substr(start, i - start));
-      if (not item.empty()) {
-        result.push_back(item);
-      }
-      start = i + 1;
-    }
-  }
-  auto item = detail::trim(value.substr(start));
-  if (not item.empty()) {
-    result.push_back(item);
-  }
-  return result;
-}
-
-// Splits link-value parameters at semicolons, honouring quoted-string escaping.
-auto split_link_params(std::string_view value)
-  -> std::pair<std::vector<std::string_view>, bool> {
-  auto result = std::vector<std::string_view>{};
-  auto start = size_t{0};
-  auto in_quotes = false;
-  auto escaped = false;
-  for (auto i = size_t{}; i < value.size(); ++i) {
-    const auto c = value[i];
-    if (escaped) {
-      escaped = false;
-      continue;
-    }
-    if (c == '\\' and in_quotes) {
-      escaped = true;
-      continue;
-    }
-    if (c == '"') {
-      in_quotes = not in_quotes;
-      continue;
-    }
-    if (c == ';' and not in_quotes) {
-      auto item = detail::trim(value.substr(start, i - start));
-      if (not item.empty()) {
-        result.push_back(item);
-      }
-      start = i + 1;
-    }
-  }
-  auto item = detail::trim(value.substr(start));
-  if (not item.empty()) {
-    result.push_back(item);
-  }
-  return {std::move(result), not in_quotes};
-}
-
-// Returns true when "next" appears as a token in a rel parameter value.
-auto rel_contains_next(std::string_view value) -> bool {
-  value = detail::trim(value);
-  if (value.size() >= 2 and value.front() == '"' and value.back() == '"') {
-    value.remove_prefix(1);
-    value.remove_suffix(1);
-  }
-  auto index = size_t{};
-  while (index < value.size()) {
-    while (index < value.size()
-           and std::isspace(static_cast<unsigned char>(value[index])) != 0) {
-      ++index;
-    }
-    const auto token_begin = index;
-    while (index < value.size()
-           and std::isspace(static_cast<unsigned char>(value[index])) == 0) {
-      ++index;
-    }
-    const auto token = value.substr(token_begin, index - token_begin);
-    if (not token.empty() and detail::ascii_icase_equal(token, "next")) {
-      return true;
-    }
-  }
-  return false;
-}
-
-// Parses a single RFC 8288 link-value and extracts its `rel=next` target URI.
-// Returns Err(Unit) for malformed link-values.
-auto next_link_target(std::string_view header)
-  -> Result<Option<std::string_view>, Unit> {
-  auto item = detail::trim(header);
-  if (item.empty()) {
     return None{};
   }
-  if (item.front() != '<') {
-    return Err{Unit{}};
-  }
-  const auto uri_end = item.find('>');
-  if (uri_end == std::string_view::npos) {
-    return Err{Unit{}};
-  }
-  auto target = item.substr(1, uri_end - 1);
-  auto params = item.substr(uri_end + 1);
-  auto [param_parts, ok] = split_link_params(params);
-  if (not ok) {
-    return Err{Unit{}};
-  }
-  auto has_next = false;
-  for (const auto part : param_parts) {
-    const auto eq = part.find('=');
-    auto name = detail::trim(part.substr(0, eq));
-    if (name.empty() or not detail::ascii_icase_equal(name, "rel")) {
-      continue;
-    }
-    if (eq == std::string_view::npos) {
-      continue;
-    }
-    if (rel_contains_next(detail::trim(part.substr(eq + 1)))) {
-      has_next = true;
-      break;
-    }
-  }
-  if (has_next) {
-    return Option<std::string_view>{target};
-  }
-  return None{};
-}
-
-// Scans all Link response headers and returns the first resolved `rel=next`
-// URL, or None if no such link is present. Emits a warning on malformed
-// headers.
-auto next_url_from_link_headers(
-  std::vector<std::pair<std::string, std::string>> const& response_headers,
-  std::string const& base_url, location paginate_loc, diagnostic_handler& dh)
-  -> Option<std::string> {
-  auto base = boost::urls::parse_uri_reference(base_url);
-  if (not base) {
-    diagnostic::warning("failed to parse request URI for link pagination: {}",
-                        base.error().message())
-      .primary(paginate_loc)
-      .note("stopping pagination")
-      .emit(dh);
-    return None{};
-  }
-  auto malformed = false;
-  for (auto const& [name, value] : response_headers) {
-    if (not detail::ascii_icase_equal(name, "link")) {
-      continue;
-    }
-    for (auto header : split_link_header(value)) {
-      auto parsed = next_link_target(header);
-      if (parsed.is_err()) {
-        malformed = true;
-        continue;
-      }
-      auto target = parsed.unwrap();
-      if (not target) {
-        continue;
-      }
-      auto ref = boost::urls::parse_uri_reference(*target);
-      if (not ref) {
-        diagnostic::warning("invalid `rel=next` URL in Link header: {}",
-                            ref.error().message())
-          .primary(paginate_loc)
-          .note("stopping pagination")
-          .emit(dh);
-        return None{};
-      }
-      auto resolved = boost::urls::url{};
-      if (auto r = boost::urls::resolve(*base, *ref, resolved); not r) {
-        diagnostic::warning("failed to resolve `rel=next` URL: {}",
-                            r.error().message())
-          .primary(paginate_loc)
-          .note("stopping pagination")
-          .emit(dh);
-        return None{};
-      }
-      return Option<std::string>{std::string{resolved.buffer()}};
-    }
-  }
-  if (malformed) {
-    diagnostic::warning("failed to parse Link header for pagination")
-      .primary(paginate_loc)
-      .note("stopping pagination")
-      .emit(dh);
-  }
-  return None{};
+  return *mode;
 }
 
 // ---- Fetch task -----------------------------------------------------------
@@ -884,13 +674,14 @@ public:
           co_return;
         }
         if (response_->is_success()) {
-          if (is_link_pagination(paginate_)) {
+          if (auto mode = builtin_pagination_mode(paginate_);
+              mode and *mode == http::PaginationMode::link) {
             TENZIR_ASSERT(paginate_);
             // Extract the rel=next URL for link pagination.
             pagination_.next_url
-              = next_url_from_link_headers(response_->headers,
-                                           pagination_.current_url,
-                                           paginate_->source, ctx.dh());
+              = http::next_url_from_link_headers(response_->headers,
+                                                 pagination_.current_url,
+                                                 paginate_->source, ctx.dh());
           }
         } else {
           if (not args_.error_field) {
@@ -963,6 +754,21 @@ public:
 
   auto process_sub(SubKeyView, table_slice slice, Push<table_slice>& push,
                    OpCtx& ctx) -> Task<void> override {
+    if (auto mode = builtin_pagination_mode(paginate_);
+        mode and *mode == http::PaginationMode::odata) {
+      TENZIR_ASSERT(paginate_);
+      auto page = http::extract_odata_page(slice, paginate_->source, ctx.dh());
+      if (not page) {
+        lifecycle_ = Lifecycle::done;
+        co_return;
+      }
+      odata_envelope_seen_ = true;
+      pagination_.next_url = std::move(page->next_url);
+      for (auto& event_slice : page->events) {
+        co_await push(std::move(event_slice));
+      }
+      co_return;
+    }
     if (not pagination_.next_url) {
       if (auto next = next_url_from_lambda(paginate_, slice,
                                            pagination_.current_url, ctx.dh())) {
@@ -974,6 +780,18 @@ public:
 
   auto finish_sub(SubKeyView, Push<table_slice>&, OpCtx& ctx)
     -> Task<void> override {
+    if (auto mode = builtin_pagination_mode(paginate_);
+        mode and *mode == http::PaginationMode::odata
+        and not odata_envelope_seen_ and response_
+        and response_->is_success()) {
+      TENZIR_ASSERT(paginate_);
+      diagnostic::error(
+        "expected OData response body to contain a top-level `value` array")
+        .primary(paginate_->source)
+        .emit(ctx);
+      lifecycle_ = Lifecycle::done;
+      co_return;
+    }
     if (pagination_.next_url) {
       // next page
       pagination_.current_url = std::move(*pagination_.next_url);
@@ -998,6 +816,7 @@ private:
   // Requires pagination_.current_url and pagination_.page_count to be set.
   auto start_fetch(OpCtx& ctx, RequestConfig request) -> Task<void> {
     response_ = None{};
+    odata_envelope_seen_ = false;
     auto parsed_url = proxygen::URL{pagination_.current_url};
     bytes_read_ = ctx.make_counter(
       MetricsLabel{"host",
@@ -1054,6 +873,7 @@ private:
   PaginationState pagination_;
   // State collected per response page; absent before first response header.
   Option<ResponseState> response_;
+  bool odata_envelope_seen_ = false;
 };
 
 class from_http_plugin final : public virtual OperatorPlugin {
@@ -1179,14 +999,12 @@ public:
             .emit(ctx);
         }
       }
-      auto paginate = Option<pagination_spec>{None{}};
       if (auto paginate_expr = ctx.get(paginate_arg)) {
         auto validated
           = validate_paginate(Option<ast::expression>{*paginate_expr}, ctx);
         if (not validated) {
           return {};
         }
-        paginate = std::move(*validated);
       }
       // Validate that the parser pipeline is present and produces events.
       TRY(auto parser, ctx.get(parser_arg));

--- a/libtenzir/include/tenzir/http.hpp
+++ b/libtenzir/include/tenzir/http.hpp
@@ -14,6 +14,7 @@
 #include "tenzir/http_pool.hpp"
 #include "tenzir/option.hpp"
 #include "tenzir/secret_resolution.hpp"
+#include "tenzir/table_slice.hpp"
 #include "tenzir/tls_options.hpp"
 
 #include <arrow/util/compression.h>
@@ -128,5 +129,33 @@ auto decompress_chunk(arrow::util::Decompressor& decompressor,
                       size_t max_output_size
                       = std::numeric_limits<size_t>::max())
   -> Result<blob, uint16_t>;
+
+enum class PaginationMode {
+  link,
+  odata,
+};
+
+auto parse_pagination_mode(std::string_view mode) -> Option<PaginationMode>;
+
+/// Scans all Link response headers and returns the first resolved `rel=next`
+/// URL, or None if no such link is present. Emits a warning on malformed
+/// headers.
+auto next_url_from_link_headers(
+  std::vector<std::pair<std::string, std::string>> const& response_headers,
+  std::string const& base_url, location paginate_loc, diagnostic_handler& dh)
+  -> Option<std::string>;
+
+struct OdataPage {
+  Option<std::string> next_url;
+  std::vector<table_slice> events;
+};
+
+/// Extracts events and the opaque next URL from an OData collection envelope.
+///
+/// The input must represent a single top-level object with a `value` array.
+/// Each object in `value` becomes one output event. Top-level `@odata.*` fields
+/// on emitted objects are omitted while nested annotations are preserved.
+auto extract_odata_page(table_slice const& slice, location paginate_loc,
+                        diagnostic_handler& dh) -> failure_or<OdataPage>;
 
 } // namespace tenzir::http

--- a/libtenzir/src/http.cpp
+++ b/libtenzir/src/http.cpp
@@ -11,6 +11,11 @@
 #include "tenzir/curl.hpp"
 #include "tenzir/detail/narrow.hpp"
 #include "tenzir/detail/string.hpp"
+#include "tenzir/series_builder.hpp"
+#include "tenzir/view3.hpp"
+
+#include <boost/url/parse.hpp>
+#include <boost/url/url.hpp>
 
 #include <algorithm>
 #include <cctype>
@@ -19,7 +24,168 @@
 
 namespace tenzir::http {
 
-namespace {} // namespace
+namespace {
+
+// Splits a raw HTTP Link header value into individual link-value items at
+// top-level commas (not inside <...> or quoted strings).
+auto split_link_header(std::string_view value)
+  -> std::vector<std::string_view> {
+  auto result = std::vector<std::string_view>{};
+  auto start = size_t{0};
+  auto in_angle = false;
+  auto in_quotes = false;
+  auto escaped = false;
+  for (auto i = size_t{}; i < value.size(); ++i) {
+    const auto c = value[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (c == '\\' and in_quotes) {
+      escaped = true;
+      continue;
+    }
+    if (c == '"' and not in_angle) {
+      in_quotes = not in_quotes;
+      continue;
+    }
+    if (c == '<' and not in_quotes) {
+      in_angle = true;
+      continue;
+    }
+    if (c == '>' and not in_quotes) {
+      in_angle = false;
+      continue;
+    }
+    if (c == ',' and not in_quotes and not in_angle) {
+      auto item = detail::trim(value.substr(start, i - start));
+      if (not item.empty()) {
+        result.push_back(item);
+      }
+      start = i + 1;
+    }
+  }
+  auto item = detail::trim(value.substr(start));
+  if (not item.empty()) {
+    result.push_back(item);
+  }
+  return result;
+}
+
+// Splits link-value parameters at semicolons, honouring quoted-string escaping.
+auto split_link_params(std::string_view value)
+  -> std::pair<std::vector<std::string_view>, bool> {
+  auto result = std::vector<std::string_view>{};
+  auto start = size_t{0};
+  auto in_quotes = false;
+  auto escaped = false;
+  for (auto i = size_t{}; i < value.size(); ++i) {
+    const auto c = value[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (c == '\\' and in_quotes) {
+      escaped = true;
+      continue;
+    }
+    if (c == '"') {
+      in_quotes = not in_quotes;
+      continue;
+    }
+    if (c == ';' and not in_quotes) {
+      auto item = detail::trim(value.substr(start, i - start));
+      if (not item.empty()) {
+        result.push_back(item);
+      }
+      start = i + 1;
+    }
+  }
+  auto item = detail::trim(value.substr(start));
+  if (not item.empty()) {
+    result.push_back(item);
+  }
+  return {std::move(result), not in_quotes};
+}
+
+// Returns true when "next" appears as a token in a rel parameter value.
+auto rel_contains_next(std::string_view value) -> bool {
+  value = detail::trim(value);
+  if (value.size() >= 2 and value.front() == '"' and value.back() == '"') {
+    value.remove_prefix(1);
+    value.remove_suffix(1);
+  }
+  auto index = size_t{};
+  while (index < value.size()) {
+    while (index < value.size()
+           and std::isspace(static_cast<unsigned char>(value[index])) != 0) {
+      ++index;
+    }
+    const auto token_begin = index;
+    while (index < value.size()
+           and std::isspace(static_cast<unsigned char>(value[index])) == 0) {
+      ++index;
+    }
+    const auto token = value.substr(token_begin, index - token_begin);
+    if (not token.empty() and detail::ascii_icase_equal(token, "next")) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Parses a single RFC 8288 link-value and extracts its `rel=next` target URI.
+// Returns Err(Unit) for malformed link-values.
+auto next_link_target(std::string_view header)
+  -> Result<Option<std::string_view>, Unit> {
+  auto item = detail::trim(header);
+  if (item.empty()) {
+    return None{};
+  }
+  if (item.front() != '<') {
+    return Err{Unit{}};
+  }
+  const auto uri_end = item.find('>');
+  if (uri_end == std::string_view::npos) {
+    return Err{Unit{}};
+  }
+  auto target = item.substr(1, uri_end - 1);
+  auto params = item.substr(uri_end + 1);
+  auto [param_parts, ok] = split_link_params(params);
+  if (not ok) {
+    return Err{Unit{}};
+  }
+  auto has_next = false;
+  for (const auto part : param_parts) {
+    const auto eq = part.find('=');
+    auto name = detail::trim(part.substr(0, eq));
+    if (name.empty() or not detail::ascii_icase_equal(name, "rel")) {
+      continue;
+    }
+    if (eq == std::string_view::npos) {
+      continue;
+    }
+    if (rel_contains_next(detail::trim(part.substr(eq + 1)))) {
+      has_next = true;
+      break;
+    }
+  }
+  if (has_next) {
+    return Option<std::string_view>{target};
+  }
+  return None{};
+}
+
+auto emit_odata_envelope_error(location paginate_loc, diagnostic_handler& dh)
+  -> failure_or<OdataPage> {
+  diagnostic::error(
+    "expected OData response body to contain a top-level `value` array")
+    .primary(paginate_loc)
+    .emit(dh);
+  return failure::promise();
+}
+
+} // namespace
 
 auto add_default_url_scheme(std::string& url, bool tls_enabled) -> void {
   if (not url.starts_with("http://") and not url.starts_with("https://")) {
@@ -342,6 +508,127 @@ auto decompress_chunk(arrow::util::Decompressor& decompressor,
   }
   out.resize(written);
   return out;
+}
+
+auto parse_pagination_mode(std::string_view mode) -> Option<PaginationMode> {
+  if (mode == "link") {
+    return PaginationMode::link;
+  }
+  if (mode == "odata") {
+    return PaginationMode::odata;
+  }
+  return None{};
+}
+
+auto next_url_from_link_headers(
+  std::vector<std::pair<std::string, std::string>> const& response_headers,
+  std::string const& base_url, location paginate_loc, diagnostic_handler& dh)
+  -> Option<std::string> {
+  auto base = boost::urls::parse_uri_reference(base_url);
+  if (not base) {
+    diagnostic::warning("failed to parse request URI for link pagination: {}",
+                        base.error().message())
+      .primary(paginate_loc)
+      .note("stopping pagination")
+      .emit(dh);
+    return None{};
+  }
+  auto malformed = false;
+  for (auto const& [name, value] : response_headers) {
+    if (not detail::ascii_icase_equal(name, "link")) {
+      continue;
+    }
+    for (auto header : split_link_header(value)) {
+      auto parsed = next_link_target(header);
+      if (parsed.is_err()) {
+        malformed = true;
+        continue;
+      }
+      auto target = parsed.unwrap();
+      if (not target) {
+        continue;
+      }
+      auto ref = boost::urls::parse_uri_reference(*target);
+      if (not ref) {
+        diagnostic::warning("invalid `rel=next` URL in Link header: {}",
+                            ref.error().message())
+          .primary(paginate_loc)
+          .note("stopping pagination")
+          .emit(dh);
+        return None{};
+      }
+      auto resolved = boost::urls::url{};
+      if (auto r = boost::urls::resolve(*base, *ref, resolved); not r) {
+        diagnostic::warning("failed to resolve `rel=next` URL: {}",
+                            r.error().message())
+          .primary(paginate_loc)
+          .note("stopping pagination")
+          .emit(dh);
+        return None{};
+      }
+      return Option<std::string>{std::string{resolved.buffer()}};
+    }
+  }
+  if (malformed) {
+    diagnostic::warning("failed to parse Link header for pagination")
+      .primary(paginate_loc)
+      .note("stopping pagination")
+      .emit(dh);
+  }
+  return None{};
+}
+
+auto extract_odata_page(table_slice const& slice, location paginate_loc,
+                        diagnostic_handler& dh) -> failure_or<OdataPage> {
+  if (slice.rows() != 1) {
+    return emit_odata_envelope_error(paginate_loc, dh);
+  }
+  auto result = OdataPage{};
+  auto builder = series_builder{};
+  auto saw_body = false;
+  for (auto body : values3(slice)) {
+    saw_body = true;
+    auto value = Option<data_view3>{None{}};
+    for (auto const& [key, field] : body) {
+      if (key == "@odata.nextLink") {
+        if (auto const* next = try_as<std::string_view>(&field)) {
+          result.next_url = std::string{*next};
+        }
+        continue;
+      }
+      if (key == "value") {
+        value = field;
+      }
+    }
+    if (not value) {
+      return emit_odata_envelope_error(paginate_loc, dh);
+    }
+    auto const* items = try_as<view3<list>>(&*value);
+    if (not items) {
+      return emit_odata_envelope_error(paginate_loc, dh);
+    }
+    for (auto item : *items) {
+      auto const* item_record = try_as<view3<record>>(item);
+      if (not item_record) {
+        diagnostic::error("expected OData `value` array to contain objects")
+          .primary(paginate_loc)
+          .emit(dh);
+        return failure::promise();
+      }
+      auto output = builder.record();
+      for (auto const& [key, field] : *item_record) {
+        if (key.starts_with("@odata.")) {
+          continue;
+        }
+        output.field(key, field);
+      }
+    }
+  }
+  if (not saw_body) {
+    return emit_odata_envelope_error(paginate_loc, dh);
+  }
+  result.events = builder.finish_as_table_slice();
+  return result;
 }
 
 } // namespace tenzir::http

--- a/test/fixtures/http_paginate.py
+++ b/test/fixtures/http_paginate.py
@@ -14,10 +14,12 @@ Exports:
   HTTP_FIXTURE_LARGE_ERROR_URL       — HTTP 500 with large streaming response body
   HTTP_FIXTURE_META_LAMBDA_URL        — next URL carried in X-Next-Page header (tests
                                         that pagination lambdas can read metadata_field)
+  HTTP_FIXTURE_ODATA_USERS_URL        — Microsoft Graph-shaped OData collection pages
 """
 
 from __future__ import annotations
 
+import json
 import socket
 import threading
 from http import HTTPStatus
@@ -43,6 +45,9 @@ _LAMBDA_PAGE_2 = "/paginate/lambda/2"
 _LARGE_ERROR_PAGE = "/paginate/error/large"
 _META_LAMBDA_PAGE_1 = "/paginate/meta-lambda/1"
 _META_LAMBDA_PAGE_2 = "/paginate/meta-lambda/2"
+_ODATA_PAGE_1 = "/graph/v1.0/users"
+_ODATA_PAGE_2 = "/graph/v1.0/users/next"
+_ODATA_SKIPTOKEN = "RFNwdAIAAQAAAD8...AAAAAAAA"
 # Port 9 is IANA Discard Protocol — always refuses connections on most systems.
 _UNREACHABLE_NEXT = "http://127.0.0.1:9/paginate/unreachable/next"
 
@@ -72,9 +77,10 @@ class _Handler(BaseHTTPRequestHandler):
             self.wfile.write(body)
 
     def do_GET(self) -> None:  # noqa: N802
-        from urllib.parse import urlsplit
+        from urllib.parse import parse_qs, urlsplit
 
-        path = urlsplit(self.path).path
+        parts = urlsplit(self.path)
+        path = parts.path
         # Chain pagination: /paginate/chain/<n>
         if path.startswith(_CHAIN_PREFIX):
             page_str = path.removeprefix(_CHAIN_PREFIX)
@@ -178,6 +184,66 @@ class _Handler(BaseHTTPRequestHandler):
         if path == _META_LAMBDA_PAGE_2:
             self._reply(b'{"page":2}\n')
             return
+        # Microsoft Graph-shaped OData collection pagination.
+        if path == _ODATA_PAGE_1:
+            base = f"http://{self.headers['Host']}"
+            next_link = f"{base}{_ODATA_PAGE_2}?$skiptoken={_ODATA_SKIPTOKEN}"
+            body = {
+                "@odata.context": f"{base}/$metadata#users",
+                "@odata.count": 3,
+                "@odata.nextLink": next_link,
+                "value": [
+                    {
+                        "@odata.etag": 'W/"user-1"',
+                        "id": "user-1",
+                        "displayName": "Ada Lovelace",
+                        "accountEnabled": True,
+                        "manager": {
+                            "@odata.type": "#microsoft.graph.user",
+                            "id": "manager-1",
+                        },
+                    },
+                    {
+                        "@odata.type": "#microsoft.graph.user",
+                        "id": "user-2",
+                        "displayName": "Grace Hopper",
+                        "mail": None,
+                    },
+                ],
+            }
+            self._reply(json.dumps(body).encode())
+            return
+        if path == _ODATA_PAGE_2:
+            query = parse_qs(parts.query, keep_blank_values=True)
+            if query.get("$skiptoken") != [_ODATA_SKIPTOKEN]:
+                self._reply(
+                    b'{"error":"missing skiptoken"}\n',
+                    status=HTTPStatus.BAD_REQUEST,
+                )
+                return
+            if self.headers.get("ConsistencyLevel") != "eventual":
+                self._reply(
+                    b'{"error":"missing consistency header"}\n',
+                    status=HTTPStatus.BAD_REQUEST,
+                )
+                return
+            base = f"http://{self.headers['Host']}"
+            body = {
+                "@odata.context": f"{base}/$metadata#users",
+                "value": [
+                    {
+                        "@odata.etag": 'W/"user-3"',
+                        "id": "user-3",
+                        "displayName": "Katherine Johnson",
+                        "department": {
+                            "@odata.type": "#microsoft.graph.department",
+                            "name": "Flight Research",
+                        },
+                    }
+                ],
+            }
+            self._reply(json.dumps(body).encode())
+            return
         # Large error body for queue-draining regression tests.
         if path == _LARGE_ERROR_PAGE:
             chunk = b"x" * 1024
@@ -218,6 +284,7 @@ def run() -> Iterator[dict[str, str]]:
             "HTTP_FIXTURE_LAMBDA_URL": f"{base}{_LAMBDA_PAGE_1}",
             "HTTP_FIXTURE_LARGE_ERROR_URL": f"{base}{_LARGE_ERROR_PAGE}",
             "HTTP_FIXTURE_META_LAMBDA_URL": f"{base}{_META_LAMBDA_PAGE_1}",
+            "HTTP_FIXTURE_ODATA_USERS_URL": f"{base}{_ODATA_PAGE_1}",
         }
     finally:
         server.shutdown()

--- a/test/fixtures/http_paginate.py
+++ b/test/fixtures/http_paginate.py
@@ -15,6 +15,8 @@ Exports:
   HTTP_FIXTURE_META_LAMBDA_URL        — next URL carried in X-Next-Page header (tests
                                         that pagination lambdas can read metadata_field)
   HTTP_FIXTURE_ODATA_USERS_URL        — Microsoft Graph-shaped OData collection pages
+  HTTP_FIXTURE_ODATA_RELATIVE_USERS_URL
+                                      — OData collection with relative nextLink
 """
 
 from __future__ import annotations
@@ -46,10 +48,38 @@ _LARGE_ERROR_PAGE = "/paginate/error/large"
 _META_LAMBDA_PAGE_1 = "/paginate/meta-lambda/1"
 _META_LAMBDA_PAGE_2 = "/paginate/meta-lambda/2"
 _ODATA_PAGE_1 = "/graph/v1.0/users"
+_ODATA_RELATIVE_PAGE_1 = "/graph/v1.0/relative-users"
 _ODATA_PAGE_2 = "/graph/v1.0/users/next"
 _ODATA_SKIPTOKEN = "RFNwdAIAAQAAAD8...AAAAAAAA"
 # Port 9 is IANA Discard Protocol — always refuses connections on most systems.
 _UNREACHABLE_NEXT = "http://127.0.0.1:9/paginate/unreachable/next"
+
+
+def _odata_first_page(base: str, next_link: str) -> bytes:
+    body = {
+        "@odata.context": f"{base}/$metadata#users",
+        "@odata.count": 3,
+        "@odata.nextLink": next_link,
+        "value": [
+            {
+                "@odata.etag": 'W/"user-1"',
+                "id": "user-1",
+                "displayName": "Ada Lovelace",
+                "accountEnabled": True,
+                "manager": {
+                    "@odata.type": "#microsoft.graph.user",
+                    "id": "manager-1",
+                },
+            },
+            {
+                "@odata.type": "#microsoft.graph.user",
+                "id": "user-2",
+                "displayName": "Grace Hopper",
+                "mail": None,
+            },
+        ],
+    }
+    return json.dumps(body).encode()
 
 
 def _page(n: int) -> bytes:
@@ -188,30 +218,12 @@ class _Handler(BaseHTTPRequestHandler):
         if path == _ODATA_PAGE_1:
             base = f"http://{self.headers['Host']}"
             next_link = f"{base}{_ODATA_PAGE_2}?$skiptoken={_ODATA_SKIPTOKEN}"
-            body = {
-                "@odata.context": f"{base}/$metadata#users",
-                "@odata.count": 3,
-                "@odata.nextLink": next_link,
-                "value": [
-                    {
-                        "@odata.etag": 'W/"user-1"',
-                        "id": "user-1",
-                        "displayName": "Ada Lovelace",
-                        "accountEnabled": True,
-                        "manager": {
-                            "@odata.type": "#microsoft.graph.user",
-                            "id": "manager-1",
-                        },
-                    },
-                    {
-                        "@odata.type": "#microsoft.graph.user",
-                        "id": "user-2",
-                        "displayName": "Grace Hopper",
-                        "mail": None,
-                    },
-                ],
-            }
-            self._reply(json.dumps(body).encode())
+            self._reply(_odata_first_page(base, next_link))
+            return
+        if path == _ODATA_RELATIVE_PAGE_1:
+            base = f"http://{self.headers['Host']}"
+            next_link = f"{_ODATA_PAGE_2}?$skiptoken={_ODATA_SKIPTOKEN}"
+            self._reply(_odata_first_page(base, next_link))
             return
         if path == _ODATA_PAGE_2:
             query = parse_qs(parts.query, keep_blank_values=True)
@@ -285,6 +297,9 @@ def run() -> Iterator[dict[str, str]]:
             "HTTP_FIXTURE_LARGE_ERROR_URL": f"{base}{_LARGE_ERROR_PAGE}",
             "HTTP_FIXTURE_META_LAMBDA_URL": f"{base}{_META_LAMBDA_PAGE_1}",
             "HTTP_FIXTURE_ODATA_USERS_URL": f"{base}{_ODATA_PAGE_1}",
+            "HTTP_FIXTURE_ODATA_RELATIVE_USERS_URL": (
+                f"{base}{_ODATA_RELATIVE_PAGE_1}"
+            ),
         }
     finally:
         server.shutdown()

--- a/test/tests/operators/from_http/paginate_invalid.txt
+++ b/test/tests/operators/from_http/paginate_invalid.txt
@@ -4,4 +4,4 @@ error: unsupported pagination mode: `invalid`
 5 | from_http "https://example.org/data.json", paginate="invalid" { read_json }
   |                                                     ^^^^^^^^^ 
   |
-  = hint: `paginate` must be `"link"` or a lambda
+  = hint: `paginate` must be `"link"`, `"odata"`, or a lambda

--- a/test/tests/operators/from_http/paginate_odata.tql
+++ b/test/tests/operators/from_http/paginate_odata.tql
@@ -1,0 +1,11 @@
+---
+fixtures: [http_paginate]
+timeout: 60
+---
+
+from_http env("HTTP_FIXTURE_ODATA_USERS_URL"),
+  headers={"ConsistencyLevel": "eventual"},
+  paginate="odata",
+  tls=false {
+  read_json
+}

--- a/test/tests/operators/from_http/paginate_odata.txt
+++ b/test/tests/operators/from_http/paginate_odata.txt
@@ -1,0 +1,25 @@
+{
+  id: "user-1",
+  displayName: "Ada Lovelace",
+  accountEnabled: true,
+  manager: {
+    "@odata.type": "#microsoft.graph.user",
+    id: "manager-1",
+  },
+  mail: null,
+}
+{
+  id: "user-2",
+  displayName: "Grace Hopper",
+  accountEnabled: null,
+  manager: null,
+  mail: null,
+}
+{
+  id: "user-3",
+  displayName: "Katherine Johnson",
+  department: {
+    "@odata.type": "#microsoft.graph.department",
+    name: "Flight Research",
+  },
+}

--- a/test/tests/operators/from_http/paginate_odata_relative.tql
+++ b/test/tests/operators/from_http/paginate_odata_relative.tql
@@ -1,0 +1,11 @@
+---
+fixtures: [http_paginate]
+timeout: 60
+---
+
+from_http env("HTTP_FIXTURE_ODATA_RELATIVE_USERS_URL"),
+  headers={"ConsistencyLevel": "eventual"},
+  paginate="odata",
+  tls=false {
+  read_json
+}

--- a/test/tests/operators/from_http/paginate_odata_relative.txt
+++ b/test/tests/operators/from_http/paginate_odata_relative.txt
@@ -1,0 +1,25 @@
+{
+  id: "user-1",
+  displayName: "Ada Lovelace",
+  accountEnabled: true,
+  manager: {
+    "@odata.type": "#microsoft.graph.user",
+    id: "manager-1",
+  },
+  mail: null,
+}
+{
+  id: "user-2",
+  displayName: "Grace Hopper",
+  accountEnabled: null,
+  manager: null,
+  mail: null,
+}
+{
+  id: "user-3",
+  displayName: "Katherine Johnson",
+  department: {
+    "@odata.type": "#microsoft.graph.department",
+    name: "Flight Research",
+  },
+}


### PR DESCRIPTION
## 🔍 Problem

- `from_http` only supported lambda pagination and RFC 8288 Link header pagination.
- OData APIs such as Microsoft Graph return collection envelopes with records in `value` and opaque next-page URLs in `@odata.nextLink`.

## 🛠️ Solution

- Add shared HTTP pagination helpers for Link headers and OData collection envelopes.
- Teach the neo `from_http` path to accept `paginate="odata"`, emit each object from `value`, and follow top-level `@odata.nextLink` URLs unchanged.
- Cover Graph-shaped pagination, header reuse on follow-up requests, invalid pagination diagnostics, and the changelog.

## 💬 Review

- Focus on the OData envelope handling and the choice to keep `@odata.nextLink` opaque.
- The legacy `http` operator path is intentionally unchanged.

<sub>
📚 Docs PR: tenzir/docs#281<br>
✅ Closes TNZ-398
</sub>