### PR TITLE
Allow top-level package metadata

### DIFF
--- a/changelog/unreleased/top-level-package-metadata.md
+++ b/changelog/unreleased/top-level-package-metadata.md
@@ -1,0 +1,11 @@
+---
+title: Top-level package metadata
+type: bugfix
+authors:
+  - tobim
+  - codex
+pr: 6149
+created: 2026-05-08T15:43:35.152192Z
+---
+
+Packages can now include a top-level `metadata` field for data consumed by external tools. Unknown package keys still fail validation, and the error now points users to `metadata` for non-engine package data.

--- a/libtenzir/src/package.cpp
+++ b/libtenzir/src/package.cpp
@@ -45,9 +45,10 @@ auto is_valid_package_identifier(std::string_view value) -> bool {
 
 auto should_ignore_package_key(std::string_view section, std::string_view key)
   -> bool {
-  // `labels` comes from configured pipelines, and `snippets` is a legacy
-  // library field superseded by `examples`.
-  return (section == "package" and key == "snippets")
+  // `metadata` is package-spec data for external tools, `snippets` is a legacy
+  // library field superseded by `examples`, and `labels` comes from configured
+  // pipelines.
+  return (section == "package" and (key == "metadata" or key == "snippets"))
          or (section == "pipeline" and key == "labels");
 }
 
@@ -55,6 +56,7 @@ auto unknown_package_key_error(std::string_view section, std::string_view key)
   -> caf::error {
   return diagnostic::error("unknown key `{}` in {} definition", key, section)
     .note("invalid package definition")
+    .hint("use the top-level `metadata` key for package data")
     .to_error();
 }
 

--- a/test/inputs/package-ignored-known-keys.yaml
+++ b/test/inputs/package-ignored-known-keys.yaml
@@ -6,6 +6,9 @@ snippets:
   - name: Legacy snippet field
     definition: version
 
+metadata:
+  source: package-spec
+
 inputs:
   message:
     name: Message

--- a/test/inputs/package-unknown-pipeline-key.yaml
+++ b/test/inputs/package-unknown-pipeline-key.yaml
@@ -9,3 +9,4 @@ pipelines:
     schedule: hourly
     definition: |
       from {message: "hello"}
+      import

--- a/test/inputs/package-unknown-top-level-key.yaml
+++ b/test/inputs/package-unknown-top-level-key.yaml
@@ -10,3 +10,4 @@ pipelines:
     description: Emits one event.
     definition: |
       from {message: "hello"}
+      import

--- a/test/tests/node/package/validation/unknown-pipeline-key.txt
+++ b/test/tests/node/package/validation/unknown-pipeline-key.txt
@@ -5,5 +5,6 @@ error: unknown key `schedule` in pipeline definition
   | ^^^^^^^^^^^^ 
   |
   = note: invalid package definition
+  = hint: use the top-level `metadata` key for package data
   = note: while parsing key demo for field pipelines
   = note: invalid package definition

--- a/test/tests/node/package/validation/unknown-top-level-key.txt
+++ b/test/tests/node/package/validation/unknown-top-level-key.txt
@@ -5,3 +5,4 @@ error: unknown key `surprise` in package definition
   | ^^^^^^^^^^^^ 
   |
   = note: invalid package definition
+  = hint: use the top-level `metadata` key for package data


### PR DESCRIPTION
## 🔍 Problem

- Packages may include non-engine metadata for external tools.
- Unknown package keys should remain validation errors, but the error did not tell users where such external data belongs.

## 🛠️ Solution

- Allow top-level `metadata` in package definitions.
- Keep all other unknown package keys fatal.
- Add a hint to unknown-key diagnostics that points users to `metadata` for non-engine package data.

## 💬 Review

- The package parser API still accepts a diagnostic handler so the tenzir-plugins companion remains compatible.
- Package validation tests cover accepted `metadata` and fatal unknown keys with the new hint.

<sub>
📚 Docs PR: tenzir/docs#311<br>
📎 Related: tenzir/tenzir-plugins#535
</sub>
