### PR TITLE
Add missing I/O byte metrics

### DIFF
--- a/libtenzir/builtins/operators/from_ftp.cpp
+++ b/libtenzir/builtins/operators/from_ftp.cpp
@@ -11,6 +11,7 @@
 #include <tenzir/async/curl.hpp>
 #include <tenzir/co_match.hpp>
 #include <tenzir/operator_plugin.hpp>
+#include <tenzir/pipeline_metrics.hpp>
 #include <tenzir/plugin/register.hpp>
 #include <tenzir/secret_resolution.hpp>
 #include <tenzir/substitute_ctx.hpp>
@@ -118,6 +119,9 @@ public:
       lifecycle_ = Lifecycle::done;
       co_return;
     }
+    bytes_read_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "from_ftp"},
+                         MetricsDirection::read, MetricsVisibility::external_);
     download_.emplace(session_->start_download(download_buffer_capacity));
     co_await ctx.spawn_sub<chunk_ptr>(caf::none, std::move(pipeline));
     co_return;
@@ -155,6 +159,7 @@ public:
           lifecycle_ = Lifecycle::done;
           co_return;
         }
+        const auto bytes = event.chunk->size();
         auto& parser = as<SubHandle<chunk_ptr>>(*sub);
         auto push_result = co_await parser.push(std::move(event.chunk));
         if (push_result.is_err()) {
@@ -162,6 +167,10 @@ public:
             download_->abort();
           }
           lifecycle_ = Lifecycle::done;
+          co_return;
+        }
+        if (bytes > 0) {
+          bytes_read_counter_.add(bytes);
         }
       },
       [&](CurlDownloadFailed failure) -> Task<void> {
@@ -232,6 +241,7 @@ private:
 
   Option<CurlSession> session_;
   Option<CurlDownloadTransfer> download_;
+  MetricsCounter bytes_read_counter_;
   FromFtpArgs args_;
   std::string resolved_url_;
   Lifecycle lifecycle_ = Lifecycle::running;

--- a/libtenzir/builtins/operators/from_mysql.cpp
+++ b/libtenzir/builtins/operators/from_mysql.cpp
@@ -14,6 +14,7 @@
 #include <tenzir/concept/parseable/numeric/real.hpp>
 #include <tenzir/detail/byteswap.hpp>
 #include <tenzir/operator_plugin.hpp>
+#include <tenzir/pipeline_metrics.hpp>
 #include <tenzir/plugin.hpp>
 #include <tenzir/series_builder.hpp>
 #include <tenzir/tls_options.hpp>
@@ -654,14 +655,14 @@ public:
   async_connection() = default;
 
   /// Connect to MySQL server asynchronously.
-  static auto
-  connect(folly::EventBase* evb, std::string const& host, uint16_t port,
-          std::chrono::milliseconds timeout = std::chrono::seconds{30})
-    -> Task<async_connection> {
+  static auto connect(folly::EventBase* evb, std::string const& host,
+                      uint16_t port, MetricsCounter bytes_read_counter,
+                      std::chrono::milliseconds timeout
+                      = std::chrono::seconds{30}) -> Task<async_connection> {
     auto addr = folly::SocketAddress{host, port};
     auto transport = co_await co_withExecutor(
       evb, folly::coro::Transport::newConnectedSocket(evb, addr, timeout));
-    co_return async_connection{std::move(transport), evb};
+    co_return async_connection{std::move(transport), evb, bytes_read_counter};
   }
 
   /// Read a MySQL packet asynchronously.
@@ -685,6 +686,7 @@ public:
             reinterpret_cast<unsigned char*>(payload.data()) + offset, len},
           "payload"));
       }
+      bytes_read_counter_.add(header.size() + len);
       if (len < max_packet_size) {
         break;
       }
@@ -1000,14 +1002,18 @@ private:
   }
 
   explicit async_connection(folly::coro::Transport transport,
-                            folly::EventBase* evb)
-    : transport_{std::in_place, std::move(transport)}, evb_{evb} {
+                            folly::EventBase* evb,
+                            MetricsCounter bytes_read_counter)
+    : transport_{std::in_place, std::move(transport)},
+      evb_{evb},
+      bytes_read_counter_{bytes_read_counter} {
   }
 
   Box<folly::coro::Transport> transport_;
   folly::EventBase* evb_ = nullptr;
   std::chrono::milliseconds read_timeout_{std::chrono::seconds{30}};
   uint8_t sequence_id_ = 0;
