### PR TITLE
Replace uses of `arrow::RecordBatch::Make`

### DIFF
--- a/libtenzir/builtins/formats/feather.cpp
+++ b/libtenzir/builtins/formats/feather.cpp
@@ -82,13 +82,11 @@ auto derive_import_time(const std::shared_ptr<arrow::Array>& time_col) {
 /// schema the input record batch is copied to the newly created record batch.
 auto unwrap_record_batch(const std::shared_ptr<arrow::RecordBatch>& rb)
   -> std::shared_ptr<arrow::RecordBatch> {
-  auto event_col = std::dynamic_pointer_cast<arrow::StructArray>(
-    rb->GetColumnByName("event"));
-  TENZIR_ASSERT(event_col);
+  const auto& event_col = as<arrow::StructArray>(*rb->GetColumnByName("event"));
   auto schema_metadata = rb->schema()->GetFieldByName("event")->metadata();
   auto event_schema
-    = arrow::schema(event_col->type()->fields(), std::move(schema_metadata));
-  return record_batch_from_struct_array(event_schema, event_col);
+    = arrow::schema(event_col.type()->fields(), std::move(schema_metadata));
+  return record_batch_from_struct_array(std::move(event_schema), event_col);
 }
 
 /// Create a constant column for the given import time with `rows` rows

--- a/libtenzir/builtins/operators/decapsulate.cpp
+++ b/libtenzir/builtins/operators/decapsulate.cpp
@@ -390,10 +390,8 @@ public:
         co_yield {};
         continue;
       }
-      auto* ptr = try_as<arrow::StructArray>(&*s->array);
-      TENZIR_ASSERT(ptr);
-      auto batch = arrow::RecordBatch::Make(s->type.to_arrow_schema(),
-                                            s->length(), ptr->fields());
+      auto batch = record_batch_from_struct_array(
+        s->type.to_arrow_schema(), as<arrow::StructArray>(*s->array));
       co_yield table_slice{batch, s->type};
     }
   }

--- a/libtenzir/builtins/operators/from_to_2.cpp
+++ b/libtenzir/builtins/operators/from_to_2.cpp
@@ -67,7 +67,7 @@ public:
       TENZIR_ASSERT(cast);
       auto schema = tenzir::type{"tenzir.from", cast->type};
       co_yield table_slice{
-        record_batch_from_struct_array(schema.to_arrow_schema(), cast->array),
+        record_batch_from_struct_array(schema.to_arrow_schema(), *cast->array),
         schema};
     }
   }
@@ -119,7 +119,7 @@ public:
     TENZIR_ASSERT(cast);
     auto schema = tenzir::type{"tenzir.from", cast->type};
     auto slice = table_slice{
-      record_batch_from_struct_array(schema.to_arrow_schema(), cast->array),
+      record_batch_from_struct_array(schema.to_arrow_schema(), *cast->array),
       schema};
     read_bytes_counter_.add(slice.approx_bytes());
     co_await push(std::move(slice));

--- a/libtenzir/builtins/operators/ocsf.cpp
+++ b/libtenzir/builtins/operators/ocsf.cpp
@@ -110,10 +110,9 @@ public:
                     std::static_pointer_cast<arrow::Array>(std::move(array))},
              ty, value_path{});
     auto schema = type{name, result.type};
-    auto arrow_schema = schema.to_arrow_schema();
     return table_slice{
-      arrow::RecordBatch::Make(std::move(arrow_schema), result.length(),
-                               as<arrow::StructArray>(*result.array).fields()),
+      record_batch_from_struct_array(schema.to_arrow_schema(),
+                                     as<arrow::StructArray>(*result.array)),
       std::move(schema),
     };
   }
@@ -563,10 +562,9 @@ public:
 
   auto trim(const table_slice& slice, const type& ty) -> table_slice {
     auto result = trim(series{slice}, ty);
-    auto arrow_schema = result.type.to_arrow_schema();
     return table_slice{
-      arrow::RecordBatch::Make(arrow_schema, result.length(),
-                               as<arrow::StructArray>(*result.array).fields()),
+      record_batch_from_struct_array(result.type.to_arrow_schema(),
+                                     as<arrow::StructArray>(*result.array)),
       std::move(result.type),
     };
   }
