### PR TITLE
Fix installer stdout smoke test

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -306,16 +306,12 @@ if [ -n "${TENZIR_TOKEN:-}" ]; then
         read_yaml
       }
       this = merge(this, {tenzir: {token: \"${TENZIR_TOKEN}\"}})
-      to_stdout {
-        write_yaml
-      }
+      write_yaml
       "
   else
     # Create new config with token.
     tql_pipeline="from {tenzir: {token: \"${TENZIR_TOKEN}\"}}
-      to_stdout {
-        write_yaml
-      }"
+      write_yaml"
   fi
 
   # Write config using tenzir and sudo tee.
@@ -332,7 +328,7 @@ fi
 # Test the installation.
 action "Checking version"
 PATH="${prefix}/bin:$PATH"
-tenzir -q 'version | select version | to_stdout { write_ndjson }'
+tenzir -q 'version | select version | write_ndjson'
 
 # Inform about next steps.
 action "Providing guidance"


### PR DESCRIPTION
## 🔍 Problem

- The installer smoke test uses `to_stdout { write_ndjson }`.
- Installed packages can still execute this path without the new IR, where `to_stdout` fails with `this operator can only be used with the new IR`.
- The optional `TENZIR_TOKEN` config path had the same `to_stdout` wrapping around YAML output.

## 🛠️ Solution

- Use writer operators directly and rely on the implicit stdout sink.
- Restore the token config pipeline to the legacy-compatible form.

## 💬 Review

- Focus on installer compatibility with current `latest` and `main` packages.
- No docs update; this fixes installer internals only.