+  MetricsCounter bytes_read_counter_;
   bool is_tls_ = false;
 };
 
@@ -1485,11 +1491,13 @@ void parse_row_into_builder(std::span<std::byte const> data,
 class async_client {
 public:
   /// Connect to MySQL server asynchronously.
-  static auto make(folly::EventBase* evb, client_config config)
+  static auto make(folly::EventBase* evb, client_config config,
+                   MetricsCounter bytes_read_counter)
     -> Task<MysqlResult<Box<async_client>>> {
     auto conn = async_connection{};
     try {
-      conn = co_await async_connection::connect(evb, config.host, config.port);
+      conn = co_await async_connection::connect(evb, config.host, config.port,
+                                                bytes_read_counter);
     } catch (folly::AsyncSocketException const& e) {
       co_return Err{
         mysql_error{0, fmt::format("connect failed: {}", e.what())}};
@@ -2131,8 +2139,12 @@ public:
     // Use the global IO executor's EventBase for async socket I/O.
     auto* evb = folly::getGlobalIOExecutor()->getEventBase();
     auto const tls_enabled = config.ssl_context != nullptr;
+    bytes_read_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "from_mysql"},
+                         MetricsDirection::read, MetricsVisibility::external_);
     // Connect asynchronously.
-    auto result = co_await async_client::make(evb, std::move(config));
+    auto result = co_await async_client::make(evb, std::move(config),
+                                              bytes_read_counter_);
     if (result.is_err()) {
       auto err = std::move(result).unwrap_err();
       auto diag
@@ -2242,6 +2254,7 @@ private:
   FromMySQLArgs args_;
   Box<async_client> client_;
   bool has_client_ = false;
+  MetricsCounter bytes_read_counter_;
   std::string query_;
   std::string schema_name_;
   std::string table_name_;

--- a/libtenzir/builtins/operators/from_stdin.cpp
+++ b/libtenzir/builtins/operators/from_stdin.cpp
@@ -11,6 +11,7 @@
 #include "tenzir/async/notify.hpp"
 #include "tenzir/chunk.hpp"
 #include "tenzir/operator_plugin.hpp"
+#include "tenzir/pipeline_metrics.hpp"
 #include "tenzir/plugin/register.hpp"
 #include "tenzir/substitute_ctx.hpp"
 
@@ -99,6 +100,9 @@ public:
       done_ = true;
       co_return;
     }
+    bytes_read_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "from_stdin"},
+                         MetricsDirection::read, MetricsVisibility::external_);
     co_await ctx.spawn_sub<chunk_ptr>(caf::none, std::move(pipe));
     ctx.spawn_task(folly::coro::co_withExecutor(
       ctx.io_executor(), read_stdin(chunk_queue_, ctx.dh())));
@@ -136,11 +140,15 @@ public:
       stdin_closed_ = true;
       co_return;
     }
+    const auto bytes = chunk->size();
     auto& pipeline = as<SubHandle<chunk_ptr>>(*sub);
     auto push_result = co_await pipeline.push(std::move(chunk));
     if (push_result.is_err()) {
       done_ = true;
       co_return;
+    }
+    if (bytes > 0) {
+      bytes_read_counter_.add(bytes);
     }
   }
 
@@ -239,6 +247,7 @@ private:
   FromStdinArgs args_;
   bool done_ = false;
   bool stdin_closed_ = false;
+  MetricsCounter bytes_read_counter_;
   mutable std::shared_ptr<Notify> sub_finished_ = std::make_shared<Notify>();
   mutable std::shared_ptr<ChunkQueue> chunk_queue_
     = std::make_shared<ChunkQueue>(queue_capacity);

--- a/libtenzir/builtins/operators/to_ftp.cpp
+++ b/libtenzir/builtins/operators/to_ftp.cpp
@@ -11,6 +11,7 @@
 #include <tenzir/async/curl.hpp>
 #include <tenzir/co_match.hpp>
 #include <tenzir/operator_plugin.hpp>
+#include <tenzir/pipeline_metrics.hpp>
 #include <tenzir/plugin/register.hpp>
 #include <tenzir/secret_resolution.hpp>
 #include <tenzir/substitute_ctx.hpp>
