### PR TITLE
Speed up ternary expression matrix test

### DIFF
--- a/test/tests/operators/if/ternary_expr/all_paths.sh
+++ b/test/tests/operators/if/ternary_expr/all_paths.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # runner: shell
+# timeout: 120
 set -eu
 
 dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)


### PR DESCRIPTION
## 🔍 Problem

- `tests/operators/if/ternary_expr/all_paths.sh` timed out in the shell runner.
- The traced pipelines finish correctly, but the test intentionally starts Tenzir for every matrix entry to compare default and eager evaluation.
- On slower machines, that matrix can exceed the shell runner's default 30s wall-clock budget.

## 🛠️ Solution

- Use the shell-runner frontmatter to raise this test's timeout to 120s.
- This keeps the Tenzir invocations unchanged, preserving the existing coverage while giving the matrix enough time to complete.

## 💬 Review

- Please check whether 120s is an appropriate budget for this matrix test.
- No changelog or docs update: this is test-only and does not change user-facing behavior.
