### PR TITLE
Allow converting subpipeline errors into warnings

### DIFF
--- a/libtenzir/builtins/operators/accept_http.cpp
+++ b/libtenzir/builtins/operators/accept_http.cpp
@@ -374,7 +374,7 @@ public:
                                       .bytes_read = std::move(bytes_read)});
         }
         co_await ctx.spawn_sub(request_id, std::move(pipeline),
-                               tag_v<chunk_ptr>);
+                               tag_v<chunk_ptr>, FateSharing::Off);
       },
       [&](RequestBody body) -> Task<void> {
         auto chunk = std::move(body.chunk);

--- a/libtenzir/builtins/operators/accept_http.cpp
+++ b/libtenzir/builtins/operators/accept_http.cpp
@@ -460,6 +460,12 @@ public:
     co_return;
   }
 
+  auto finish_sub(SubKeyView key, failure error, Push<table_slice>& push,
+                  OpCtx& ctx) -> Task<void> override {
+    TENZIR_UNUSED(error);
+    co_await finish_sub(key, push, ctx);
+  }
+
   auto finalize(Push<table_slice>& push, OpCtx& ctx)
     -> Task<FinalizeBehavior> override {
     TENZIR_UNUSED(push, ctx);

--- a/libtenzir/builtins/operators/accept_tcp.cpp
+++ b/libtenzir/builtins/operators/accept_tcp.cpp
@@ -358,6 +358,12 @@ public:
     co_return;
   }
 
+  auto finish_sub(SubKeyView key, failure error, Push<table_slice>& push,
+                  OpCtx& ctx) -> Task<void> override {
+    TENZIR_UNUSED(error);
+    co_await finish_sub(key, push, ctx);
+  }
+
   auto finalize(Push<table_slice>& push, OpCtx& ctx)
     -> Task<FinalizeBehavior> override {
     TENZIR_UNUSED(push, ctx);

--- a/libtenzir/builtins/operators/accept_tcp.cpp
+++ b/libtenzir/builtins/operators/accept_tcp.cpp
@@ -291,8 +291,8 @@ public:
           co_return;
         }
         auto key = sub_key_for(conn_id);
-        co_await ctx.spawn_sub<chunk_ptr>(std::move(key),
-                                          std::move(pipeline_copy));
+        co_await ctx.spawn_sub<chunk_ptr>(
+          std::move(key), std::move(pipeline_copy), FateSharing::Off);
         auto [_, inserted]
           = connections_.emplace(conn_id, std::move(transport));
         TENZIR_ASSERT(inserted);

--- a/libtenzir/include/tenzir/async.hpp
+++ b/libtenzir/include/tenzir/async.hpp
@@ -305,6 +305,12 @@ public:
     co_return;
   }
 
+  virtual auto finish_sub(SubKeyView key, failure error, Push<Output>& push,
+                          OpCtx& ctx) -> Task<void> {
+    TENZIR_UNUSED(error);
+    co_await finish_sub(key, push, ctx);
+  }
+
 protected:
   ~OperatorOutputBase() = default;
 };
@@ -343,6 +349,12 @@ public:
   virtual auto finish_sub(SubKeyView key, OpCtx& ctx) -> Task<void> {
     TENZIR_UNUSED(key, ctx);
     co_return;
+  }
+
+  virtual auto finish_sub(SubKeyView key, failure error, OpCtx& ctx)
+    -> Task<void> {
+    TENZIR_UNUSED(error);
+    co_await finish_sub(key, ctx);
   }
 
 protected:

--- a/libtenzir/include/tenzir/async.hpp
+++ b/libtenzir/include/tenzir/async.hpp
@@ -106,6 +106,8 @@ private:
 using AnySubHandle
   = variant<SubHandle<void>, SubHandle<chunk_ptr>, SubHandle<table_slice>>;
 