@@ -973,10 +971,9 @@ public:
 
   auto derive(const table_slice& slice, const type& ty) -> table_slice {
     auto result = derive(series{slice}, ty, value_path{});
-    auto arrow_schema = result.type.to_arrow_schema();
     return table_slice{
-      arrow::RecordBatch::Make(arrow_schema, result.length(),
-                               as<arrow::StructArray>(*result.array).fields()),
+      record_batch_from_struct_array(result.type.to_arrow_schema(),
+                                     as<arrow::StructArray>(*result.array)),
       std::move(result.type),
     };
   }

--- a/libtenzir/builtins/operators/print.cpp
+++ b/libtenzir/builtins/operators/print.cpp
@@ -115,10 +115,8 @@ public:
                       as<record_type>(slice.schema()).key(*target_index)),
           field.type,
         };
-        auto rb = arrow::RecordBatch::Make(
-          field.type.to_arrow_schema(), array->length(),
-          check(static_cast<const arrow::StructArray&>(*array).Flatten(
-            tenzir::arrow_memory_pool())));
+        auto rb = record_batch_from_struct_array(
+          field.type.to_arrow_schema(), as<arrow::StructArray>(*array));
         auto slice = table_slice{rb, field.type};
         auto builder = series_builder{type{string_type{}}};
         for (size_t i = 0; i < slice.rows(); i++) {

--- a/libtenzir/builtins/operators/replace.cpp
+++ b/libtenzir/builtins/operators/replace.cpp
@@ -292,7 +292,7 @@ public:
                                            args_.what.inner);
         co_yield table_slice{
           record_batch_from_struct_array(slice.schema().to_arrow_schema(),
-                                         rs.array),
+                                         *rs.array),
           slice.schema(),
         };
       } else {
@@ -302,7 +302,7 @@ public:
         for (auto& r : rs) {
           auto rty = type{slice.schema().name(), r.type, auto{attrs}};
           co_yield table_slice{
-            record_batch_from_struct_array(rty.to_arrow_schema(), r.array),
+            record_batch_from_struct_array(rty.to_arrow_schema(), *r.array),
             std::move(rty),
           };
         }
@@ -350,7 +350,7 @@ public:
                                          args_.what.inner);
       co_await push(table_slice{
         record_batch_from_struct_array(input.schema().to_arrow_schema(),
-                                       rs.array),
+                                       *rs.array),
         input.schema(),
       });
       co_return;
@@ -361,7 +361,7 @@ public:
     for (auto& r : rs) {
       auto rty = type{input.schema().name(), r.type, auto{attrs}};
       co_await push(table_slice{
-        record_batch_from_struct_array(rty.to_arrow_schema(), r.array),
+        record_batch_from_struct_array(rty.to_arrow_schema(), *r.array),
         std::move(rty),
       });
     }

--- a/libtenzir/builtins/operators/unroll.cpp
+++ b/libtenzir/builtins/operators/unroll.cpp
@@ -9,6 +9,7 @@
 #include <tenzir/arc.hpp>
 #include <tenzir/argument_parser.hpp>
 #include <tenzir/argument_parser2.hpp>
+#include <tenzir/arrow_table_slice.hpp>
 #include <tenzir/arrow_utils.hpp>
 #include <tenzir/bitmap.hpp>
 #include <tenzir/collect.hpp>
@@ -157,8 +158,8 @@ auto finish_unroll_builder(arrow::StructBuilder& builder, const type& result_ty,
     emit_unroll_error(dh, status);
     return {.failed = true};
   }
-  auto batch = arrow::RecordBatch::Make(result_ty.to_arrow_schema(),
-                                        result->length(), result->fields());
+  auto batch
+    = record_batch_from_struct_array(result_ty.to_arrow_schema(), *result);
   return {.slice = table_slice{batch, result_ty}};
 }
 

--- a/libtenzir/builtins/operators/yield.cpp
+++ b/libtenzir/builtins/operators/yield.cpp
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include <tenzir/argument_parser.hpp>
+#include <tenzir/arrow_table_slice.hpp>
 #include <tenzir/arrow_utils.hpp>
 #include <tenzir/pipeline.hpp>
 #include <tenzir/plugin.hpp>
@@ -173,13 +174,10 @@ public:
           detail::narrow<int>(index), tenzir::arrow_memory_pool()));
       }
     }
