### PR TITLE
Keep `save_stdout` legacy-only

### DIFF
--- a/libtenzir/builtins/commands/exec.cpp
+++ b/libtenzir/builtins/commands/exec.cpp
@@ -76,13 +76,20 @@ auto exec_command(const invocation& inv, caf::actor_system& sys) -> bool {
   cfg.dump_metrics
     = caf::get_or(inv.options, "tenzir.exec.dump-metrics", false);
   auto as_file = caf::get_or(inv.options, "tenzir.exec.file", false);
-  cfg.implicit_bytes_sink = caf::get_or(
-    inv.options, "tenzir.exec.implicit-bytes-sink", cfg.implicit_bytes_sink);
+  cfg.neo = caf::get_or(inv.options, "tenzir.neo", cfg.neo);
+  const auto use_neo_executor
+    = cfg.neo or cfg.dump_ir or cfg.dump_inst_ir or cfg.dump_opt_ir;
+  const auto stdout_color
+    = (color_mode == "auto" and not no_color_env and isatty(STDOUT_FILENO))
+      or color_mode == "always";
+  cfg.implicit_bytes_sink
+    = caf::get_or(inv.options, "tenzir.exec.implicit-bytes-sink",
+                  use_neo_executor ? "" : cfg.implicit_bytes_sink);
   cfg.implicit_events_sink = caf::get_or(
     inv.options, "tenzir.exec.implicit-events-sink",
-    make_default_implicit_events_sink(
-      (color_mode == "auto" and not no_color_env and isatty(STDOUT_FILENO))
-      or color_mode == "always"));
+    use_neo_executor
+      ? (stdout_color ? R"(to_stdout { write_tql color=true })" : "to_stdout")
+      : make_default_implicit_events_sink(stdout_color));
   cfg.implicit_bytes_source
     = caf::get_or(inv.options, "tenzir.exec.implicit-bytes-source",
                   cfg.implicit_bytes_source);
@@ -92,7 +99,6 @@ auto exec_command(const invocation& inv, caf::actor_system& sys) -> bool {
   cfg.multi = caf::get_or(inv.options, "tenzir.exec.multi", cfg.multi);
   cfg.legacy = caf::get_or(inv.options, "tenzir.legacy", cfg.legacy);
   cfg.strict = caf::get_or(inv.options, "tenzir.exec.strict", cfg.strict);
-  cfg.neo = caf::get_or(inv.options, "tenzir.neo", cfg.neo);
   auto profile_str
     = caf::get_or(inv.options, "tenzir.exec.profile", std::string{});
   if (not profile_str.empty()) {

--- a/libtenzir/builtins/connectors/file.cpp
+++ b/libtenzir/builtins/connectors/file.cpp
@@ -6,9 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2023 The Tenzir Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#include "tenzir/async.hpp"
-#include "tenzir/async/blocking_executor.hpp"
-
 #include <tenzir/argument_parser.hpp>
 #include <tenzir/concept/parseable/tenzir/data.hpp>
 #include <tenzir/concept/parseable/tenzir/pipeline.hpp>
@@ -24,7 +21,6 @@
 #include <tenzir/file.hpp>
 #include <tenzir/fwd.hpp>
 #include <tenzir/logger.hpp>
-#include <tenzir/operator_plugin.hpp>
 #include <tenzir/parser_interface.hpp>
 #include <tenzir/plugin.hpp>
 #include <tenzir/tql2/plugin.hpp>
@@ -701,48 +697,7 @@ public:
   }
 };
 
