### PR TITLE
Pin clang-format version used by git hook

### DIFF
--- a/scripts/clang-format-diff.py
+++ b/scripts/clang-format-diff.py
@@ -25,7 +25,9 @@ from __future__ import absolute_import, division, print_function
 
 import argparse
 import difflib
+import os
 import re
+import shlex
 import subprocess
 import sys
 
@@ -33,6 +35,32 @@ if sys.version_info.major >= 3:
     from io import StringIO
 else:
     from io import BytesIO as StringIO
+
+
+def default_binary():
+    version_file = os.path.normpath(
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            os.pardir,
+            ".clang-format-version",
+        )
+    )
+    script = sys.argv[0] if sys.argv else "clang-format-diff.py"
+    hint = (
+        "either write a clang-format version to {0}, e.g.\n"
+        "  echo 21.1.8 > {0}\n"
+        "or pass an explicit binary via -binary, e.g.\n"
+        "  git diff -U0 --no-color $(git merge-base origin/main HEAD) HEAD "
+        "| {1} -p1 -binary 'uvx clang-format@21.1.8'"
+    ).format(version_file, script)
+    try:
+        with open(version_file) as f:
+            version = f.read().strip()
+    except OSError as e:
+        sys.exit("error: cannot read {}: {}\n{}".format(version_file, e.strerror, hint))
+    if not version:
+        sys.exit("error: {} is empty\n{}".format(version_file, hint))
+    return "uvx clang-format@{}".format(version)
 
 
 def main():
@@ -87,10 +115,14 @@ def main():
     )
     parser.add_argument(
         "-binary",
-        default="clang-format",
-        help="location of binary to use for clang-format",
+        default=None,
+        help="command to invoke clang-format (may include arguments, parsed with shlex); "
+        "defaults to 'uvx clang-format@<version>' using the version from "
+        ".clang-format-version at the repo root",
     )
     args = parser.parse_args()
+    if args.binary is None:
+        args.binary = default_binary()
 
     # Extract changed lines for each file.
     filename = None
@@ -126,7 +158,7 @@ def main():
     for filename, lines in lines_by_file.items():
         if args.i and args.verbose:
             print("Formatting {}".format(filename))
-        command = [args.binary, filename]
+        command = shlex.split(args.binary) + [filename]
         if args.i:
             command.append("-i")
         if args.sort_includes:

--- a/scripts/git-setup.sh
+++ b/scripts/git-setup.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # shellcheck disable=SC2016
 
-# This script creates 4 local git aliases and installs a pre-commit hook that
+# This script creates 4 local git aliases and installs a pre-push hook that
 # assists with working in the Tenzir repository:
 # - `git format-show`        checks if clang-format is happy with the current
 #                            staging area.
@@ -11,11 +11,11 @@
 #                            since the current branch was created/rebased.
 # - `git format-branch`      formats the code that was modified since the
 #                            current branch was created/rebased.
-# The pre-commit hook runs `git format-show` to check for style violations
-# and prevents the commit if it finds any.
+# The pre-push hook runs `git format-show-branch` to check for style violations
+# and prevents the push if it finds any.
 
 usage() {
-  echo "usage: $(basename "$0") [options] [<format-show|format|pre-commit>]"
+  echo "usage: $(basename "$0") [options] [<format-show|format|pre-push>]"
   echo
   echo 'available options:'
   echo "    -f              force installation (overwrite existing)"
@@ -26,7 +26,7 @@ usage() {
 install_format_show_branch() {
   if ! git config --local --get alias.format-show-branch >/dev/null || [ "$force" = TRUE ]; then
     echo 'Adding alias for `git format-show-branch`'
-    git config --local alias.format-show-branch "!f() { git diff -U0 --no-color \$@ \$(git merge-base origin/main HEAD) -- \"*.cpp\" \"*.cpp.in\" \"*.hpp\" \"*.hpp.in\" | ${format_call} -p1; }; f"
+    git config --local alias.format-show-branch "!f() { git diff -U0 --no-color \$@ \$(git merge-base origin/main HEAD) HEAD -- \"*.cpp\" \"*.cpp.in\" \"*.hpp\" \"*.hpp.in\" | ${format_call} -p1; }; f"
   else
     echo 'alias for `git format-show-branch` already exists, skipping'
   fi
@@ -59,15 +59,21 @@ install_format() {
   fi
 }
 
-install_pre_commit() {
+install_pre_push() {
   GIT_DIR="$(git rev-parse --git-common-dir)"
+  PRE_PUSH="${GIT_DIR}/hooks/pre-push"
   PRE_COMMIT="${GIT_DIR}/hooks/pre-commit"
-  if [ ! -f "${PRE_COMMIT}" ] || [ "$force" = TRUE ]; then
-    echo 'adding pre-commit hook for format checking'
-    printf "#!/bin/sh\ngit format-show --cached" >"${PRE_COMMIT}"
-    chmod +x "${PRE_COMMIT}"
+  # Migrate away from the legacy pre-commit format hook.
+  if [ -f "${PRE_COMMIT}" ] && grep -q 'git format-show --cached' "${PRE_COMMIT}"; then
+    echo 'removing legacy pre-commit format hook'
+    rm "${PRE_COMMIT}"
+  fi
+  if [ ! -f "${PRE_PUSH}" ] || [ "$force" = TRUE ]; then
+    echo 'adding pre-push hook for format checking'
+    printf "#!/bin/sh\ngit format-show-branch" >"${PRE_PUSH}"
+    chmod +x "${PRE_PUSH}"
   else
-    echo 'git pre-commit hook already exists, skipping'
+    echo 'git pre-push hook already exists, skipping'
   fi
 }
 
@@ -93,7 +99,7 @@ while getopts "fp:h?" opt; do
       ;;
   esac
 done
-shift "$(("$OPTIND" - 1))"
+shift $((OPTIND - 1))
 
 if [ ! "${script_git_tl}" = "${current_git_tl}" ]; then
   fixed_path=TRUE
@@ -109,7 +115,7 @@ if [ -z "$*" ]; then
   install_format
   install_format_show_branch
   install_format_branch
-  install_pre_commit
+  install_pre_push
 else
   case "$1" in
     format-show)
@@ -124,8 +130,8 @@ else
     format-branch)
       install_format_branch
       ;;
-    pre-commit)
-      install_pre_commit
+    pre-push)
+      install_pre_push
       ;;
   esac
 fi


### PR DESCRIPTION
Pin the clang-format version used by the git hook to get consistent results across all platforms. The `21.1.8` version matches the one currently used by `treefmt`.

Also move the installed git hook from a pre-commit hook to a pre-push hook to be less interruptive, in particular for agent workflows.