+enum class FateSharing { Off, On };
+
 class OpCtx {
 public:
   virtual ~OpCtx() = default;
@@ -131,14 +133,17 @@ public:
   /// subpipeline is routed through the `process_sub` function of the operator.
   ///
   /// When the pipeline completes, `finish_sub` is called.
-  virtual auto spawn_sub(SubKey key, ir::pipeline pipe, element_type_tag input)
+  virtual auto spawn_sub(SubKey key, ir::pipeline pipe, element_type_tag input,
+                         FateSharing fate_sharing = FateSharing::On)
     -> Task<AnySubHandle&>
     = 0;
 
   template <class Input>
-  auto spawn_sub(SubKey key, ir::pipeline pipe) -> Task<SubHandle<Input>&> {
-    co_return as<SubHandle<Input>>(
-      co_await spawn_sub(std::move(key), std::move(pipe), tag_v<Input>));
+  auto spawn_sub(SubKey key, ir::pipeline pipe,
+                 FateSharing fate_sharing = FateSharing::On)
+    -> Task<SubHandle<Input>&> {
+    co_return as<SubHandle<Input>>(co_await spawn_sub(
+      std::move(key), std::move(pipe), tag_v<Input>, fate_sharing));
   }
 
   virtual auto

--- a/libtenzir/src/async/executor.cpp
+++ b/libtenzir/src/async/executor.cpp
@@ -87,9 +87,7 @@ struct ExplicitAny {
   Any value;
 };
 
-struct Terminated {
-  bool failed = false;
-};
+struct Terminated {};
 
 template <class T>
 class IdentityOperator final : public Operator<T, T> {
@@ -694,9 +692,11 @@ private:
     auto cancel_source = std::make_shared<folly::CancellationSource>();
     auto sub_dh
       = std::make_shared<ErrorDemotingDiagHandler>(dh_, cancel_source);
+    auto& sub_dh_ref = *sub_dh;
+    auto sub_cancel_token = sub_dh->cancellation_token();
     return spawn_sub_impl(std::move(key), std::move(pipe), input, false,
-                          *sub_dh, sub_dh->cancellation_token(),
-                          std::move(sub_dh), true);
+                          sub_dh_ref, sub_cancel_token, std::move(sub_dh),
+                          true);
   }
 
   auto spawn_sub_fused(SubKey key, ir::pipeline pipe, element_type_tag input)
@@ -839,6 +839,7 @@ private:
       using Event = variant<Terminated, Option<AnyOperatorMsg>>;
       // TODO: Fully implement checkpointing with `allow_output`.
       auto allow_output = true;
+      TENZIR_UNUSED(local_dh);
       auto driver = SelectSet<Event>{};
       co_await driver.activate([&] -> Task<void> {
         auto add_pull = [&] {
@@ -850,22 +851,19 @@ private:
                               }));
         };
         add_pull();
-        driver.add(
-          [runner = std::move(runner), sub_cancel_token,
-           local_dh = std::move(local_dh)] mutable -> Task<Terminated> {
-            auto token = folly::cancellation_token_merge(
-              co_await folly::coro::co_current_cancellation_token,
-              sub_cancel_token);
-            co_await catch_cancellation(
-              folly::coro::co_withCancellation(token, std::move(runner)));
-            co_return Terminated{.failed
-                                 = local_dh and local_dh->failure().is_error()};
-          });
+        driver.add([runner = std::move(runner),
+                    sub_cancel_token] mutable -> Task<Terminated> {
+          auto token = folly::cancellation_token_merge(
+            co_await folly::coro::co_current_cancellation_token,
+            sub_cancel_token);
+          co_await catch_cancellation(
+            folly::coro::co_withCancellation(token, std::move(runner)));
+          co_return Terminated{};
+        });
         while (auto next = co_await driver.next([&](Event const& event) {
           // Block subpipeline output after receiving its checkpoint.
           return allow_output or not is<Option<AnyOperatorMsg>>(event);
         })) {
-          auto stop = false;
           co_await co_match(
             *next,
             [&](Option<AnyOperatorMsg> output) -> Task<void> {
@@ -901,15 +899,11 @@ private:
                 });
               add_pull();
             },
-            [&](Terminated terminated) -> Task<void> {
+            [&](Terminated) -> Task<void> {
               // We wait with informing the parent until everything is done to
               // ensure that we don't send anything anymore.
-              stop = terminated.failed;
               co_return;
             });
-          if (stop) {
-            break;
-          }
         }
         // Now is the time to notify the parent. For now, this happens just by
         // dropping `to_parent` and `to_control_sender`, closing the channels.