-    auto record = std::dynamic_pointer_cast<arrow::StructArray>(array);
-    TENZIR_ASSERT(record);
-    auto fields = check(record->Flatten(tenzir::arrow_memory_pool()));
-    auto result
-      = table_slice{arrow::RecordBatch::Make(new_type.to_arrow_schema(),
-                                             array->length(), fields),
-                    new_type};
+    auto result = table_slice{
+      record_batch_from_struct_array(new_type.to_arrow_schema(),
+                                     as<arrow::StructArray>(*array)),
+      new_type};
     TENZIR_ASSERT_EXPENSIVE(to_record_batch(result)->Validate().ok());
     return result;
   }

--- a/libtenzir/include/tenzir/arrow_table_slice.hpp
+++ b/libtenzir/include/tenzir/arrow_table_slice.hpp
@@ -198,9 +198,8 @@ transform_columns(const table_slice& slice,
 ///
 /// If the struct array has row-level nulls, they are flattened into the child
 /// arrays so the resulting record batch preserves the same semantics.
-auto record_batch_from_struct_array(
-  const std::shared_ptr<arrow::Schema>& schema,
-  const std::shared_ptr<arrow::StructArray>& array)
+auto record_batch_from_struct_array(std::shared_ptr<arrow::Schema> schema,
+                                    const arrow::StructArray& array)
   -> std::shared_ptr<arrow::RecordBatch>;
 
 /// Remove all unspecified columns from both a Tenzir schema and an Arrow record

--- a/libtenzir/include/tenzir/replace_columns.hpp
+++ b/libtenzir/include/tenzir/replace_columns.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "tenzir/arrow_table_slice.hpp"
 #include "tenzir/collect.hpp"
 #include "tenzir/detail/enum.hpp"
 #include "tenzir/series.hpp"
@@ -197,11 +198,9 @@ auto replace(const table_slice& slice, F transform,
   auto attrs = std::vector<tenzir::type::attribute_view>{};
   auto transformed_type = transformed->type;
   transformed_type.assign_metadata(slice.schema());
-  auto& transformed_array = as<arrow::StructArray>(*transformed->array);
-  auto output_batch
-    = arrow::RecordBatch::Make(transformed_type.to_arrow_schema(),
-                               transformed_array.length(),
-                               transformed_array.fields());
+  auto output_batch = record_batch_from_struct_array(
+    transformed_type.to_arrow_schema(),
+    as<arrow::StructArray>(*transformed->array));
   auto result = table_slice{output_batch, std::move(transformed_type)};
   result.offset(slice.offset());
   result.import_time(slice.import_time());

--- a/libtenzir/src/arrow_table_slice.cpp
+++ b/libtenzir/src/arrow_table_slice.cpp
@@ -662,19 +662,15 @@ transform_columns(type schema,
   };
 }
 
-auto record_batch_from_struct_array(
-  const std::shared_ptr<arrow::Schema>& schema,
-  const std::shared_ptr<arrow::StructArray>& array)
+auto record_batch_from_struct_array(std::shared_ptr<arrow::Schema> schema,
+                                    const arrow::StructArray& array)
   -> std::shared_ptr<arrow::RecordBatch> {
   TENZIR_ASSERT(schema);
-  TENZIR_ASSERT(array);
-  auto columns = arrow::ArrayVector{};
-  if (array->null_count() > 0) {
-    columns = check(array->Flatten(tenzir::arrow_memory_pool()));
-  } else {
-    columns = array->fields();
-  }
-  return arrow::RecordBatch::Make(schema, array->length(), std::move(columns));
+  auto columns = array.null_count() > 0
+                   ? check(array.Flatten(tenzir::arrow_memory_pool()))
+                   : array.fields();
+  return arrow::RecordBatch::Make(std::move(schema), array.length(),
+                                  std::move(columns));
 }
 
 table_slice
@@ -697,7 +693,7 @@ transform_columns(const table_slice& slice,
     return {};
   }
   auto output_batch = record_batch_from_struct_array(
-    output_schema.to_arrow_schema(), output_struct_array);
+    output_schema.to_arrow_schema(), *output_struct_array);
   auto result = table_slice{output_batch, std::move(output_schema)};
   result.offset(slice.offset());
   result.import_time(slice.import_time());

