### PR TITLE
Merge mixed integer type columns in `series_builder`

### DIFF
--- a/changelog/unreleased/lossless-int64uint64-merging-during-parsing.md
+++ b/changelog/unreleased/lossless-int64uint64-merging-during-parsing.md
@@ -1,0 +1,14 @@
+---
+title: Lossless int64/uint64 merging during parsing
+type: change
+authors:
+  - IyeOnline
+  - claude
+created: 2026-05-05T16:34:33.815786Z
+---
+
+Parsing data that mixes `int64` and `uint64` values in the same field no longer
+produces unnecessary table-slice splits, improving batching performance. Fields
+like `flow_id` that are always non-negative but occasionally exceed the signed
+integer limit of  `2^63 − 1` are now merged into a single `uint64` column where
+possible, instead of being emitted as separate slices.

--- a/libtenzir/src/series_builder.cpp
+++ b/libtenzir/src/series_builder.cpp
@@ -632,6 +632,11 @@ public:
   }
 
   void append(view_type value) {
+    if constexpr (std::signed_integral<value_type>) {
+      if (value < 0) {
+        all_non_negative_ = false;
+      }
+    }
     check(append_builder(type_, *inner_, value));
   }
 
@@ -639,9 +644,16 @@ public:
     return inner_->null_count() == inner_->length();
   }
 
+  auto all_non_negative() const -> bool
+    requires std::signed_integral<value_type>
+  {
+    return all_non_negative_;
+  }
+
 private:
   std::shared_ptr<builder_type> inner_;
   T type_;
+  bool all_non_negative_ = true;
 };
 
 template <>
@@ -978,7 +990,19 @@ void dynamic_builder::atom(detail::atom_view value) {
                                "builder");
         }
       } else {
-        prepare<atom_view_to_type_t<decltype(value)>>()->append(value);
+        using atom_type = atom_view_to_type_t<decltype(value)>;
+        // Non-negative int64 values are compatible with an existing uint64
+        // builder: cast and append directly to avoid a pointless flush.
+        if constexpr (std::same_as<atom_type, int64_type>) {
+          if (value >= 0) {
+            if (auto* uint_b
+                = dynamic_cast<typed_builder<uint64_type>*>(builder_.get())) {
+              uint_b->append(static_cast<uint64_t>(value));
+              return;
+            }
+          }
+        }
+        prepare<atom_type>()->append(value);
       }
     },
     value);
@@ -1013,6 +1037,27 @@ auto dynamic_builder::prepare() -> detail::typed_builder<Type>* {
     // This builder is in conflict mode because the current event contains a
     // type conflict.
     return cast->prepare<Type>();
+  }
+  // Lossless int64 → uint64 upgrade: if all stored values are non-negative,
+  // migrate to a uint64 builder instead of flushing.
+  if constexpr (std::same_as<Type, uint64_type>) {
+    if (auto* int_b
+        = dynamic_cast<typed_builder<int64_type>*>(builder_.get())) {
+      if (int_b->all_non_negative()) {
+        auto array = int_b->finish(); // guaranteed no negatives
+        builder_ = std::make_unique<typed_builder<uint64_type>>(root_);
+        auto* tgt = static_cast<typed_builder<uint64_type>*>(builder_.get());
+        for (int64_t i = 0; i < array->length(); ++i) {
+          if (array->IsNull(i)) {
+            tgt->resize(tgt->length() + 1);
+          } else {
+            tgt->append(static_cast<uint64_t>(array->Value(i)));
+          }
+        }
+        return prepare<Type>(); // hits the "already correct type" branch
+      }
+      // all_non_negative_ == false: fall through to finish_previous_events
+    }
   }
   // Otherwise, there is a type conflict. There are three cases to consider:
   //
