### PR TITLE
Quiet HTTP request fixture

### DIFF
--- a/test/fixtures/http_request.py
+++ b/test/fixtures/http_request.py
@@ -2,10 +2,8 @@ from __future__ import annotations
 
 import shutil
 import ssl
-import sys
 import tempfile
 import threading
-import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -91,12 +89,6 @@ def http_request() -> FixtureHandle:
     sent_count = [0]
     stopped_early = [False]
     stop_event = threading.Event()
-    t0 = time.monotonic()
-    dbg: list[str] = []
-
-    def _log(msg: str) -> None:
-        dbg.append(f"  [{time.monotonic() - t0:6.2f}s] {msg}")
-
     tls_dir: Path | None = None
     tls_cert_and_key: Path | None = None
     tls_ca: Path | None = None
@@ -108,13 +100,10 @@ def http_request() -> FixtureHandle:
     request_specs = _to_request_specs(opts)
 
     def _worker() -> None:
-        _log(f"worker started, endpoint={endpoint}")
         if opts.initial_delay > 0:
-            _log(f"initial delay {opts.initial_delay}s")
-            time.sleep(opts.initial_delay)
+            stop_event.wait(opts.initial_delay)
         for req_idx, spec in enumerate(request_specs):
             if stop_event.is_set():
-                _log(f"request {req_idx}: stop requested before sending")
                 stopped_early[0] = True
                 return
             proto = "https" if spec.tls else "http"
@@ -126,10 +115,8 @@ def http_request() -> FixtureHandle:
             if spec.tls and tls_dir and tls_ca is not None:
                 ssl_context = ssl.create_default_context(cafile=str(tls_ca))
             connection_refused_error: str | None = None
-            last_exc_str: str | None = None
-            for attempt in range(max(opts.max_attempts_per_request, 1)):
+            for _ in range(max(opts.max_attempts_per_request, 1)):
                 if stop_event.is_set():
-                    _log(f"request {req_idx}: stop requested on attempt {attempt}")
                     stopped_early[0] = True
                     return
                 req = Request(
@@ -140,13 +127,9 @@ def http_request() -> FixtureHandle:
                         req, timeout=opts.request_timeout, context=ssl_context
                     ) as response:
                         body = response.read().decode("utf-8", errors="replace")
-                        _log(
-                            f"request {req_idx}: sent on attempt {attempt}, "
-                            f"status={response.status}"
-                        )
                         if response.status != spec.expected_status:
                             errors.append(
-                                "expected HTTP status "
+                                f"request {req_idx}: expected HTTP status "
                                 f"{spec.expected_status}, got {response.status}"
                             )
                         if (
@@ -154,25 +137,23 @@ def http_request() -> FixtureHandle:
                             and body != spec.expected_body
                         ):
                             errors.append(
-                                f"expected HTTP body {spec.expected_body!r}, got {body!r}"
+                                f"request {req_idx}: expected HTTP body "
+                                f"{spec.expected_body!r}, got {body!r}"
                             )
                         sent_count[0] += 1
                         sent = True
                         break
                 except HTTPError as exc:
                     body = exc.read().decode("utf-8", errors="replace")
-                    _log(
-                        f"request {req_idx}: HTTP error on attempt {attempt}, "
-                        f"status={exc.code}"
-                    )
                     if exc.code != spec.expected_status:
                         errors.append(
-                            "expected HTTP status "
+                            f"request {req_idx}: expected HTTP status "
                             f"{spec.expected_status}, got {exc.code}"
                         )
                     if spec.expected_body is not None and body != spec.expected_body:
                         errors.append(
-                            f"expected HTTP body {spec.expected_body!r}, got {body!r}"
+                            f"request {req_idx}: expected HTTP body "
+                            f"{spec.expected_body!r}, got {body!r}"
                         )
                     sent_count[0] += 1
                     sent = True
@@ -181,14 +162,9 @@ def http_request() -> FixtureHandle:
                     exc_str = str(exc)
                     if "connection refused" in exc_str.lower():
                         connection_refused_error = exc_str
-                    last_exc_str = exc_str
-                    time.sleep(opts.retry_delay)
+                    stop_event.wait(opts.retry_delay)
             if not sent:
                 attempts = max(opts.max_attempts_per_request, 1)
-                _log(
-                    f"request {req_idx}: gave up after {attempts} attempts, "
-                    f"last_exc={last_exc_str!r}"
-                )
                 if connection_refused_error is not None:
                     errors.append(
                         "connection refused while delivering HTTP request to "
@@ -197,8 +173,7 @@ def http_request() -> FixtureHandle:
                     )
                 return
             if opts.inter_request_delay > 0:
-                time.sleep(opts.inter_request_delay)
-        _log("worker finished")
+                stop_event.wait(opts.inter_request_delay)
 
     worker = threading.Thread(target=_worker, daemon=True)
     worker.start()
@@ -211,39 +186,19 @@ def http_request() -> FixtureHandle:
     def _teardown() -> None:
         stop_event.set()
         worker.join(timeout=2)
-        elapsed = time.monotonic() - t0
-        failed = False
         try:
             if worker.is_alive():
-                failed = True
                 raise RuntimeError(
                     "http_request fixture worker did not stop within 2 seconds"
                 )
             if errors:
-                failed = True
                 raise AssertionError("; ".join(errors))
             expected_count = len(request_specs)
             if not stopped_early[0] and sent_count[0] < expected_count:
-                failed = True
                 raise AssertionError(
                     f"expected to send {expected_count} requests, sent {sent_count[0]}"
                 )
         finally:
-            incomplete = stopped_early[0] and sent_count[0] < len(request_specs)
-            # Also log when teardown runs suspiciously late: the fixture
-            # succeeded but the subprocess hung (e.g. server destructor
-            # blocked on thread_.join).
-            late = elapsed > 5.0
-            if failed or incomplete or late:
-                _log(
-                    f"teardown: sent={sent_count[0]}, "
-                    f"stopped_early={stopped_early[0]}, errors={errors}"
-                )
-                print(
-                    "http_request fixture log:\n" + "\n".join(dbg),
-                    file=sys.stderr,
-                    flush=True,
-                )
             if tls_dir is not None:
                 shutil.rmtree(tls_dir, ignore_errors=True)
 


### PR DESCRIPTION
## 🔍 Problem

- The HTTP request fixture buffers verbose per-request diagnostics.
- Large request-count tests can dump noisy output that obscures the actual failure.

## 🛠️ Solution

- Remove the fixture-local debug log and stderr dump.
- Keep failures reported through assertions instead of ad-hoc logging.

## 💬 Review

- Check that failure messages still carry enough request context.