--- a/libtenzir/src/cast.cpp
+++ b/libtenzir/src/cast.cpp
@@ -27,7 +27,7 @@ auto cast(table_slice from_slice, const type& to_schema) -> table_slice {
       as<record_type>(from_slice.schema()), from_struct_array,
       as<record_type>(to_schema));
   const auto to_batch = record_batch_from_struct_array(
-    to_schema.to_arrow_schema(), to_struct_array);
+    to_schema.to_arrow_schema(), *to_struct_array);
   auto result = table_slice{to_batch, to_schema};
   result.offset(from_slice.offset());
   result.import_time(from_slice.import_time());

--- a/libtenzir/src/multi_series_builder.cpp
+++ b/libtenzir/src/multi_series_builder.cpp
@@ -444,10 +444,9 @@ auto series_to_table_slice(series array, std::string_view fallback_name)
   if (array.type.name().empty()) {
     array.type = tenzir::type{fallback_name, array.type};
   }
-  auto cast = std::dynamic_pointer_cast<arrow::StructArray>(array.array);
-  TENZIR_ASSERT(cast);
   auto arrow_schema = array.type.to_arrow_schema();
-  auto batch = record_batch_from_struct_array(std::move(arrow_schema), cast);
+  auto batch = record_batch_from_struct_array(
+    std::move(arrow_schema), as<arrow::StructArray>(*array.array));
   TENZIR_ASSERT(batch);
   TENZIR_ASSERT_EXPENSIVE(batch->Validate().ok());
   return table_slice{std::move(batch), std::move(array.type)};

--- a/libtenzir/src/plugin.cpp
+++ b/libtenzir/src/plugin.cpp
@@ -586,9 +586,8 @@ auto plugin_parser::parse_strings(std::shared_ptr<arrow::StringArray> input,
     TENZIR_ASSERT(null_builder->AppendNull().ok());
     auto null_array = std::shared_ptr<arrow::StructArray>{};
     TENZIR_ASSERT(null_builder->Finish(&null_array).ok());
-    auto null_batch = arrow::RecordBatch::Make(
-      last.schema().to_arrow_schema(), 1,
-      check(null_array->Flatten(tenzir::arrow_memory_pool())));
+    auto null_batch = record_batch_from_struct_array(
+      last.schema().to_arrow_schema(), *null_array);
     last
       = concatenate({std::move(last), table_slice{null_batch, last.schema()}});
   };

--- a/libtenzir/src/series_builder.cpp
+++ b/libtenzir/src/series_builder.cpp
@@ -1477,10 +1477,9 @@ auto series_builder::finish_as_table_slice(std::string_view name)
       // which creates potential for confusion.
       array.type = tenzir::type{"tenzir.unknown", array.type};
     }
-    auto cast = std::dynamic_pointer_cast<arrow::StructArray>(array.array);
-    TENZIR_ASSERT(cast);
     auto arrow_schema = array.type.to_arrow_schema();
-    auto batch = record_batch_from_struct_array(std::move(arrow_schema), cast);
+    auto batch = record_batch_from_struct_array(
+      std::move(arrow_schema), as<arrow::StructArray>(*array.array));
     TENZIR_ASSERT(batch);
 #if TENZIR_ENABLE_ASSERTIONS
     const auto v = batch->Validate();

--- a/libtenzir/src/table_slice.cpp
+++ b/libtenzir/src/table_slice.cpp
@@ -943,7 +943,7 @@ table_slice concatenate(std::vector<table_slice> slices) {
     return {};
   }
   const auto array = finish(*builder);
-  auto batch = record_batch_from_struct_array(std::move(arrow_schema), array);
+  auto batch = record_batch_from_struct_array(std::move(arrow_schema), *array);
   auto result = table_slice{batch, schema};
   result.offset(slices[0].offset());
   result.import_time(slices[0].import_time());
@@ -1210,7 +1210,7 @@ auto partition(const table_slice& slice, const arrow::BooleanArray& mask)
       return {};
     }
     auto array = finish(builder);
-    auto result_batch = record_batch_from_struct_array(arrow_schema, array);
+    auto result_batch = record_batch_from_struct_array(arrow_schema, *array);
     auto result = table_slice{result_batch, schema};
     result.offset(slice.offset());
     result.import_time(slice.import_time());
