### PR TITLE
Clean up tenzir-plugins build integration

### DIFF
--- a/.github/workflows/nix-build-job.yaml
+++ b/.github/workflows/nix-build-job.yaml
@@ -75,7 +75,7 @@ jobs:
         with:
           name: tenzir
           authToken: "${{ secrets.CACHIX_TENZIR_API_TOKEN }}"
-          pushFilter: "tenzir-ee"
+          pushFilter: "(tenzir-ee|tenzir-plugins-source)"
       - name: Import Apple signing certificates
         id: import_apple_signing_certificates
         if: runner.os == 'macOS'
@@ -188,7 +188,6 @@ jobs:
             --arch ${{ inputs.arch }} \
             --test-root test-legacy \
             --test-pattern "tests/functions/time"
-
       # =========================================================================
       # Sign Phase (macOS only)
       # =========================================================================

--- a/.github/workflows/style-check.yaml
+++ b/.github/workflows/style-check.yaml
@@ -28,6 +28,7 @@ jobs:
         with:
           name: tenzir
           authToken: "${{ secrets.CACHIX_TENZIR_API_TOKEN }}"
+          pushFilter: "(tenzir-ee|tenzir-plugins-source)"
       - name: Configure ssh-agent
         uses: webfactory/ssh-agent@v0.9.0
         with:

--- a/.github/workflows/tenzir.yaml
+++ b/.github/workflows/tenzir.yaml
@@ -1088,8 +1088,7 @@ jobs:
         with:
           name: tenzir
           authToken: "${{ secrets.CACHIX_TENZIR_API_TOKEN }}"
-          # Avoid pushing the full enterprise edition.
-          pushFilter: "tenzir-ee"
+          pushFilter: "(tenzir-ee|tenzir-plugins-source)"
       - name: Install workspace dependencies
         working-directory: python
         run: |
@@ -1145,8 +1144,7 @@ jobs:
         with:
           name: tenzir
           authToken: "${{ secrets.CACHIX_TENZIR_API_TOKEN }}"
-          # Avoid pushing the full enterprise edition.
-          pushFilter: "tenzir-ee"
+          pushFilter: "(tenzir-ee|tenzir-plugins-source)"
       - name: Download signed tarball (macOS)
         if: runner.os == 'macOS'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -130,7 +130,10 @@ rec {
         let
           tenzir-plugins-source =
             if builtins.pathExists ./../contrib/tenzir-plugins/README.md then
-              ./../contrib/tenzir-plugins
+              builtins.path {
+                path = ./../contrib/tenzir-plugins;
+                name = "tenzir-plugins-source";
+              }
             else
               pkgs.callPackage ./tenzir/plugins/source.nix { };
           pkg = tenzir-de.override {

--- a/nix/tenzir/plugins/source.nix
+++ b/nix/tenzir/plugins/source.nix
@@ -6,7 +6,10 @@ let
   source = builtins.fromJSON (builtins.readFile ./source.json);
   tenzir-plugins-tarball = import <nix/fetchurl.nix> source;
 in
-runCommand "tenzir-plugins-source" { } ''
+runCommand "tenzir-plugins-source" {
+  allowSubstitutes = false;
+  preferLocalBuild = true;
+} ''
   mkdir -p $out
   tar --strip-components=1 -C $out -xf ${tenzir-plugins-tarball}
 ''


### PR DESCRIPTION
## 🔍 Problem

- `tenzir-static` can realize the closed-source `tenzir-plugins` source tree in CI.
- The Cachix push filter only excluded `tenzir-ee`, so the plugin source path could still be uploaded.

## 🛠️ Solution

- Name the local `contrib/tenzir-plugins` store import `tenzir-plugins-source`.
- Mark the fallback `tenzir-plugins-source` derivation as non-substitutable and locally preferred.
- Extend the existing Cachix `pushFilter` to exclude `tenzir-plugins-source` everywhere it is configured.

## 💬 Review

- Check that the `builtins.path` naming in `nix/package.nix` covers the local submodule case that was previously ending up as `*-source`.
- Check that keeping the existing `cachix-action` flow plus the broader filter is preferable to explicit output-only pushes.