@@ -1099,6 +1144,20 @@ void detail::field_ref::atom(detail::atom_view value) {
         builder->resize(origin_->length_ - 1);
         builder->atom(value);
       } else {
+        using atom_type = atom_view_to_type_t<decltype(value)>;
+        // Non-negative int64 values are compatible with an existing uint64
+        // field: resize and append directly to avoid a pointless flush.
+        if constexpr (std::same_as<atom_type, int64_type>) {
+          if (value >= 0) {
+            if (auto* field = builder()) {
+              if (field->kind().template is<uint64_type>()) {
+                field->resize(origin_->length() - 1);
+                field->atom(detail::atom_view{static_cast<uint64_t>(value)});
+                return;
+              }
+            }
+          }
+        }
         origin_->prepare<atom_type>(name_)->append(value);
       }
     },

--- a/libtenzir/test/series_builder.cpp
+++ b/libtenzir/test/series_builder.cpp
@@ -474,6 +474,94 @@ TEST("playground") {
   ])"}});
 }
 
+TEST("uint64 record field accepts non-negative int64 without flush") {
+  auto b = series_builder{};
+  b.record().field("x").data(uint64_t{1});
+  b.record().field("x").data(uint64_t{2});
+  b.record().field("x").data(int64_t{3});
+  finish_and_check(b, {{3, R"(struct<x: uint64>)", R"(-- is_valid: all not null
+-- child 0 type: uint64
+  [
+    1,
+    2,
+    3
+  ])"}});
+}
+
+TEST("uint64 record field flushes on negative int64") {
+  auto b = series_builder{};
+  b.record().field("x").data(uint64_t{1});
+  b.record().field("x").data(uint64_t{2});
+  b.record().field("x").data(int64_t{-3});
+  finish_and_check(b, {{2, R"(struct<x: uint64>)", R"(-- is_valid: all not null
+-- child 0 type: uint64
+  [
+    1,
+    2
+  ])"},
+                       {1, R"(struct<x: int64>)", R"(-- is_valid: all not null
+-- child 0 type: int64
+  [
+    -3
+  ])"}});
+}
+
+TEST("uint64 builder accepts non-negative int64 without flush") {
+  auto b = series_builder{};
+  b.data(uint64_t{1});
+  b.data(uint64_t{2});
+  b.data(uint64_t{3});
+  b.data(int64_t{4});
+  finish_and_check(b, {{4, "uint64", R"([
+  1,
+  2,
+  3,
+  4
+])"}});
+}
+
+TEST("uint64 builder flushes on negative int64") {
+  auto b = series_builder{};
+  b.data(uint64_t{1});
+  b.data(uint64_t{2});
+  b.data(int64_t{-3});
+  finish_and_check(b, {{2, "uint64", R"([
+  1,
+  2
+])"},
+                       {1, "int64", R"([
+  -3
+])"}});
+}
+
+TEST("int64 to uint64 upgrade when all non-negative") {
+  auto b = series_builder{};
+  b.data(int64_t{1});
+  b.data(int64_t{2});
+  b.data(int64_t{3});
+  b.data(uint64_t{4});
+  finish_and_check(b, {{4, "uint64", R"([
+  1,
+  2,
+  3,
+  4
+])"}});
+}
+
+TEST("int64 to uint64 keeps int64 when negative values present") {
+  auto b = series_builder{};
+  b.data(int64_t{-1});
+  b.data(int64_t{2});
+  b.data(uint64_t{4});
+  finish_and_check(b, {{2, "int64", R"([
+  -1,
+  2
+])"},
+                       {1, "uint64", R"([
+  4
+])"}});
+}
+
 } // namespace
 
 } // namespace tenzir


### PR DESCRIPTION
The series builder performs conflict resolution by cutting batches on a
type miss-match between rows. This included a change between a signed and
an unsigned integer.

Such changes can happen very often for fields like `flow_id`, which by
it's nature uses the entire uint64 value range. Our parsers, as well as
external libraries (simdjson) however prefer treating any number as signed
unless it is greater than 2^63-1. This means that a `flow_id` column will
almost alternating types, which completely breaks batching.

The resolution employed here consists of two parts:

* When adding an unsigned value to a signed column, change the column to
  unsigned, if all values are non-negative.
* When adding a signed value to an unsigned column, add it as unsigned if
  it is not negative.