-struct SaveStdoutArgs {
-  location self;
-};
-
-class SaveStdout final : public Operator<chunk_ptr, void> {
-public:
-  explicit SaveStdout(SaveStdoutArgs args) : args_{std::move(args)} {
-  }
-
-  auto process(chunk_ptr input, OpCtx& ctx) -> Task<void> override {
-    TENZIR_ASSERT(input);
-    auto err = co_await spawn_blocking([input = std::move(input)] {
-      auto written = std::fwrite(input->data(), 1, input->size(), stdout);
-      return written != input->size() ? errno : 0;
-    });
-    if (err != 0) {
-      diagnostic::error("failed to write to stdout: {}",
-                        detail::describe_errno(err))
-        .primary(args_.self)
-        .emit(ctx);
-    }
-  }
-
-  auto finalize(OpCtx& ctx) -> Task<FinalizeBehavior> override {
-    auto err = co_await spawn_blocking([] {
-      return std::fflush(stdout) != 0 ? errno : 0;
-    });
-    if (err != 0) {
-      diagnostic::warning("failed to flush stdout: {}",
-                          detail::describe_errno(err))
-        .primary(args_.self)
-        .emit(ctx);
-    }
-    co_return FinalizeBehavior::done;
-  }
-
-private:
-  SaveStdoutArgs args_;
-};
-
-class save_stdout_plugin final : public operator_plugin2<save_file_operator>,
-                                 public OperatorPlugin {
+class save_stdout_plugin final : public operator_plugin2<save_file_operator> {
 public:
   auto name() const -> std::string override {
     return "save_stdout";
@@ -754,12 +709,6 @@ public:
     auto args = saver_args{};
     args.path = located{"-", inv.self.get_location()};
     return std::make_unique<save_file_operator>(std::move(args));
-  }
-
-  auto describe() const -> Description override {
-    auto d = Describer<SaveStdoutArgs, SaveStdout>{};
-    d.operator_location(&SaveStdoutArgs::self);
-    return d.without_optimize();
   }
 };
 

--- a/tenzir/tests/exec/functions/list/add.txt
+++ b/tenzir/tests/exec/functions/list/add.txt
@@ -8,7 +8,7 @@
 {xs:[1]}
 {xs:[1,2,3,4]}
 warning: type mismatch between list content and value
-  --> exec/functions/list/add.tql:35:6
+  --> tests/exec/functions/list/add.tql:35:6
    |
 35 | xs = xs.add("1")
    |      ~~ list contains `int64`

--- a/test-legacy/tests/compiler/opt/export_where.diff
+++ b/test-legacy/tests/compiler/opt/export_where.diff
@@ -32,11 +32,11 @@
 +    GenericIr {
 +      op: {
 +        path: [
-+          `write_tql` @ 0..0
++          `to_stdout` @ 0..0
 +        ],
-+        ref: std::write_tql/op
++        ref: std::to_stdout/op
 +      },
-+      desc: "write_tql",
++      desc: "to_stdout",
 +      args: [
 +        
 +      ],
@@ -47,7 +47,7 @@
        named_args: [
          
        ]
-     },
+-    },
 -    where_ir {
 -      self: 22..27,
 -      predicate: binary_expr {
@@ -58,24 +58,6 @@
 -        op: "eq" @ 32..34,
 -        right: constant int64 42 @ 35..39
 -      }
-+    GenericIr {
-+      op: {
-+        path: [
-+          `save_stdout` @ 0..0
-+        ],
-+        ref: std::save_stdout/op
-+      },
-+      desc: "save_stdout",
-+      args: [
-+        
-+      ],
-+      filter: [
-+        
-+      ],
-+      order: "ordered",
-+      named_args: [
-+        
-+      ]
      }
    ]
  }

--- a/test-legacy/tests/compiler/opt/export_where_in.diff
+++ b/test-legacy/tests/compiler/opt/export_where_in.diff
@@ -40,11 +40,11 @@
 +    GenericIr {
 +      op: {
 +        path: [
-+          `write_tql` @ 0..0
++          `to_stdout` @ 0..0
 +        ],
-+        ref: std::write_tql/op
++        ref: std::to_stdout/op
 +      },
-+      desc: "write_tql",
++      desc: "to_stdout",
 +      args: [
 +        
 +      ],
@@ -55,7 +55,7 @@
        named_args: [
          
        ]
-     },
+-    },
 -    where_ir {
 -      self: 7..12,
 -      predicate: binary_expr {
@@ -74,24 +74,6 @@
 -          end: 28..29
 -        }
 -      }
-+    GenericIr {
-+      op: {
-+        path: [
-+          `save_stdout` @ 0..0
-+        ],
-+        ref: std::save_stdout/op
-+      },
-+      desc: "save_stdout",
-+      args: [
-+        
-+      ],
-+      filter: [
-+        
-+      ],
-+      order: "ordered",
-+      named_args: [
-+        
-+      ]
      }
    ]
  }

