### PR TITLE
Update release workflow pin

### DIFF
--- a/.github/workflows/release-major.yaml
+++ b/.github/workflows/release-major.yaml
@@ -3,22 +3,10 @@ name: Release (Major)
 on:
   workflow_dispatch:
     inputs:
-      bump:
-        description: |
-          Major release mode
-
-          Use `major` to start a new major release or major RC series. Use
-          `auto` to continue or promote the latest outstanding major RC.
-        required: false
-        default: major
-        type: choice
-        options:
-          - major
-          - auto
       rc:
         description: |
-          Create or continue the release-candidate series for the resolved
-          stable version.
+          Create or continue the next major release-candidate series. Leave
+          disabled to promote the latest outstanding major RC to stable.
         required: false
         default: false
         type: boolean
@@ -41,7 +29,7 @@ jobs:
   release:
     uses: ./.github/workflows/release.yaml
     with:
-      bump: ${{ inputs.bump }}
+      bump: ${{ inputs.rc && 'major' || 'auto' }}
       rc: ${{ inputs.rc }}
       intro: ${{ inputs.intro }}
       title: ${{ inputs.title }}

--- a/.github/workflows/release-major.yaml
+++ b/.github/workflows/release-major.yaml
@@ -26,7 +26,43 @@ on:
         type: string
 
 jobs:
+  validate-major-release:
+    name: Validate major release mode
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Validate major promotion target
+        env:
+          RC: ${{ inputs.rc }}
+        run: |
+          if [ "$RC" = "true" ]; then
+            exit 0
+          fi
+
+          outstanding_major_rc=""
+          for manifest in changelog/releases/v*.0.0-rc.*/manifest.yaml; do
+            [ -e "$manifest" ] || continue
+            release_dir="${manifest%/manifest.yaml}"
+            rc_version="${release_dir##*/}"
+            stable_version="${rc_version%%-rc.*}"
+
+            if [ ! -d "changelog/releases/${stable_version}" ]; then
+              outstanding_major_rc="$rc_version"
+            fi
+          done
+
+          if [ -z "$outstanding_major_rc" ]; then
+            echo "::error::No outstanding major release candidate found. Run with rc=true to start or continue a major RC series."
+            exit 1
+          fi
+
+          echo "Found outstanding major release candidate: ${outstanding_major_rc}"
+
   release:
+    needs: validate-major-release
     uses: ./.github/workflows/release.yaml
     with:
       bump: ${{ inputs.rc && 'major' || 'auto' }}

--- a/.github/workflows/release-major.yaml
+++ b/.github/workflows/release-major.yaml
@@ -26,43 +26,7 @@ on:
         type: string
 
 jobs:
-  validate-major-release:
-    name: Validate major release mode
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-
-      - name: Validate major promotion target
-        env:
-          RC: ${{ inputs.rc }}
-        run: |
-          if [ "$RC" = "true" ]; then
-            exit 0
-          fi
-
-          outstanding_major_rc=""
-          for manifest in changelog/releases/v*.0.0-rc.*/manifest.yaml; do
-            [ -e "$manifest" ] || continue
-            release_dir="${manifest%/manifest.yaml}"
-            rc_version="${release_dir##*/}"
-            stable_version="${rc_version%%-rc.*}"
-
-            if [ ! -d "changelog/releases/${stable_version}" ]; then
-              outstanding_major_rc="$rc_version"
-            fi
-          done
-
-          if [ -z "$outstanding_major_rc" ]; then
-            echo "::error::No outstanding major release candidate found. Run with rc=true to start or continue a major RC series."
-            exit 1
-          fi
-
-          echo "Found outstanding major release candidate: ${outstanding_major_rc}"
-
   release:
-    needs: validate-major-release
     uses: ./.github/workflows/release.yaml
     with:
       bump: ${{ inputs.rc && 'major' || 'auto' }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -117,9 +117,6 @@ jobs:
         uv --directory python add --package tenzir-operator --frozen "tenzir-common>=${VERSION_NUMBER},<${UPPER_BOUND}"
         uv --directory python lock
 
-        # Stage tracked version updates for the release commit.
-        git add -u
-
         echo "Updated version.json with tenzir-version: ${VERSION_NUMBER}"
         echo "Updated Python package versions to: ${VERSION_NUMBER}"
       publish-no-latest-on-non-main: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,9 +62,36 @@ on:
         type: string
 
 jobs:
+  validate-release-config:
+    name: Validate release workflow configuration
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Validate release configuration
+        env:
+          TENZIR_GITHUB_APP_ID: ${{ vars.TENZIR_GITHUB_APP_ID }}
+          TENZIR_GITHUB_APP_PRIVATE_KEY: ${{ secrets.TENZIR_GITHUB_APP_PRIVATE_KEY }}
+          TENZIR_BOT_GPG_SIGNING_KEY: ${{ secrets.TENZIR_BOT_GPG_SIGNING_KEY }}
+        run: |
+          if [ -z "$TENZIR_GITHUB_APP_ID" ]; then
+            echo "::error::Repository variable 'TENZIR_GITHUB_APP_ID' must be set for release runs."
+            exit 1
+          fi
+
+          if [ -z "$TENZIR_GITHUB_APP_PRIVATE_KEY" ]; then
+            echo "::error::Repository secret 'TENZIR_GITHUB_APP_PRIVATE_KEY' must be set for release runs."
+            exit 1
+          fi
+
+          if [ -z "$TENZIR_BOT_GPG_SIGNING_KEY" ]; then
+            echo "::error::Repository secret 'TENZIR_BOT_GPG_SIGNING_KEY' must be set for release runs."
+            exit 1
+          fi
+
   release:
     name: Release
-    uses: tenzir/ship/.github/workflows/reusable-release-advanced.yaml@49fe3d4df9785b29bddeb1a83be5e33032ab25a1
+    needs: validate-release-config
+    uses: tenzir/ship/.github/workflows/release.yaml@87509bbc44fc9dc383816ab5b0706584c21fbd64
     permissions:
       contents: write
     with:
@@ -90,15 +117,19 @@ jobs:
         uv --directory python add --package tenzir-operator --frozen "tenzir-common>=${VERSION_NUMBER},<${UPPER_BOUND}"
         uv --directory python lock
 
-        # Keep existing release behavior by staging tracked updates.
-        git add -u
-
         echo "Updated version.json with tenzir-version: ${VERSION_NUMBER}"
         echo "Updated Python package versions to: ${VERSION_NUMBER}"
       publish-no-latest-on-non-main: true
       copy-release-to-main-on-non-main: true
       update-latest-branch-on-main: true
-    secrets: inherit
+      github_app_id: ${{ vars.TENZIR_GITHUB_APP_ID }}
+      git_user_name: tenzir-bot
+      git_user_email: engineering@tenzir.com
+      sign_commits: true
+      sign_tags: true
+    secrets:
+      github_app_private_key: ${{ secrets.TENZIR_GITHUB_APP_PRIVATE_KEY }}
+      gpg_private_key: ${{ secrets.TENZIR_BOT_GPG_SIGNING_KEY }}
 
   sbom:
     name: Attach SBOM

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -117,6 +117,9 @@ jobs:
         uv --directory python add --package tenzir-operator --frozen "tenzir-common>=${VERSION_NUMBER},<${UPPER_BOUND}"
         uv --directory python lock
 
+        # Stage tracked version updates for the release commit.
+        git add -u
+
         echo "Updated version.json with tenzir-version: ${VERSION_NUMBER}"
         echo "Updated Python package versions to: ${VERSION_NUMBER}"
       publish-no-latest-on-non-main: true


### PR DESCRIPTION
## 🔍 Problem

- The release workflow still called the removed advanced reusable workflow in `tenzir/ship`.
- Major release promotion could still force a major bump instead of promoting the outstanding RC.

## 🛠️ Solution

- Pin releases to the current `tenzir/ship` reusable release workflow.
- Pass the bot authentication and signing inputs explicitly, and validate the required repository configuration before release runs.
- Derive the major release bump from the `rc` input so stable promotion uses automatic RC promotion.

## 💬 Review

- Check the pinned `tenzir/ship` commit and the mapped app/GPG secrets.
- Check that the major release workflow matches the intended RC start/continue/promote flow.
- Validated with `git diff --check` and `actionlint`.