@@ -1276,6 +1270,9 @@ private:
           signal,
           [&](EndOfData) -> Task<void> {
             LOGV("got end of data in {}", op_name());
+            if (phase_ != Phase::running) {
+              co_return;
+            }
             TENZIR_ASSERT(not input_is_void_);
             got_end_of_data_ = true;
             co_await handle_done(false);
@@ -1287,7 +1284,7 @@ private:
     // We always pull from upstream, even if the operator is done, since we want
     // to continue receiving checkpoints and our shutdown logic depends on it.
     driver_.add(pull_upstream());
-    if (base_op().state() == OperatorState::done) {
+    if (phase_ == Phase::running and base_op().state() == OperatorState::done) {
       co_await handle_done(false);
     }
   }
@@ -1429,6 +1426,14 @@ private:
     }
     LOGV("running done in {}", op_name());
     auto first_time = phase_ == Phase::running;
+    if (not force and not first_time) {
+      if (operator_draining_ and base_op().state() == OperatorState::done) {
+        operator_draining_ = false;
+      } else {
+        co_await check_done();
+        co_return;
+      }
+    }
     phase_ = force ? Phase::stopping_forced : Phase::stopping_gracefully;
     if (force) {
       // Cancel operator-scoped tasks immediately so that background IO

--- a/libtenzir/src/async/executor.cpp
+++ b/libtenzir/src/async/executor.cpp
@@ -87,7 +87,9 @@ struct ExplicitAny {
   Any value;
 };
 
-struct Terminated {};
+struct Terminated {
+  bool failed = false;
+};
 
 template <class T>
 class IdentityOperator final : public Operator<T, T> {
@@ -125,13 +127,15 @@ struct SubMessage {
 struct SubPipeline {
   SubPipeline(AnyOpPush push, Receiver<Checkpoint> from_sub,
               Sender<FromControl> from_control_sender,
-              Receiver<ToControl> to_control_receiver, element_type_tag input)
+              Receiver<ToControl> to_control_receiver, element_type_tag input,
+              std::shared_ptr<DiagHandler> local_dh = {})
     : push{Option<AnyOpPush>{std::move(push)}},
       from_sub{std::move(from_sub)},
       from_control_sender{
         Option<Sender<FromControl>>{std::move(from_control_sender)}},
       to_control_receiver{std::move(to_control_receiver)},
       input{input},
+      local_dh{std::move(local_dh)},
       handle{match(input, [this]<class Input>(tag<Input>) -> AnySubHandle {
         // TODO: There surely is a better way to model this than passing `this`.
         return AnySubHandle{std::in_place_type<SubHandle<Input>>, *this};
@@ -160,6 +164,10 @@ struct SubPipeline {
   element_type_tag input;
   /// True if this subpipeline received the last checkpoint, requiring a commit.
   bool wants_commit = false;
+  /// Diagnostic handler used by non-fate-sharing subpipelines.
+  std::shared_ptr<DiagHandler> local_dh;
+  /// True once `finish_sub` was called for this subpipeline.
+  bool finish_reported = false;
   /// Set when process(SubMessage) observes the from_sub channel drain.
   bool from_sub_done = false;
   /// Set when process(SubMessage) observes the to_control channel drain.
@@ -725,7 +733,7 @@ private:
   auto spawn_sub_impl(SubKey key, ir::pipeline pipe, element_type_tag input,
                       bool fused, DiagHandler& sub_dh,
                       folly::CancellationToken sub_cancel_token,
-                      std::shared_ptr<void> keep_alive,
+                      std::shared_ptr<DiagHandler> local_dh,
                       bool construction_errors_are_nonfatal)
     -> Task<AnySubHandle&> {
     auto sub_id = id_.sub(next_subpipeline_id_);
@@ -812,7 +820,8 @@ private:
     // its runner so shutdown paths can already observe and drain it.
     auto [it, inserted] = subpipelines_.try_emplace(
       std::move(key), std::move(push_sub), std::move(from_sub),
-      std::move(from_control_sender), std::move(to_control_receiver), input);
+      std::move(from_control_sender), std::move(to_control_receiver), input,
+      local_dh);
     if (not inserted) {
       panic("already have a subpipeline for that key");
     }
@@ -824,8 +833,8 @@ private:
                             runner = std::move(runner),
                             pull_sub = std::move(pull_sub),
                             to_parent = std::move(to_parent), sub_cancel_token,
-                            keep_alive
-                            = std::move(keep_alive)]() mutable -> Task<void> {
+                            local_dh
+                            = std::move(local_dh)]() mutable -> Task<void> {
       // The main loop of the subpipeline (or combiner?).
       using Event = variant<Terminated, Option<AnyOperatorMsg>>;
       // TODO: Fully implement checkpointing with `allow_output`.
@@ -843,19 +852,20 @@ private:
         add_pull();
         driver.add(
           [runner = std::move(runner), sub_cancel_token,
-           keep_alive = std::move(keep_alive)] mutable -> Task<Terminated> {
-            TENZIR_UNUSED(keep_alive);
+           local_dh = std::move(local_dh)] mutable -> Task<Terminated> {
             auto token = folly::cancellation_token_merge(
               co_await folly::coro::co_current_cancellation_token,
               sub_cancel_token);
             co_await catch_cancellation(
               folly::coro::co_withCancellation(token, std::move(runner)));
-            co_return Terminated{};
+            co_return Terminated{.failed
+                                 = local_dh and local_dh->failure().is_error()};
           });
         while (auto next = co_await driver.next([&](Event const& event) {
           // Block subpipeline output after receiving its checkpoint.
           return allow_output or not is<Option<AnyOperatorMsg>>(event);
         })) {
+          auto stop = false;
           co_await co_match(
             *next,
             [&](Option<AnyOperatorMsg> output) -> Task<void> {
@@ -891,11 +901,15 @@ private:
                 });
               add_pull();
             },
-            [&](Terminated) -> Task<void> {
+            [&](Terminated terminated) -> Task<void> {
               // We wait with informing the parent until everything is done to
               // ensure that we don't send anything anymore.
+              stop = terminated.failed;
               co_return;
             });
+          if (stop) {
+            break;
+          }
         }
         // Now is the time to notify the parent. For now, this happens just by
         // dropping `to_parent` and `to_control_sender`, closing the channels.
@@ -1092,6 +1106,20 @@ private:
       });
   }
 
+  auto call_finish_sub(SubKeyView key, failure error) -> Task<void> {
+    auto& ctx_ref = static_cast<OpCtx&>(*this);
+    co_await co_match(
+      op_, [&]<class In, class Out>(Box<Operator<In, Out>>& op) -> Task<void> {
+        if constexpr (std::same_as<Out, void>) {
+          co_await op->finish_sub(key, error, ctx_ref);
+        } else {
+          auto& push = as<Box<Push<OperatorMsg<Out>>>>(push_downstream_);
+          auto wrapper = OpPushWrapper{push};
+          co_await op->finish_sub(key, error, wrapper, ctx_ref);
+        }
+      });
+  }
+
   template <class DataInput>
   auto call_process(DataInput input) -> Task<void> {
     auto& ctx_ref = static_cast<OpCtx&>(*this);
@@ -1259,6 +1287,9 @@ private:
     // We always pull from upstream, even if the operator is done, since we want
     // to continue receiving checkpoints and our shutdown logic depends on it.
     driver_.add(pull_upstream());
+    if (base_op().state() == OperatorState::done) {
+      co_await handle_done(false);
+    }
   }
 
   auto begin_checkpoint(Checkpoint checkpoint) -> Task<void> {
@@ -1329,9 +1360,18 @@ private:
       if (not closed) {
         co_return;
       }
+      auto sub_failure = failure_or<void>{};
+      if (sub.local_dh) {
+        sub_failure = sub.local_dh->failure();
+      }
+      auto finish_reported = sub.finish_reported;
       subpipelines_.erase(it);
-      if (phase_ != Phase::stopping_forced) {
-        co_await call_finish_sub(make_view(message.key));
+      if (phase_ != Phase::stopping_forced and not finish_reported) {
+        if (sub_failure.is_error()) {
+          co_await call_finish_sub(make_view(message.key), sub_failure.error());
+        } else {
+          co_await call_finish_sub(make_view(message.key));
+        }
       }
       co_await check_done();
     };
@@ -1444,7 +1484,14 @@ private:
     if (phase_ == Phase::running or phase_ == Phase::stopped) {
       co_return;
     }
-    if (not subpipelines_.empty()) {
+    auto has_unreported_subpipeline = false;
+    for (auto const& [_, sub] : subpipelines_) {
+      if (not sub.finish_reported) {
+        has_unreported_subpipeline = true;
+        break;
+      }
+    }
+    if (phase_ != Phase::stopping_forced and has_unreported_subpipeline) {
       // We need to wait for all subpipelines to finish.
       co_return;
     }
@@ -1548,9 +1595,9 @@ auto run_operator(Box<Operator<Input, Output>> op,
   };
   auto result
     = co_await catch_cancellation(std::move(runner).run_to_completion());
-  // Ensure that we only cancel if cancellation was requested from outside.
-  co_await folly::coro::co_safe_point;
-  TENZIR_ASSERT(result);
+  if (not result) {
+    co_return;
+  }
   co_return;
 }
 
@@ -1642,7 +1689,6 @@ private:
                       -> Task<std::pair<size_t, Terminated>> {
           co_await folly::coro::co_withExecutor(std::move(executor),
                                                 std::move(task));
-          LOGI("got termination from operator {}", index);
           co_return {index, Terminated{}};
         });
       });

--- a/libtenzir/src/async/executor.cpp
+++ b/libtenzir/src/async/executor.cpp
@@ -238,6 +238,44 @@ private:
   secret_censor censor_;
 };
 