@@ -134,6 +135,9 @@ public:
       lifecycle_ = Lifecycle::done;
       co_return;
     }
+    bytes_write_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "to_ftp"},
+                         MetricsDirection::write, MetricsVisibility::external_);
     auto code = easy.set([](std::span<const std::byte>) {});
     if (code != curl::easy::code::ok) {
       diagnostic::error("failed to configure FTP upload")
@@ -265,8 +269,10 @@ private:
           if (not accepting_chunks) {
             co_return false;
           }
+          const auto bytes = message.chunk->size();
           if (co_await upload.push(std::move(message.chunk))) {
             uploaded_anything = true;
+            bytes_write_counter_.add(bytes);
             co_return false;
           }
           accepting_chunks = false;
@@ -332,6 +338,7 @@ private:
   };
   ToFtpArgs args_;
   std::string resolved_url_;
+  MetricsCounter bytes_write_counter_;
   Lifecycle lifecycle_ = Lifecycle::running;
 };
 

--- a/libtenzir/builtins/operators/to_stdout.cpp
+++ b/libtenzir/builtins/operators/to_stdout.cpp
@@ -11,6 +11,7 @@
 #include <tenzir/compile_ctx.hpp>
 #include <tenzir/detail/posix.hpp>
 #include <tenzir/operator_plugin.hpp>
+#include <tenzir/pipeline_metrics.hpp>
 #include <tenzir/plugin/register.hpp>
 #include <tenzir/session.hpp>
 #include <tenzir/substitute_ctx.hpp>
@@ -160,6 +161,9 @@ public:
       done_ = true;
       co_return;
     }
+    bytes_write_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "to_stdout"},
+                         MetricsDirection::write, MetricsVisibility::external_);
     if (auto error = stdout_nonblocking_.activate()) {
       diagnostic::error("{}", *error).primary(args_.self).emit(ctx);
       done_ = true;
@@ -209,6 +213,7 @@ public:
     if (not chunk or chunk->size() == 0 or not writer_) {
       co_return;
     }
+    const auto bytes = chunk->size();
     auto error = co_await folly::coro::co_withExecutor(
       io_executor_, write_chunk(*writer_, std::move(chunk)));
     if (error) {
@@ -216,6 +221,8 @@ public:
       // Only the first write error matters; blocking here would let concurrent
       // `process_sub()` calls stall behind an already queued error.
       std::ignore = queue_->try_enqueue(std::move(write_error));
+    } else {
+      bytes_write_counter_.add(bytes);
     }
     co_return;
   }
@@ -254,6 +261,7 @@ private:
   // `process_sub()` reports the first stdout write error back to the main
   // loop, which owns the operator lifecycle state.
   mutable Box<ErrorQueue> queue_{std::in_place, error_queue_capacity};
+  MetricsCounter bytes_write_counter_;
   bool done_ = false;
 };
 

--- a/plugins/amqp/builtins/from_amqp.cpp
+++ b/plugins/amqp/builtins/from_amqp.cpp
@@ -12,6 +12,7 @@
 #include <tenzir/co_match.hpp>
 #include <tenzir/concepts.hpp>
 #include <tenzir/operator_plugin.hpp>
+#include <tenzir/pipeline_metrics.hpp>
 #include <tenzir/series_builder.hpp>
 #include <tenzir/tql2/plugin.hpp>
 
@@ -180,6 +181,9 @@ public:
     if (not setup_ok) {
       co_return;
     }
+    bytes_read_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "from_amqp"},
+                         MetricsDirection::read, MetricsVisibility::external_);
     ctx.spawn_task(consume_loop(std::move(engine), queue_));
   }
 
@@ -211,8 +215,12 @@ public:
         if (not msg.chunk) {
           co_return;
         }
+        const auto bytes = msg.chunk->size();
         auto row = builder_.record();
         row.field("message").data(blob{as_bytes(msg.chunk)});
