### PR TITLE
Limit rebuild memory admission

### DIFF
--- a/changelog/unreleased/rebuild-size-limit.md
+++ b/changelog/unreleased/rebuild-size-limit.md
@@ -5,6 +5,7 @@ authors:
   - tobim
   - codex
 created: 2026-05-11T12:33:13.375284Z
+pr: 6155
 ---
 
 Rebuilds now avoid loading too much data into memory at once. Partitions store

--- a/changelog/unreleased/rebuild-size-limit.md
+++ b/changelog/unreleased/rebuild-size-limit.md
@@ -11,7 +11,8 @@ pr: 6155
 Rebuilds now avoid loading too much data into memory at once. Partitions store
 their approximate in-memory size in metadata, and the new
 `tenzir.rebuild.max-size` setting and `tenzir rebuild --max-size` option make
-rebuild admit only partitions that still fit into the current memory budget:
+rebuild admit only partitions whose estimated input and output buffers still
+fit into the current memory budget:
 
 ```sh
 tenzir rebuild --max-size=512MiB

--- a/changelog/unreleased/rebuild-size-limit.md
+++ b/changelog/unreleased/rebuild-size-limit.md
@@ -1,0 +1,23 @@
+---
+title: Rebuild size limit
+type: bugfix
+authors:
+  - tobim
+  - codex
+created: 2026-05-11T12:33:13.375284Z
+---
+
+Rebuilds now avoid loading too much data into memory at once. Partitions store
+their approximate in-memory size in metadata, and the new
+`tenzir.rebuild.max-size` setting and `tenzir rebuild --max-size` option make
+rebuild admit only partitions that still fit into the current memory budget:
+
+```sh
+tenzir rebuild --max-size=512MiB
+```
+
+By default, Tenzir uses 50% of the currently available system memory. Set the
+limit to `0` to restore the previous unlimited behavior. For existing
+partitions without size metadata, rebuild estimates the size from measured
+partitions with the same schema, falling back to an event-count heuristic only
+when no schema-specific measurement exists.

--- a/libtenzir/builtins/commands/rebuild.cpp
+++ b/libtenzir/builtins/commands/rebuild.cpp
@@ -259,6 +259,12 @@ auto estimate_approx_bytes(
   return partition.events * legacy_approx_bytes_per_event;
 }
 
+auto estimate_rebuild_memory_requirement(uint64_t approx_bytes) -> uint64_t {
+  // The transformer buffers both the input slices and the slices emitted by the
+  // rebatch pipeline, so the admission check must budget for both sides.
+  return saturating_add(approx_bytes, approx_bytes);
+}
+
 auto fits_size_limit(uint64_t current, uint64_t next, uint64_t limit) -> bool {
   if (limit == 0) {
     return true;
@@ -553,7 +559,7 @@ struct rebuilder_state {
     }
     auto current_run_partitions = std::vector<partition_info>{};
     auto current_run_events = size_t{0};
-    auto current_run_approx_bytes = uint64_t{0};
+    auto current_run_memory_requirement = uint64_t{0};
     auto skipped_partitions = size_t{0};
     // Take the first partition and collect as many of the same
     // type as possible to create new paritions. The approach used may
@@ -570,27 +576,31 @@ struct rebuilder_state {
             and current_run_events < max_partition_size) {
           const auto approx_bytes
             = estimate_approx_bytes(run->schema_size_estimates, partition);
-          if (not fits_size_limit(current_run_approx_bytes, approx_bytes,
-                                  run->options.max_size)) {
+          const auto memory_requirement
+            = estimate_rebuild_memory_requirement(approx_bytes);
+          if (not fits_size_limit(current_run_memory_requirement,
+                                  memory_requirement, run->options.max_size)) {
             if (current_run_partitions.empty()) {
-              TENZIR_WARN(
-                "{} skips partition {} because its estimated in-memory size "
-                "of {} bytes exceeds the rebuild size limit of {} bytes",
-                *self, partition.uuid, approx_bytes, run->options.max_size);
+              TENZIR_WARN("{} skips partition {} because its estimated memory "
+                          "requirement "
+                          "of {} bytes exceeds the rebuild size limit of {} "
+                          "bytes",
+                          *self, partition.uuid, memory_requirement,
+                          run->options.max_size);
               ++skipped_partitions;
               return true;
             }
             return false;
           }
           current_run_events += partition.events;
-          current_run_approx_bytes
-            = saturating_add(current_run_approx_bytes, approx_bytes);
+          current_run_memory_requirement = saturating_add(
+            current_run_memory_requirement, memory_requirement);
           current_run_partitions.push_back(partition);
           TENZIR_TRACE("{} selects partition {} (v{}, {}) with "
                        "{} events and {} bytes (total: {} events, {} bytes)",
                        *self, partition.uuid, partition.version,
-                       partition.schema, partition.events, approx_bytes,
-                       current_run_events, current_run_approx_bytes);
+                       partition.schema, partition.events, memory_requirement,
+                       current_run_events, current_run_memory_requirement);
           return true;
         }
         return false;

--- a/libtenzir/builtins/commands/rebuild.cpp
+++ b/libtenzir/builtins/commands/rebuild.cpp
@@ -16,6 +16,7 @@
 #include <tenzir/defaults.hpp>
 #include <tenzir/detail/inspection_common.hpp>
 #include <tenzir/detail/narrow.hpp>
+#include <tenzir/detail/settings.hpp>
 #include <tenzir/detail/weak_run_delayed.hpp>
 #include <tenzir/fwd.hpp>
 #include <tenzir/index.hpp>
@@ -39,6 +40,14 @@
 #include <caf/typed_event_based_actor.hpp>
 #include <fmt/format.h>
 
+#include <cmath>
+#include <optional>
+#include <unordered_map>
+
+#if __has_include(<unistd.h>)
+#  include <unistd.h>
+#endif
+
 namespace tenzir::plugins::rebuild {
 
 namespace {
@@ -49,14 +58,15 @@ struct start_options {
   bool undersized = false;
   size_t parallel = 1;
   size_t max_partitions = std::numeric_limits<size_t>::max();
+  uint64_t max_size = std::numeric_limits<uint64_t>::max();
   class expression expression = {};
   bool detached = false;
   bool automatic = false;
 
   friend auto inspect(auto& f, start_options& x) {
     return detail::apply_all(f, x.all, x.undersized, x.parallel,
-                             x.max_partitions, x.expression, x.detached,
-                             x.automatic);
+                             x.max_partitions, x.max_size, x.expression,
+                             x.detached, x.automatic);
   }
 };
 
@@ -88,6 +98,118 @@ namespace {
 /// configured 'tenzir.max-partition-size'.
 inline constexpr auto undersized_threshold = 0.8;
 
+/// Sentinel for resolving the default rebuild size limit in the rebuilder actor.
+inline constexpr auto use_default_rebuild_size_limit
+  = std::numeric_limits<uint64_t>::max();
+
+/// Fallback estimate for partitions whose metadata predates `approx_bytes`.
+inline constexpr auto legacy_approx_bytes_per_event = uint64_t{250};
+
+struct schema_size_estimate {
+  uint64_t events = 0;
+  uint64_t approx_bytes = 0;
+};
+
+auto available_memory_bytes() -> std::optional<uint64_t> {
+#if defined(_SC_AVPHYS_PAGES) && defined(_SC_PAGESIZE)
+  const auto pages = ::sysconf(_SC_AVPHYS_PAGES);
+  const auto page_size = ::sysconf(_SC_PAGESIZE);
+  if (pages <= 0 or page_size <= 0) {
+    return std::nullopt;
+  }
+  const auto unsigned_pages = static_cast<uint64_t>(pages);
+  const auto unsigned_page_size = static_cast<uint64_t>(page_size);
+  if (unsigned_pages
+      > std::numeric_limits<uint64_t>::max() / unsigned_page_size) {
+    return std::nullopt;
+  }
+  return unsigned_pages * unsigned_page_size;
+#else
+  return std::nullopt;
+#endif
+}
+
+auto default_rebuild_size_limit() -> uint64_t {
+  if (auto available = available_memory_bytes()) {
+    return *available / 2;
+  }
+  return defaults::rebuild_size_limit;
+}
+
+auto parse_rebuild_size_limit(const caf::settings& options)
+  -> caf::expected<uint64_t> {
+  constexpr auto key = "tenzir.rebuild.max-size";
+  if (caf::get_if(&options, key) == nullptr) {
+    return use_default_rebuild_size_limit;
+  }
+  return detail::get_bytesize(options, key, uint64_t{0});
+}
+
+auto saturating_add(uint64_t lhs, uint64_t rhs) -> uint64_t {
+  if (rhs > std::numeric_limits<uint64_t>::max() - lhs) {
+    return std::numeric_limits<uint64_t>::max();
+  }
+  return lhs + rhs;
+}
+
+auto estimate_from_bytes_per_event(size_t events, uint64_t total_events,
+                                   uint64_t total_approx_bytes) -> uint64_t {
+  TENZIR_ASSERT(total_events > 0);
+  if (events == 0) {
+    return 0;
+  }
+  if (events <= std::numeric_limits<uint64_t>::max() / total_approx_bytes) {
+    const auto product = static_cast<uint64_t>(events) * total_approx_bytes;
+    return product / total_events + (product % total_events == 0 ? 0 : 1);
+  }
+  const auto estimate = std::ceil(static_cast<long double>(events)
+                                  * static_cast<long double>(total_approx_bytes)
+                                  / static_cast<long double>(total_events));
+  if (estimate
+      >= static_cast<long double>(std::numeric_limits<uint64_t>::max())) {
+    return std::numeric_limits<uint64_t>::max();
+  }
+  return static_cast<uint64_t>(estimate);
+}
+
+void update_schema_size_estimate(
+  std::unordered_map<std::string, schema_size_estimate>& estimates,
+  const partition_info& partition) {
+  if (partition.events == 0 or partition.approx_bytes == 0) {
+    return;
+  }
+  auto& estimate = estimates[partition.schema.make_fingerprint()];
+  estimate.events = saturating_add(estimate.events, partition.events);
+  estimate.approx_bytes
+    = saturating_add(estimate.approx_bytes, partition.approx_bytes);
+}
+
+auto estimate_approx_bytes(
+  const std::unordered_map<std::string, schema_size_estimate>& estimates,
+  const partition_info& partition) -> uint64_t {
+  if (partition.approx_bytes != 0) {
+    return partition.approx_bytes;
+  }
+  if (const auto it = estimates.find(partition.schema.make_fingerprint());
+      it != estimates.end() and it->second.events != 0
+      and it->second.approx_bytes != 0) {
+    return estimate_from_bytes_per_event(partition.events, it->second.events,
+                                         it->second.approx_bytes);
+  }
+  if (partition.events
+      > std::numeric_limits<uint64_t>::max() / legacy_approx_bytes_per_event) {
+    return std::numeric_limits<uint64_t>::max();
+  }
+  return partition.events * legacy_approx_bytes_per_event;
+}
+
+auto fits_size_limit(uint64_t current, uint64_t next, uint64_t limit) -> bool {
+  if (limit == 0) {
+    return true;
+  }
+  return next <= limit and current <= limit - next;
+}
+
 /// Statistics for an ongoing rebuild. Numbers are partitions.
 struct statistics {
   size_t num_total = {};
@@ -99,6 +221,8 @@ struct statistics {
 /// The state of an in-progress rebuild.
 struct run {
   std::vector<partition_info> remaining_partitions = {};
+  std::unordered_map<std::string, schema_size_estimate> schema_size_estimates
+    = {};
   struct statistics statistics = {};
   start_options options = {};
   std::vector<caf::typed_response_promise<void>> stop_requests = {};
@@ -137,6 +261,7 @@ struct rebuilder_state {
   size_t desired_batch_size = 0u;
   size_t automatic_rebuild = 0u;
   duration rebuild_interval = {};
+  uint64_t rebuild_size_limit = use_default_rebuild_size_limit;
 
   /// The state of the ongoing rebuild.
   std::optional<struct run> run = {};
@@ -163,6 +288,7 @@ struct rebuilder_state {
          {"undersized", run->options.undersized},
          {"parallel", run->options.parallel},
          {"max-partitions", run->options.max_partitions},
+         {"max-size", run->options.max_size},
          {"expression", fmt::to_string(run->options.expression)},
          {"detached", run->options.detached},
          {"automatic", run->options.automatic},
@@ -201,6 +327,11 @@ struct rebuilder_state {
             rp.deliver(std::move(err));
           });
       return rp;
+    }
+    if (options.max_size == use_default_rebuild_size_limit) {
+      options.max_size = rebuild_size_limit == use_default_rebuild_size_limit
+                           ? default_rebuild_size_limit()
+                           : rebuild_size_limit;
     }
     run.emplace();
     run->options = std::move(options);
@@ -252,6 +383,10 @@ struct rebuilder_state {
         [this, finish](catalog_lookup_result& lookup_result) mutable {
           TENZIR_ASSERT(run->statistics.num_total == 0);
           for (auto& [type, result] : lookup_result.candidate_infos) {
+            for (const auto& partition : result.partition_infos) {
+              update_schema_size_estimate(run->schema_size_estimates,
+                                          partition);
+            }
             if (not run->options.all) {
               std::erase_if(
                 result.partition_infos, [&](const partition_info& partition) {
@@ -362,6 +497,8 @@ struct rebuilder_state {
     }
     auto current_run_partitions = std::vector<partition_info>{};
     auto current_run_events = size_t{0};
+    auto current_run_approx_bytes = uint64_t{0};
+    auto skipped_partitions = size_t{0};
     // Take the first partition and collect as many of the same
     // type as possible to create new paritions. The approach used may
     // collects too many partitions if there is no exact match, but that is
@@ -375,18 +512,43 @@ struct rebuilder_state {
       [&](const partition_info& partition) {
         if (schema == partition.schema
             and current_run_events < max_partition_size) {
+          const auto approx_bytes
+            = estimate_approx_bytes(run->schema_size_estimates, partition);
+          if (not fits_size_limit(current_run_approx_bytes, approx_bytes,
+                                  run->options.max_size)) {
+            if (current_run_partitions.empty()) {
+              TENZIR_WARN(
+                "{} skips partition {} because its estimated in-memory size "
+                "of {} bytes exceeds the rebuild size limit of {} bytes",
+                *self, partition.uuid, approx_bytes, run->options.max_size);
+              ++skipped_partitions;
+              return true;
+            }
+            return false;
+          }
           current_run_events += partition.events;
+          current_run_approx_bytes
+            = saturating_add(current_run_approx_bytes, approx_bytes);
           current_run_partitions.push_back(partition);
           TENZIR_TRACE("{} selects partition {} (v{}, {}) with "
-                       "{} events (total: {})",
+                       "{} events and {} bytes (total: {} events, {} bytes)",
                        *self, partition.uuid, partition.version,
-                       partition.schema, partition.events, current_run_events);
+                       partition.schema, partition.events, approx_bytes,
+                       current_run_events, current_run_approx_bytes);
           return true;
         }
         return false;
       });
     run->remaining_partitions.erase(first_removed,
                                     run->remaining_partitions.end());
+    if (skipped_partitions > 0) {
+      run->statistics.num_total -= skipped_partitions;
+    }
+    if (current_run_partitions.empty()) {
+      // Pick up new work until we run out of remaining partitions.
+      return self->mail(atom::internal_v, atom::rebuild_v)
+        .delegate(static_cast<rebuilder_actor>(self));
+    }
     run->statistics.num_rebuilding += current_run_partitions.size();
     // If we have just a single partition then we shouldn't rebuild if our
     // intent was to merge undersized partitions, unless the partition is
@@ -442,6 +604,9 @@ struct rebuilder_state {
           }
           TENZIR_DEBUG("{} rebuilt {} into {} partitions", *self,
                        num_partitions, result.size());
+          for (const auto& partition : result) {
+            update_schema_size_estimate(run->schema_size_estimates, partition);
+          }
           // If the number of events in the resulting partitions does not
           // match the number of events in the partitions that went in we ran
           // into a conflict with other partition transformations on an
@@ -486,6 +651,7 @@ struct rebuilder_state {
       .undersized = true,
       .parallel = automatic_rebuild,
       .max_partitions = std::numeric_limits<size_t>::max(),
+      .max_size = rebuild_size_limit,
       .expression = trivially_true_expression(),
       .detached = true,
       .automatic = true,
@@ -523,6 +689,16 @@ rebuilder(rebuilder_actor::stateful_pointer<rebuilder_state> self,
                   defaults::import::table_slice_size);
   self->state().automatic_rebuild = caf::get_or(
     content(self->system().config()), "tenzir.automatic-rebuild", size_t{1});
+  if (auto rebuild_size_limit
+      = parse_rebuild_size_limit(content(self->system().config()))) {
+    self->state().rebuild_size_limit = *rebuild_size_limit;
+  } else {
+    const auto fallback = default_rebuild_size_limit();
+    TENZIR_WARN("{} failed to parse tenzir.rebuild.max-size: {}; using "
+                "default of {} bytes",
+                *self, rebuild_size_limit.error(), fallback);
+    self->state().rebuild_size_limit = fallback;
+  }
   if (self->state().automatic_rebuild > 0) {
     self->state().rebuild_interval
       = caf::get_or(content(self->system().config()), "tenzir.rebuild-interval",
@@ -660,12 +836,17 @@ rebuild_start_command(const invocation& inv, caf::actor_system& sys) {
     }
     expr = std::move(*parsed);
   }
+  auto max_size = parse_rebuild_size_limit(inv.options);
+  if (not max_size) {
+    return caf::make_message(std::move(max_size.error()));
+  }
   auto options = start_options{
     .all = caf::get_or(inv.options, "tenzir.rebuild.all", false),
     .undersized = caf::get_or(inv.options, "tenzir.rebuild.undersized", false),
     .parallel = caf::get_or(inv.options, "tenzir.rebuild.parallel", size_t{1}),
     .max_partitions = caf::get_or(inv.options, "tenzir.rebuild.max-partitions",
                                   std::numeric_limits<size_t>::max()),
+    .max_size = *max_size,
     .expression = std::move(expr),
     .detached = caf::get_or(inv.options, "tenzir.rebuild.detached", false),
     .automatic = false,
@@ -749,6 +930,10 @@ public:
         .add<std::string>("read,r", "path for reading the (optional) query")
         .add<int64_t>("max-partitions,n", "number of partitions to rebuild at "
                                           "most (default: unlimited)")
+        .add<std::string>("max-size", "approximate in-memory size budget for "
+                                      "partitions admitted to one rebuild "
+                                      "transformation (default: 50% of "
+                                      "available memory, 0 disables the limit)")
         .add<int64_t>("parallel,j", "number of runs to start in parallel "
                                     "(default: 1)"));
     rebuild->add_subcommand("start",

--- a/libtenzir/builtins/commands/rebuild.cpp
+++ b/libtenzir/builtins/commands/rebuild.cpp
@@ -40,8 +40,12 @@
 #include <caf/typed_event_based_actor.hpp>
 #include <fmt/format.h>
 
+#include <algorithm>
+#include <charconv>
 #include <cmath>
+#include <fstream>
 #include <optional>
+#include <string>
 #include <unordered_map>
 
 #if __has_include(<unistd.h>)
@@ -110,7 +114,47 @@ struct schema_size_estimate {
   uint64_t approx_bytes = 0;
 };
 
-auto available_memory_bytes() -> std::optional<uint64_t> {
+auto read_uint64_file(std::string_view path) -> std::optional<uint64_t> {
+  auto file = std::ifstream{std::string{path}};
+  auto value = std::string{};
+  if (not(file >> value) or value == "max") {
+    return std::nullopt;
+  }
+  auto result = uint64_t{0};
+  const auto* first = value.data();
+  const auto* last = first + value.size();
+  const auto [ptr, ec] = std::from_chars(first, last, result);
+  if (ec != std::errc{} or ptr != last) {
+    return std::nullopt;
+  }
+  return result;
+}
+
+auto cgroup_available_memory_bytes(std::string_view limit_path,
+                                   std::string_view usage_path)
+  -> std::optional<uint64_t> {
+  const auto limit = read_uint64_file(limit_path);
+  const auto usage = read_uint64_file(usage_path);
+  if (not limit or not usage) {
+    return std::nullopt;
+  }
+  if (*usage >= *limit) {
+    return 0;
+  }
+  return *limit - *usage;
+}
+
+auto cgroup_available_memory_bytes() -> std::optional<uint64_t> {
+  if (auto result = cgroup_available_memory_bytes(
+        "/sys/fs/cgroup/memory.max", "/sys/fs/cgroup/memory.current")) {
+    return result;
+  }
+  return cgroup_available_memory_bytes(
+    "/sys/fs/cgroup/memory/memory.limit_in_bytes",
+    "/sys/fs/cgroup/memory/memory.usage_in_bytes");
+}
+
+auto system_available_memory_bytes() -> std::optional<uint64_t> {
 #if defined(_SC_AVPHYS_PAGES) && defined(_SC_PAGESIZE)
   const auto pages = ::sysconf(_SC_AVPHYS_PAGES);
   const auto page_size = ::sysconf(_SC_PAGESIZE);
@@ -129,9 +173,21 @@ auto available_memory_bytes() -> std::optional<uint64_t> {
 #endif
 }
 
+auto available_memory_bytes() -> std::optional<uint64_t> {
+  const auto cgroup_available = cgroup_available_memory_bytes();
+  const auto system_available = system_available_memory_bytes();
+  if (cgroup_available and system_available) {
+    return std::min(*cgroup_available, *system_available);
+  }
+  if (cgroup_available) {
+    return cgroup_available;
+  }
+  return system_available;
+}
+
 auto default_rebuild_size_limit() -> uint64_t {
   if (auto available = available_memory_bytes()) {
-    return *available / 2;
+    return std::max<uint64_t>(*available / 2, 1);
   }
   return defaults::rebuild_size_limit;
 }

--- a/libtenzir/fbs/partition_synopsis.fbs
+++ b/libtenzir/fbs/partition_synopsis.fbs
@@ -23,6 +23,10 @@ table LegacyPartitionSynopsis {
   /// The schema of this partition. Note that this field was not present for
   /// partition synopses with a version number of 0.
   schema: [ubyte] (nested_flatbuffer: "tenzir.fbs.Type");
+
+  /// The approximate number of bytes required to materialize this partition as
+  /// table slices in memory.
+  approx_bytes: ulong;
 }
 
 union PartitionSynopsis {

--- a/libtenzir/include/tenzir/actors.hpp
+++ b/libtenzir/include/tenzir/actors.hpp
@@ -264,7 +264,7 @@ using filesystem_actor = typed_actor_fwd<
 
 /// The interface of a PARTITION TRANSFORMER actor.
 using partition_transformer_actor = typed_actor_fwd<
-  // INTERNAL: Load the next selected input partition.
+  // INTERNAL: Start the transform pipeline.
   auto(atom::internal, atom::load)->caf::result<void>,
   // Persist the transformed partitions and return the generated
   // partition synopses.

--- a/libtenzir/include/tenzir/actors.hpp
+++ b/libtenzir/include/tenzir/actors.hpp
@@ -264,6 +264,8 @@ using filesystem_actor = typed_actor_fwd<
 
 /// The interface of a PARTITION TRANSFORMER actor.
 using partition_transformer_actor = typed_actor_fwd<
+  // INTERNAL: Load the next selected input partition.
+  auto(atom::internal, atom::load)->caf::result<void>,
   // Persist the transformed partitions and return the generated
   // partition synopses.
   auto(atom::persist)->caf::result<std::vector<partition_synopsis_pair>>,

--- a/libtenzir/include/tenzir/defaults.hpp
+++ b/libtenzir/include/tenzir/defaults.hpp
@@ -226,6 +226,10 @@ inline constexpr caf::timespan active_partition_timeout
 /// Timeout after which a new automatic rebuild is triggered.
 inline constexpr caf::timespan rebuild_interval = std::chrono::minutes{30};
 
+/// Fallback approximate number of input or output bytes per rebuild
+/// transformation when the dynamic default cannot be determined.
+inline constexpr uint64_t rebuild_size_limit = 1ull << 30; // 1 GiB
+
 /// Maximum number of in-memory INDEX partitions.
 inline constexpr size_t max_in_mem_partitions = 1;
 

--- a/libtenzir/include/tenzir/index.hpp
+++ b/libtenzir/include/tenzir/index.hpp
@@ -252,7 +252,8 @@ struct index_state {
   /// old entries when the size exceeds `max_inmem_partitions`.
   detail::lru_cache<uuid, partition_actor, partition_factory> inmem_partitions;
 
-  /// The set of partitions that exist on disk.
+  /// A best-effort cache of partitions that the index has persisted itself.
+  /// The catalog is the source of truth for persisted partition visibility.
   std::unordered_set<uuid> persisted_partitions = {};
 
   /// The maximum number of events that a partition can hold.

--- a/libtenzir/include/tenzir/index.hpp
+++ b/libtenzir/include/tenzir/index.hpp
@@ -145,6 +145,10 @@ struct index_state {
   /// Maps partitions to their expected location on the file system.
   [[nodiscard]] std::filesystem::path partition_path(const uuid& id) const;
 
+  /// Returns a format string that can be formatted with a partition id to
+  /// get the input location of that partition for the partition transformer.
+  [[nodiscard]] std::string partition_path_template() const;
+
   /// The path to which a partition transformer should write a partition with
   /// the UUID `id`.
   [[nodiscard]] std::filesystem::path

--- a/libtenzir/include/tenzir/partition_synopsis.hpp
+++ b/libtenzir/include/tenzir/partition_synopsis.hpp
@@ -64,6 +64,10 @@ struct partition_synopsis final : public caf::ref_counted {
   // Number of events in the partition.
   uint64_t events = 0;
 
+  /// Approximate number of bytes required to materialize this partition as
+  /// table slices in memory.
+  uint64_t approx_bytes = 0;
+
   /// The minimum import timestamp of all contained table slices.
   time min_import_time = time::max();
 
@@ -108,10 +112,11 @@ struct partition_info {
 
   partition_info() noexcept = default;
 
-  partition_info(class uuid uuid, size_t events, time max_import_time,
-                 type schema, uint64_t version) noexcept
+  partition_info(class uuid uuid, size_t events, uint64_t approx_bytes,
+                 time max_import_time, type schema, uint64_t version) noexcept
     : uuid{uuid},
       events{events},
+      approx_bytes{approx_bytes},
       max_import_time{max_import_time},
       schema{std::move(schema)},
       version{version} {
@@ -119,8 +124,12 @@ struct partition_info {
   }
 
   partition_info(class uuid uuid, const partition_synopsis& synopsis)
-    : partition_info{uuid, synopsis.events, synopsis.max_import_time,
-                     synopsis.schema, synopsis.version} {
+    : partition_info{uuid,
+                     synopsis.events,
+                     synopsis.approx_bytes,
+                     synopsis.max_import_time,
+                     synopsis.schema,
+                     synopsis.version} {
     // nop
   }
 
@@ -130,6 +139,10 @@ struct partition_info {
   /// Total number of events in the partition. The sum of all
   /// values in `stats`.
   size_t events = 0ull;
+
+  /// Approximate number of bytes required to materialize this partition as
+  /// table slices in memory.
+  uint64_t approx_bytes = 0;
 
   /// The newest import timestamp of the table slices in this partition.
   time max_import_time = {};
@@ -165,6 +178,7 @@ struct partition_info {
     return f.object(x)
       .pretty_name("tenzir.partition-info")
       .fields(f.field("uuid", x.uuid), f.field("events", x.events),
+              f.field("approx-bytes", x.approx_bytes),
               f.field("max-import-time", x.max_import_time),
               f.field("schema", x.schema), f.field("version", x.version));
   }

--- a/libtenzir/include/tenzir/partition_transformer.hpp
+++ b/libtenzir/include/tenzir/partition_transformer.hpp
@@ -77,6 +77,12 @@ struct partition_transformer_state {
   /// Cached transform error, if the transform returns one.
   caf::error transform_error = {};
 
+  /// The partitions selected as input for the transform.
+  std::vector<partition_info> input_partitions = {};
+
+  /// The next input partition to load.
+  size_t next_input_partition = 0;
+
   /// The maximum number of events per partition. (not really necessary, but
   /// required by the partition synopsis)
   size_t partition_capacity = 0ull;
@@ -116,8 +122,9 @@ struct partition_transformer_state {
   /// Options for creating new value indices.
   caf::settings index_opts = {};
 
-  // Two format strings that can be formatted with a `tenzir::uuid`
-  // as the single parameter. They give the
+  // Format strings that can be formatted with a `tenzir::uuid` as the single
+  // parameter for input partitions and transformed output files.
+  std::string input_partition_path_template;
   std::string partition_path_template;
   std::string synopsis_path_template;
 
@@ -148,8 +155,10 @@ auto partition_transformer(
   partition_transformer_actor::stateful_pointer<partition_transformer_state>,
   std::string store_id, const index_config& synopsis_opts,
   const caf::settings& index_opts, catalog_actor catalog, filesystem_actor fs,
-  pipeline transform, std::string partition_path_template,
-  std::string synopsis_path_template, std::string origin = "rebuild")
+  std::vector<partition_info> input_partitions, pipeline transform,
+  std::string input_partition_path_template,
+  std::string partition_path_template, std::string synopsis_path_template,
+  std::string origin = "rebuild")
   -> partition_transformer_actor::behavior_type;
 
 } // namespace tenzir

--- a/libtenzir/include/tenzir/partition_transformer.hpp
+++ b/libtenzir/include/tenzir/partition_transformer.hpp
@@ -68,9 +68,6 @@ struct partition_transformer_state {
   /// The transform to be applied to the data.
   pipeline transform = {};
 
-  /// Collector for the received table slices.
-  std::vector<table_slice> input = {};
-
   /// Cached stream error, if the stream terminated abnormally.
   caf::error stream_error = {};
 
@@ -80,21 +77,12 @@ struct partition_transformer_state {
   /// The partitions selected as input for the transform.
   std::vector<partition_info> input_partitions = {};
 
-  /// The next input partition to load.
-  size_t next_input_partition = 0;
-
   /// The maximum number of events per partition. (not really necessary, but
   /// required by the partition synopsis)
   size_t partition_capacity = 0ull;
 
   /// Total number of rows in all transformed `slices`.
   size_t events = 0ull;
-
-  /// Oldest import timestamp of the input data.
-  tenzir::time min_import_time = tenzir::time::max();
-
-  /// Newest import timestamp of the input data.
-  tenzir::time max_import_time = tenzir::time::min();
 
   /// The data of the newly created partition(s).
   std::multimap<type, active_partition_state::serialization_data> data = {};
@@ -158,7 +146,6 @@ auto partition_transformer(
   std::vector<partition_info> input_partitions, pipeline transform,
   std::string input_partition_path_template,
   std::string partition_path_template, std::string synopsis_path_template,
-  std::string origin = "rebuild")
-  -> partition_transformer_actor::behavior_type;
+  std::string origin = "rebuild") -> partition_transformer_actor::behavior_type;
 
 } // namespace tenzir

--- a/libtenzir/src/application.cpp
+++ b/libtenzir/src/application.cpp
@@ -98,6 +98,11 @@ void add_root_opts(command& cmd) {
   cmd.options.add<duration>("?tenzir", "rebuild-interval",
                             "timespan after which an automatic rebuild is "
                             "triggered (default: 2h)");
+  cmd.options.add<std::string>("?tenzir.rebuild", "max-size",
+                               "approximate in-memory size budget for "
+                               "partitions admitted to one rebuild "
+                               "transformation (default: 50% of available "
+                               "memory, 0 disables the limit)");
 }
 
 auto make_start_command() {

--- a/libtenzir/src/catalog.cpp
+++ b/libtenzir/src/catalog.cpp
@@ -252,6 +252,7 @@ auto build_partition_slices(const std::vector<partition_synopsis_pair>& synopses
             + synopsis.synopsis->indexes_file.size
             + synopsis.synopsis->sketches_file.size);
     event.field("events").data(synopsis.synopsis->events);
+    event.field("approx_bytes").data(synopsis.synopsis->approx_bytes);
     event.field("min_import_time").data(synopsis.synopsis->min_import_time);
     event.field("max_import_time").data(synopsis.synopsis->max_import_time);
     event.field("version").data(synopsis.synopsis->version);

--- a/libtenzir/src/detail/settings.cpp
+++ b/libtenzir/src/detail/settings.cpp
@@ -66,7 +66,13 @@ get_bytesize(caf::settings opts, std::string_view key, uint64_t defval) {
   size_t result = 0;
   caf::put_missing(opts, key, defval);
   if (caf::holds_alternative<caf::config_value::integer>(opts, key)) {
-    result = caf::get<caf::config_value::integer>(opts, key);
+    const auto integer = caf::get<caf::config_value::integer>(opts, key);
+    if (integer < 0) {
+      return caf::make_error(ec::parse_error,
+                             "invalid negative byte size for key '"
+                               + std::string{key} + "'");
+    }
+    result = static_cast<size_t>(integer);
   } else if (caf::holds_alternative<std::string>(opts, key)) {
     auto result_str = caf::get<std::string>(opts, key);
     if (not parsers::bytesize(result_str, result)) {

--- a/libtenzir/src/index.cpp
+++ b/libtenzir/src/index.cpp
@@ -231,7 +231,7 @@ caf::error extract_partition_synopsis(
 
 caf::expected<flatbuffers::Offset<fbs::Index>>
 pack(flatbuffers::FlatBufferBuilder& builder, const index_state& state) {
-  TENZIR_DEBUG("index persists {} uuids of definitely persisted and {}"
+  TENZIR_DEBUG("index persists {} uuids of known persisted and {}"
                "uuids of maybe persisted partitions",
                state.persisted_partitions.size(), state.unpersisted.size());
   std::vector<flatbuffers::Offset<fbs::LegacyUUID>> partition_offsets;
@@ -304,13 +304,6 @@ filesystem_actor& partition_factory::filesystem() {
 
 partition_actor partition_factory::operator()(const uuid& id) const {
   // Load partition from disk.
-  if (state_.persisted_partitions.find(id)
-      == state_.persisted_partitions.end()) {
-    TENZIR_WARN("{} did not find partition {} in it's internal state, but "
-                "tries "
-                "to load it regardless",
-                *state_.self, id);
-  }
   const auto path = state_.partition_path(id);
   TENZIR_TRACE("{} loads partition {} for path {}", *state_.self, id, path);
   materializations_++;
@@ -1021,8 +1014,8 @@ auto index_state::schedule_lookups() -> size_t {
       // We need to first check whether the ID is the active partition or one
       // of our unpersisted ones. Only then can we dispatch to our LRU cache.
       partition_actor part;
-      tenzir::type partition_type{};
-      for (const auto& [type, active_partition] : active_partitions) {
+      for (const auto& active_partition_entry : active_partitions) {
+        const auto& active_partition = active_partition_entry.second;
         if (active_partition.actor != nullptr
             and active_partition.id == partition_id) {
           part = active_partition.actor;
@@ -1032,8 +1025,7 @@ auto index_state::schedule_lookups() -> size_t {
       if (not part) {
         if (auto it = unpersisted.find(partition_id); it != unpersisted.end()) {
           part = it->second.actor;
-        } else if (auto it = persisted_partitions.find(partition_id);
-                   it != persisted_partitions.end()) {
+        } else {
           part = inmem_partitions.get_or_load(partition_id);
         }
       }
@@ -1523,14 +1515,6 @@ index(index_actor::stateful_pointer<index_state> self,
       TENZIR_DEBUG("{} applies a pipeline to partitions {}", *self,
                    selected_partitions);
       TENZIR_ASSERT(self->state().store_actor_plugin);
-      std::erase_if(selected_partitions, [&](const auto& entry) {
-        if (self->state().persisted_partitions.contains(entry.uuid)) {
-          return false;
-        }
-        TENZIR_WARN("{} skips unknown partition {} for pipeline {:?}", *self,
-                    entry.uuid, pipe);
-        return true;
-      });
       auto corrected_partitions = catalog_lookup_result{};
       for (const auto& partition : selected_partitions) {
         if (self->state()

--- a/libtenzir/src/index.cpp
+++ b/libtenzir/src/index.cpp
@@ -335,6 +335,10 @@ std::filesystem::path index_state::partition_path(const uuid& id) const {
   return dir / fmt::format("{:l}", id);
 }
 
+std::string index_state::partition_path_template() const {
+  return (dir / "{:l}").string();
+}
+
 std::filesystem::path
 index_state::transformer_partition_path(const uuid& id) const {
   return markersdir / fmt::format("{:l}", id);
@@ -1516,12 +1520,15 @@ index(index_actor::stateful_pointer<index_state> self,
                    selected_partitions);
       TENZIR_ASSERT(self->state().store_actor_plugin);
       auto corrected_partitions = catalog_lookup_result{};
+      auto input_partitions = std::vector<partition_info>{};
+      input_partitions.reserve(selected_partitions.size());
       for (const auto& partition : selected_partitions) {
         if (self->state()
               .partitions_in_transformation.insert(partition.uuid)
               .second) {
           corrected_partitions.candidate_infos[partition.schema]
             .partition_infos.emplace_back(partition);
+          input_partitions.emplace_back(partition);
         } else {
           // Getting overlapping partitions triggers a warning, and we
           // silently ignore the partition at the cost of the transformation
@@ -1538,6 +1545,8 @@ index(index_actor::stateful_pointer<index_state> self,
         return std::vector<partition_info>{};
       }
       auto store_id = std::string{self->state().store_actor_plugin->name()};
+      auto input_partition_path_template
+        = self->state().partition_path_template();
       auto partition_path_template
         = self->state().transformer_partition_path_template();
       auto partition_synopsis_path_template
@@ -1546,7 +1555,9 @@ index(index_actor::stateful_pointer<index_state> self,
       partition_transformer_actor partition_transfomer = self->spawn(
         partition_transformer, store_id, self->state().synopsis_opts,
         self->state().index_opts, self->state().catalog,
-        self->state().filesystem, pipe, std::move(partition_path_template),
+        self->state().filesystem, std::move(input_partitions), pipe,
+        std::move(input_partition_path_template),
+        std::move(partition_path_template),
         std::move(partition_synopsis_path_template), std::move(origin));
       /// Monitor the actor to remove it from the collection of active
       /// transformers.
@@ -1563,38 +1574,7 @@ index(index_actor::stateful_pointer<index_state> self,
         std::move(partition_transformer_addr),
         std::move(partition_completion_disposable));
       TENZIR_ASSERT(inserted);
-      // match_everything == '"" in #schema'
-      static const auto match_everything
-        = tenzir::predicate{meta_extractor{meta_extractor::schema},
-                            relational_operator::ni, data{""}};
-      auto query_context = query_context::make_extract(
-        fmt::format("{:?}", pipe), partition_transfomer, match_everything);
-      auto transform_id = self->state().pending_queries.create_query_id();
-      query_context.id = transform_id;
-      // We set the query priority for partition transforms to zero so they
-      // always get less priority than queries.
-      query_context.priority = 0;
-      TENZIR_TRACE("{} emplaces {} for pipeline {:?}", *self, query_context,
-                   pipe);
-      auto query_contexts = query_state::type_query_context_map{};
-      for (const auto& [type, _] : corrected_partitions.candidate_infos) {
-        query_contexts[type] = query_context;
-      }
-      auto input_size
-        = detail::narrow_cast<uint32_t>(corrected_partitions.size());
-      auto err = self->state().pending_queries.insert(
-        query_state{.query_contexts_per_type = query_contexts,
-                    .client = caf::actor_cast<receiver_actor<atom::done>>(
-                      partition_transfomer),
-                    .candidate_partitions = input_size,
-                    .requested_partitions = input_size},
-        catalog_lookup_result{corrected_partitions});
-      TENZIR_ASSERT(err == caf::none);
-      const auto num_scheduled = self->state().schedule_lookups();
-      TENZIR_DEBUG("{} scheduled {} partitions following a request to "
-                   "transform partitions",
-                   *self, num_scheduled);
-      auto marker_path = self->state().marker_path(transform_id);
+      auto marker_path = self->state().marker_path(uuid::random());
       auto rp = self->make_response_promise<std::vector<partition_info>>();
       auto deliver =
         [self, rp, corrected_partitions, marker_path](

--- a/libtenzir/src/partition_synopsis.cpp
+++ b/libtenzir/src/partition_synopsis.cpp
@@ -14,10 +14,24 @@
 #include "tenzir/index_config.hpp"
 #include "tenzir/synopsis_factory.hpp"
 
+#include <limits>
+
 namespace tenzir {
+
+namespace {
+
+auto saturating_add(uint64_t lhs, uint64_t rhs) -> uint64_t {
+  if (rhs > std::numeric_limits<uint64_t>::max() - lhs) {
+    return std::numeric_limits<uint64_t>::max();
+  }
+  return lhs + rhs;
+}
+
+} // namespace
 
 partition_synopsis::partition_synopsis(partition_synopsis&& that) noexcept {
   events = std::exchange(that.events, {});
+  approx_bytes = std::exchange(that.approx_bytes, {});
   min_import_time = std::exchange(that.min_import_time, time::max());
   max_import_time = std::exchange(that.max_import_time, time::min());
   version = std::exchange(that.version, version::current_partition_version);
@@ -31,6 +45,7 @@ partition_synopsis&
 partition_synopsis::operator=(partition_synopsis&& that) noexcept {
   if (this != &that) {
     events = std::exchange(that.events, {});
+    approx_bytes = std::exchange(that.approx_bytes, {});
     min_import_time = std::exchange(that.min_import_time, time::max());
     max_import_time = std::exchange(that.max_import_time, time::min());
     version = std::exchange(that.version, version::current_partition_version);
@@ -107,6 +122,7 @@ void partition_synopsis::add(const table_slice& slice,
                              size_t partition_capacity,
                              const index_config& fp_rates) {
   memusage_ = 0; // Invalidate cached size.
+  approx_bytes = saturating_add(approx_bytes, slice.approx_bytes());
   auto make_synopsis
     = [](const type& t, const caf::settings& synopsis_options) -> synopsis_ptr {
     if (t.attribute("skip")) {
@@ -196,6 +212,7 @@ size_t partition_synopsis::memusage() const {
 partition_synopsis* partition_synopsis::copy() const {
   auto result = std::make_unique<partition_synopsis>();
   result->events = events;
+  result->approx_bytes = approx_bytes;
   result->min_import_time = min_import_time;
   result->max_import_time = max_import_time;
   result->version = version;
@@ -254,6 +271,7 @@ pack(flatbuffers::FlatBufferBuilder& builder, const partition_synopsis& x) {
   ps_builder.add_import_time_range(&import_time_range);
   ps_builder.add_version(x.version);
   ps_builder.add_schema(schema_vector);
+  ps_builder.add_approx_bytes(x.approx_bytes);
   return ps_builder.Finish();
 }
 
@@ -301,6 +319,7 @@ caf::error unpack(const fbs::partition_synopsis::LegacyPartitionSynopsis& x,
                            "are no longer supported");
   }
   ps.events = x.id_range()->end();
+  ps.approx_bytes = x.approx_bytes();
   if (x.import_time_range()) {
     ps.min_import_time = time{} + duration{x.import_time_range()->begin()};
     ps.max_import_time = time{} + duration{x.import_time_range()->end()};

--- a/libtenzir/src/partition_transformer.cpp
+++ b/libtenzir/src/partition_transformer.cpp
@@ -11,11 +11,12 @@
 #include "tenzir/detail/fanout_counter.hpp"
 #include "tenzir/fbs/utils.hpp"
 #include "tenzir/logger.hpp"
-#include "tenzir/passive_partition.hpp"
 #include "tenzir/partition_synopsis.hpp"
+#include "tenzir/passive_partition.hpp"
 #include "tenzir/pipeline.hpp"
 #include "tenzir/pipeline_executor.hpp"
 #include "tenzir/plugin.hpp"
+#include "tenzir/store.hpp"
 
 #include <caf/actor_from_state.hpp>
 #include <caf/event_based_actor.hpp>
@@ -89,111 +90,42 @@ void quit_or_stall(
   }
 }
 
-void fail_input_load(
-  partition_transformer_actor::stateful_pointer<partition_transformer_state>
-    self,
-  caf::error error) {
-  self->state().stream_error = std::move(error);
-  store_or_fulfill(self, partition_transformer_state::stream_data{});
-}
+struct partition_source_state {
+  caf::error error = {};
+  tenzir::time min_import_time = tenzir::time::max();
+  tenzir::time max_import_time = tenzir::time::min();
+};
 
-void load_next_input_partition(
-  partition_transformer_actor::stateful_pointer<partition_transformer_state>
-    self) {
-  if (self->state().next_input_partition
-      >= self->state().input_partitions.size()) {
-    self->mail(atom::done_v).send(static_cast<partition_transformer_actor>(self));
-    return;
-  }
-  const auto partition
-    = self->state().input_partitions[self->state().next_input_partition];
-  const auto filename = fmt::format(
-    TENZIR_FMT_RUNTIME(self->state().input_partition_path_template),
-    partition.uuid);
-  auto partition_path = std::filesystem::path{filename};
-  self->mail(atom::mmap_v, partition_path)
-    .request(self->state().fs, caf::infinite)
-    .then(
-      [self, partition](chunk_ptr& chunk) mutable {
-        auto partition_state = passive_partition_state{};
-        if (auto err = partition_state.initialize_from_chunk(chunk);
-            err.valid()) {
-          fail_input_load(
-            self, diagnostic::error(std::move(err))
-                    .note("failed to load partition {}", partition.uuid)
-                    .to_error());
-          return;
-        }
-        if (partition_state.id != partition.uuid) {
-          fail_input_load(
-            self, caf::make_error(ec::format_error,
-                                  "unexpected ID for passive partition: "
-                                  "expected {}, got {}",
-                                  partition.uuid, partition_state.id));
-          return;
-        }
-        auto const* plugin
-          = plugins::find<store_actor_plugin>(partition_state.store_id);
-        if (not plugin) {
-          fail_input_load(self,
-                          caf::make_error(ec::format_error,
-                                          "encountered unhandled store backend "
-                                          "'{}' for partition {}",
-                                          partition_state.store_id,
-                                          partition.uuid));
-          return;
-        }
-        auto store
-          = plugin->make_store(self->state().fs, partition_state.store_header);
-        if (not store) {
-          fail_input_load(self, std::move(store.error()));
-          return;
-        }
-        static const auto match_everything
-          = tenzir::predicate{meta_extractor{meta_extractor::schema},
-                              relational_operator::ni, data{""}};
-        auto query_context = query_context::make_extract(
-          "partition-transformer",
-          static_cast<partition_transformer_actor>(self), match_everything);
-        query_context.id = uuid::random();
-        self->mail(atom::query_v, std::move(query_context))
-          .request(*store, caf::infinite)
-          .then(
-            [self, store = *store](uint64_t) mutable {
-              self->send_exit(store, caf::exit_reason::normal);
-              ++self->state().next_input_partition;
-              load_next_input_partition(self);
-            },
-            [self, store = *store, partition](caf::error& error) mutable {
-              self->send_exit(store, caf::exit_reason::normal);
-              fail_input_load(
-                self, diagnostic::error(std::move(error))
-                        .note("failed to query partition {}", partition.uuid)
-                        .to_error());
-            });
-      },
-      [self, partition_path, partition](caf::error& error) mutable {
-        fail_input_load(
-          self, diagnostic::error(std::move(error))
-                  .note("failed to mmap partition {} at {}", partition.uuid,
-                        partition_path)
-                  .to_error());
-      });
-}
-
-class fixed_source final : public crtp_operator<fixed_source> {
+class partition_source final : public crtp_operator<partition_source> {
 public:
-  explicit fixed_source(std::vector<table_slice> slices)
-    : slices_{std::move(slices)} {
+  partition_source(std::vector<partition_info> partitions,
+                   std::string partition_path_template,
+                   std::filesystem::path archive_dir,
+                   std::shared_ptr<partition_source_state> state)
+    : partitions_{std::move(partitions)},
+      partition_path_template_{std::move(partition_path_template)},
+      archive_dir_{std::move(archive_dir)},
+      state_{std::move(state)} {
+    TENZIR_ASSERT(state_);
   }
 
   auto name() const -> std::string override {
-    return "<fixed_source>";
+    return "<partition_source>";
   }
 
   auto operator()() const -> generator<table_slice> {
-    for (const auto& slice : slices_) {
-      co_yield slice;
+    for (const auto& partition : partitions_) {
+      for (auto&& slice : load_partition(partition)) {
+        const auto import_time = slice.import_time();
+        state_->min_import_time
+          = std::min(state_->min_import_time, import_time);
+        state_->max_import_time
+          = std::max(state_->max_import_time, import_time);
+        co_yield std::move(slice);
+      }
+      if (state_->error.valid()) {
+        co_return;
+      }
     }
   }
 
@@ -204,7 +136,87 @@ public:
   }
 
 private:
-  std::vector<table_slice> slices_;
+  void fail(caf::error error) const {
+    state_->error = std::move(error);
+  }
+
+  auto load_partition(const partition_info& partition) const
+    -> generator<table_slice> {
+    const auto filename = fmt::format(
+      TENZIR_FMT_RUNTIME(partition_path_template_), partition.uuid);
+    auto partition_path = std::filesystem::path{filename};
+    auto partition_chunk = chunk::mmap(partition_path);
+    if (not partition_chunk) {
+      fail(diagnostic::error(partition_chunk.error())
+             .note("failed to mmap partition {} at {}", partition.uuid,
+                   partition_path)
+             .to_error());
+      co_return;
+    }
+    auto partition_state = passive_partition_state{};
+    if (auto err = partition_state.initialize_from_chunk(*partition_chunk);
+        err.valid()) {
+      fail(diagnostic::error(std::move(err))
+             .note("failed to load partition {}", partition.uuid)
+             .to_error());
+      co_return;
+    }
+    if (partition_state.id != partition.uuid) {
+      fail(caf::make_error(ec::format_error,
+                           "unexpected ID for passive partition: "
+                           "expected {}, got {}",
+                           partition.uuid, partition_state.id));
+      co_return;
+    }
+    auto const* plugin = plugins::find<store_plugin>(partition_state.store_id);
+    if (not plugin) {
+      fail(caf::make_error(ec::format_error,
+                           "encountered unhandled store backend "
+                           "'{}' for partition {}",
+                           partition_state.store_id, partition.uuid));
+      co_return;
+    }
+    if (partition_state.store_header.size() != uuid::num_bytes) {
+      fail(caf::make_error(ec::format_error,
+                           "unexpected store header size for "
+                           "partition {}: expected {}, got {}",
+                           partition.uuid, uuid::num_bytes,
+                           partition_state.store_header.size()));
+      co_return;
+    }
+    auto store = plugin->make_passive_store();
+    if (not store) {
+      fail(std::move(store.error()));
+      co_return;
+    }
+    const auto store_uuid
+      = uuid{partition_state.store_header.subspan<0, uuid::num_bytes>()};
+    auto store_path
+      = archive_dir_
+        / fmt::format("{}.{}", store_uuid, partition_state.store_id);
+    auto store_chunk = chunk::mmap(store_path);
+    if (not store_chunk) {
+      fail(diagnostic::error(store_chunk.error())
+             .note("failed to mmap store for partition {} at {}",
+                   partition.uuid, store_path)
+             .to_error());
+      co_return;
+    }
+    if (auto err = (*store)->load(std::move(*store_chunk)); err.valid()) {
+      fail(diagnostic::error(std::move(err))
+             .note("failed to load store for partition {}", partition.uuid)
+             .to_error());
+      co_return;
+    }
+    for (auto&& slice : (*store)->slices()) {
+      co_yield std::move(slice);
+    }
+  }
+
+  std::vector<partition_info> partitions_;
+  std::string partition_path_template_;
+  std::filesystem::path archive_dir_;
+  std::shared_ptr<partition_source_state> state_;
 };
 
 class collecting_sink final : public crtp_operator<collecting_sink> {
@@ -417,9 +429,9 @@ auto partition_transformer(
   std::string store_id, const index_config& synopsis_opts,
   const caf::settings& index_opts, catalog_actor catalog, filesystem_actor fs,
   std::vector<partition_info> input_partitions, pipeline transform,
-  std::string input_partition_path_template, std::string partition_path_template,
-  std::string synopsis_path_template, std::string origin)
-  -> partition_transformer_actor::behavior_type {
+  std::string input_partition_path_template,
+  std::string partition_path_template, std::string synopsis_path_template,
+  std::string origin) -> partition_transformer_actor::behavior_type {
   self->state().synopsis_opts = synopsis_opts;
   self->state().input_partition_path_template
     = std::move(input_partition_path_template);
@@ -440,17 +452,14 @@ auto partition_transformer(
     .send(static_cast<partition_transformer_actor>(self));
   return {
     [self](atom::internal, atom::load) -> caf::result<void> {
-      load_next_input_partition(self);
+      self->mail(atom::done_v)
+        .send(static_cast<partition_transformer_actor>(self));
       return {};
     },
-    [self](tenzir::table_slice& slice) {
-      // Adjust the import time range iff necessary.
-      const auto old_import_time = slice.import_time();
-      self->state().min_import_time
-        = std::min(self->state().min_import_time, old_import_time);
-      self->state().max_import_time
-        = std::max(self->state().max_import_time, old_import_time);
-      self->state().input.push_back(std::move(slice));
+    [](tenzir::table_slice&) -> caf::result<void> {
+      return caf::make_error(ec::logic_error,
+                             "partition transformer no longer accepts "
+                             "externally pushed table slices");
     },
     [self](atom::done) -> caf::result<void> {
       // We copy the pipeline because we will modify it.
@@ -459,8 +468,21 @@ auto partition_transformer(
       if (not open) {
         return open.error();
       }
-      pipe.prepend(
-        std::make_unique<fixed_source>(std::move(self->state().input)));
+      auto db_dir = std::filesystem::path{caf::get_or(
+        content(self->state().fs->home_system().config()),
+        "tenzir.state-directory", defaults::state_directory.data())};
+      std::error_code err{};
+      auto archive_dir = std::filesystem::absolute(db_dir, err) / "archive";
+      if (err) {
+        return caf::make_error(ec::filesystem_error,
+                               "failed to resolve state directory {}: {}",
+                               db_dir, err.message());
+      }
+      auto source_state = std::make_shared<partition_source_state>();
+      pipe.prepend(std::make_unique<partition_source>(
+        self->state().input_partitions,
+        self->state().input_partition_path_template, std::move(archive_dir),
+        source_state));
       auto output = std::make_shared<std::vector<table_slice>>();
       pipe.append(std::make_unique<collecting_sink>(output));
       auto closed = pipe.check_type<void, void>();
@@ -479,12 +501,18 @@ auto partition_transformer(
                       diagnostics_receiver, metrics_receiver, node_actor{},
                       false, false, std::string{});
       // Monitor the executor to detect when it finishes and process results.
-      self->monitor(executor, [self, output, executor](const caf::error& err) {
+      self->monitor(executor, [self, source_state, output,
+                               executor](const caf::error& err) {
         if (err.valid() and err != caf::exit_reason::normal) {
           TENZIR_ERROR("{} pipeline executor failed: {}", *self, err);
           self->state().transform_error = err;
         } else {
           TENZIR_DEBUG("{} pipeline executor completed successfully", *self);
+        }
+        if (source_state->error.valid()) {
+          self->state().stream_error = std::move(source_state->error);
+          store_or_fulfill(self, partition_transformer_state::stream_data{});
+          return;
         }
         // Process the collected output slices.
         for (auto& slice : *output) {
@@ -498,10 +526,10 @@ auto partition_transformer(
           }
           auto* unshared_synopsis = partition_data.synopsis.unshared_ptr();
           if (slice.import_time() == time{}) {
-            slice.import_time(self->state().min_import_time);
+            slice.import_time(source_state->min_import_time);
           }
-          unshared_synopsis->min_import_time = self->state().min_import_time;
-          unshared_synopsis->max_import_time = self->state().max_import_time;
+          unshared_synopsis->min_import_time = source_state->min_import_time;
+          unshared_synopsis->max_import_time = source_state->max_import_time;
           partition_data.events += slice.rows();
           self->state().events += slice.rows();
           self->state().partition_buildup[partition_data.id].slices.push_back(

--- a/libtenzir/src/partition_transformer.cpp
+++ b/libtenzir/src/partition_transformer.cpp
@@ -11,6 +11,7 @@
 #include "tenzir/detail/fanout_counter.hpp"
 #include "tenzir/fbs/utils.hpp"
 #include "tenzir/logger.hpp"
+#include "tenzir/passive_partition.hpp"
 #include "tenzir/partition_synopsis.hpp"
 #include "tenzir/pipeline.hpp"
 #include "tenzir/pipeline_executor.hpp"
@@ -86,6 +87,98 @@ void quit_or_stall(
     finished->promise.deliver(std::move(finished->result));
     self->quit();
   }
+}
+
+void fail_input_load(
+  partition_transformer_actor::stateful_pointer<partition_transformer_state>
+    self,
+  caf::error error) {
+  self->state().stream_error = std::move(error);
+  store_or_fulfill(self, partition_transformer_state::stream_data{});
+}
+
+void load_next_input_partition(
+  partition_transformer_actor::stateful_pointer<partition_transformer_state>
+    self) {
+  if (self->state().next_input_partition
+      >= self->state().input_partitions.size()) {
+    self->mail(atom::done_v).send(static_cast<partition_transformer_actor>(self));
+    return;
+  }
+  const auto partition
+    = self->state().input_partitions[self->state().next_input_partition];
+  const auto filename = fmt::format(
+    TENZIR_FMT_RUNTIME(self->state().input_partition_path_template),
+    partition.uuid);
+  auto partition_path = std::filesystem::path{filename};
+  self->mail(atom::mmap_v, partition_path)
+    .request(self->state().fs, caf::infinite)
+    .then(
+      [self, partition](chunk_ptr& chunk) mutable {
+        auto partition_state = passive_partition_state{};
+        if (auto err = partition_state.initialize_from_chunk(chunk);
+            err.valid()) {
+          fail_input_load(
+            self, diagnostic::error(std::move(err))
+                    .note("failed to load partition {}", partition.uuid)
+                    .to_error());
+          return;
+        }
+        if (partition_state.id != partition.uuid) {
+          fail_input_load(
+            self, caf::make_error(ec::format_error,
+                                  "unexpected ID for passive partition: "
+                                  "expected {}, got {}",
+                                  partition.uuid, partition_state.id));
+          return;
+        }
+        auto const* plugin
+          = plugins::find<store_actor_plugin>(partition_state.store_id);
+        if (not plugin) {
+          fail_input_load(self,
+                          caf::make_error(ec::format_error,
+                                          "encountered unhandled store backend "
+                                          "'{}' for partition {}",
+                                          partition_state.store_id,
+                                          partition.uuid));
+          return;
+        }
+        auto store
+          = plugin->make_store(self->state().fs, partition_state.store_header);
+        if (not store) {
+          fail_input_load(self, std::move(store.error()));
+          return;
+        }
+        static const auto match_everything
+          = tenzir::predicate{meta_extractor{meta_extractor::schema},
+                              relational_operator::ni, data{""}};
+        auto query_context = query_context::make_extract(
+          "partition-transformer",
+          static_cast<partition_transformer_actor>(self), match_everything);
+        query_context.id = uuid::random();
+        self->mail(atom::query_v, std::move(query_context))
+          .request(*store, caf::infinite)
+          .then(
+            [self, store = *store](uint64_t) mutable {
+              self->send_exit(store, caf::exit_reason::normal);
+              ++self->state().next_input_partition;
+              load_next_input_partition(self);
+            },
+            [self, store = *store, partition](caf::error& error) mutable {
+              self->send_exit(store, caf::exit_reason::normal);
+              fail_input_load(
+                self, diagnostic::error(std::move(error))
+                        .note("failed to query partition {}", partition.uuid)
+                        .to_error());
+            });
+      },
+      [self, partition_path, partition](caf::error& error) mutable {
+        fail_input_load(
+          self, diagnostic::error(std::move(error))
+                  .note("failed to mmap partition {} at {}", partition.uuid,
+                        partition_path)
+                  .to_error());
+      });
 }
 
 class fixed_source final : public crtp_operator<fixed_source> {
@@ -323,10 +416,13 @@ auto partition_transformer(
     self,
   std::string store_id, const index_config& synopsis_opts,
   const caf::settings& index_opts, catalog_actor catalog, filesystem_actor fs,
-  pipeline transform, std::string partition_path_template,
+  std::vector<partition_info> input_partitions, pipeline transform,
+  std::string input_partition_path_template, std::string partition_path_template,
   std::string synopsis_path_template, std::string origin)
   -> partition_transformer_actor::behavior_type {
   self->state().synopsis_opts = synopsis_opts;
+  self->state().input_partition_path_template
+    = std::move(input_partition_path_template);
   self->state().partition_path_template = std::move(partition_path_template);
   self->state().synopsis_path_template = std::move(synopsis_path_template);
   // For historic reasons, the `tenzir.max-partition-size` is stored as the
@@ -336,10 +432,17 @@ auto partition_transformer(
   self->state().index_opts = index_opts;
   self->state().fs = std::move(fs);
   self->state().catalog = std::move(catalog);
+  self->state().input_partitions = std::move(input_partitions);
   self->state().transform = std::move(transform);
   self->state().store_id = std::move(store_id);
   self->state().origin = std::move(origin);
+  self->mail(atom::internal_v, atom::load_v)
+    .send(static_cast<partition_transformer_actor>(self));
   return {
+    [self](atom::internal, atom::load) -> caf::result<void> {
+      load_next_input_partition(self);
+      return {};
+    },
     [self](tenzir::table_slice& slice) {
       // Adjust the import time range iff necessary.
       const auto old_import_time = slice.import_time();

--- a/libtenzir/test/configuration.cpp
+++ b/libtenzir/test/configuration.cpp
@@ -171,4 +171,9 @@ WITH_FIXTURE(fixture) {
     parse(std::vector<std::string>{"rebuild", "--all="});
     CHECK_EQUAL(get<bool>("tenzir.rebuild.all"), true);
   }
+
+  TEST("command line parses rebuild size limit") {
+    parse(std::vector<std::string>{"rebuild", "--max-size=512MiB"});
+    CHECK_EQUAL(get<std::string>("tenzir.rebuild.max-size"), "512MiB");
+  }
 }

--- a/libtenzir/test/detail/settings.cpp
+++ b/libtenzir/test/detail/settings.cpp
@@ -57,3 +57,10 @@ TEST("unpack nested settings properly") {
   REQUIRE_EQUAL(out->size(), std::size_t{1});
   CHECK_EQUAL(out->front(), 20);
 }
+
+TEST("negative byte size is rejected") {
+  caf::settings settings;
+  caf::put(settings, "bytes", caf::config_value::integer{-1});
+  const auto out = tenzir::detail::get_bytesize(settings, "bytes", 0);
+  CHECK(not out);
+}


### PR DESCRIPTION
## 🔍 Problem

Rebuild can load too many encrypted partitions before transformation starts, so the process can be OOM killed instead of staying within an operator-level budget.

## 🛠️ Solution

- Store the approximate in-memory size of each partition in synopsis metadata.
- Add `tenzir.rebuild.max-size` and `tenzir rebuild --max-size` to bound admitted partition batches before disk data is loaded.
- Estimate legacy partitions from same-schema measurements at runtime, then fall back to the existing event-count heuristic.

## 💬 Review

Focus on the admission logic for legacy partitions without size metadata and the flatbuffer compatibility of the appended synopsis field.