@@ -1721,8 +1721,8 @@ auto flatten(table_slice slice, std::string_view separator) -> flatten_result {
   if (not schema) {
     return {};
   }
-  auto batch = arrow::RecordBatch::Make(
-    schema.to_arrow_schema(), transformed->length(), transformed->fields());
+  auto batch
+    = record_batch_from_struct_array(schema.to_arrow_schema(), *transformed);
   auto result = table_slice{batch, std::move(schema)};
   result.offset(slice.offset());
   result.import_time(slice.import_time());
@@ -1894,10 +1894,10 @@ auto unflatten(const table_slice& slice, std::string_view sep) -> table_slice {
   }
   auto array = check(to_record_batch(slice)->ToStructArray());
   auto result = unflatten(array, sep);
-  auto cast = std::dynamic_pointer_cast<arrow::StructArray>(std::move(result));
-  TENZIR_ASSERT(cast);
-  auto schema = type{slice.schema().name(), type::from_arrow(*cast->type())};
-  auto batch = record_batch_from_struct_array(schema.to_arrow_schema(), cast);
+  auto schema = type{slice.schema().name(),
+                     type::from_arrow(*as<arrow::StructArray>(*result).type())};
+  auto batch = record_batch_from_struct_array(schema.to_arrow_schema(),
+                                              as<arrow::StructArray>(*result));
   auto out = table_slice{batch, std::move(schema)};
   out.import_time(slice.import_time());
   out.offset(slice.offset());

--- a/libtenzir/src/tql2/set.cpp
+++ b/libtenzir/src/tql2/set.cpp
@@ -281,8 +281,8 @@ auto assign(const ast::field_path& left, series right, const table_slice& input,
   auto schema = arrow::schema(result.array->type()->fields(),
                               to_record_batch(input)->schema()->metadata());
   auto slice = table_slice{
-    arrow::RecordBatch::Make(std::move(schema), result.length(),
-                             as<arrow::StructArray>(*result.array).fields()),
+    record_batch_from_struct_array(std::move(schema),
+                                   as<arrow::StructArray>(*result.array)),
     std::move(result.type),
   };
   slice.import_time(input.import_time());

--- a/libtenzir/test/arrow_table_slice.cpp
+++ b/libtenzir/test/arrow_table_slice.cpp
@@ -37,7 +37,7 @@ TEST("record batch from struct array preserves row nulls") {
   };
   auto struct_array = make_struct_array(2, bitmap, fields, {ints, strings});
   auto batch
-    = record_batch_from_struct_array(arrow::schema(fields), struct_array);
+    = record_batch_from_struct_array(arrow::schema(fields), *struct_array);
   REQUIRE(batch);
   auto a
     = std::dynamic_pointer_cast<arrow::Int64Array>(batch->GetColumnByName("a"));

--- a/libtenzir/test/sort_function.cpp
+++ b/libtenzir/test/sort_function.cpp
@@ -6,6 +6,7 @@
 // SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+#include "tenzir/arrow_table_slice.hpp"
 #include "tenzir/arrow_utils.hpp"
 #include "tenzir/data.hpp"
 #include "tenzir/table_slice.hpp"
@@ -14,8 +15,6 @@
 #include "tenzir/tql2/parser.hpp"
 #include "tenzir/tql2/resolve.hpp"
 
-#include <arrow/record_batch.h>
-
 using namespace tenzir;
 
 namespace {
@@ -23,10 +22,9 @@ namespace {
 auto make_input_slice(data row) -> table_slice {
   auto row_series = data_to_series(row, int64_t{1});
   auto schema = type{"input", as<record_type>(row_series.type)};
-  const auto& row_array = as<arrow::StructArray>(*row_series.array);
   return table_slice{
-    arrow::RecordBatch::Make(schema.to_arrow_schema(), int64_t{1},
-                             row_array.fields()),
+    record_batch_from_struct_array(schema.to_arrow_schema(),
+                                   as<arrow::StructArray>(*row_series.array)),
     std::move(schema),
   };
 }


### PR DESCRIPTION
It's contextually possible to miss-use the arrow function as you may
accidentally drop the struct arrays null-bitmap.

I simply replaced every usage that originated from a struct array, even ones in dead code.

I checked all remaining use sites, and they are not starting from a struct array, or the struct array they are starting from was created from a table slice, so we have a non-null guarantee to begin with.