+        if (bytes > 0) {
+          bytes_read_counter_.add(bytes);
+        }
         co_await pusher_.push(builder_.yield_ready(), push);
       },
       [&](AmqpError err) -> Task<void> {
@@ -260,6 +268,7 @@ private:
   series_builder builder_{
     type{"tenzir.amqp", record_type{{"message", blob_type{}}}}};
   SeriesPusher pusher_;
+  MetricsCounter bytes_read_counter_;
 };
 
 class from_amqp_plugin final : public virtual OperatorPlugin {

--- a/plugins/amqp/builtins/to_amqp.cpp
+++ b/plugins/amqp/builtins/to_amqp.cpp
@@ -12,6 +12,7 @@
 #include <tenzir/concept/printable/tenzir/json2.hpp>
 #include <tenzir/concepts.hpp>
 #include <tenzir/operator_plugin.hpp>
+#include <tenzir/pipeline_metrics.hpp>
 #include <tenzir/series_builder.hpp>
 #include <tenzir/tql2/entity_path.hpp>
 #include <tenzir/tql2/eval.hpp>
@@ -170,8 +171,12 @@ public:
       .style = no_style(),
       .oneline = true,
     }};
-    worker_handle_ = ctx.spawn_task(
-      publish_loop(engine_, engine_mutex_, queue_, args_, channel_, dh));
+    bytes_write_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "to_amqp"},
+                         MetricsDirection::write, MetricsVisibility::external_);
+    worker_handle_
+      = ctx.spawn_task(publish_loop(engine_, engine_mutex_, queue_, args_,
+                                    channel_, dh, bytes_write_counter_));
     if (hb_interval > std::chrono::seconds{0}) {
       ctx.spawn_task(heartbeat_loop(engine_, engine_mutex_, hb_interval,
                                     args_.url.source, dh));
@@ -215,8 +220,8 @@ private:
   static auto publish_loop(std::shared_ptr<amqp_engine> engine,
                            std::shared_ptr<std::mutex> engine_mutex,
                            std::shared_ptr<MessageQueue> queue, ToAmqpArgs args,
-                           uint16_t channel, diagnostic_handler& dh)
-    -> Task<void> {
+                           uint16_t channel, diagnostic_handler& dh,
+                           MetricsCounter bytes_write_counter) -> Task<void> {
     auto opts = amqp_engine::publish_options{
       .channel = channel,
       .exchange = args.exchange ? std::string_view{args.exchange->inner}
@@ -255,6 +260,10 @@ private:
               .note("routing key: {}", opts.routing_key)
               .note("{}", err)
               .emit(dh);
+            continue;
+          }
+          if (not bytes.empty()) {
+            bytes_write_counter.add(bytes.size());
           }
         }
       };
@@ -309,6 +318,7 @@ private:
   Option<AsyncHandle<void>> worker_handle_;
   Option<json_printer2> printer_;
   bool is_default_printer_ = false;
+  MetricsCounter bytes_write_counter_;
 };
 
 class to_amqp_plugin final : public virtual OperatorPlugin {

--- a/plugins/clickhouse/builtins/to_clickhouse.cpp
+++ b/plugins/clickhouse/builtins/to_clickhouse.cpp
@@ -12,6 +12,7 @@
 #include "tenzir/atomic.hpp"
 #include "tenzir/detail/weak_run_delayed.hpp"
 #include "tenzir/operator_plugin.hpp"
+#include "tenzir/pipeline_metrics.hpp"
 #include "tenzir/plugin/register.hpp"
 #include "tenzir/tql2/eval.hpp"
 #include "tenzir/tql2/plugin.hpp"
@@ -187,6 +188,7 @@ public:
     std::unordered_map<uuid, table_slice> pending_inserts;
     std::mutex pending_inserts_mutex;
     Atomic<bool> done{false};
+    MetricsCounter bytes_write_counter;
     std::vector<AsyncHandle<void>> worker_handles;
   };
 
@@ -232,6 +234,9 @@ public:
       state_->done.store(true, std::memory_order_release);
       co_return;
     }