+// Forwards diagnostics to a parent handler, but emits errors as warnings and
+// cancels its source so the owner can stop the isolated computation.
+class ErrorDemotingDiagHandler final : public DiagHandler {
+public:
+  ErrorDemotingDiagHandler(DiagHandler& dh,
+                           std::shared_ptr<folly::CancellationSource> source)
+    : dh_{dh}, cancel_source_{std::move(source)} {
+  }
+
+  auto emit(diagnostic d) -> void override {
+    auto lock = std::scoped_lock{mutex_};
+    if (dedup_.insert(d)) {
+      if (d.severity == severity::error) {
+        failure_ = failure::promise();
+        cancel_source_->requestCancellation();
+        d.severity = severity::warning;
+      }
+      dh_->emit(std::move(d));
+    }
+  }
+
+  auto failure() -> failure_or<void> override {
+    auto lock = std::scoped_lock{mutex_};
+    return failure_;
+  }
+
+  auto cancellation_token() const -> folly::CancellationToken {
+    return cancel_source_->getToken();
+  }
+
+private:
+  std::mutex mutex_;
+  Ref<DiagHandler> dh_;
+  std::shared_ptr<folly::CancellationSource> cancel_source_;
+  diagnostic_deduplicator dedup_;
+  failure_or<void> failure_;
+};
+
 /// Decorator over any `ExecCtx` that produces fused channels and shares a
 /// single executor across all operators. This gives run-to-completion
 /// semantics per slice: a push blocks until the downstream operator has
