### PR TITLE
Fix retention for mixed-age partitions

### DIFF
--- a/changelog/unreleased/retention-for-mixed-age-metrics-partitions.md
+++ b/changelog/unreleased/retention-for-mixed-age-metrics-partitions.md
@@ -1,6 +1,7 @@
 ---
 title: Retention for mixed-age metrics partitions
 type: bugfix
+pr: 6086
 authors:
   - tobim
   - codex

--- a/changelog/unreleased/retention-for-mixed-age-metrics-partitions.md
+++ b/changelog/unreleased/retention-for-mixed-age-metrics-partitions.md
@@ -1,0 +1,12 @@
+---
+title: Retention for mixed-age metrics partitions
+type: bugfix
+authors:
+  - tobim
+  - codex
+created: 2026-04-28T17:18:58.524365Z
+---
+
+Default retention policies now continue deleting metrics and diagnostics as their timestamps age into the retention window, even when older and newer events share a partition.
+
+Previously, a partition that still contained newer events after retention could be skipped by later retention runs, leaving those events behind after they expired.


### PR DESCRIPTION
## 🔍 Problem

Default metrics and diagnostics retention could leave expired events behind when a partition contained both expired and non-expired rows. The compactor rewrote the non-expired survivor rows into a new partition and marked that partition as processed forever, so later runs skipped it after those rows aged past the retention cutoff.

## 🛠️ Solution

Temporal compaction now stores a per-rule watermark for each replacement partition. Future runs use the watermark as the lower bound, so retention only processes the newly expired time range instead of treating survivor partitions as done permanently.

Legacy boolean compaction history remains a fallback for existing non-deletion transforms, while deletion rules such as `where false` can recover from previously stuck survivor partitions.

## 💬 Review

Focus on the watermark semantics in the compaction history and the temporal compactor path. The FlatBuffer field was appended after the existing deprecated field to preserve schema compatibility.