+    state_->bytes_write_counter
+      = ctx.make_counter(MetricsLabel{"operator", "to_clickhouse"},
+                         MetricsDirection::write, MetricsVisibility::external_);
     state_->worker_handles.reserve(args_.jobs);
     for (auto i = uint64_t{0}; i < args_.jobs; ++i) {
       auto client = std::shared_ptr<easy_client>{};
@@ -358,6 +363,9 @@ private:
       if (not success) {
         shared_state->done.store(true, std::memory_order_release);
         continue;
+      }
+      if (auto bytes = slice.approx_bytes(); bytes > 0) {
+        shared_state->bytes_write_counter.add(bytes);
       }
       // Remove the slice from the persisted state.
       auto const guard = std::scoped_lock{shared_state->pending_inserts_mutex};

--- a/plugins/from_velociraptor/builtins/from_velociraptor.cpp
+++ b/plugins/from_velociraptor/builtins/from_velociraptor.cpp
@@ -13,6 +13,7 @@
 #include <tenzir/box.hpp>
 #include <tenzir/co_match.hpp>
 #include <tenzir/operator_plugin.hpp>
+#include <tenzir/pipeline_metrics.hpp>
 #include <tenzir/plugin/register.hpp>
 #include <tenzir/tql2/plugin.hpp>
 #include <tenzir/variant.hpp>
@@ -251,6 +252,9 @@ public:
   }
 
   auto start(OpCtx& ctx) -> Task<void> override {
+    bytes_read_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "from_velociraptor"},
+                         MetricsDirection::read, MetricsVisibility::external_);
     auto normalized = normalize_args(args_, ctx);
     TENZIR_ASSERT(normalized);
     auto config = select_client_config(args_, ctx.dh());
@@ -293,6 +297,10 @@ public:
       collect_message(std::move(*next));
     }
     for (auto& response : responses) {
+      const auto bytes = response.ByteSizeLong();
+      if (bytes > 0) {
+        bytes_read_counter_.add(bytes);
+      }
       if (auto slices = parse(response)) {
         for (auto& slice : *slices) {
           co_await push(std::move(slice));
@@ -327,6 +335,7 @@ private:
                                            message_queue_capacity};
   Option<Box<VelociraptorReadReactor>> reactor_;
   bool stream_finished_ = false;
+  MetricsCounter bytes_read_counter_;
 };
 
 class FromVelociraptorPlugin final : public virtual OperatorPlugin {

--- a/plugins/google-cloud-pubsub/builtins/from_plugin.cpp
+++ b/plugins/google-cloud-pubsub/builtins/from_plugin.cpp
@@ -13,6 +13,7 @@
 #include <tenzir/defaults.hpp>
 #include <tenzir/detail/scope_guard.hpp>
 #include <tenzir/operator_plugin.hpp>
+#include <tenzir/pipeline_metrics.hpp>
 #include <tenzir/plugin/register.hpp>
 #include <tenzir/series_builder.hpp>
 #include <tenzir/tql2/plugin.hpp>
@@ -262,7 +263,10 @@ public:
   explicit FromGoogleCloudPubsub(from_args args) : args_{std::move(args)} {
   }
 
-  auto start(OpCtx& /*ctx*/) -> Task<void> override {
+  auto start(OpCtx& ctx) -> Task<void> override {
+    bytes_read_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "from_google_cloud_pubsub"},
+                         MetricsDirection::read, MetricsVisibility::external_);
     auto subscription = pubsub::Subscription(args_.project_id.inner,
                                              args_.subscription_id.inner);
     // Detect whether the subscription has message ordering enabled.
@@ -351,6 +355,9 @@ public:
         ctx.dh(),
       };
       for (const auto& msg : messages) {
+        if (not msg.data.empty()) {
+          bytes_read_counter_.add(msg.data.size());
+        }
         auto event = msb.record();
         event.field("message").data(msg.data);
         if (args_.metadata_field) {
@@ -393,6 +400,7 @@ private:
   bool done_ = false;
   Option<SessionHandle> session_;
   std::shared_ptr<SharedState> shared_ = std::make_shared<SharedState>();
+  MetricsCounter bytes_read_counter_;
 };
 
 } // namespace

--- a/plugins/google-cloud-pubsub/builtins/to_plugin.cpp
+++ b/plugins/google-cloud-pubsub/builtins/to_plugin.cpp
@@ -11,6 +11,7 @@
 #include <tenzir/detail/scope_guard.hpp>
 #include <tenzir/location.hpp>
 #include <tenzir/operator_plugin.hpp>
+#include <tenzir/pipeline_metrics.hpp>
 #include <tenzir/plugin/register.hpp>
 #include <tenzir/tql2/eval.hpp>
 #include <tenzir/tql2/plugin.hpp>
@@ -195,11 +196,18 @@ public:
   using publish_future
     = google::cloud::future<google::cloud::StatusOr<std::string>>;
 
+  struct InflightPublish {
+    publish_future future;
+    size_t bytes = 0;
+  };
+
   explicit ToGoogleCloudPubsub(to_args args) : args_{std::move(args)} {
   }
 
   auto start(OpCtx& ctx) -> Task<void> override {
-    TENZIR_UNUSED(ctx);
+    bytes_write_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "to_google_cloud_pubsub"},
+                         MetricsDirection::write, MetricsVisibility::external_);
     auto topic = pubsub::Topic(args_.project_id.inner, args_.topic_id.inner);
     publisher_.emplace(pubsub::MakePublisherConnection(std::move(topic)));
     co_return;
