### PR TITLE
Test installer on macOS 26

### DIFF
--- a/.github/workflows/installer.yaml
+++ b/.github/workflows/installer.yaml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [macos-15]
+        image: [macos-26]
         tag: ["latest", "main"]
     runs-on: ${{ matrix.image }}
     env:


### PR DESCRIPTION
## 🔍 Problem

- The installer workflow still validates the macOS package on `macos-15`.
- The package now intentionally targets macOS 26, so the validation job aborts when it executes `tenzir` on the older runner.

## 🛠️ Solution

- Run the stock macOS installer validation on `macos-26`.
- Keep the package deployment target unchanged.

## 💬 Review

- Focus on whether all macOS installer validation should follow the package target baseline.