@@ -639,18 +677,57 @@ private:
     co_return {};
   }
 
-  auto spawn_sub(SubKey key, ir::pipeline pipe, element_type_tag input)
-    -> Task<AnySubHandle&> override {
-    return spawn_sub_impl(std::move(key), std::move(pipe), input, false);
+  auto spawn_sub(SubKey key, ir::pipeline pipe, element_type_tag input,
+                 FateSharing fate_sharing) -> Task<AnySubHandle&> override {
+    if (fate_sharing == FateSharing::On) {
+      return spawn_sub_impl(std::move(key), std::move(pipe), input, false, dh_,
+                            folly::CancellationToken{}, {}, false);
+    }
+    auto cancel_source = std::make_shared<folly::CancellationSource>();
+    auto sub_dh
+      = std::make_shared<ErrorDemotingDiagHandler>(dh_, cancel_source);
+    return spawn_sub_impl(std::move(key), std::move(pipe), input, false,
+                          *sub_dh, sub_dh->cancellation_token(),
+                          std::move(sub_dh), true);
   }
 
   auto spawn_sub_fused(SubKey key, ir::pipeline pipe, element_type_tag input)
     -> Task<AnySubHandle&> override {
-    return spawn_sub_impl(std::move(key), std::move(pipe), input, true);
+    return spawn_sub_impl(std::move(key), std::move(pipe), input, true, dh_,
+                          folly::CancellationToken{}, {}, false);
+  }
+
+  auto make_closed_sub(SubKey key, element_type_tag input, PipeId sub_id)
+    -> AnySubHandle& {
+    auto [from_sub_sender, from_sub] = channel<Checkpoint>(1);
+    auto [from_control_sender, from_control_receiver] = channel<FromControl>(1);
+    auto [to_control_sender, to_control_receiver] = channel<ToControl>(1);
+    TENZIR_UNUSED(from_sub_sender, from_control_receiver, to_control_sender);
+    auto push_sub = match(input, [&]<class In>(tag<In>) -> AnyOpPush {
+      auto [push, pull] = exec_ctx_.make_channel<In>(id_.to(sub_id.op(0)));
+      TENZIR_UNUSED(pull);
+      return AnyOpPush{std::move(push)};
+    });
+    auto [it, inserted] = subpipelines_.try_emplace(
+      std::move(key), std::move(push_sub), std::move(from_sub),
+      std::move(from_control_sender), std::move(to_control_receiver), input);
+    if (not inserted) {
+      panic("already have a subpipeline for that key");
+    }
+    it->second.closed_data = true;
+    it->second.push = None{};
+    it->second.from_control_sender = None{};
+    add_from_sub_recv(it);
+    add_to_control_recv(it);
+    return it->second.handle;
   }
 
   auto spawn_sub_impl(SubKey key, ir::pipeline pipe, element_type_tag input,
-                      bool fused) -> Task<AnySubHandle&> {
+                      bool fused, DiagHandler& sub_dh,
+                      folly::CancellationToken sub_cancel_token,
+                      std::shared_ptr<void> keep_alive,
+                      bool construction_errors_are_nonfatal)
+    -> Task<AnySubHandle&> {
     auto sub_id = id_.sub(next_subpipeline_id_);
     if (not fused) {
       // For the parallel operator, which is currently the only user of the
@@ -659,8 +736,11 @@ private:
       next_subpipeline_id_ += 1;
     }
     // Instantiate for the case where it was not instantiated yet.
-    if (not pipe.substitute(substitute_ctx{base_ctx{dh_, *reg_}, nullptr},
+    if (not pipe.substitute(substitute_ctx{base_ctx{sub_dh, *reg_}, nullptr},
                             true)) {
+      if (construction_errors_are_nonfatal) {
+        co_return make_closed_sub(std::move(key), input, sub_id);
+      }
       // We just emitted an error. Either we return some placeholder no-op
       // handle now, or we just sleep and wait for cancellation. For now, we
       // pick the simple option, but we might need to reconsider how we want to
@@ -680,10 +760,13 @@ private:
       std::rotate(pipe.operators.begin(), pipe.operators.begin() + offset,
                   pipe.operators.end());
     }
-    auto output = pipe.infer_type(input, dh_);
+    auto output = pipe.infer_type(input, sub_dh);
     // The caller is responsible for passing a well-typed pipeline that
     // type-checks against `input`. And since optimizations are type-preserving,
     // we know that this cannot fail.
+    if (construction_errors_are_nonfatal and (not output or not *output)) {
+      co_return make_closed_sub(std::move(key), input, sub_id);
+    }
     TENZIR_ASSERT(output);
     TENZIR_ASSERT(*output);
     auto spawned = std::move(pipe).spawn(input);
@@ -711,12 +794,12 @@ private:
                                     std::move(push_downstream),
                                     std::move(from_control_receiver),
                                     std::move(to_control_sender),
-                                    std::move(sub_id), exec_ctx_, sys_, dh_)
+                                    std::move(sub_id), exec_ctx_, sys_, sub_dh)
                   : run_chain(std::move(chain), std::move(pull_upstream),
                               std::move(push_downstream),
                               std::move(from_control_receiver),
                               std::move(to_control_sender), std::move(sub_id),
-                              exec_ctx_, sys_, dh_);
+                              exec_ctx_, sys_, sub_dh);
         return {
           std::move(runner),
           AnyOpPush{std::move(push_upstream)},
@@ -740,8 +823,9 @@ private:
     operator_scope_->spawn([this, key = std::move(sub_key),
                             runner = std::move(runner),
                             pull_sub = std::move(pull_sub),
-                            to_parent
-                            = std::move(to_parent)]() mutable -> Task<void> {
+                            to_parent = std::move(to_parent), sub_cancel_token,
+                            keep_alive
+                            = std::move(keep_alive)]() mutable -> Task<void> {
       // The main loop of the subpipeline (or combiner?).
       using Event = variant<Terminated, Option<AnyOperatorMsg>>;
       // TODO: Fully implement checkpointing with `allow_output`.
@@ -757,10 +841,17 @@ private:
                               }));
         };
         add_pull();