@@ -221,10 +229,12 @@ public:
                 .emit(dh);
               continue;
             }
-            inflight_.push_back(
-              publisher_->Publish(pubsub::MessageBuilder{}
-                                    .SetData(std::string{array.GetView(i)})
-                                    .Build()));
+            const auto data = array.GetView(i);
+            inflight_.push_back(InflightPublish{
+              .future = publisher_->Publish(
+                pubsub::MessageBuilder{}.SetData(std::string{data}).Build()),
+              .bytes = data.size(),
+            });
           }
         },
         [&](const auto&) {
@@ -236,13 +246,11 @@ public:
         });
     }
     // Prune completed publish futures to prevent unbounded memory growth.
-    while (not inflight_.empty() and inflight_.front().is_ready()) {
-      auto result = inflight_.front().get();
+    while (not inflight_.empty() and inflight_.front().future.is_ready()) {
+      auto publish = std::move(inflight_.front());
       inflight_.pop_front();
-      if (not result) {
-        diagnostic::error("failed to publish: {}", result.status().message())
-          .emit(dh);
-      }
+      auto result = publish.future.get();
+      handle_publish_result(result, publish.bytes, dh);
     }
     co_return;
   }
@@ -257,24 +265,34 @@ public:
   }
 
 private:
+  auto handle_publish_result(google::cloud::StatusOr<std::string>& result,
+                             size_t bytes, diagnostic_handler& dh) -> void {
+    if (not result) {
+      diagnostic::error("failed to publish: {}", result.status().message())
+        .emit(dh);
+      return;
+    }
+    if (bytes > 0) {
+      bytes_write_counter_.add(bytes);
+    }
+  }
+
   auto drain_inflight(diagnostic_handler& dh) -> Task<void> {
     if (publisher_) {
       publisher_->Flush();
     }
     while (not inflight_.empty()) {
-      auto future = std::move(inflight_.front());
+      auto publish = std::move(inflight_.front());
       inflight_.pop_front();
-      auto result = co_await std::move(future);
-      if (not result) {
-        diagnostic::error("failed to publish: {}", result.status().message())
-          .emit(dh);
-      }
+      auto result = co_await std::move(publish.future);
+      handle_publish_result(result, publish.bytes, dh);
     }
   }
 
   to_args args_;
   Option<pubsub::Publisher> publisher_;
-  std::deque<publish_future> inflight_;
+  std::deque<InflightPublish> inflight_;
+  MetricsCounter bytes_write_counter_;
 };
 
 } // namespace

--- a/plugins/nic/builtins/from_nic.cpp
+++ b/plugins/nic/builtins/from_nic.cpp
@@ -13,6 +13,7 @@
 #include <tenzir/detail/narrow.hpp>
 #include <tenzir/operator_plugin.hpp>
 #include <tenzir/pcap.hpp>
+#include <tenzir/pipeline_metrics.hpp>
 #include <tenzir/plugin.hpp>
 #include <tenzir/session.hpp>
 #include <tenzir/substitute_ctx.hpp>
@@ -349,6 +350,9 @@ public:
       done_ = true;
       co_return;
     }
+    bytes_read_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "from_nic"},
+                         MetricsDirection::read, MetricsVisibility::external_);
     co_await ctx.spawn_sub<chunk_ptr>(caf::none, std::move(parser));
     auto io_executor = ctx.io_executor();
     auto* evb = io_executor->getEventBase();
@@ -388,10 +392,13 @@ public:
       capture_closed_ = true;
       co_return;
     }