--- a/test-legacy/tests/compiler/opt/export_where_now.diff
+++ b/test-legacy/tests/compiler/opt/export_where_now.diff
@@ -32,11 +32,11 @@
 +    GenericIr {
 +      op: {
 +        path: [
-+          `write_tql` @ 0..0
++          `to_stdout` @ 0..0
 +        ],
-+        ref: std::write_tql/op
++        ref: std::to_stdout/op
 +      },
-+      desc: "write_tql",
++      desc: "to_stdout",
 +      args: [
 +        
 +      ],
@@ -47,7 +47,7 @@
        named_args: [
          
        ]
-     },
+-    },
 -    where_ir {
 -      self: 336..341,
 -      predicate: binary_expr {
@@ -58,24 +58,6 @@
 -        op: "eq" @ 346..348,
 -        right: constant bool true @ 349..353
 -      }
-+    GenericIr {
-+      op: {
-+        path: [
-+          `save_stdout` @ 0..0
-+        ],
-+        ref: std::save_stdout/op
-+      },
-+      desc: "save_stdout",
-+      args: [
-+        
-+      ],
-+      filter: [
-+        
-+      ],
-+      order: "ordered",
-+      named_args: [
-+        
-+      ]
      }
    ]
  }

--- a/test-legacy/tests/compiler/opt/export_where_optional_field.diff
+++ b/test-legacy/tests/compiler/opt/export_where_optional_field.diff
@@ -32,11 +32,11 @@
 +    GenericIr {
 +      op: {
 +        path: [
-+          `write_tql` @ 0..0
++          `to_stdout` @ 0..0
 +        ],
-+        ref: std::write_tql/op
++        ref: std::to_stdout/op
 +      },
-+      desc: "write_tql",
++      desc: "to_stdout",
 +      args: [
 +        
 +      ],
@@ -47,7 +47,7 @@
        named_args: [
          
        ]
-     },
+-    },
 -    where_ir {
 -      self: 78..83,
 -      predicate: binary_expr {
@@ -58,24 +58,6 @@
 -        op: "eq" @ 89..91,
 -        right: constant int64 42 @ 92..94
 -      }
-+    GenericIr {
-+      op: {
-+        path: [
-+          `save_stdout` @ 0..0
-+        ],
-+        ref: std::save_stdout/op
-+      },
-+      desc: "save_stdout",
-+      args: [
-+        
-+      ],
-+      filter: [
-+        
-+      ],
-+      order: "ordered",
-+      named_args: [
-+        
-+      ]
      }
    ]
  }

--- a/test/inputs/package-roots/basic/basicpkg/operators/echo.tql
+++ b/test/inputs/package-roots/basic/basicpkg/operators/echo.tql
@@ -1,3 +1,4 @@
 from {message: "hello from package", id: "basicpkg"}
-write_json
-save_stdout
+to_stdout {
+  write_json
+}

--- a/test/inputs/package-roots/conflict/alpha-beta/operators/ping.tql
+++ b/test/inputs/package-roots/conflict/alpha-beta/operators/ping.tql
@@ -1,3 +1,4 @@
 from {source: "alpha-beta"}
-write_json
-save_stdout
+to_stdout {
+  write_json
+}

--- a/test/inputs/package-roots/conflict/alpha_beta/operators/pong.tql
+++ b/test/inputs/package-roots/conflict/alpha_beta/operators/pong.tql
@@ -1,3 +1,4 @@
 from {source: "alpha_beta"}
-write_json
-save_stdout
+to_stdout {
+  write_json
+}

--- a/test/inputs/package-roots/hyphen/hyphen-package/operators/greet.tql
+++ b/test/inputs/package-roots/hyphen/hyphen-package/operators/greet.tql
@@ -3,5 +3,6 @@ from {
   normalized: "hyphen_package",
   message: "hello from hyphenated package",
 }
-write_json
-save_stdout
+to_stdout {
+  write_json
+}

--- a/test/inputs/package-roots/udo-args/argspkg/operators/greet.tql
+++ b/test/inputs/package-roots/udo-args/argspkg/operators/greet.tql
@@ -24,5 +24,6 @@ from {
   age: $age,
   excited: $excited
 }
