### PR TITLE
Skip ABS race test without Azure sink operator

### DIFF
--- a/test/tests/operators/to_abs/finalize_close_race/test.yaml
+++ b/test/tests/operators/to_abs/finalize_close_race/test.yaml
@@ -1,6 +1,10 @@
 suite: to-abs-finalize-close-race
 fixtures: [abs_slow_proxy]
+requires:
+  operators:
+    - to_azure_blob_storage
 timeout: 240
 skip:
   on:
     - fixture-unavailable
+    - capability-unavailable


### PR DESCRIPTION
## 🔍 Problem

The ABS finalize-close race test fails in environments where the optional Azure Blob Storage plugin is unavailable because the Python test reaches pipeline compilation and reports `to_azure_blob_storage` as missing.

## 🛠️ Solution

Declare the sink operator as a suite capability requirement and opt into capability-based skipping.

## 💬 Review

Focus on whether the suite-level requirement matches the optional ABS plugin behavior.
