### PR TITLE
Fix append_array_slice

### DIFF
--- a/libtenzir/src/arrow_table_slice.cpp
+++ b/libtenzir/src/arrow_table_slice.cpp
@@ -608,9 +608,25 @@ transform_columns(type schema,
   // is preserved structurally when reassembling the result (same-length path).
   // Callers that trigger the length-changing path must handle null bitmap
   // propagation themselves (see `flatten_record` in table_slice.cpp).
+  auto child_arrays = arrow::ArrayVector{};
+  child_arrays.reserve(struct_array->num_fields());
+  for (const auto& field : struct_array->fields()) {
+    if (struct_array->offset() == 0) {
+      child_arrays.push_back(field);
+    } else {
+      child_arrays.push_back(
+        field->Slice(struct_array->offset(), struct_array->length()));
+    }
+  }
+  auto null_bitmap = struct_array->null_bitmap();
+  if (struct_array->offset() != 0 and struct_array->null_bitmap_data()) {
+    null_bitmap = check(arrow::internal::CopyBitmap(
+      tenzir::arrow_memory_pool(), struct_array->null_bitmap_data(),
+      struct_array->offset(), struct_array->length()));
+  }
   auto layer = unpacked_layer{
     .fields = {},
-    .arrays = struct_array->fields(),
+    .arrays = std::move(child_arrays),
   };
   const auto num_columns
     = detail::narrow_cast<size_t>(struct_array->num_fields());
@@ -635,12 +651,11 @@ transform_columns(type schema,
     arrow_fields.push_back(field.type.to_arrow_field(field.name));
   }
   auto new_struct_array = std::shared_ptr<arrow::StructArray>{};
-  // TODO: Does it make sense to add `struct_array->offset()` here?
   if (layer.arrays.empty()
       or struct_array->length() == layer.arrays[0]->length()) {
     new_struct_array = std::make_shared<arrow::StructArray>(
       std::make_shared<arrow::StructType>(arrow_fields), struct_array->length(),
-      layer.arrays, struct_array->null_bitmap(), struct_array->null_count());
+      layer.arrays, std::move(null_bitmap), struct_array->null_count(), 0);
   } else {
     // FIXME: Callers should not rely on this hack. The signature of this
     // function does not really allow this, as it can change the behavior for

--- a/libtenzir/src/arrow_table_slice.cpp
+++ b/libtenzir/src/arrow_table_slice.cpp
@@ -669,7 +669,7 @@ auto record_batch_from_struct_array(
   TENZIR_ASSERT(schema);
   TENZIR_ASSERT(array);
   auto columns = arrow::ArrayVector{};
-  if (array->null_count() > 0) {
+  if (array->null_count() > 0 || array->offset() != 0) {
     columns = check(array->Flatten(tenzir::arrow_memory_pool()));
   } else {
     columns = array->fields();

--- a/libtenzir/src/arrow_utils.cpp
+++ b/libtenzir/src/arrow_utils.cpp
@@ -286,8 +286,8 @@ auto append_array_slice(type_to_arrow_builder_t<Ty>& builder, const Ty& ty,
     }
     for (auto field = 0; field < builder.num_fields(); ++field) {
       TRY(append_array_slice(*builder.field_builder(field),
-                             ty.field(field).type, *array.field(field), begin,
-                             count));
+                             ty.field(field).type, *array.field(field),
+                             begin + array.offset(), count));
     }
   } else if constexpr (std::same_as<Ty, list_type>) {
     for (auto row = begin; row < end; ++row) {

--- a/libtenzir/src/arrow_utils.cpp
+++ b/libtenzir/src/arrow_utils.cpp
@@ -286,8 +286,8 @@ auto append_array_slice(type_to_arrow_builder_t<Ty>& builder, const Ty& ty,
     }
     for (auto field = 0; field < builder.num_fields(); ++field) {
       TRY(append_array_slice(*builder.field_builder(field),
-                             ty.field(field).type, *array.field(field),
-                             begin + array.offset(), count));
+                             ty.field(field).type, *array.field(field), begin,
+                             count));
     }
   } else if constexpr (std::same_as<Ty, list_type>) {
     for (auto row = begin; row < end; ++row) {

--- a/libtenzir/test/arrow_table_slice.cpp
+++ b/libtenzir/test/arrow_table_slice.cpp
@@ -53,4 +53,87 @@ TEST("record batch from struct array preserves row nulls") {
   CHECK(b->IsNull(1));
 }
 
+TEST("record batch from struct array preserves offsets") {
+  auto int_builder = arrow::Int64Builder{arrow_memory_pool()};
+  tenzir::check(int_builder.Append(int64_t{42}));
+  tenzir::check(int_builder.Append(int64_t{1337}));
+  auto ints = finish(int_builder);
+  auto string_builder = arrow::StringBuilder{arrow_memory_pool()};
+  tenzir::check(string_builder.Append("skip"));
+  tenzir::check(string_builder.Append("keep"));
+  auto strings = finish(string_builder);
+  auto fields = arrow::FieldVector{
+    arrow::field("a", arrow::int64()),
+    arrow::field("b", arrow::utf8()),
+  };
+  auto struct_array
+    = make_struct_array(2, nullptr, fields, arrow::ArrayVector{ints, strings});
+  auto sliced = std::dynamic_pointer_cast<arrow::StructArray>(
+    struct_array->Slice(int64_t{1}, int64_t{1}));
+  REQUIRE(sliced);
+  auto batch = record_batch_from_struct_array(arrow::schema(fields), sliced);
+  REQUIRE(batch);
+  auto a
+    = std::dynamic_pointer_cast<arrow::Int64Array>(batch->GetColumnByName("a"));
+  auto b = std::dynamic_pointer_cast<arrow::StringArray>(
+    batch->GetColumnByName("b"));
+  REQUIRE(a);
+  REQUIRE(b);
+  CHECK_EQUAL(a->length(), int64_t{1});
+  CHECK_EQUAL(b->length(), int64_t{1});
+  CHECK(not a->IsNull(0));
+  CHECK(not b->IsNull(0));
+  CHECK_EQUAL(a->Value(0), int64_t{1337});
+  CHECK_EQUAL(b->GetString(0), "keep");
+}
+
+TEST("transform columns preserves offsets and row nulls") {
+  auto int_builder = arrow::Int64Builder{arrow_memory_pool()};
+  tenzir::check(int_builder.Append(int64_t{42}));
+  tenzir::check(int_builder.Append(int64_t{1337}));
+  auto ints = finish(int_builder);
+  auto string_builder = arrow::StringBuilder{arrow_memory_pool()};
+  tenzir::check(string_builder.Append("leak"));
+  tenzir::check(string_builder.Append("keep"));
+  auto strings = finish(string_builder);
+  auto bitmap = tenzir::check(arrow::AllocateBitmap(2, arrow_memory_pool()));
+  std::memset(bitmap->mutable_data(), 0, bitmap->size());
+  arrow::bit_util::SetBit(bitmap->mutable_data(), 1);
+  auto fields = arrow::FieldVector{
+    arrow::field("a", arrow::int64()),
+    arrow::field("b", arrow::utf8()),
+  };
+  auto schema
+    = type{"test", record_type{{"a", int64_type{}}, {"b", string_type{}}}};
+  auto struct_array = make_struct_array(2, bitmap, fields, {ints, strings});
+  auto batch
+    = record_batch_from_struct_array(schema.to_arrow_schema(), struct_array);
+  auto slice = table_slice{batch, schema};
+  auto sliced = subslice(slice, 1, 2);
+  auto transformed = transform_columns(
+    sliced, std::vector<indexed_transformation>{{
+              .index = {0},
+              .fun =
+                [](struct record_type::field field,
+                   std::shared_ptr<arrow::Array> array) {
+                  return indexed_transformation::result_type{
+                    {std::move(field), std::move(array)}};
+                },
+            }});
+  auto transformed_batch = to_record_batch(transformed);
+  REQUIRE(transformed_batch);
+  auto a = std::dynamic_pointer_cast<arrow::Int64Array>(
+    transformed_batch->GetColumnByName("a"));
+  auto b = std::dynamic_pointer_cast<arrow::StringArray>(
+    transformed_batch->GetColumnByName("b"));
+  REQUIRE(a);
+  REQUIRE(b);
+  CHECK_EQUAL(a->length(), int64_t{1});
+  CHECK_EQUAL(b->length(), int64_t{1});
+  CHECK(not a->IsNull(0));
+  CHECK(not b->IsNull(0));
+  CHECK_EQUAL(a->Value(0), int64_t{1337});
+  CHECK_EQUAL(b->GetString(0), "keep");
+}
+
 } // namespace tenzir


### PR DESCRIPTION
Potential fix for TNZ-445

I've let agents loose on "Rebuilder is setting fields to null" problem and so far they came up with 3 fixes:

- Fix A: append_array_slice offset (wrong)
- Fix B: record_batch_from_struct_array (does not fix it, but removes a footgun)
- Fix C: transform_columns (does not fix it, an unrelated improvement)