-write_json
-save_stdout
+to_stdout {
+  write_json
+}

--- a/test/inputs/package-roots/udo-args/argspkg/operators/require_constant.tql
+++ b/test/inputs/package-roots/udo-args/argspkg/operators/require_constant.tql
@@ -9,5 +9,6 @@ args:
 strict {
   suffix_value = "suffix: " + $suffix
 }
-write_json
-save_stdout
+to_stdout {
+  write_json
+}

--- a/test/inputs/package-roots/udo-args/argspkg/operators/require_option.tql
+++ b/test/inputs/package-roots/udo-args/argspkg/operators/require_option.tql
@@ -11,5 +11,6 @@ args:
 from {
   combined: $value + $required_opt
 }
-write_json
-save_stdout
+to_stdout {
+  write_json
+}

--- a/test/tests/compiler/opt/if_ordered_downstream.diff
+++ b/test/tests/compiler/opt/if_ordered_downstream.diff
@@ -84,11 +84,11 @@
      GenericIr {
        op: {
          path: [
-           `write_tql` @ 42..51
+           `to_stdout` @ 42..51
          ],
-         ref: std::write_tql/op
+         ref: std::to_stdout/op
        },
-       desc: "write_tql",
+       desc: "to_stdout",
        args: [
          
        ],
@@ -98,26 +98,38 @@
        order: "ordered",
        named_args: [
          
-       ]
-     },
-     GenericIr {
-       op: {
-         path: [
-           `save_stdout` @ 52..63
-         ],
-         ref: std::save_stdout/op
-       },
-       desc: "save_stdout",
-       args: [
-         
        ],
-       filter: [
-         
-       ],
-       order: "ordered",
-       named_args: [
-         
-       ]
+       pipeline: {
+         pipeline: {
+           lets: [
+             
+           ],
+           operators: [
+             GenericIr {
+               op: {
+                 path: [
+                   `write_tql` @ 56..65
+                 ],
+                 ref: std::write_tql/op
+               },
+               desc: "write_tql",
+               args: [
+                 
+               ],
+               filter: [
+                 
+               ],
+               order: "ordered",
+               named_args: [
+                 
+               ]
+             }
+           ]
+         } @ 52..67,
+         let_ids: {
+           
+         }
+       }
      }
    ]
  }

--- a/test/tests/compiler/opt/if_ordered_downstream.tql
+++ b/test/tests/compiler/opt/if_ordered_downstream.tql
@@ -4,5 +4,6 @@ if true {
 } else {
   head
 }
-write_tql
-save_stdout
+to_stdout {
+  write_tql
+}

--- a/test/tests/compiler/opt/unordered.diff
+++ b/test/tests/compiler/opt/unordered.diff
@@ -32,11 +32,11 @@
 +    GenericIr {
 +      op: {
 +        path: [
-+          `write_tql` @ 0..0
++          `to_stdout` @ 0..0
 +        ],
-+        ref: std::write_tql/op
++        ref: std::to_stdout/op
 +      },
-+      desc: "write_tql",
++      desc: "to_stdout",
 +      args: [
 +        
 +      ],
@@ -47,16 +47,12 @@
        named_args: [
          
        ]
-     },
+-    },
 -    UnorderedIr {
 -      pipeline: {
 -        lets: [
 -          
-+    GenericIr {
-+      op: {
-+        path: [
-+          `save_stdout` @ 0..0
-         ],
+-        ],
 -        operators: [
 -          where_ir {
 -            self: 21..26,
@@ -70,20 +66,8 @@
 -            }
 -          }
 -        ]
-+        ref: std::save_stdout/op
-       },
+-      },
 -      loc: 7..16
-+      desc: "save_stdout",
-+      args: [
-+        
-+      ],
-+      filter: [
-+        
-+      ],
-+      order: "ordered",
-+      named_args: [
-+        
-+      ]
      }
    ]
  }