+    const auto bytes = chunk->size();
     auto& pipeline = as<SubHandle<chunk_ptr>>(*sub);
     auto push_result = co_await pipeline.push(std::move(chunk));
     if (push_result.is_err()) {
       done_ = true;
+    } else if (bytes > 0) {
+      bytes_read_counter_.add(bytes);
     }
   }
 
@@ -468,6 +475,7 @@ private:
   FromNicArgs args_;
   bool done_ = false;
   bool capture_closed_ = false;
+  MetricsCounter bytes_read_counter_;
   mutable std::shared_ptr<Notify> sub_finished_ = std::make_shared<Notify>();
   mutable std::shared_ptr<ChunkQueue> chunk_queue_
     = std::make_shared<ChunkQueue>(queue_capacity);

--- a/plugins/sqs/include/operators.hpp
+++ b/plugins/sqs/include/operators.hpp
@@ -10,6 +10,7 @@
 
 #include <tenzir/async.hpp>
 #include <tenzir/fwd.hpp>
+#include <tenzir/pipeline_metrics.hpp>
 #include <tenzir/tql2/ast.hpp>
 
 #include <memory>
@@ -52,6 +53,7 @@ private:
   FromSqsArgs args_;
   std::chrono::seconds poll_time_ = default_poll_time;
   std::shared_ptr<AsyncSqsQueue> queue_;
+  MetricsCounter bytes_read_counter_;
 };
 
 class ToSqs final : public Operator<table_slice, void> {
@@ -65,6 +67,7 @@ public:
 private:
   ToSqsArgs args_;
   std::shared_ptr<AsyncSqsQueue> queue_;
+  MetricsCounter bytes_write_counter_;
 };
 
 } // namespace tenzir::plugins::sqs

--- a/plugins/sqs/src/operators.cpp
+++ b/plugins/sqs/src/operators.cpp
@@ -106,6 +106,9 @@ auto FromSqs::start(OpCtx& ctx) -> Task<void> {
                      args_.poll_time->inner)
                  : default_poll_time;
   queue_ = co_await make_async_sqs_queue(args_, ctx);
