### PR TITLE
Prevent demo image push in non-release builds

### DIFF
--- a/.github/workflows/tenzir.yaml
+++ b/.github/workflows/tenzir.yaml
@@ -394,7 +394,7 @@ jobs:
                | ."image-registries") += ["docker.io"] |
               (.editions[] | ."image-registries") |= unique' \
               <<< "${docker_config}")"
-          # Non-release builds must not push the demo image.
+          # `push` and `workflow_dispatch` hit this branch; they must not push the demo image.
           else
             docker_config="$(jq -c '
               (.editions[] | select(.name == "tenzir-demo") | ."image-registries") |= []' \

--- a/.github/workflows/tenzir.yaml
+++ b/.github/workflows/tenzir.yaml
@@ -394,6 +394,11 @@ jobs:
                | ."image-registries") += ["docker.io"] |
               (.editions[] | ."image-registries") |= unique' \
               <<< "${docker_config}")"
+          # Non-release builds must not push the demo image.
+          else
+            docker_config="$(jq -c '
+              (.editions[] | select(.name == "tenzir-demo") | ."image-registries") |= []' \
+              <<< "${docker_config}")"
           fi
           echo "docker-config=${docker_config}" >> "$GITHUB_OUTPUT"
           echo "::notice docker-config = ${docker_config}"


### PR DESCRIPTION
## Description

This change prevents the demo image from being pushed to container registries during non-release builds. Previously, the Docker configuration only explicitly added registries for release builds, but didn't prevent the demo image from being pushed in other scenarios.

The fix adds an `else` clause that clears the image registries for the `tenzir-demo` edition when the build is not a release, ensuring the demo image is only pushed during official releases.

## Changes

- Modified `.github/workflows/tenzir.yaml` to filter out image registries for the demo edition in non-release builds

## Test Plan

CI will validate that the workflow syntax is correct and the jq configuration is properly applied during non-release builds.

https://claude.ai/code/session_015NDFyNCVG8kMC2hjDKgVfN