-        driver.add([runner = std::move(runner)] mutable -> Task<Terminated> {
-          co_await std::move(runner);
-          co_return Terminated{};
-        });
+        driver.add(
+          [runner = std::move(runner), sub_cancel_token,
+           keep_alive = std::move(keep_alive)] mutable -> Task<Terminated> {
+            TENZIR_UNUSED(keep_alive);
+            auto token = folly::cancellation_token_merge(
+              co_await folly::coro::co_current_cancellation_token,
+              sub_cancel_token);
+            co_await catch_cancellation(
+              folly::coro::co_withCancellation(token, std::move(runner)));
+            co_return Terminated{};
+          });
         while (auto next = co_await driver.next([&](Event const& event) {
           // Block subpipeline output after receiving its checkpoint.
           return allow_output or not is<Option<AnyOperatorMsg>>(event);

--- a/test/fixtures/tcp.py
+++ b/test/fixtures/tcp.py
@@ -240,10 +240,11 @@ def _run_client_worker(
     if invalid_tls_handshake_first:
         _send_invalid_tls_handshake(port, stop_event)
     next_payloads = iter(payloads) if payloads is not None else None
+    current_payload: bytes | None = None
     while not stop_event.is_set():
         if next_payloads is None:
             current_payload = payload
-        else:
+        elif current_payload is None:
             try:
                 current_payload = next(next_payloads)
             except StopIteration:
@@ -301,6 +302,7 @@ def _run_client_worker(
                             idle_deadline = time.monotonic() + 2
         except (ssl.SSLError, OSError):
             pass
+        current_payload = None
         if inter_connection_delay > 0:
             stop_event.wait(inter_connection_delay)
         time.sleep(_CLIENT_RETRY_DELAY)

--- a/test/fixtures/tcp.py
+++ b/test/fixtures/tcp.py
@@ -31,8 +31,10 @@ class TcpOptions:
     client_send_delay: float = 0.0
     client_split_payload_at: int | None = None
     client_split_send_delay: float = 0.0
+    inter_connection_delay: float = 0.0
     mode: str = "client"  # "client" sends data; "server" receives data
     payload: str = "foo\n"
+    payloads: list[str] | None = None
 
 
 @dataclass(frozen=True)
@@ -60,6 +62,7 @@ def tcp() -> FixtureHandle:
     stop_event = threading.Event()
     state = _TcpState()
     payload = opts.payload.encode()
+    payloads = [entry.encode() for entry in opts.payloads] if opts.payloads else None
     temp_dir = Path(tempfile.mkdtemp(prefix="tcp-")) if opts.tls or opts.certs else None
     cert_path: Path | None = None
     key_path: Path | None = None
@@ -87,6 +90,7 @@ def tcp() -> FixtureHandle:
                 "stop_event": stop_event,
                 "state": state,
                 "payload": payload,
+                "payloads": payloads,
                 "tls": opts.tls,
                 "ca_path": ca_path,
                 "capture_path": client_capture_path,
@@ -94,6 +98,7 @@ def tcp() -> FixtureHandle:
                 "send_delay": opts.client_send_delay,
                 "split_payload_at": opts.client_split_payload_at,
                 "split_send_delay": opts.client_split_send_delay,
+                "inter_connection_delay": opts.inter_connection_delay,
             },
             daemon=True,
         )
@@ -216,6 +221,7 @@ def _run_client_worker(
     stop_event: threading.Event,
     state: _TcpState,
     payload: bytes,
+    payloads: list[bytes] | None,
     tls: bool,
     ca_path: Path | None,
     capture_path: str | None,
@@ -223,6 +229,7 @@ def _run_client_worker(
     send_delay: float,
     split_payload_at: int | None,
     split_send_delay: float,
+    inter_connection_delay: float,
 ) -> None:
     context: ssl.SSLContext | None = None
     if tls:
@@ -232,7 +239,15 @@ def _run_client_worker(
         context.load_verify_locations(cafile=ca_path)
     if invalid_tls_handshake_first:
         _send_invalid_tls_handshake(port, stop_event)
+    next_payloads = iter(payloads) if payloads is not None else None
     while not stop_event.is_set():
+        if next_payloads is None:
+            current_payload = payload
+        else:
+            try:
+                current_payload = next(next_payloads)
+            except StopIteration:
+                return
         try:
             raw_sock = socket.create_connection((_HOST, port), timeout=1)
         except (ConnectionRefusedError, OSError):
@@ -249,14 +264,14 @@ def _run_client_worker(
                     sock.settimeout(0.2)
                     if send_delay > 0:
                         stop_event.wait(send_delay)
-                    if payload:
+                    if current_payload:
                         if split_payload_at is None:
-                            sock.sendall(payload)
+                            sock.sendall(current_payload)
                         else:
-                            sock.sendall(payload[:split_payload_at])
+                            sock.sendall(current_payload[:split_payload_at])
                             if split_send_delay > 0:
                                 stop_event.wait(split_send_delay)
-                            sock.sendall(payload[split_payload_at:])
+                            sock.sendall(current_payload[split_payload_at:])
                     if context is None:
                         try:
                             sock.shutdown(socket.SHUT_WR)
@@ -286,6 +301,8 @@ def _run_client_worker(
                             idle_deadline = time.monotonic() + 2
         except (ssl.SSLError, OSError):
             pass
+        if inter_connection_delay > 0:
+            stop_event.wait(inter_connection_delay)
         time.sleep(_CLIENT_RETRY_DELAY)
 
 

--- a/test/tests/operators/accept_http/subpipeline_error_nonfatal.tql
+++ b/test/tests/operators/accept_http/subpipeline_error_nonfatal.tql
@@ -1,0 +1,21 @@
+---
+fixtures:
+  - http_request:
+      initial_delay: 1.0
+      requests:
+        - path: /ingest
+          body: "{\n"
+          expected_status: 200
+          expected_body: ""
+        - path: /ingest
+          body: '{"value":42}\n'
+          expected_status: 200
+          expected_body: ""
+          stop_on_connection_drop: true
+timeout: 60
+---
+
+accept_http env("HTTP_REQUEST_ENDPOINT") {
+  read_json
+}
+head 1

--- a/test/tests/operators/accept_http/subpipeline_error_nonfatal.tql
+++ b/test/tests/operators/accept_http/subpipeline_error_nonfatal.tql
@@ -8,7 +8,7 @@ fixtures:
           expected_status: 200
           expected_body: ""
         - path: /ingest
-          body: '{"value":42}\n'
+          body: "{\"value\":42}\n"
           expected_status: 200
           expected_body: ""
           stop_on_connection_drop: true

--- a/test/tests/operators/accept_http/subpipeline_error_nonfatal.txt
+++ b/test/tests/operators/accept_http/subpipeline_error_nonfatal.txt
@@ -1,4 +1,4 @@
-warning: json parser: parser input ended with incomplete object
 {
   value: 42,
 }
+warning: json parser: parser input ended with incomplete object

--- a/test/tests/operators/accept_http/subpipeline_error_nonfatal.txt
+++ b/test/tests/operators/accept_http/subpipeline_error_nonfatal.txt
@@ -1,0 +1,4 @@
+warning: json parser: parser input ended with incomplete object
+{
+  value: 42,
+}

--- a/test/tests/operators/accept_tcp/subpipeline_error_nonfatal.tql
+++ b/test/tests/operators/accept_tcp/subpipeline_error_nonfatal.tql
@@ -4,7 +4,7 @@ fixtures:
       mode: client
       payloads:
         - "{\n"
-        - '{"value":42}\n'
+        - "{\"value\":42}\n"
       inter_connection_delay: 0.2
 timeout: 60
 ---

--- a/test/tests/operators/accept_tcp/subpipeline_error_nonfatal.tql
+++ b/test/tests/operators/accept_tcp/subpipeline_error_nonfatal.tql
@@ -1,0 +1,15 @@
+---
+fixtures:
+  - tcp:
+      mode: client
+      payloads:
+        - "{\n"
+        - '{"value":42}\n'
+      inter_connection_delay: 0.2
+timeout: 60
+---
+
+accept_tcp env("TCP_ENDPOINT") {
+  read_json
+}
+head 1

--- a/test/tests/operators/accept_tcp/subpipeline_error_nonfatal.txt
+++ b/test/tests/operators/accept_tcp/subpipeline_error_nonfatal.txt
@@ -1,4 +1,4 @@
-warning: json parser: parser input ended with incomplete object
 {
   value: 42,
 }
+warning: json parser: parser input ended with incomplete object

--- a/test/tests/operators/accept_tcp/subpipeline_error_nonfatal.txt
+++ b/test/tests/operators/accept_tcp/subpipeline_error_nonfatal.txt
@@ -1,0 +1,4 @@
+warning: json parser: parser input ended with incomplete object
+{
+  value: 42,
+}


### PR DESCRIPTION
Route non-fate-sharing subpipelines through a local diagnostic handler that downgrades runtime errors and cancels only the subpipeline task. Keep parent cancellation merged into the runner so ordinary shutdown still propagates.

Assisted-by: GPT-5 (Codex)<!--

Fixes TNZ-546.