--- a/test/tests/compiler/opt/unordered_barrier.diff
+++ b/test/tests/compiler/opt/unordered_barrier.diff
@@ -78,30 +78,11 @@
 +    GenericIr {
 +      op: {
 +        path: [
-+          `write_tql` @ 0..0
++          `to_stdout` @ 0..0
 +        ],
-+        ref: std::write_tql/op
++        ref: std::to_stdout/op
 +      },
-+      desc: "write_tql",
-+      args: [
-+        
-+      ],
-+      filter: [
-+        
-+      ],
-+      order: "ordered",
-+      named_args: [
-+        
-+      ]
-+    },
-+    GenericIr {
-+      op: {
-+        path: [
-+          `save_stdout` @ 0..0
-+        ],
-+        ref: std::save_stdout/op
-+      },
-+      desc: "save_stdout",
++      desc: "to_stdout",
 +      args: [
 +        
 +      ],

--- a/test/tests/node/package/add/multi/004.tql
+++ b/test/tests/node/package/add/multi/004.tql
@@ -1,4 +1,5 @@
 package::list
 sort id
-write_tql
-save_stdout
+to_stdout {
+  write_tql
+}

--- a/test/tests/node/package/add/multi/005.tql
+++ b/test/tests/node/package/add/multi/005.tql
@@ -1,4 +1,5 @@
 pipeline::list
 select id, definition
-write_tql
-save_stdout
+to_stdout {
+  write_tql
+}

--- a/test/tests/node/package/add/multi/006.tql
+++ b/test/tests/node/package/add/multi/006.tql
@@ -1,4 +1,5 @@
 context::list
 sort name
-write_tql
-save_stdout
+to_stdout {
+  write_tql
+}

--- a/test/tests/node/package/add/multi/009.tql
+++ b/test/tests/node/package/add/multi/009.tql
@@ -1,3 +1,4 @@
 package::list
-write_tql
-save_stdout
+to_stdout {
+  write_tql
+}

--- a/test/tests/node/package/add/multi/010.tql
+++ b/test/tests/node/package/add/multi/010.tql
@@ -1,4 +1,5 @@
 pipeline::list
 select id, definition
-write_tql
-save_stdout
+to_stdout {
+  write_tql
+}

--- a/test/tests/node/package/add/multi/011.tql
+++ b/test/tests/node/package/add/multi/011.tql
@@ -1,4 +1,5 @@
 context::list
 sort name
-write_tql
-save_stdout
+to_stdout {
+  write_tql
+}

--- a/test/tests/node/package/add/single/002.tql
+++ b/test/tests/node/package/add/single/002.tql
@@ -1,4 +1,5 @@
 package::list
 sort id
-write_tql
-save_stdout
+to_stdout {
+  write_tql
+}

--- a/test/tests/node/package/add/single/003.tql
+++ b/test/tests/node/package/add/single/003.tql
@@ -1,4 +1,5 @@
 pipeline::list
 select id, definition
-write_tql
-save_stdout
+to_stdout {
+  write_tql
+}

--- a/test/tests/node/package/add/single/004.tql
+++ b/test/tests/node/package/add/single/004.tql
@@ -1,4 +1,5 @@
 context::list
 sort name
-write_tql
-save_stdout
+to_stdout {
+  write_tql
+}

--- a/test/tests/node/package/add/single/006.tql
+++ b/test/tests/node/package/add/single/006.tql
@@ -1,4 +1,5 @@
 package::list
 summarize num_packages=count()
-write_tql
-save_stdout
+to_stdout {
+  write_tql
+}

--- a/test/tests/node/package/add/single/007.tql
+++ b/test/tests/node/package/add/single/007.tql
@@ -1,4 +1,5 @@
 pipeline::list
 summarize num_pipelines=count()
-write_tql
-save_stdout
+to_stdout {
+  write_tql
+}

--- a/test/tests/node/package/add/single/008.tql
+++ b/test/tests/node/package/add/single/008.tql
@@ -1,4 +1,5 @@
 context::list
 summarize num_contexts=count()
-write_tql
-save_stdout
+to_stdout {
+  write_tql
+}

--- a/test/tests/operators/if/both_sink.tql
+++ b/test/tests/operators/if/both_sink.tql
@@ -1,6 +1,6 @@
 from {x: 1}, {x: 2}
 if x > 1 {
-  write_json | save_stdout
+  to_stdout { write_json }
 } else {
   discard
 }

--- a/test/tests/operators/if/else_void.tql
+++ b/test/tests/operators/if/else_void.tql
@@ -2,7 +2,8 @@ from {x: 1}, {x: 2}, {x: 3}
 if x > 1 {
   x = x * 10
 } else {
-  write_json
-  save_stdout
+  to_stdout {
+    write_json
+  }
 }
 sort x

--- a/test/tests/operators/pcap/decapsulate_basic.tql
+++ b/test/tests/operators/pcap/decapsulate_basic.tql
@@ -4,4 +4,6 @@ from_file f"{env("TENZIR_INPUTS")}/pcap/example.pcap.gz" {
   read_pcap
 }
 this = decapsulate(this)
-write_tql compact=true
+to_stdout {
+  write_tql compact=true
+}

--- a/test/tests/operators/serve/01_fetch_serve_1.tql
+++ b/test/tests/operators/serve/01_fetch_serve_1.tql
@@ -7,4 +7,6 @@ api "/serve", {
 }
 unroll events
 this = events.data
-write_tql
+to_stdout {
+  write_tql
+}

--- a/test/tests/operators/serve/02_fetch_serve_2.tql
+++ b/test/tests/operators/serve/02_fetch_serve_2.tql
@@ -7,4 +7,6 @@ api "/serve", {
 }
 unroll events
 this = events.data
-write_tql
+to_stdout {
+  write_tql
+}

--- a/test/tests/operators/serve/03_fetch_serve_multi.tql
+++ b/test/tests/operators/serve/03_fetch_serve_multi.tql
@@ -17,4 +17,6 @@ this = responses
 unroll response.events
 data = response.events.data
 select id, data
-write_tql
+to_stdout {
+  write_tql
+}

--- a/test/tests/operators/shell/source.tql
+++ b/test/tests/operators/shell/source.tql
@@ -1,3 +1,5 @@
 shell "printf '{\"value\":1}\n{\"value\":3}\n{\"value\":5}\n'"
 read_ndjson
-write_ndjson
+to_stdout {
+  write_ndjson
+}

--- a/test/tests/operators/shell/source_malformed_command.tql
+++ b/test/tests/operators/shell/source_malformed_command.tql
@@ -3,3 +3,5 @@ error: true
 ---
 
 shell "sh -n -c 'if then echo hi; fi' >/dev/null 2>&1"
+read_lines
+discard

--- a/test/tests/operators/shell/source_nonzero_exit.tql
+++ b/test/tests/operators/shell/source_nonzero_exit.tql
@@ -3,3 +3,5 @@ error: true
 ---
 
 shell "exit 7"
+read_lines
+discard

--- a/test/tests/operators/write_json/arrays_of_objects.tql
+++ b/test/tests/operators/write_json/arrays_of_objects.tql
@@ -1,2 +1,4 @@
 from {}, {x:1}, {y:1}
-write_json arrays_of_objects=true
+to_stdout {
+  write_json arrays_of_objects=true
+}

--- a/test/tests/operators/write_json/floats.tql
+++ b/test/tests/operators/write_json/floats.tql
@@ -5,4 +5,6 @@ from {
   d: "nan".float(), // printed as `null`
   e: 0.000000001, // scientific notation
 }
-write_json
+to_stdout {
+  write_json
+}

--- a/test/tests/operators/write_kv/basic.tql
+++ b/test/tests/operators/write_kv/basic.tql
@@ -8,4 +8,6 @@ from {},
   {x:r#"\n\r
 "#, y:0},
   {l:[0,1],l2:["hello\n"],l3:[]}
-write_kv
+to_stdout {
+  write_kv
+}

--- a/test/tests/operators/write_ndjson/arrays_of_objects.tql
+++ b/test/tests/operators/write_ndjson/arrays_of_objects.tql
@@ -1,2 +1,4 @@
 from {}, {x:1}, {y:1}
-write_ndjson arrays_of_objects=true
+to_stdout {
+  write_ndjson arrays_of_objects=true
+}

--- a/test/tests/operators/write_syslog/basic.tql
+++ b/test/tests/operators/write_syslog/basic.tql
@@ -53,4 +53,6 @@ from {
   },
   message: null,
 }
-write_syslog
+to_stdout {
+  write_syslog
+}

--- a/test/tests/operators/write_syslog/defaults.tql
+++ b/test/tests/operators/write_syslog/defaults.tql
@@ -1,4 +1,6 @@
 from {
   message: "hello",
 }
-write_syslog
+to_stdout {
+  write_syslog
+}

--- a/test/tests/operators/write_syslog/structured_data_escaping.tql
+++ b/test/tests/operators/write_syslog/structured_data_escaping.tql
@@ -14,4 +14,6 @@ from {
   },
   message: "Hello",
 }
