### PR TITLE
Stabilize accept_http readiness tests

### DIFF
--- a/test/fixtures/_utils.py
+++ b/test/fixtures/_utils.py
@@ -26,6 +26,9 @@ def _is_port_available(port: int, sock_type: int) -> bool:
             sock.bind(("127.0.0.1", port))
         except OSError:
             return False
+    if sock_type == socket.SOCK_STREAM:
+        with socket.socket(socket.AF_INET, sock_type) as sock:
+            return sock.connect_ex(("127.0.0.1", port)) != 0
     return True
 
 

--- a/test/fixtures/http_request.py
+++ b/test/fixtures/http_request.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import shutil
+import socket
 import ssl
 import tempfile
 import threading
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -98,10 +100,25 @@ def http_request() -> FixtureHandle:
             tls_dir, common_name=endpoint, san_entries=[f"IP:{_HOST}"]
         )
     request_specs = _to_request_specs(opts)
+    first_request_at = time.monotonic() + opts.initial_delay
+
+    def _wait_until_ready() -> bool:
+        while not stop_event.is_set():
+            try:
+                with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                    if sock.connect_ex((_HOST, port)) == 0:
+                        return True
+            except OSError:
+                pass
+            stop_event.wait(opts.retry_delay)
+        return False
 
     def _worker() -> None:
-        if opts.initial_delay > 0:
-            stop_event.wait(opts.initial_delay)
+        if not _wait_until_ready():
+            return
+        remaining_initial_delay = first_request_at - time.monotonic()
+        if remaining_initial_delay > 0:
+            stop_event.wait(remaining_initial_delay)
         for req_idx, spec in enumerate(request_specs):
             if stop_event.is_set():
                 stopped_early[0] = True


### PR DESCRIPTION
## 🔍 Problem

- `accept_http` integration tests can send fixture requests before the listener is ready.
- The deterministic fixture port allocator can also pick ports with IPv6 wildcard listeners, which only show up as connectable after allocation.

## 🛠️ Solution

- Wait for the fixture endpoint to accept TCP connections before sending HTTP requests.
- Preserve `initial_delay` as the earliest time the first request may be sent.
- Reject TCP ports that are already connectable when allocating fixture ports.

## 💬 Review

- Focus on the fixture synchronization semantics: no explicit readiness timeout, teardown stops the worker.
