### PR TITLE
Strip internal tql2. prefix from operator descriptions

### DIFF
--- a/libtenzir/src/operator_plugin.cpp
+++ b/libtenzir/src/operator_plugin.cpp
@@ -683,6 +683,10 @@ auto OperatorPlugin::describe_shared() const
     if (desc->name.empty()) {
       desc->name = name();
     }
+    constexpr auto tql2_prefix = std::string_view{"tql2."};
+    if (desc->name.starts_with(tql2_prefix)) {
+      desc->name.erase(0, tql2_prefix.size());
+    }
     if (desc->docs.empty()) {
       desc->docs = "https://docs.tenzir.com/reference/operators/" + desc->name;
     }

--- a/test/tests/operators/parallel/error_bytes_input.txt
+++ b/test/tests/operators/parallel/error_bytes_input.txt
@@ -4,4 +4,4 @@ error: operator does not accept bytes
 7 | parallel { pass }
   | ^^^^^^^^ 
   |
-  = docs: https://docs.tenzir.com/reference/operators/tql2.parallel
+  = docs: https://docs.tenzir.com/reference/operators/parallel


### PR DESCRIPTION
## 🔍 Problem

Operator plugins that register under legacy names like `tql2.foo` surface that
internal prefix through `OperatorPlugin::describe_shared()`. The prefix then
leaks into diagnostics and into the auto-generated
`https://docs.tenzir.com/reference/operators/...` URL, neither of which should
expose the `tql2.` artifact.

## 🛠️ Solution

- Strip a leading `tql2.` from the description name in `describe_shared()`
  before it is used for the default docs URL or returned to callers.

## 💬 Review

- Single, narrow site of fixup. Anything that still wants the raw plugin name
  can call `name()` directly; only the shared `Description` is normalized.