-write_syslog
+to_stdout {
+  write_syslog
+}

--- a/test/tests/operators/write_yaml/basic.tql
+++ b/test/tests/operators/write_yaml/basic.tql
@@ -1,2 +1,4 @@
 from {}, {x: 1}, {y: [1, 2], z: null}
-write_yaml
+to_stdout {
+  write_yaml
+}

--- a/test/tests/operators/write_zeek_tsv/basic.tql
+++ b/test/tests/operators/write_zeek_tsv/basic.tql
@@ -1,2 +1,4 @@
 from {uid: "foo", msg: "bar"}, {uid: "baz", msg: "qux"}
-write_zeek_tsv disable_timestamp_tags=true
+to_stdout {
+  write_zeek_tsv disable_timestamp_tags=true
+}

--- a/test/tests/operators/xsv/csv.tql
+++ b/test/tests/operators/xsv/csv.tql
@@ -1,4 +1,6 @@
 from_file f"{env("TENZIR_INPUTS")}/xsv/sample.csv" {
     read_csv
 }
-write_csv
+to_stdout {
+  write_csv
+}

--- a/test/tests/operators/xsv/ssv.tql
+++ b/test/tests/operators/xsv/ssv.tql
@@ -1,4 +1,6 @@
 from_file f"{env("TENZIR_INPUTS")}/xsv/sample.ssv" {
     read_ssv
 }
