### PR TITLE
Add `take` for consuming fields

### DIFF
--- a/changelog/unreleased/take-expression-keyword-for-consumed-fields.md
+++ b/changelog/unreleased/take-expression-keyword-for-consumed-fields.md
@@ -1,0 +1,15 @@
+---
+title: Take expression keyword for consumed fields
+type: change
+authors:
+  - mavam
+created: 2026-05-05T18:28:58.096342Z
+---
+
+The `take` expression keyword now replaces `move` for consuming fields in assignments:
+
+```tql
+new_field = take old_field
+```
+
+The previous `move` expression keyword is deprecated but still accepted during the transition. The statement-level `move` operator remains unchanged.

--- a/libtenzir/include/tenzir/tql2/ast.hpp
+++ b/libtenzir/include/tenzir/tql2/ast.hpp
@@ -358,7 +358,7 @@ struct binary_expr {
   }
 };
 
-TENZIR_ENUM(unary_op, pos, neg, not_, move);
+TENZIR_ENUM(unary_op, pos, neg, not_, move, take);
 
 struct unary_expr {
   unary_expr() = default;

--- a/libtenzir/include/tenzir/tql2/tokens.hpp
+++ b/libtenzir/include/tenzir/tql2/tokens.hpp
@@ -23,7 +23,7 @@ TENZIR_ENUM(
   // identifiers
   identifier, dollar_ident,
   // keywords
-  this_, if_, else_, match, not_, and_, or_, move, underscore, let, in,
+  this_, if_, else_, match, not_, and_, or_, move, take, underscore, let, in,
   reserved_keyword,
   // literals
   scalar, true_, false_, null, ip, subnet, datetime,

--- a/libtenzir/src/tql2/eval_unary.cpp
+++ b/libtenzir/src/tql2/eval_unary.cpp
@@ -167,16 +167,18 @@ auto evaluator::eval(ast::unary_expr const& x, ActiveRows const& active)
     X(neg);
     X(not_);
 #undef X
-    case move: {
+    case move:
+    case take: {
+      auto keyword = x.op.inner == move ? "move" : "take";
       if (ast::field_path::try_from(x.expr)) {
-        diagnostic::warning("move is not supported here")
+        diagnostic::warning("{} is not supported here", keyword)
           .primary(x.op, "has no effect")
-          .hint("move only works on fields within assignments")
+          .hint("{} only works on fields within assignments", keyword)
           .emit(ctx_);
       } else {
-        diagnostic::warning("move has no effect")
+        diagnostic::warning("{} has no effect", keyword)
           .primary(x.expr, "is not a field")
-          .hint("move only works on fields within assignments")
+          .hint("{} only works on fields within assignments", keyword)
           .emit(ctx_);
       }
       return eval(x.expr, active);

--- a/libtenzir/src/tql2/parser.cpp
+++ b/libtenzir/src/tql2/parser.cpp
@@ -266,6 +266,12 @@ public:
       auto entity = parse_entity(expect(tk::move).as_identifier());
       return parse_invocation(std::move(entity));
     }
+    if (silent_peek(tk::take) and not silent_peek_n(tk::equal, 1)
+        and not silent_peek_n(tk::dot, 1)
+        and not silent_peek_n(tk::question_mark, 1)) {
+      auto entity = parse_entity(expect(tk::take).as_identifier());
+      return parse_invocation(std::move(entity));
+    }
     auto unary_expr = parse_unary_expression();
     if (auto* call = try_as<ast::function_call>(unary_expr)) {
       // TODO: We patch a top-level function call to be an operator invocation
@@ -337,7 +343,7 @@ public:
   }
 
   auto parse_type_def() -> ast::type_def {
-    if (auto id = accept(tk::identifier)) {
+    if (auto id = accept_identifier()) {
       using tn = struct type_name;
       return tn{id.as_identifier()};
     }
@@ -355,7 +361,7 @@ public:
     auto scope = ignore_newlines(true);
     auto fields = std::vector<ast::record_def::field>{};
     while (not peek(tk::rbrace)) {
-      auto name = expect(tk::identifier).as_identifier();
+      auto name = expect_identifier().as_identifier();
       expect(tk::colon);
       auto def = parse_type_def();
       fields.emplace_back(std::move(name), std::move(def));
@@ -498,14 +504,14 @@ public:
   // TODO: Future us/ast problem with type expressions
 
   auto parse_entity() -> ast::entity {
-    return parse_entity(expect(tk::identifier).as_identifier());
+    return parse_entity(expect_identifier().as_identifier());
   }
 
   auto parse_entity(ast::identifier root) -> ast::entity {
     auto path = std::vector<ast::identifier>{};
     path.push_back(std::move(root));
     while (accept(tk::colon_colon)) {
-      path.push_back(expect(tk::identifier).as_identifier());
+      path.push_back(expect_identifier().as_identifier());
     }
     return ast::entity{std::move(path)};
   }
@@ -521,6 +527,11 @@ public:
       };
     }
     if (auto op = peek_unary_op()) {
+      if (*op == unary_op::take
+          and (silent_peek_n(tk::equal, 1) or silent_peek_n(tk::dot, 1)
+               or silent_peek_n(tk::question_mark, 1))) {
+        return parse_primary_expression();
+      }
       auto location = advance();
       if (*op == unary_op::move) {
         diagnostic::warning(
@@ -547,7 +558,7 @@ public:
         dot = accept(tk::dot);
       }
       if (dot) {
-        auto name = expect(tk::identifier);
+        auto name = expect_identifier();
         if (peek(tk::lpar) or peek(tk::colon_colon)) {
           auto entity = parse_entity(name.as_identifier());
           expr = parse_function_call(std::move(expr), std::move(entity));
@@ -675,11 +686,11 @@ public:
       auto next_stash = next_;
       auto last_stash = last_;
       auto tries_stash = tries_;
-      if (auto first_param = accept(tk::identifier)) {
+      if (auto first_param = accept_identifier()) {
         auto params = std::vector<ast::identifier>{};
         params.push_back(first_param.as_identifier());
         while (accept(tk::comma)) {
-          params.push_back(expect(tk::identifier).as_identifier());
+          params.push_back(expect_identifier().as_identifier());
         }
         if (accept(tk::rpar)) {
           if (auto arrow = accept(tk::fat_arrow)) {
@@ -727,7 +738,7 @@ public:
     }
     if (auto at = accept(tk::at)) {
       auto begin = at.location;
-      auto ident = expect(tk::identifier).as_identifier();
+      auto ident = expect_identifier().as_identifier();
       auto kind = ast::meta_kind{};
       if (ident.name == "name") {
         kind = ast::meta::name;
@@ -754,7 +765,7 @@ public:
     if (auto token = accept(tk::this_)) {
       return ast::this_{token.location};
     }
-    auto ident = accept(tk::identifier);
+    auto ident = accept_identifier();
     if (not ident) {
       diagnostic::error("expected expression, got {}", next_description())
         .primary(next_location(), "got {}", next_description())
@@ -1042,7 +1053,7 @@ public:
     // TODO: Use a different representation for field names that are strings or
     // format strings in the AST.
     auto ident = std::invoke([this]() {
-      if (auto result = accept(tk::identifier)) {
+      if (auto result = accept_identifier()) {
         return result.as_identifier();
       }
       auto string = parse_string();
@@ -1345,6 +1356,23 @@ public:
 
   auto expect(token_kind kind) -> accept_result {
     if (auto result = accept(kind)) {
+      return result;
+    }
+    throw_token();
+  }
+
+  auto accept_identifier() -> accept_result {
+    if (auto result = accept(tk::identifier)) {
+      return result;
+    }
+    if (auto result = accept(tk::take)) {
+      return result;
+    }
+    return {};
+  }
+
+  auto expect_identifier() -> accept_result {
+    if (auto result = accept_identifier()) {
       return result;
     }
     throw_token();

--- a/libtenzir/src/tql2/parser.cpp
+++ b/libtenzir/src/tql2/parser.cpp
@@ -32,6 +32,7 @@ auto precedence(unary_op x) -> int {
   using enum unary_op;
   switch (x) {
     case move:
+    case take:
       return 10;
     case pos:
     case neg:
@@ -521,6 +522,12 @@ public:
     }
     if (auto op = peek_unary_op()) {
       auto location = advance();
+      if (*op == unary_op::move) {
+        diagnostic::warning(
+          "`move` as an expression keyword is deprecated; use `take` instead")
+          .primary(location)
+          .emit(diag_);
+      }
       auto expr = parse_expression(precedence(*op));
       return unary_expr{
         located{*op, location},
@@ -1252,6 +1259,7 @@ public:
     return unary_op::y;                                                        \
   }
     X(move, move);
+    X(take, take);
     X(not_, not_);
     X(minus, neg);
 #undef X

--- a/libtenzir/src/tql2/parser.cpp
+++ b/libtenzir/src/tql2/parser.cpp
@@ -266,9 +266,7 @@ public:
       auto entity = parse_entity(expect(tk::move).as_identifier());
       return parse_invocation(std::move(entity));
     }
-    if (silent_peek(tk::take) and not silent_peek_n(tk::equal, 1)
-        and not silent_peek_n(tk::dot, 1)
-        and not silent_peek_n(tk::question_mark, 1)) {
+    if (silent_peek(tk::take)) {
       auto entity = parse_entity(expect(tk::take).as_identifier());
       return parse_invocation(std::move(entity));
     }
@@ -343,7 +341,7 @@ public:
   }
 
   auto parse_type_def() -> ast::type_def {
-    if (auto id = accept_identifier()) {
+    if (auto id = accept(tk::identifier)) {
       using tn = struct type_name;
       return tn{id.as_identifier()};
     }
@@ -361,7 +359,7 @@ public:
     auto scope = ignore_newlines(true);
     auto fields = std::vector<ast::record_def::field>{};
     while (not peek(tk::rbrace)) {
-      auto name = expect_identifier().as_identifier();
+      auto name = expect(tk::identifier).as_identifier();
       expect(tk::colon);
       auto def = parse_type_def();
       fields.emplace_back(std::move(name), std::move(def));
@@ -504,14 +502,14 @@ public:
   // TODO: Future us/ast problem with type expressions
 
   auto parse_entity() -> ast::entity {
-    return parse_entity(expect_identifier().as_identifier());
+    return parse_entity(expect(tk::identifier).as_identifier());
   }
 
   auto parse_entity(ast::identifier root) -> ast::entity {
     auto path = std::vector<ast::identifier>{};
     path.push_back(std::move(root));
     while (accept(tk::colon_colon)) {
-      path.push_back(expect_identifier().as_identifier());
+      path.push_back(expect(tk::identifier).as_identifier());
     }
     return ast::entity{std::move(path)};
   }
@@ -527,11 +525,6 @@ public:
       };
     }
     if (auto op = peek_unary_op()) {
-      if (*op == unary_op::take
-          and (silent_peek_n(tk::equal, 1) or silent_peek_n(tk::dot, 1)
-               or silent_peek_n(tk::question_mark, 1))) {
-        return parse_primary_expression();
-      }
       auto location = advance();
       if (*op == unary_op::move) {
         diagnostic::warning(
@@ -558,7 +551,7 @@ public:
         dot = accept(tk::dot);
       }
       if (dot) {
-        auto name = expect_identifier();
+        auto name = expect(tk::identifier);
         if (peek(tk::lpar) or peek(tk::colon_colon)) {
           auto entity = parse_entity(name.as_identifier());
           expr = parse_function_call(std::move(expr), std::move(entity));
@@ -686,11 +679,11 @@ public:
       auto next_stash = next_;
       auto last_stash = last_;
       auto tries_stash = tries_;
-      if (auto first_param = accept_identifier()) {
+      if (auto first_param = accept(tk::identifier)) {
         auto params = std::vector<ast::identifier>{};
         params.push_back(first_param.as_identifier());
         while (accept(tk::comma)) {
-          params.push_back(expect_identifier().as_identifier());
+          params.push_back(expect(tk::identifier).as_identifier());
         }
         if (accept(tk::rpar)) {
           if (auto arrow = accept(tk::fat_arrow)) {
@@ -738,7 +731,7 @@ public:
     }
     if (auto at = accept(tk::at)) {
       auto begin = at.location;
-      auto ident = expect_identifier().as_identifier();
+      auto ident = expect(tk::identifier).as_identifier();
       auto kind = ast::meta_kind{};
       if (ident.name == "name") {
         kind = ast::meta::name;
@@ -765,7 +758,7 @@ public:
     if (auto token = accept(tk::this_)) {
       return ast::this_{token.location};
     }
-    auto ident = accept_identifier();
+    auto ident = accept(tk::identifier);
     if (not ident) {
       diagnostic::error("expected expression, got {}", next_description())
         .primary(next_location(), "got {}", next_description())
@@ -1053,7 +1046,7 @@ public:
     // TODO: Use a different representation for field names that are strings or
     // format strings in the AST.
     auto ident = std::invoke([this]() {
-      if (auto result = accept_identifier()) {
+      if (auto result = accept(tk::identifier)) {
         return result.as_identifier();
       }
       auto string = parse_string();
@@ -1361,22 +1354,6 @@ public:
     throw_token();
   }
 
-  auto accept_identifier() -> accept_result {
-    if (auto result = accept(tk::identifier)) {
-      return result;
-    }
-    if (auto result = accept(tk::take)) {
-      return result;
-    }
-    return {};
-  }
-
-  auto expect_identifier() -> accept_result {
-    if (auto result = accept_identifier()) {
-      return result;
-    }
-    throw_token();
-  }
 
   auto silent_peek(token_kind kind) -> bool {
     return next_ < tokens_.size() and tokens_[next_].kind == kind;

--- a/libtenzir/src/tql2/parser.cpp
+++ b/libtenzir/src/tql2/parser.cpp
@@ -1354,7 +1354,6 @@ public:
     throw_token();
   }
 
-
   auto silent_peek(token_kind kind) -> bool {
     return next_ < tokens_.size() and tokens_[next_].kind == kind;
   }

--- a/libtenzir/src/tql2/set.cpp
+++ b/libtenzir/src/tql2/set.cpp
@@ -313,7 +313,8 @@ struct move_resolver final : ast::visitor<move_resolver> {
 
   auto visit(ast::expression& x) -> void {
     if (auto* unary = try_as<ast::unary_expr>(x)) {
-      if (unary->op.inner == ast::unary_op::move) {
+      if (unary->op.inner == ast::unary_op::move
+          or unary->op.inner == ast::unary_op::take) {
         if (auto field = ast::field_path::try_from(unary->expr)) {
           out.push_back(std::move(*field));
           x = std::move(unary->expr);

--- a/libtenzir/src/tql2/tokens.cpp
+++ b/libtenzir/src/tql2/tokens.cpp
@@ -157,6 +157,7 @@ auto tokenize_permissive(std::string_view content) -> std::vector<token> {
     | X("null", null)
     | X("or", or_)
     | X("move", move)
+    | X("take", take)
     | X("this", this_)
     | X("true", true_)
 #undef X
@@ -347,6 +348,7 @@ auto describe(token_kind k) -> std::string_view {
     X(reserved_keyword, "reserved keyword");
     X(rpar, "`)`");
     X(scalar, "scalar");
+    X(take, "`take`");
     X(single_quote, "`'`");
     X(slash, "`/`");
     X(star, "`*`");

--- a/libtenzir/test/tql2_parser.cpp
+++ b/libtenzir/test/tql2_parser.cpp
@@ -129,21 +129,6 @@ TEST("tql2 parser: move operator is not deprecated") {
   CHECK(dh.empty());
 }
 
-TEST("tql2 parser: take remains usable in identifier contexts") {
-  auto dh = collecting_diagnostic_handler{};
-  auto provider = session_provider::make(dh);
-  auto invocation
-    = parse_pipeline_with_bad_diagnostics("take foo", provider.as_session());
-  REQUIRE(invocation);
-  auto access = parse_assignment_with_bad_diagnostics("x = foo.take",
-                                                      provider.as_session());
-  REQUIRE(access);
-  auto field
-    = parse_assignment_with_bad_diagnostics("take = 1", provider.as_session());
-  REQUIRE(field);
-  CHECK(dh.empty());
-}
-
 TEST("tql2 parser: deep left-associated or location") {
   auto expr = ast::expression{ast::constant{false, location{0, 1}}};
   auto end = size_t{1};

--- a/libtenzir/test/tql2_parser.cpp
+++ b/libtenzir/test/tql2_parser.cpp
@@ -135,8 +135,8 @@ TEST("tql2 parser: take remains usable in identifier contexts") {
   auto invocation
     = parse_pipeline_with_bad_diagnostics("take foo", provider.as_session());
   REQUIRE(invocation);
-  auto access = parse_assignment_with_bad_diagnostics(
-    "x = foo.take", provider.as_session());
+  auto access = parse_assignment_with_bad_diagnostics("x = foo.take",
+                                                      provider.as_session());
   REQUIRE(access);
   auto field
     = parse_assignment_with_bad_diagnostics("take = 1", provider.as_session());

--- a/libtenzir/test/tql2_parser.cpp
+++ b/libtenzir/test/tql2_parser.cpp
@@ -92,6 +92,43 @@ TEST("tql2 parser: expression stream keeps parsed prefix on hard suffix "
   CHECK(not dh.empty());
 }
 
+TEST("tql2 parser: take expression keyword") {
+  auto dh = collecting_diagnostic_handler{};
+  auto provider = session_provider::make(dh);
+  auto parsed = parse_assignment_with_bad_diagnostics(
+    "new_field = take old_field", provider.as_session());
+  REQUIRE(parsed);
+  auto* unary = try_as<ast::unary_expr>(parsed->right);
+  REQUIRE(unary);
+  CHECK_EQUAL(unary->op.inner, ast::unary_op::take);
+  CHECK(dh.empty());
+}
+
+TEST("tql2 parser: move expression keyword is deprecated") {
+  auto dh = collecting_diagnostic_handler{};
+  auto provider = session_provider::make(dh);
+  auto parsed = parse_assignment_with_bad_diagnostics(
+    "new_field = move old_field", provider.as_session());
+  REQUIRE(parsed);
+  auto* unary = try_as<ast::unary_expr>(parsed->right);
+  REQUIRE(unary);
+  CHECK_EQUAL(unary->op.inner, ast::unary_op::move);
+  auto diags = std::move(dh).collect();
+  REQUIRE_EQUAL(diags.size(), size_t{1});
+  CHECK_EQUAL(diags[0].severity, severity::warning);
+  CHECK_EQUAL(diags[0].message, "`move` as an expression keyword is "
+                                "deprecated; use `take` instead");
+}
+
+TEST("tql2 parser: move operator is not deprecated") {
+  auto dh = collecting_diagnostic_handler{};
+  auto provider = session_provider::make(dh);
+  auto parsed
+    = parse_pipeline_with_bad_diagnostics("move x=foo", provider.as_session());
+  REQUIRE(parsed);
+  CHECK(dh.empty());
+}
+
 TEST("tql2 parser: deep left-associated or location") {
   auto expr = ast::expression{ast::constant{false, location{0, 1}}};
   auto end = size_t{1};

--- a/libtenzir/test/tql2_parser.cpp
+++ b/libtenzir/test/tql2_parser.cpp
@@ -129,6 +129,21 @@ TEST("tql2 parser: move operator is not deprecated") {
   CHECK(dh.empty());
 }
 
+TEST("tql2 parser: take remains usable in identifier contexts") {
+  auto dh = collecting_diagnostic_handler{};
+  auto provider = session_provider::make(dh);
+  auto invocation
+    = parse_pipeline_with_bad_diagnostics("take foo", provider.as_session());
+  REQUIRE(invocation);
+  auto access = parse_assignment_with_bad_diagnostics(
+    "x = foo.take", provider.as_session());
+  REQUIRE(access);
+  auto field
+    = parse_assignment_with_bad_diagnostics("take = 1", provider.as_session());
+  REQUIRE(field);
+  CHECK(dh.empty());
+}
+
 TEST("tql2 parser: deep left-associated or location") {
   auto expr = ast::expression{ast::constant{false, location{0, 1}}};
   auto end = size_t{1};

--- a/test-legacy/tests/language/expr/move/merge.tql
+++ b/test-legacy/tests/language/expr/move/merge.tql
@@ -2,4 +2,4 @@ from {
   xs: [1, 2, 3],
   ys: [3, 1, 2],
 }
-zs = zip(take xs, take ys).map(x => [x.left, x.right].max())
+zs = zip(move xs, move ys).map(x => [x.left, x.right].max())

--- a/test-legacy/tests/language/expr/move/merge.tql
+++ b/test-legacy/tests/language/expr/move/merge.tql
@@ -2,4 +2,4 @@ from {
   xs: [1, 2, 3],
   ys: [3, 1, 2],
 }
-zs = zip(move xs, move ys).map(x => [x.left, x.right].max())
+zs = zip(take xs, take ys).map(x => [x.left, x.right].max())

--- a/test/tests/operators/dns_lookup/batch_splitting.tql
+++ b/test/tests/operators/dns_lookup/batch_splitting.tql
@@ -2,7 +2,7 @@ from {
   events: [{ x: 0 }, { x:1 }]
 }
 unroll events
-select x=move events.x
+select x=take events.x
 dns_lookup 1.1.1.1 if x == 0 else "one.one.one.one"
 unroll dns_lookup
 where dns_lookup.type? != "AAAA"


### PR DESCRIPTION
## 🔍 Problem

The field-consuming assignment keyword currently reuses `move`, which is easy to confuse with the statement-level `move` operator.

## 🛠️ Solution

- Add `take` for field-consuming assignments.
- Keep expression `move` working during the transition with a deprecation warning.
- Keep the statement-level `move` operator unchanged and warning-free.

## 💬 Review

Focus on parser ambiguity between expression `move`/`take` and the statement-level `move` operator.

<sub>
📚 Docs PR: tenzir/docs#289<br>
✅ Closes TNZ-409
</sub>
