### PR TITLE
Fix treefmt for plugin submodule changes

### DIFF
--- a/.github/workflows/style-check.yaml
+++ b/.github/workflows/style-check.yaml
@@ -30,7 +30,7 @@ jobs:
           authToken: "${{ secrets.CACHIX_TENZIR_API_TOKEN }}"
       - name: Configure ssh-agent
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: webfactory/ssh-agent@dc588b651fe13675774614f8e6a936a468676387  # v0.9.0
         with:
           ssh-private-key: ${{ secrets.TENZIR_PLUGINS_DEPLOY_KEY }}
       - name: Run treefmt
@@ -67,10 +67,11 @@ jobs:
           if [ "$tenzir_plugins_gitlink_changed" = true ] || [ "${#tenzir_plugins_files[@]}" -gt 0 ]; then
             git submodule update --init contrib/tenzir-plugins
             if [ "$tenzir_plugins_gitlink_changed" = true ]; then
-              git -C contrib/tenzir-plugins fetch --no-tags --depth=1 origin main
+              plugins_base=$(git rev-parse "$base:contrib/tenzir-plugins")
+              git -C contrib/tenzir-plugins fetch --no-tags --depth=1 origin "$plugins_base"
               while IFS= read -r file; do
                 tenzir_plugins_files+=("contrib/tenzir-plugins/$file")
-              done < <(git -C contrib/tenzir-plugins diff --name-only --diff-filter=ACMR origin/main HEAD)
+              done < <(git -C contrib/tenzir-plugins diff --name-only --diff-filter=ACMR "$plugins_base" HEAD)
             fi
           fi
           if [ "${#tenzir_plugins_files[@]}" -gt 0 ]; then

--- a/.github/workflows/style-check.yaml
+++ b/.github/workflows/style-check.yaml
@@ -29,7 +29,12 @@ jobs:
           name: tenzir
           authToken: "${{ secrets.CACHIX_TENZIR_API_TOKEN }}"
       - name: Configure ssh-agent
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: |
+          github.event_name != 'pull_request' ||
+          (
+            github.actor != 'dependabot[bot]' &&
+            github.event.pull_request.head.repo.full_name == github.repository
+          )
         uses: webfactory/ssh-agent@dc588b651fe13675774614f8e6a936a468676387  # v0.9.0
         with:
           ssh-private-key: ${{ secrets.TENZIR_PLUGINS_DEPLOY_KEY }}

--- a/.github/workflows/style-check.yaml
+++ b/.github/workflows/style-check.yaml
@@ -28,6 +28,11 @@ jobs:
         with:
           name: tenzir
           authToken: "${{ secrets.CACHIX_TENZIR_API_TOKEN }}"
+      - name: Configure ssh-agent
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.TENZIR_PLUGINS_DEPLOY_KEY }}
       - name: Run treefmt
         env:
           BASE_REF: ${{ github.base_ref || 'main' }}
@@ -41,9 +46,13 @@ jobs:
           base="origin/$BASE_REF"
           main_files=()
           tenzir_plugins_files=()
+          tenzir_plugins_gitlink_changed=false
           while IFS= read -r file; do
             case "$file" in
-              contrib/tenzir-plugins|contrib/tenzir-plugins/*)
+              contrib/tenzir-plugins)
+                tenzir_plugins_gitlink_changed=true
+                ;;
+              contrib/tenzir-plugins/*)
                 tenzir_plugins_files+=("$file")
                 ;;
               *)
@@ -55,9 +64,16 @@ jobs:
           if [ "${#main_files[@]}" -gt 0 ]; then
             nix run .#format -- --fail-on-change "${main_files[@]}"
           fi
-          if [ "${#tenzir_plugins_files[@]}" -gt 0 ]; then
-            git config submodule.contrib/tenzir-plugins.url https://github.com/tenzir/tenzir-plugins
+          if [ "$tenzir_plugins_gitlink_changed" = true ] || [ "${#tenzir_plugins_files[@]}" -gt 0 ]; then
             git submodule update --init contrib/tenzir-plugins
+            if [ "$tenzir_plugins_gitlink_changed" = true ]; then
+              git -C contrib/tenzir-plugins fetch --no-tags --depth=1 origin main
+              while IFS= read -r file; do
+                tenzir_plugins_files+=("contrib/tenzir-plugins/$file")
+              done < <(git -C contrib/tenzir-plugins diff --name-only --diff-filter=ACMR origin/main HEAD)
+            fi
+          fi
+          if [ "${#tenzir_plugins_files[@]}" -gt 0 ]; then
             nix run .#format -- --fail-on-change "${tenzir_plugins_files[@]}"
           fi
 


### PR DESCRIPTION
## 🔍 Problem

- The style workflow treats a changed `contrib/tenzir-plugins` gitlink as a path to format.
- That either requires unauthenticated access to a private submodule or formats the entire plugin checkout, which can fail on unrelated plugin formatting drift.
- The deploy-key setup must not run unconditionally for forked pull requests.

## 🛠️ Solution

- Use the private deploy key only for trusted same-repository PRs and merge-group runs.
- When the plugin gitlink changes, check out the submodule and derive changed plugin files against `tenzir-plugins/main`.
- Run treefmt only on those changed plugin files instead of the whole submodule.

## 💬 Review

- Focus on the fork-PR secret guard and the changed-file derivation for submodule bumps.

<sub>
📎 Related: tenzir/tenzir#6154
</sub>