-write_ssv
+to_stdout {
+  write_ssv
+}

--- a/test/tests/operators/xsv/tsv.tql
+++ b/test/tests/operators/xsv/tsv.tql
@@ -1,4 +1,6 @@
 from_file f"{env("TENZIR_INPUTS")}/xsv/sample.tsv" {
     read_tsv
 }
-write_tsv
+to_stdout {
+  write_tsv
+}

--- a/test/tests/operators/xsv/xsv.tql
+++ b/test/tests/operators/xsv/xsv.tql
@@ -1,4 +1,6 @@
 from_file f"{env("TENZIR_INPUTS")}/xsv/sample.csv" {
   read_xsv field_separator=",", list_separator=";", null_value=""
 }
-write_xsv field_separator=",", list_separator=";", null_value=""
+to_stdout {
+  write_xsv field_separator=",", list_separator=";", null_value=""
+}


### PR DESCRIPTION
## 🔍 Problem

- `save_stdout` was accidentally ported to the neo executor.
- `save_stdout` should remain a legacy operator; neo event pipelines should use the existing event sink `to_stdout` instead.

## 🛠️ Solution

- Remove the neo descriptor from `save_stdout`, leaving its legacy implementation intact.
- Keep `to_stdout` event-only and preserve its existing surface: bare `to_stdout` prints events as TQL, and an optional subpipeline can format events with writers such as `write_json` or `write_ndjson`.
- Use `to_stdout` as the neo implicit event sink and leave neo byte output without an implicit `to_*` stdout sink.
- Update neo tests/fixtures that previously used `save_stdout` under neo.
- Bump `contrib/tenzir-plugins` to pick up matching context plugin test updates that rely on the implicit stdout sink.

## 💬 Review

- Check that legacy `save_stdout` remains available while neo execution no longer depends on it.
- Check that `to_stdout` remains event-only.
- Autocomplete may still list `save_stdout` briefly; this PR intentionally avoids adding registry filtering for that temporary mismatch.

<sub>
📚 Docs PR: tenzir/docs#290<br>
📎 Plugins PR: tenzir/tenzir-plugins#530
</sub>