### PR TITLE
Run neo integration tests in static Nix builds

### DIFF
--- a/libtenzir/builtins/operators/cache.cpp
+++ b/libtenzir/builtins/operators/cache.cpp
@@ -1377,7 +1377,7 @@ public:
     return {};
   }
 
-  auto spawn(element_type_tag input) and -> AnyOperator override {
+  auto spawn(element_type_tag input) && -> AnyOperator override {
     TENZIR_ASSERT(mode_value_);
     TENZIR_ASSERT(id_value_);
     auto args = CacheArgs{};

--- a/libtenzir/builtins/operators/discard.cpp
+++ b/libtenzir/builtins/operators/discard.cpp
@@ -96,7 +96,7 @@ public:
     return {};
   }
 
-  auto spawn(element_type_tag input) and -> AnyOperator override {
+  auto spawn(element_type_tag input) && -> AnyOperator override {
     return input.match([]<class T>(tag<T>) -> AnyOperator {
       if constexpr (std::is_void_v<T>) {
         TENZIR_UNREACHABLE();

--- a/libtenzir/builtins/operators/from_to_2.cpp
+++ b/libtenzir/builtins/operators/from_to_2.cpp
@@ -164,7 +164,7 @@ public:
     return {};
   }
 
-  auto spawn(element_type_tag input) and -> AnyOperator override {
+  auto spawn(element_type_tag input) && -> AnyOperator override {
     TENZIR_ASSERT(input.is<void>());
     return From{std::move(events_)};
   }

--- a/libtenzir/builtins/operators/sort.cpp
+++ b/libtenzir/builtins/operators/sort.cpp
@@ -230,7 +230,7 @@ public:
     return {};
   }
 
-  auto sorted() and -> generator<table_slice> {
+  auto sorted() && -> generator<table_slice> {
     // If there is nothing to sort, then we can just return early.
     if (cache_.empty()) {
       co_return;
@@ -638,19 +638,19 @@ public:
       expr_ = ast::expression{ast::this_{location::unknown}};
       return;
     }
-    std::move(*args.expr)
-      .match(
-        [&](ast::unary_expr&& unary) {
-          if (unary.op.inner == ast::unary_op::neg) {
-            expr_ = std::move(unary.expr);
-            reverse_ = true;
-          } else {
-            expr_ = std::move(unary);
-          }
-        },
-        [&](auto&& other) {
-          expr_ = std::move(other);
-        });
+    match(
+      std::move(*args.expr),
+      [&](ast::unary_expr&& unary) {
+        if (unary.op.inner == ast::unary_op::neg) {
+          expr_ = std::move(unary.expr);
+          reverse_ = true;
+        } else {
+          expr_ = std::move(unary);
+        }
+      },
+      [&](auto&& other) {
+        expr_ = std::forward<decltype(other)>(other);
+      });
   }
 
   auto process(table_slice input, Push<table_slice>& push, OpCtx& ctx)

--- a/libtenzir/builtins/operators/summarize.cpp
+++ b/libtenzir/builtins/operators/summarize.cpp
@@ -993,7 +993,7 @@ public:
     return {};
   }
 
-  auto spawn(element_type_tag input) and -> AnyOperator override {
+  auto spawn(element_type_tag input) && -> AnyOperator override {
     TENZIR_ASSERT(input.is<table_slice>());
     return Summarize{std::move(cfg_)};
   }

--- a/libtenzir/builtins/operators/unordered.cpp
+++ b/libtenzir/builtins/operators/unordered.cpp
@@ -49,7 +49,7 @@ public:
   }
 
   auto optimize(ir::optimize_filter filter,
-                event_order /*order*/) and -> ir::optimize_result override {
+                event_order /*order*/) && -> ir::optimize_result override {
     auto opt = std::move(pipeline_).optimize(std::move(filter),
                                              event_order::unordered);
     // Wrap each replacement operator in its own single-operator UnorderedIr
@@ -62,12 +62,12 @@ public:
     return opt;
   }
 
-  auto spawn(element_type_tag input) and -> AnyOperator override {
+  auto spawn(element_type_tag input) && -> AnyOperator override {
     TENZIR_ASSERT(pipeline_.operators.size() == 1);
     return std::move(*pipeline_.operators[0]).spawn(input);
   }
 
-  auto move() and -> Box<ir::Operator> override {
+  auto move() && -> Box<ir::Operator> override {
     return UnorderedIr{std::move(*this)};
   }
 

--- a/libtenzir/builtins/operators/version.cpp
+++ b/libtenzir/builtins/operators/version.cpp
@@ -211,7 +211,7 @@ public:
     TENZIR_UNUSED(ctx, instantiate);
     return {};
   }
-  auto spawn(element_type_tag input) and -> AnyOperator override {
+  auto spawn(element_type_tag input) && -> AnyOperator override {
     TENZIR_ASSERT(input.is<void>());
     return Version{};
   }

--- a/libtenzir/builtins/operators/where_map.cpp
+++ b/libtenzir/builtins/operators/where_map.cpp
@@ -876,7 +876,7 @@ public:
     return {};
   }
 
-  auto spawn(element_type_tag input) and -> AnyOperator override {
+  auto spawn(element_type_tag input) && -> AnyOperator override {
     TENZIR_ASSERT(input.is<table_slice>());
     return Where{std::move(predicate_)};
   }
@@ -892,7 +892,7 @@ public:
   }
 
   auto optimize(ir::optimize_filter filter,
-                event_order order) and -> ir::optimize_result override {
+                event_order order) && -> ir::optimize_result override {
     // TODO: Shall we avoid optimizing if it doesn't make sense?
     filter.insert(filter.begin(), std::move(predicate_));
     return ir::optimize_result{std::move(filter), order, {}};

--- a/libtenzir/include/tenzir/async/executor.hpp
+++ b/libtenzir/include/tenzir/async/executor.hpp
@@ -88,7 +88,7 @@ public:
     return operators_[index];
   }
 
-  auto unwrap() and -> std::vector<AnyOperator> {
+  auto unwrap() && -> std::vector<AnyOperator> {
     return std::move(operators_);
   }
 

--- a/libtenzir/include/tenzir/async/fused.hpp
+++ b/libtenzir/include/tenzir/async/fused.hpp
@@ -146,7 +146,7 @@ struct FusedSenderReceiver {
   FusedSender<T> sender;
   FusedReceiver<T> receiver;
 
-  auto into_push_pull() and -> PushPull<T> {
+  auto into_push_pull() && -> PushPull<T> {
     return {
       FusedPush<T>{std::move(sender)},
       FusedPull<T>{std::move(receiver)},

--- a/libtenzir/include/tenzir/async/mail.hpp
+++ b/libtenzir/include/tenzir/async/mail.hpp
@@ -113,7 +113,7 @@ public:
   auto
   request(Handle receiver, caf::timespan timeout = caf::infinite,
           std::source_location location
-          = std::source_location::current()) and -> folly::SemiFuture<Result> {
+          = std::source_location::current()) && -> folly::SemiFuture<Result> {
     auto [promise, future] = folly::makePromiseContract<Result>();
     std::apply(
       [&](auto&&... xs) mutable {

--- a/libtenzir/include/tenzir/describe_operator.hpp
+++ b/libtenzir/include/tenzir/describe_operator.hpp
@@ -24,13 +24,12 @@ struct operator_description {
 template <class T>
 struct operator_description_builder {
   auto positional(std::string name,
-                  std::string T::*) and -> operator_description_builder<T>;
+                  std::string T::*) && -> operator_description_builder<T>;
+
+  auto named(std::string name, bool T::*) && -> operator_description_builder<T>;
 
   auto
-  named(std::string name, bool T::*) and -> operator_description_builder<T>;
-
-  auto
-  named(std::string name, duration T::*) and -> operator_description_builder<T>;
+  named(std::string name, duration T::*) && -> operator_description_builder<T>;
 
   operator operator_description() const;
 };
@@ -53,15 +52,15 @@ private:
   public:
     auto map(std::function<
              auto(located<duration>, diagnostic_handler&)->located<duration>>
-               f) and -> arg<Args>;
+               f) && -> arg<Args>;
 
     auto
     validate(std::function<
              auto(located<duration>, diagnostic_handler& dh)->failure_or<void>>
-               f) and -> arg<Args>;
+               f) && -> arg<Args>;
 
     template <class T>
-    auto excludes(T Args::*) and -> arg<Args>;
+    auto excludes(T Args::*) && -> arg<Args>;
   };
 
 public:
@@ -89,7 +88,7 @@ public:
     -> failure_or<void> override {
   }
 
-  auto instantiate(prepare_ctx ctx) and -> failure_or<ir::executable> override {
+  auto instantiate(prepare_ctx ctx) && -> failure_or<ir::executable> override {
   }
 
   template <class Inspector>

--- a/libtenzir/include/tenzir/diagnostics.hpp
+++ b/libtenzir/include/tenzir/diagnostics.hpp
@@ -170,14 +170,14 @@ struct [[nodiscard]] diagnostic : std::exception {
                                       = std::source_location::current())
     -> diagnostic_builder;
 
-  auto modify() and -> diagnostic_builder;
+  auto modify() && -> diagnostic_builder;
 
   /// Wraps the diagnostic in an error object.
   auto to_error() const& -> caf::error {
     return caf::make_error(ec::diagnostic, *this);
   }
 
-  auto to_error() and -> caf::error {
+  auto to_error() && -> caf::error {
     return caf::make_error(ec::diagnostic, std::move(*this));
   }
 
@@ -233,7 +233,7 @@ public:
   // -- annotations -----------------------------------------------------------
 
   auto primary(into_location source, std::string text
-                                     = "") and -> diagnostic_builder {
+                                     = "") && -> diagnostic_builder {
     result_.annotations.push_back(
       diagnostic_annotation{true, std::move(text), source});
     return std::move(*this);
@@ -242,13 +242,13 @@ public:
   template <class... Ts>
     requires(sizeof...(Ts) > 0)
   auto primary(into_location source, fmt::format_string<Ts...> str,
-               Ts&&... xs) and -> diagnostic_builder {
+               Ts&&... xs) && -> diagnostic_builder {
     return std::move(*this).primary(
       source, fmt::format(std::move(str), std::forward<Ts>(xs)...));
   }
 
   auto secondary(into_location source, std::string text
-                                       = "") and -> diagnostic_builder {
+                                       = "") && -> diagnostic_builder {
     result_.annotations.push_back(
       diagnostic_annotation{false, std::move(text), source});
     return std::move(*this);
@@ -257,19 +257,19 @@ public:
   template <class... Ts>
     requires(sizeof...(Ts) > 0)
   auto secondary(into_location source, fmt::format_string<Ts...> str,
-                 Ts&&... xs) and -> diagnostic_builder {
+                 Ts&&... xs) && -> diagnostic_builder {
     return std::move(*this).secondary(
       source, fmt::format(std::move(str), std::forward<Ts>(xs)...));
   }
 
   // -- notes -----------------------------------------------------------------
 
-  auto severity(enum severity s) and -> diagnostic_builder {
+  auto severity(enum severity s) && -> diagnostic_builder {
     result_.severity = s;
     return std::move(*this);
   }
 
-  auto note(std::string str) and -> diagnostic_builder {
+  auto note(std::string str) && -> diagnostic_builder {
     if (not str.empty()) {
       result_.notes.push_back(
         diagnostic_note{diagnostic_note_kind::note, std::move(str)});
@@ -280,12 +280,12 @@ public:
   template <class... Ts>
     requires(sizeof...(Ts) > 0)
   auto
-  note(fmt::format_string<Ts...> str, Ts&&... xs) and -> diagnostic_builder {
+  note(fmt::format_string<Ts...> str, Ts&&... xs) && -> diagnostic_builder {
     return std::move(*this).note(
       fmt::format(std::move(str), std::forward<Ts>(xs)...));
   }
 
-  auto docs(std::string str) and -> diagnostic_builder {
+  auto docs(std::string str) && -> diagnostic_builder {
     if (not str.empty()) {
       result_.notes.push_back(
         diagnostic_note{diagnostic_note_kind::docs, std::move(str)});
@@ -296,12 +296,12 @@ public:
   template <class... Ts>
     requires(sizeof...(Ts) > 0)
   auto
-  docs(fmt::format_string<Ts...> str, Ts&&... xs) and -> diagnostic_builder {
+  docs(fmt::format_string<Ts...> str, Ts&&... xs) && -> diagnostic_builder {
     return std::move(*this).docs(
       fmt::format(std::move(str), std::forward<Ts>(xs)...));
   }
 
-  auto usage(std::string str) and -> diagnostic_builder {
+  auto usage(std::string str) && -> diagnostic_builder {
     if (not str.empty()) {
       result_.notes.push_back(
         diagnostic_note{diagnostic_note_kind::usage, std::move(str)});
@@ -312,12 +312,12 @@ public:
   template <class... Ts>
     requires(sizeof...(Ts) > 0)
   auto
-  usage(fmt::format_string<Ts...> str, Ts&&... xs) and -> diagnostic_builder {
+  usage(fmt::format_string<Ts...> str, Ts&&... xs) && -> diagnostic_builder {
     return std::move(*this).usage(
       fmt::format(std::move(str), std::forward<Ts>(xs)...));
   }
 
-  auto hint(std::string str) and -> diagnostic_builder {
+  auto hint(std::string str) && -> diagnostic_builder {
     if (not str.empty()) {
       result_.notes.push_back(
         diagnostic_note{diagnostic_note_kind::hint, std::move(str)});
@@ -328,7 +328,7 @@ public:
   template <class... Ts>
     requires(sizeof...(Ts) > 0)
   auto
-  hint(fmt::format_string<Ts...> str, Ts&&... xs) and -> diagnostic_builder {
+  hint(fmt::format_string<Ts...> str, Ts&&... xs) && -> diagnostic_builder {
     return std::move(*this).hint(
       fmt::format(std::move(str), std::forward<Ts>(xs)...));
   }
@@ -339,11 +339,11 @@ public:
 
   // -- finalizing ------------------------------------------------------------
 
-  auto done() and -> diagnostic {
+  auto done() && -> diagnostic {
     return std::move(result_);
   }
 
-  auto to_error() and -> caf::error {
+  auto to_error() && -> caf::error {
     return std::move(*this).done().to_error();
   }
 
@@ -394,7 +394,7 @@ inline auto diagnostic::warning(caf::error err, std::source_location location)
   return builder(severity::warning, std::move(err), location);
 }
 
-inline auto diagnostic::modify() and -> diagnostic_builder {
+inline auto diagnostic::modify() && -> diagnostic_builder {
   return diagnostic_builder{std::move(*this)};
 }
 
@@ -411,17 +411,17 @@ public:
     result.push_back(std::move(diag));
   }
 
-  auto collect() and -> std::vector<diagnostic> {
+  auto collect() && -> std::vector<diagnostic> {
     return std::move(result);
   }
 
-  auto forward_to(diagnostic_handler& other) and -> void {
+  auto forward_to(diagnostic_handler& other) && -> void {
     for (auto diag : std::move(result)) {
       std::move(diag).modify().emit(other);
     }
   }
 
-  auto to_error() and -> caf::error {
+  auto to_error() && -> caf::error {
     return caf::make_error(ec::diagnostic, std::move(result));
   }
 
@@ -532,7 +532,7 @@ public:
     return this->index() == 1;
   }
 
-  auto unwrap() and -> T {
+  auto unwrap() && -> T {
     TENZIR_ASSERT(is_success());
     if constexpr (not std::same_as<T, void>) {
       return std::get<0>(std::move(*this));
@@ -558,7 +558,7 @@ public:
     }
   }
 
-  auto to_expected() and -> caf::expected<T> {
+  auto to_expected() && -> caf::expected<T> {
     if (is_success()) {
       if constexpr (std::is_void_v<T>) {
         return {};

--- a/libtenzir/include/tenzir/exec.hpp
+++ b/libtenzir/include/tenzir/exec.hpp
@@ -63,7 +63,7 @@ public:
     return operators_.end();
   }
 
-  auto unwrap() and -> std::vector<operator_ptr> {
+  auto unwrap() && -> std::vector<operator_ptr> {
     return std::move(operators_);
   }
 

--- a/libtenzir/include/tenzir/ir.hpp
+++ b/libtenzir/include/tenzir/ir.hpp
@@ -42,7 +42,7 @@ public:
   virtual auto copy() const -> Box<Operator>;
 
   /// A virtual move constructor.
-  virtual auto move() and -> Box<Operator>;
+  virtual auto move() && -> Box<Operator>;
 
   /// Return the output type of this operator for a given input type.
   ///
@@ -67,14 +67,14 @@ public:
   ///
   /// TODO: Describe this in more detail.
   virtual auto
-  optimize(optimize_filter filter, event_order order) and -> optimize_result;
+  optimize(optimize_filter filter, event_order order) && -> optimize_result;
 
   /// Return the executable matching this operator.
   ///
   /// The implementation may assume that the operator was previously
   /// instantiated, i.e., `substitute` was called with `instantiate == true`.
   /// However, other methods such as `optimize` may be called in between.
-  virtual auto spawn(element_type_tag input) and -> AnyOperator = 0;
+  virtual auto spawn(element_type_tag input) && -> AnyOperator = 0;
 
   /// Return the "main location" of the operator.
   ///
@@ -125,7 +125,7 @@ struct pipeline {
   auto substitute(substitute_ctx ctx, bool instantiate) -> failure_or<void>;
 
   /// @see Operator
-  auto spawn(element_type_tag input) and -> std::vector<AnyOperator>;
+  auto spawn(element_type_tag input) && -> std::vector<AnyOperator>;
 
   /// @see Operator
   auto infer_type(element_type_tag input, diagnostic_handler& dh) const
@@ -135,7 +135,7 @@ struct pipeline {
   // where they will be defined?
   /// @see Operator
   auto
-  optimize(optimize_filter filter, event_order order) and -> optimize_result;
+  optimize(optimize_filter filter, event_order order) && -> optimize_result;
 };
 
 struct CompileResult {

--- a/libtenzir/include/tenzir/pipeline.hpp
+++ b/libtenzir/include/tenzir/pipeline.hpp
@@ -521,7 +521,7 @@ public:
   void prepend(operator_ptr op);
 
   /// Returns the sequence of operators that this pipeline was built from.
-  auto unwrap() and -> std::vector<operator_ptr>;
+  auto unwrap() && -> std::vector<operator_ptr>;
   auto operators() const& -> std::span<const operator_ptr>;
   auto operators() and = delete;
 
@@ -547,7 +547,7 @@ public:
   auto is_closed() const -> bool;
 
   /// Splits a pipeline into multiple closed pipelines.
-  auto split_at_void() and -> caf::expected<std::vector<pipeline>>;
+  auto split_at_void() && -> caf::expected<std::vector<pipeline>>;
 
   /// Returns an operator location that is consistent with all operators of the
   /// pipeline or `std::nullopt` if there is none.
@@ -825,7 +825,7 @@ public:
 
   auto operator=(operator_box&& box) -> operator_box& = default;
 
-  auto unwrap() and -> operator_ptr {
+  auto unwrap() && -> operator_ptr {
     return std::move(*this);
   }
 

--- a/libtenzir/include/tenzir/result.hpp
+++ b/libtenzir/include/tenzir/result.hpp
@@ -28,7 +28,7 @@ public:
     return value_;
   }
 
-  auto unwrap() and -> T {
+  auto unwrap() && -> T {
     return std::move(value_);
   }
 
@@ -54,7 +54,7 @@ public:
   explicit(false) Result(Err<Error> err) : value_{std::move(err)} {
   }
 
-  auto expect(std::string_view msg) and -> Value {
+  auto expect(std::string_view msg) && -> Value {
     if (auto value = try_as<VoidToUnit<Value>>(value_)) [[likely]] {
       return unit_to_void(std::move(*value));
     }
@@ -74,7 +74,7 @@ public:
   }
 
   template <class F>
-  auto map_err(F&& f) and -> Result<Value, std::invoke_result_t<F, Error>> {
+  auto map_err(F&& f) && -> Result<Value, std::invoke_result_t<F, Error>> {
     if (is_ok()) [[likely]] {
       return std::move(*this).unwrap_unchecked();
     } else {
@@ -91,15 +91,15 @@ public:
     return as<VoidToUnit<Value>>(value_);
   }
 
-  auto unwrap() and -> Value {
+  auto unwrap() && -> Value {
     return unit_to_void(as<VoidToUnit<Value>>(std::move(value_)));
   }
 
-  auto unwrap_unchecked() and -> Value {
+  auto unwrap_unchecked() && -> Value {
     return unit_to_void(std::move(*try_as<VoidToUnit<Value>>(value_)));
   }
 
-  auto unwrap_err_unchecked() and -> Error {
+  auto unwrap_err_unchecked() && -> Error {
     return unit_to_void(std::move(*try_as<Err<Error>>(value_)).unwrap());
   }
 
@@ -111,7 +111,7 @@ public:
     return as<Err<Error>>(value_).unwrap();
   }
 
-  auto unwrap_err() and -> Error {
+  auto unwrap_err() && -> Error {
     return as<Err<Error>>(std::move(value_)).unwrap();
   }
 

--- a/libtenzir/include/tenzir/session.hpp
+++ b/libtenzir/include/tenzir/session.hpp
@@ -22,7 +22,7 @@ public:
   static auto make(diagnostic_handler& dh) -> session_provider;
 
   auto as_session() & -> session;
-  auto as_session() and -> session = delete;
+  auto as_session() && -> session = delete;
 
 private:
   friend class session;

--- a/libtenzir/include/tenzir/tql2/ast.hpp
+++ b/libtenzir/include/tenzir/tql2/ast.hpp
@@ -222,7 +222,7 @@ struct expression {
   template <class Result = void, class... Fs>
   auto match(Fs&&... fs) & -> decltype(auto);
   template <class Result = void, class... Fs>
-  auto match(Fs&&... fs) and -> decltype(auto);
+  auto match(Fs&&... fs) && -> decltype(auto);
   template <class Result = void, class... Fs>
   auto match(Fs&&... fs) const& -> decltype(auto);
   template <class Result = void, class... Fs>
@@ -277,7 +277,7 @@ public:
     return expr_;
   };
 
-  auto unwrap() and -> ast::expression {
+  auto unwrap() && -> ast::expression {
     return std::move(expr_);
   }
 
@@ -676,7 +676,7 @@ struct pipeline {
     return f.apply(x.body);
   }
 
-  auto compile(compile_ctx ctx) and -> failure_or<ir::pipeline>;
+  auto compile(compile_ctx ctx) && -> failure_or<ir::pipeline>;
 };
 
 /// Substitute occurrences of named dollar variables with the given
@@ -966,7 +966,7 @@ auto expression::match(Fs&&... fs) & -> decltype(auto) {
 }
 
 template <class Result, class... Fs>
-auto expression::match(Fs&&... fs) and -> decltype(auto) {
+auto expression::match(Fs&&... fs) && -> decltype(auto) {
   TENZIR_ASSERT(kind);
   return kind->match<Result>(std::forward<Fs>(fs)...);
 }

--- a/libtenzir/include/tenzir/variant.hpp
+++ b/libtenzir/include/tenzir/variant.hpp
@@ -199,7 +199,7 @@ public:
   }
 
   template <class Result = void, class... Fs>
-  auto match(Fs&&... fs) and -> decltype(auto) {
+  auto match(Fs&&... fs) && -> decltype(auto) {
     return detail::match<Result>(std::move(*this), std::forward<Fs>(fs)...);
   }
 

--- a/libtenzir/src/async/executor.cpp
+++ b/libtenzir/src/async/executor.cpp
@@ -425,7 +425,7 @@ public:
   Runner& operator=(const Runner&) = delete;
   ~Runner() override = default;
 
-  auto run_to_completion() and -> Task<void> {
+  auto run_to_completion() && -> Task<void> {
     auto cancellation_token
       = co_await folly::coro::co_current_cancellation_token;
     auto guard = detail::scope_guard{[&] noexcept {
@@ -1452,7 +1452,7 @@ public:
     // TODO: Validate types, just to make sure.
   }
 
-  auto run_to_completion() and -> Task<void> {
+  auto run_to_completion() && -> Task<void> {
     auto guard = detail::scope_guard{[&] noexcept {
       LOGI("returning from chain runner {}", id_);
     }};

--- a/libtenzir/src/dcso_bloom_filter.cpp
+++ b/libtenzir/src/dcso_bloom_filter.cpp
@@ -187,7 +187,7 @@ public:
     return (*this)(x);
   }
 
-  auto last_error() and -> caf::error {
+  auto last_error() && -> caf::error {
     return std::move(last_error_);
   }
 

--- a/libtenzir/src/ir.cpp
+++ b/libtenzir/src/ir.cpp
@@ -151,13 +151,13 @@ public:
     return {};
   }
 
-  auto spawn(element_type_tag input) and -> AnyOperator override {
+  auto spawn(element_type_tag input) && -> AnyOperator override {
     TENZIR_ASSERT(input.is<table_slice>());
     return Set{std::move(assignments_), order_};
   }
 
   auto optimize(ir::optimize_filter filter,
-                event_order order) and -> ir::optimize_result override {
+                event_order order) && -> ir::optimize_result override {
     // Remember the order for potential rebatches.
     order_ = order;
     auto ops = std::vector<Box<ir::Operator>>{};
@@ -380,7 +380,7 @@ public:
     return {};
   }
 
-  auto spawn(element_type_tag input) and -> AnyOperator override {
+  auto spawn(element_type_tag input) && -> AnyOperator override {
     TENZIR_ASSERT(input.is<table_slice>());
     auto dh = null_diagnostic_handler{};
     auto output = infer_type(input, dh);
@@ -476,7 +476,7 @@ auto ir::CompileResult::unwrap() && -> pipeline {
   return std::move(pipeline_);
 }
 
-auto ast::pipeline::compile(compile_ctx ctx) and -> failure_or<ir::pipeline> {
+auto ast::pipeline::compile(compile_ctx ctx) && -> failure_or<ir::pipeline> {
   // TODO: Or do we assume that entities are already resolved?
   TRY(resolve_entities(*this, ctx));
   auto lets = std::vector<ir::let>{};
@@ -626,8 +626,7 @@ auto ir::pipeline::substitute(substitute_ctx ctx, bool instantiate)
   return {};
 }
 
-auto ir::pipeline::spawn(
-  element_type_tag input) and -> std::vector<AnyOperator> {
+auto ir::pipeline::spawn(element_type_tag input) && -> std::vector<AnyOperator> {
   // TODO: Assert that we were instantiated, or instantiate ourselves?
   TENZIR_ASSERT(lets.empty());
   // TODO: This is probably not the right place for optimizations.
@@ -665,7 +664,7 @@ auto ir::pipeline::infer_type(element_type_tag input,
 }
 
 auto ir::pipeline::optimize(optimize_filter filter,
-                            event_order order) and -> optimize_result {
+                            event_order order) && -> optimize_result {
   auto replacement = pipeline{std::move(lets), {}};
   for (auto& op : std::ranges::reverse_view(operators)) {
     auto opt = std::move(*op).optimize(std::move(filter), order);
@@ -680,7 +679,7 @@ auto ir::pipeline::optimize(optimize_filter filter,
 }
 
 auto ir::Operator::optimize(optimize_filter filter,
-                            event_order order) and -> optimize_result {
+                            event_order order) && -> optimize_result {
   (void)order;
   auto replacement = std::vector<Box<Operator>>{};
   replacement.push_back(std::move(*this).move());
@@ -716,7 +715,7 @@ auto ir::Operator::copy() const -> Box<Operator> {
   return Box<Operator>::from_non_null(std::move(copy));
 }
 
-auto ir::Operator::move() and -> Box<Operator> {
+auto ir::Operator::move() && -> Box<Operator> {
   // TODO: This should be overriden by something like CRTP.
   return copy();
 }

--- a/libtenzir/src/operator_plugin.cpp
+++ b/libtenzir/src/operator_plugin.cpp
@@ -364,7 +364,7 @@ public:
     return failure::promise();
   }
 
-  auto spawn(element_type_tag input) and -> AnyOperator override {
+  auto spawn(element_type_tag input) && -> AnyOperator override {
     // The spawner must be retrieved before filling args, because we move them
     // out and thus the passed `DescribeCtx` would be incomplete.
     auto spawner = std::optional<AnySpawn>{};

--- a/libtenzir/src/pipeline.cpp
+++ b/libtenzir/src/pipeline.cpp
@@ -171,7 +171,7 @@ void pipeline::prepend(operator_ptr op) {
   }
 }
 
-auto pipeline::unwrap() and -> std::vector<operator_ptr> {
+auto pipeline::unwrap() && -> std::vector<operator_ptr> {
   return std::move(operators_);
 }
 
@@ -385,7 +385,7 @@ auto pipeline::is_closed() const -> bool {
   return check_type<void, void>().has_value();
 }
 
-auto pipeline::split_at_void() and -> caf::expected<std::vector<pipeline>> {
+auto pipeline::split_at_void() && -> caf::expected<std::vector<pipeline>> {
   const auto guess_or_infer_type
     = [](std::optional<operator_type> input,
          const operator_ptr& op) -> caf::expected<operator_type> {

--- a/libtenzir/src/tql2/eval.cpp
+++ b/libtenzir/src/tql2/eval.cpp
@@ -60,7 +60,7 @@ public:
     enter(const_cast<T&>(x));
   }
 
-  auto result() and -> std::vector<ast::field_path> {
+  auto result() && -> std::vector<ast::field_path> {
     return std::move(captures_);
   }
 

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -66,6 +66,7 @@ in
   musl = callFunction ./overrides/musl.nix { inherit (prevPkgs) musl; };
   mold-unwrapped = callFunction ./overrides/mold.nix { inherit (prevPkgs) mold-unwrapped; };
   mvfst = callFunction ./overrides/mvfst.nix { inherit (prevPkgs) mvfst; };
+  ngtcp2 = callFunction ./overrides/ngtcp2.nix { inherit (prevPkgs) ngtcp2; };
   protobufc = callFunction ./overrides/protobufc.nix { inherit (prevPkgs) protobufc; };
   rabbitmq-c = callFunction ./overrides/rabbitmq-c.nix { inherit (prevPkgs) rabbitmq-c; };
   restinio = callFunction ./overrides/restinio.nix { inherit (prevPkgs) restinio; };

--- a/nix/overrides/ngtcp2.nix
+++ b/nix/overrides/ngtcp2.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  ngtcp2,
+  stdenv,
+  libev,
+  nghttp3,
+}:
+let
+  enableLibOnly =
+    stdenv.hostPlatform.isStatic
+    || stdenv.hostPlatform.isFreeBSD
+    || stdenv.hostPlatform.isCygwin
+    || stdenv.hostPlatform.isWindows;
+in
+ngtcp2.overrideAttrs (orig: {
+  # ngtcp2's CMake only looks for libev and nghttp3 when building examples.
+  # nixpkgs still injects them for lib-only static builds, which leaks libev's
+  # headers into downstream consumers.
+  buildInputs = lib.subtractLists (lib.optionals enableLibOnly [ libev nghttp3 ]) (orig.buildInputs or [ ]);
+  propagatedBuildInputs =
+    lib.subtractLists (lib.optionals enableLibOnly [ libev nghttp3 ]) (orig.propagatedBuildInputs or [ ]);
+})

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -20,9 +20,6 @@ rec {
     ../test/tests/operators/from_http/tls_skip_peer_verification.tql
     ../test/tests/operators/from_http/url_without_scheme.tql
 
-    # executor crashes
-    ../test/tests/operators/where/deep_left_associated_no_crash.tql
-
     # accept_http is flaky in the sandbox.
     ../test/tests/operators/accept_http
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -7,7 +7,136 @@
   forceClang ? false,
 }:
 rec {
-  integration-test-tree = ../test-legacy;
+  excluded-integration-test-files = lib.fileset.unions [
+    (lib.fileset.fileFilter (file: file.hasExt "tql" || file.hasExt "py" || file.hasExt "sh") ../test/tests)
+    (lib.fileset.fileFilter (file: file.hasExt "tql" || file.hasExt "py" || file.hasExt "sh") ../test-legacy/tests)
+  ];
+  integration-test-support-tree =
+    lib.fileset.difference
+      (lib.fileset.unions [
+        ../test
+        ../test-legacy
+      ])
+      excluded-integration-test-files;
+  included-integration-tests = lib.fileset.unions [
+    # Uncomment individual test paths while iterating on sandbox failures.
+    # Keep suite metadata like `test.yaml` commented out unless a selected
+    # test needs it.
+
+    # Closed-source plugin not shipped in the Nix build.
+    # ../test-legacy/tests/operators/to_sentinelone_data_lake
+
+    # accept_http startup / TLS handshake failures
+    # ../test/tests/operators/accept_http/basic_ingest.tql
+    # ../test/tests/operators/accept_http/tls.tql
+    # ../test/tests/operators/accept_http/tls_min_version_supported.tql
+    # ../test/tests/operators/accept_http/request_variable.tql
+
+    # dns lookup output mismatches in the sandboxed environment
+    # ../test/tests/operators/dns_lookup/batch_splitting.tql
+    # ../test/tests/operators/dns_lookup/forward_lookup.tql
+    # ../test/tests/operators/dns_lookup/localhost_test.tql
+
+    # broad timeout bucket
+    # ../test/tests/operators/bitz/error_invalid_magic.tql
+    # ../test/tests/operators/bitz/error_missing_header.tql
+    # ../test/tests/operators/bitz/error_truncated_header.tql
+    # ../test/tests/operators/bitz/round_trip.tql
+    # ../test/tests/operators/bitz/write_skips_empty_slices.tql
+    # ../test/tests/operators/compress_decompress/brotli_roundtrip.tql
+    # ../test/tests/operators/compress_decompress/bz2_roundtrip.tql
+    # ../test/tests/operators/compress_decompress/gzip_deflate_format.tql
+    # ../test/tests/operators/compress_decompress/gzip_roundtrip.tql
+    # ../test/tests/operators/compress_decompress/gzip_with_level.tql
+    # ../test/tests/operators/compress_decompress/lz4_roundtrip.tql
+    # ../test/tests/operators/compress_decompress/zstd_roundtrip.tql
+    ../test/tests/operators/from_stdin/basic.tql
+    # ../test/tests/operators/from_stdin/empty.tql
+    # ../test/tests/operators/from_stdin/unterminated_eof.tql
+    # ../test/tests/operators/read_gelf/basic.tql
+    # ../test/tests/operators/read_gelf/null_delimited.tql
+    # ../test/tests/operators/read_gelf/single_message.tql
+    # ../test/tests/operators/read_grok/basic.tql
+    # ../test/tests/operators/read_json/arrays_of_objects.tql
+    # ../test/tests/operators/read_json/basic.tql
+    # ../test/tests/operators/read_json/incomplete_object.tql
+    # ../test/tests/operators/read_json/record_list_different_fields.tql
+    # ../test/tests/operators/read_json/record_list_new_field.tql
+    # ../test/tests/operators/read_json/type_conflict.tql
+    # ../test/tests/operators/read_json/type_conflict_batching.tql
+    # ../test/tests/operators/read_ndjson/basic.tql
+    # ../test/tests/operators/read_ndjson/duplicate_keys_unparsed.tql
+    # ../test/tests/operators/read_ndjson/type_mismatch.tql
+    # ../test/tests/operators/read_suricata/basic.tql
+    # ../test/tests/operators/read_suricata/eve_fileinfo_sample.tql
+    # ../test/tests/operators/read_tql/basic_types.tql
+    # ../test/tests/operators/read_tql/compact.tql
+    # ../test/tests/operators/read_tql/empty_structures.tql
+    # ../test/tests/operators/read_tql/multiple_records.tql
+    # ../test/tests/operators/read_tql/native_types.tql
+    # ../test/tests/operators/read_tql/nested.tql
+    # ../test/tests/operators/read_tql/quoted_fields.tql
+    # ../test/tests/operators/read_tql/strings.tql
+    # ../test/tests/operators/read_tql/trailing_comma.tql
+    # ../test/tests/operators/read_tql/whitespace_between_records.tql
+    # ../test/tests/operators/read_tql/whitespace_excessive.tql
+    # ../test/tests/operators/read_tql/whitespace_list.tql
+    # ../test/tests/operators/read_tql/whitespace_minimal.tql
+    # ../test/tests/operators/read_tql/whitespace_mixed.tql
+    # ../test/tests/operators/read_tql/whitespace_multiline.tql
+    # ../test/tests/operators/read_yaml/basic.tql
+    # ../test/tests/operators/read_yaml/warning_prefix.tql
+    # ../test/tests/operators/read_zeek_json/basic.tql
+    # ../test/tests/operators/read_zeek_json/conn_sample.tql
+    # ../test/tests/operators/xsv/error_write_csv_heterogeneous_schemas.tql
+    # ../test/tests/operators/yara/basic.tql
+    # ../test/tests/operators/yara/basic_list.tql
+    # ../test/tests/operators/yara/empty.tql
+
+    # from_http TLS CA lookup failures
+    # ../test/tests/operators/from_http/tls_min_version_supported.tql
+    # ../test/tests/operators/from_http/tls_skip_peer_verification.tql
+    # ../test/tests/operators/from_http/url_without_scheme.tql
+
+    # plugin not available in the Nix build
+    # ../test/tests/operators/from_sentinelone_data_lake/all_types.tql
+    # ../test/tests/operators/from_sentinelone_data_lake/basic.tql
+    # ../test/tests/operators/from_sentinelone_data_lake/empty.tql
+    # ../test/tests/operators/from_sentinelone_data_lake/http_error.tql
+    # ../test/tests/operators/from_sentinelone_data_lake/start_end.tql
+    # ../test/tests/operators/from_sentinelone_data_lake/many_rows.tql
+    # ../test/tests/operators/from_sentinelone_data_lake/special_floats.tql
+    # ../test/tests/operators/from_sentinelone_data_lake/nested_fields.tql
+    # ../test/tests/operators/from_sentinelone_data_lake/typed_strings.tql
+    # ../test/tests/operators/from_sentinelone_data_lake/typed_strings_raw.tql
+    # ../test/tests/operators/from_sentinelone_data_lake/validate_empty_query.tql
+    # ../test/tests/operators/from_sentinelone_data_lake/validate_empty_url.tql
+    # ../test/tests/operators/from_sentinelone_data_lake/validate_start_gt_end.tql
+
+    # executor crashes
+    # ../test/tests/operators/load_balance/basic.tql
+    # ../test/tests/operators/load_balance/multi_worker_sink.tql
+    # ../test/tests/operators/load_balance/nested_parallel.tql
+    # ../test/tests/operators/to_stdout/basic.tql
+    # ../test/tests/operators/to_stdout/subpipeline.tql
+    # ../test/tests/operators/where/deep_left_associated_no_crash.tql
+
+    # ZMQ hangs
+    # ../test/tests/operators/accept_zmq/keep_prefix_read_all.tql
+    # ../test/tests/operators/accept_zmq/plain_read_json.tql
+    # ../test/tests/operators/from_zmq/plain_read_json.tql
+    # ../test/tests/operators/from_zmq/prefix_read_json.tql
+
+    # Fixture writes into the read-only source tree in the Nix sandbox.
+    # ../test/tests/operators/files/dangling_symlink_permissions.tql
+    # ../test/tests/operators/files/recurse_permission_denied.tql
+    # ../test/tests/operators/files/recurse_permission_denied_skip.tql
+    # ../test/tests/operators/files/test.yaml
+  ];
+  integration-test-tree = lib.fileset.unions [
+    integration-test-support-tree
+    included-integration-tests
+  ];
   tenzir-tree = lib.fileset.unions [
     ../changelog
     ../cmake

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -23,40 +23,19 @@ rec {
     # Keep suite metadata like `test.yaml` commented out unless a selected
     # test needs it.
 
-    # Closed-source plugin not shipped in the Nix build.
+    # plugins not available in the Nix build.
     # ../test-legacy/tests/operators/to_sentinelone_data_lake
+    # ../test/tests/operators/from_sentinelone_data_lake
 
     # dns lookup output mismatches in the sandboxed environment
-    ../test/tests/operators/dns_lookup/batch_splitting.tql
-    ../test/tests/operators/dns_lookup/forward_lookup.tql
-    ../test/tests/operators/dns_lookup/localhost_test.tql
+    # ../test/tests/operators/dns_lookup
 
     # from_http TLS CA lookup failures
     # ../test/tests/operators/from_http/tls_min_version_supported.tql
     # ../test/tests/operators/from_http/tls_skip_peer_verification.tql
     # ../test/tests/operators/from_http/url_without_scheme.tql
 
-    # plugin not available in the Nix build
-    # ../test/tests/operators/from_sentinelone_data_lake/all_types.tql
-    # ../test/tests/operators/from_sentinelone_data_lake/basic.tql
-    # ../test/tests/operators/from_sentinelone_data_lake/empty.tql
-    # ../test/tests/operators/from_sentinelone_data_lake/http_error.tql
-    # ../test/tests/operators/from_sentinelone_data_lake/start_end.tql
-    # ../test/tests/operators/from_sentinelone_data_lake/many_rows.tql
-    # ../test/tests/operators/from_sentinelone_data_lake/special_floats.tql
-    # ../test/tests/operators/from_sentinelone_data_lake/nested_fields.tql
-    # ../test/tests/operators/from_sentinelone_data_lake/typed_strings.tql
-    # ../test/tests/operators/from_sentinelone_data_lake/typed_strings_raw.tql
-    # ../test/tests/operators/from_sentinelone_data_lake/validate_empty_query.tql
-    # ../test/tests/operators/from_sentinelone_data_lake/validate_empty_url.tql
-    # ../test/tests/operators/from_sentinelone_data_lake/validate_start_gt_end.tql
-
     # executor crashes
-    # ../test/tests/operators/load_balance/basic.tql
-    # ../test/tests/operators/load_balance/multi_worker_sink.tql
-    # ../test/tests/operators/load_balance/nested_parallel.tql
-    # ../test/tests/operators/to_stdout/basic.tql
-    # ../test/tests/operators/to_stdout/subpipeline.tql
     # ../test/tests/operators/where/deep_left_associated_no_crash.tql
 
     # ZMQ hangs
@@ -64,12 +43,6 @@ rec {
     # ../test/tests/operators/accept_zmq/plain_read_json.tql
     # ../test/tests/operators/from_zmq/plain_read_json.tql
     # ../test/tests/operators/from_zmq/prefix_read_json.tql
-
-    # Fixture writes into the read-only source tree in the Nix sandbox.
-    # ../test/tests/operators/files/dangling_symlink_permissions.tql
-    # ../test/tests/operators/files/recurse_permission_denied.tql
-    # ../test/tests/operators/files/recurse_permission_denied_skip.tql
-    # ../test/tests/operators/files/test.yaml
   ];
   integration-test-tree = lib.fileset.unions [
     integration-test-support-tree

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -26,72 +26,10 @@ rec {
     # Closed-source plugin not shipped in the Nix build.
     # ../test-legacy/tests/operators/to_sentinelone_data_lake
 
-    # accept_http startup / TLS handshake failures
-    # ../test/tests/operators/accept_http/basic_ingest.tql
-    # ../test/tests/operators/accept_http/tls.tql
-    # ../test/tests/operators/accept_http/tls_min_version_supported.tql
-    # ../test/tests/operators/accept_http/request_variable.tql
-
     # dns lookup output mismatches in the sandboxed environment
-    # ../test/tests/operators/dns_lookup/batch_splitting.tql
-    # ../test/tests/operators/dns_lookup/forward_lookup.tql
-    # ../test/tests/operators/dns_lookup/localhost_test.tql
-
-    # broad timeout bucket
-    # ../test/tests/operators/bitz/error_invalid_magic.tql
-    # ../test/tests/operators/bitz/error_missing_header.tql
-    # ../test/tests/operators/bitz/error_truncated_header.tql
-    # ../test/tests/operators/bitz/round_trip.tql
-    # ../test/tests/operators/bitz/write_skips_empty_slices.tql
-    # ../test/tests/operators/compress_decompress/brotli_roundtrip.tql
-    # ../test/tests/operators/compress_decompress/bz2_roundtrip.tql
-    # ../test/tests/operators/compress_decompress/gzip_deflate_format.tql
-    # ../test/tests/operators/compress_decompress/gzip_roundtrip.tql
-    # ../test/tests/operators/compress_decompress/gzip_with_level.tql
-    # ../test/tests/operators/compress_decompress/lz4_roundtrip.tql
-    # ../test/tests/operators/compress_decompress/zstd_roundtrip.tql
-    ../test/tests/operators/from_stdin/basic.tql
-    # ../test/tests/operators/from_stdin/empty.tql
-    # ../test/tests/operators/from_stdin/unterminated_eof.tql
-    # ../test/tests/operators/read_gelf/basic.tql
-    # ../test/tests/operators/read_gelf/null_delimited.tql
-    # ../test/tests/operators/read_gelf/single_message.tql
-    # ../test/tests/operators/read_grok/basic.tql
-    # ../test/tests/operators/read_json/arrays_of_objects.tql
-    # ../test/tests/operators/read_json/basic.tql
-    # ../test/tests/operators/read_json/incomplete_object.tql
-    # ../test/tests/operators/read_json/record_list_different_fields.tql
-    # ../test/tests/operators/read_json/record_list_new_field.tql
-    # ../test/tests/operators/read_json/type_conflict.tql
-    # ../test/tests/operators/read_json/type_conflict_batching.tql
-    # ../test/tests/operators/read_ndjson/basic.tql
-    # ../test/tests/operators/read_ndjson/duplicate_keys_unparsed.tql
-    # ../test/tests/operators/read_ndjson/type_mismatch.tql
-    # ../test/tests/operators/read_suricata/basic.tql
-    # ../test/tests/operators/read_suricata/eve_fileinfo_sample.tql
-    # ../test/tests/operators/read_tql/basic_types.tql
-    # ../test/tests/operators/read_tql/compact.tql
-    # ../test/tests/operators/read_tql/empty_structures.tql
-    # ../test/tests/operators/read_tql/multiple_records.tql
-    # ../test/tests/operators/read_tql/native_types.tql
-    # ../test/tests/operators/read_tql/nested.tql
-    # ../test/tests/operators/read_tql/quoted_fields.tql
-    # ../test/tests/operators/read_tql/strings.tql
-    # ../test/tests/operators/read_tql/trailing_comma.tql
-    # ../test/tests/operators/read_tql/whitespace_between_records.tql
-    # ../test/tests/operators/read_tql/whitespace_excessive.tql
-    # ../test/tests/operators/read_tql/whitespace_list.tql
-    # ../test/tests/operators/read_tql/whitespace_minimal.tql
-    # ../test/tests/operators/read_tql/whitespace_mixed.tql
-    # ../test/tests/operators/read_tql/whitespace_multiline.tql
-    # ../test/tests/operators/read_yaml/basic.tql
-    # ../test/tests/operators/read_yaml/warning_prefix.tql
-    # ../test/tests/operators/read_zeek_json/basic.tql
-    # ../test/tests/operators/read_zeek_json/conn_sample.tql
-    # ../test/tests/operators/xsv/error_write_csv_heterogeneous_schemas.tql
-    # ../test/tests/operators/yara/basic.tql
-    # ../test/tests/operators/yara/basic_list.tql
-    # ../test/tests/operators/yara/empty.tql
+    ../test/tests/operators/dns_lookup/batch_splitting.tql
+    ../test/tests/operators/dns_lookup/forward_lookup.tql
+    ../test/tests/operators/dns_lookup/localhost_test.tql
 
     # from_http TLS CA lookup failures
     # ../test/tests/operators/from_http/tls_min_version_supported.tql

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -7,47 +7,37 @@
   forceClang ? false,
 }:
 rec {
-  excluded-integration-test-files = lib.fileset.unions [
-    (lib.fileset.fileFilter (file: file.hasExt "tql" || file.hasExt "py" || file.hasExt "sh") ../test/tests)
-    (lib.fileset.fileFilter (file: file.hasExt "tql" || file.hasExt "py" || file.hasExt "sh") ../test-legacy/tests)
-  ];
-  integration-test-support-tree =
-    lib.fileset.difference
-      (lib.fileset.unions [
-        ../test
-        ../test-legacy
-      ])
-      excluded-integration-test-files;
-  included-integration-tests = lib.fileset.unions [
-    # Uncomment individual test paths while iterating on sandbox failures.
-    # Keep suite metadata like `test.yaml` commented out unless a selected
-    # test needs it.
-
+  excluded-integration-tests = lib.fileset.unions [
     # plugins not available in the Nix build.
-    # ../test-legacy/tests/operators/to_sentinelone_data_lake
-    # ../test/tests/operators/from_sentinelone_data_lake
+    ../test/tests/operators/from_sentinelone_data_lake
+    ../test/tests/operators/to_sentinelone_data_lake
 
     # dns lookup output mismatches in the sandboxed environment
-    # ../test/tests/operators/dns_lookup
+    ../test/tests/operators/dns_lookup
 
     # from_http TLS CA lookup failures
-    # ../test/tests/operators/from_http/tls_min_version_supported.tql
-    # ../test/tests/operators/from_http/tls_skip_peer_verification.tql
-    # ../test/tests/operators/from_http/url_without_scheme.tql
+    ../test/tests/operators/from_http/tls_min_version_supported.tql
+    ../test/tests/operators/from_http/tls_skip_peer_verification.tql
+    ../test/tests/operators/from_http/url_without_scheme.tql
 
     # executor crashes
-    # ../test/tests/operators/where/deep_left_associated_no_crash.tql
+    ../test/tests/operators/where/deep_left_associated_no_crash.tql
+
+    # accept_http is flaky in the sandbox.
+    ../test/tests/operators/accept_http
 
     # ZMQ hangs
-    # ../test/tests/operators/accept_zmq/keep_prefix_read_all.tql
-    # ../test/tests/operators/accept_zmq/plain_read_json.tql
-    # ../test/tests/operators/from_zmq/plain_read_json.tql
-    # ../test/tests/operators/from_zmq/prefix_read_json.tql
+    ../test/tests/operators/accept_zmq/keep_prefix_read_all.tql
+    ../test/tests/operators/accept_zmq/plain_read_json.tql
+    ../test/tests/operators/from_zmq/plain_read_json.tql
+    ../test/tests/operators/from_zmq/prefix_read_json.tql
   ];
-  integration-test-tree = lib.fileset.unions [
-    integration-test-support-tree
-    included-integration-tests
-  ];
+  integration-test-tree = lib.fileset.difference
+    (lib.fileset.unions [
+      ../test
+      ../test-legacy
+    ])
+    excluded-integration-tests;
   tenzir-tree = lib.fileset.unions [
     ../changelog
     ../cmake

--- a/nix/tenzir/check.nix
+++ b/nix/tenzir/check.nix
@@ -35,13 +35,13 @@ stdenvNoCC.mkDerivation {
             -j $NIX_BUILD_CORES \
             ${path}/test
         fi
-        if [ -d "${path}/test-legacy/tests" ]; then
-          echo "running ${path} legacy integration tests"
-          tenzir-test \
-            --root "${src}/test-legacy" \
-            -j $NIX_BUILD_CORES \
-            ${path}/test-legacy
-        fi
+        #if [ -d "${path}/test-legacy/tests" ]; then
+        #  echo "running ${path} legacy integration tests"
+        #  tenzir-test -d \
+        #    --root "${src}/test-legacy" \
+        #    -j $NIX_BUILD_CORES \
+        #    ${path}/test-legacy
+        #fi
       '';
     in
     ''

--- a/nix/tenzir/check.nix
+++ b/nix/tenzir/check.nix
@@ -28,8 +28,15 @@ stdenvNoCC.mkDerivation {
         ps.trustme
       ]);
       template = path: ''
-        if [ -d "${path}/test-legacy/tests" ]; then
+        if [ -d "${path}/test/tests" ]; then
           echo "running ${path} integration tests"
+          tenzir-test \
+            --root "${src}/test" \
+            -j $NIX_BUILD_CORES \
+            ${path}/test
+        fi
+        if [ -d "${path}/test-legacy/tests" ]; then
+          echo "running ${path} legacy integration tests"
           tenzir-test \
             --root "${src}/test-legacy" \
             -j $NIX_BUILD_CORES \

--- a/nix/tenzir/check.nix
+++ b/nix/tenzir/check.nix
@@ -35,13 +35,13 @@ stdenvNoCC.mkDerivation {
             -j $NIX_BUILD_CORES \
             ${path}/test
         fi
-        #if [ -d "${path}/test-legacy/tests" ]; then
-        #  echo "running ${path} legacy integration tests"
-        #  tenzir-test -d \
-        #    --root "${src}/test-legacy" \
-        #    -j $NIX_BUILD_CORES \
-        #    ${path}/test-legacy
-        #fi
+        if [ -d "${path}/test-legacy/tests" ]; then
+          echo "running ${path} legacy integration tests"
+          tenzir-test \
+            --root "${src}/test-legacy" \
+            -j $NIX_BUILD_CORES \
+            ${path}/test-legacy
+        fi
       '';
     in
     ''

--- a/test/fixtures/files_permission_tree.py
+++ b/test/fixtures/files_permission_tree.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from tenzir_test import FixtureHandle, fixture
 from tenzir_test.fixtures import FixtureUnavailable
 
-RELATIVE_ROOT = Path("tests/operators/files/permission-root")
+FIXTURE_ROOT = Path("/tmp/tenzir-files-permission-root")
 
 
 def _make_writable(path: Path) -> None:
@@ -22,8 +22,7 @@ def files_permission_tree() -> FixtureHandle:
     """Create a deterministic local tree for recursive `files` tests."""
     if hasattr(os, "geteuid") and os.geteuid() == 0:
         raise FixtureUnavailable("root can traverse chmod 000 directories")
-    test_root = Path(__file__).resolve().parents[1]
-    root = test_root / RELATIVE_ROOT
+    root = FIXTURE_ROOT
     blocked = root / "blocked"
     _make_writable(blocked)
     shutil.rmtree(root, ignore_errors=True)
@@ -44,6 +43,6 @@ def files_permission_tree() -> FixtureHandle:
         shutil.rmtree(root, ignore_errors=True)
 
     return FixtureHandle(
-        env={"FILES_PERMISSION_ROOT": str(RELATIVE_ROOT)},
+        env={"FILES_PERMISSION_ROOT": str(root)},
         teardown=_teardown,
     )

--- a/test/fixtures/files_permission_tree.py
+++ b/test/fixtures/files_permission_tree.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 
 import os
 import shutil
+import tempfile
 from pathlib import Path
 
 from tenzir_test import FixtureHandle, fixture
-from tenzir_test.fixtures import FixtureUnavailable
-
-FIXTURE_ROOT = Path("/tmp/tenzir-files-permission-root")
+from tenzir_test.fixtures import FixtureUnavailable, current_context
 
 
 def _make_writable(path: Path) -> None:
@@ -22,7 +21,11 @@ def files_permission_tree() -> FixtureHandle:
     """Create a deterministic local tree for recursive `files` tests."""
     if hasattr(os, "geteuid") and os.geteuid() == 0:
         raise FixtureUnavailable("root can traverse chmod 000 directories")
-    root = FIXTURE_ROOT
+    context = current_context()
+    tmp_dir = context.env.get("TENZIR_TMP_DIR") if context is not None else None
+    if tmp_dir is None:
+        tmp_dir = tempfile.mkdtemp(prefix="tenzir-files-permission-")
+    root = Path(tmp_dir) / "files-permission-root"
     blocked = root / "blocked"
     _make_writable(blocked)
     shutil.rmtree(root, ignore_errors=True)

--- a/test/tests/operators/files/recurse_permission_denied.py
+++ b/test/tests/operators/files/recurse_permission_denied.py
@@ -1,0 +1,60 @@
+# runner: python
+"""Verify unreadable directories are warned about during recursive traversal."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def _resolve_tenzir_binary() -> tuple[str, ...]:
+    env_val = os.environ.get("TENZIR_BINARY")
+    if env_val:
+        return tuple(shlex.split(env_val))
+    which_result = shutil.which("tenzir")
+    if which_result:
+        return (which_result,)
+    raise RuntimeError("tenzir executable not found (set TENZIR_BINARY or add to PATH)")
+
+
+def main() -> None:
+    root = os.environ["FILES_PERMISSION_ROOT"]
+    pipeline = (
+        f'files "{root}", recurse=true\n'
+        f'path = path.replace("{root}", "<ROOT>")\n'
+        "select path, type\n"
+        "sort path\n"
+    )
+    tenzir = _resolve_tenzir_binary()
+    with tempfile.TemporaryDirectory(prefix="files-permission-") as tmpdir:
+        pipeline_path = Path(tmpdir) / "pipeline.tql"
+        pipeline_path.write_text(pipeline, encoding="utf-8")
+        result = subprocess.run(
+            [
+                *tenzir,
+                "--bare-mode",
+                "--console-verbosity=quiet",
+                "--multi",
+                "--neo",
+                "-f",
+                str(pipeline_path),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=os.environ.copy(),
+        )
+    combined = (result.stdout + result.stderr).replace(root, "<ROOT>")
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"pipeline failed with exit code {result.returncode}\n{combined}"
+        )
+    print(combined, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/tests/operators/files/recurse_permission_denied.tql
+++ b/test/tests/operators/files/recurse_permission_denied.tql
@@ -1,4 +1,0 @@
-files env("FILES_PERMISSION_ROOT"), recurse=true
-path = path.replace(env("FILES_PERMISSION_ROOT"), "<ROOT>")
-select path, type
-sort path

--- a/test/tests/operators/files/recurse_permission_denied.txt
+++ b/test/tests/operators/files/recurse_permission_denied.txt
@@ -22,4 +22,4 @@
   path: "<ROOT>/ok/data.json",
   type: "regular",
 }
-warning: skipping unreadable directory `tests/operators/files/permission-root/blocked`: Permission denied
+warning: skipping unreadable directory `/tmp/tenzir-files-permission-root/blocked`: Permission denied

--- a/test/tests/operators/files/recurse_permission_denied.txt
+++ b/test/tests/operators/files/recurse_permission_denied.txt
@@ -22,4 +22,4 @@
   path: "<ROOT>/ok/data.json",
   type: "regular",
 }
-warning: skipping unreadable directory `/tmp/tenzir-files-permission-root/blocked`: Permission denied
+warning: skipping unreadable directory `<ROOT>/blocked`: Permission denied


### PR DESCRIPTION
## 🔍 Problem

- The static Nix build was not exercising the neo integration tests from `test/`.
- Enabling them exposed a small set of sandbox-specific failures and one flaky configured-contexts case fixed in the plugin submodule.
- A bad `libev` dependency in the build closure was causing `from_stdin` to hang at runtime.

## 🛠️ Solution

- Run both `test/` and `test-legacy/` integration suites in the Nix check phase.
- Switch the Nix test selection to a blacklist of known sandbox failures instead of an allowlist.
- Override static `ngtcp2` builds to drop example-only `libev` and `nghttp3` inputs.
- Move the `files` permission fixture to a writable `/tmp` tree for sandbox runs.
- Bump `contrib/tenzir-plugins` to pick up the configured-contexts test fix.

## 💬 Review

- Focus on whether the Nix test selection now matches the intended policy for sandbox-only failures.
- The `ngtcp2` override is intentionally narrow: it only strips dependencies that upstream uses for examples in lib-only static builds.
- The fixture change is test-only and keeps the existing permission-denied coverage, but from a writable location.

<sub>
📎 Related: tenzir/tenzir-plugins#522
</sub>