+  bytes_read_counter_
+    = ctx.make_counter(MetricsLabel{"operator", "from_sqs"},
+                       MetricsDirection::read, MetricsVisibility::external_);
 }
 
 auto FromSqs::await_task(diagnostic_handler& dh) const -> Task<Any> {
@@ -214,6 +217,10 @@ auto FromSqs::process_task(Any result, Push<table_slice>& push, OpCtx& ctx)
   opts.settings.default_schema_name = "tenzir.sqs";
   auto msb = multi_series_builder{std::move(opts), ctx.dh()};
   for (const auto& message : messages) {
+    const auto& body = message.GetBody();
+    if (not body.empty()) {
+      bytes_read_counter_.add(body.size());
+    }
     build_event(msb, message);
   }
   for (auto&& slice : msb.finalize_as_table_slice()) {
@@ -234,6 +241,9 @@ ToSqs::ToSqs(ToSqsArgs args) : args_{std::move(args)} {
 
 auto ToSqs::start(OpCtx& ctx) -> Task<void> {
   queue_ = co_await make_async_sqs_queue(args_, ctx);
+  bytes_write_counter_
+    = ctx.make_counter(MetricsLabel{"operator", "to_sqs"},
+                       MetricsDirection::write, MetricsVisibility::external_);
 }
 
 auto ToSqs::process(table_slice input, OpCtx& ctx) -> Task<void> {
@@ -253,6 +263,9 @@ auto ToSqs::process(table_slice input, OpCtx& ctx) -> Task<void> {
         auto bytes = as_bytes(array.Value(i));
         co_await queue_->send_message(Aws::String{
           reinterpret_cast<const char*>(bytes.data()), bytes.size()});
+        if (not bytes.empty()) {
+          bytes_write_counter_.add(bytes.size());
+        }
       }
     };
     if (auto strings = messages.template as<string_type>()) {

--- a/plugins/zmq/builtins/from_zmq.cpp
+++ b/plugins/zmq/builtins/from_zmq.cpp
@@ -17,6 +17,7 @@
 #include <tenzir/error.hpp>
 #include <tenzir/ir.hpp>
 #include <tenzir/operator_plugin.hpp>
+#include <tenzir/pipeline_metrics.hpp>
 #include <tenzir/plugin.hpp>
 #include <tenzir/substitute_ctx.hpp>
 #include <tenzir/tql2/eval.hpp>
@@ -86,6 +87,17 @@ public:
   }
 
   auto start(OpCtx& ctx) -> Task<void> override {
+    if constexpr (Mode == transport::ConnectionMode::connect) {
+      bytes_read_counter_
+        = ctx.make_counter(MetricsLabel{"operator", "from_zmq"},
+                           MetricsDirection::read,
+                           MetricsVisibility::external_);
+    } else {
+      bytes_read_counter_
+        = ctx.make_counter(MetricsLabel{"operator", "accept_zmq"},
+                           MetricsDirection::read,
+                           MetricsVisibility::external_);
+    }
     endpoint_ = transport::normalize_endpoint(args_.endpoint.inner);
     if (args_.prefix) {
       auto prefix = const_eval(*args_.prefix, ctx.dh());
@@ -162,6 +174,7 @@ public:
           // safely drop it and behave as if it was never received.
           co_return;
         }
+        const auto bytes = payload->size();
         if (not args_.keep_prefix and not prefix_.empty()) {
           auto stripped = transport::strip_prefix(std::move(payload), prefix_);
           if (not stripped) {
@@ -192,6 +205,8 @@ public:
         auto push_result = co_await sub_pipeline.push(std::move(payload));
         if (push_result.is_err()) {
           request_stop();
+        } else if (bytes > 0) {
+          bytes_read_counter_.add(bytes);
         }
         co_await sub_pipeline.close();
       });
@@ -279,6 +294,7 @@ private:
   bool read_loop_finished_ = true;
   size_t active_parsers_ = 0;
   uint64_t next_sub_id_ = 0;
+  MetricsCounter bytes_read_counter_;
 };
 
 template <transport::ConnectionMode Mode>

--- a/plugins/zmq/builtins/to_zmq.cpp
+++ b/plugins/zmq/builtins/to_zmq.cpp
@@ -16,6 +16,7 @@
 #include <tenzir/error.hpp>
 #include <tenzir/ir.hpp>
 #include <tenzir/operator_plugin.hpp>
+#include <tenzir/pipeline_metrics.hpp>
 #include <tenzir/plugin.hpp>
 #include <tenzir/table_slice.hpp>
 #include <tenzir/tql2/eval.hpp>
@@ -119,6 +120,17 @@ public:
   }
 
   auto start(OpCtx& ctx) -> Task<void> override {
+    if constexpr (Mode == transport::ConnectionMode::connect) {
+      bytes_write_counter_
+        = ctx.make_counter(MetricsLabel{"operator", "to_zmq"},
+                           MetricsDirection::write,
+                           MetricsVisibility::external_);
+    } else {
+      bytes_write_counter_
+        = ctx.make_counter(MetricsLabel{"operator", "serve_zmq"},
+                           MetricsDirection::write,
+                           MetricsVisibility::external_);
+    }
     endpoint_ = transport::normalize_endpoint(args_.endpoint.inner);
     if (args_.monitor) {
       if (auto err = socket_.enable_peer_monitoring(); not err) {
@@ -196,6 +208,9 @@ public:
         err = socket_.send(framed, 0ms);
       }
       if (not err) {
+        if (framed->size() > 0) {
+          bytes_write_counter_.add(framed->size());
+        }
         continue;
       }
       diagnostic::error("failed to send ZeroMQ message")
@@ -221,6 +236,7 @@ private:
   Encoding encoding_;
   transport::Socket socket_{transport::SocketRole::publisher};
   bool done_ = false;
+  MetricsCounter bytes_write_counter_;
 };
 
 template <transport::ConnectionMode Mode>


### PR DESCRIPTION
## 🔍 Problem

Several source and sink operators that move bytes across external boundaries did not report explicit byte throughput counters.

## 🛠️ Solution

- Add external read/write byte counters to the missing TQL2 source and sink operators.
- Count concrete payload sizes at successful handoff points where available.
- Use approximate slice bytes for ClickHouse inserts because the client does not expose serialized block sizes.

## 💬 Review

Focus on counter placement semantics, especially asynchronous handoff points for AMQP, Pub/Sub, SQS, ZMQ, and ClickHouse.
