### PR TITLE
Add event count metrics to new executor

### DIFF
--- a/.agents/references/executor.md
+++ b/.agents/references/executor.md
@@ -110,9 +110,11 @@ members.
   visibility only for executor-internal handoff accounting.
 - Use `MetricsUnit::bytes` for encoded bytes read or written and
   `MetricsUnit::events` for event rows.
-- If an operator emits `table_slice`s directly, increment the events counter by
+- If an operator emits `table_slice`s directly and it does not accept a parsing
+  (`chunk_ptr -> table_slice`) pipeline, increment the events counter by
   `slice.rows()` immediately before pushing the slice downstream.
-- If an operator consumes `table_slice`s directly, increment the events counter
+- If an operator consumes `table_slice`s directly and it does not accept a
+  printing (`table_slice -> chunk_ptr`) pipeline, increment the events counter
   by `slice.rows()` when accepting the slice for output.
 - Operators that run parser or printer subpipelines should not count the rows
   flowing through those subpipelines. The nested parser or printer operators own

--- a/.agents/references/executor.md
+++ b/.agents/references/executor.md
@@ -110,15 +110,15 @@ members.
   visibility only for executor-internal handoff accounting.
 - Use `MetricsUnit::bytes` for encoded bytes read or written and
   `MetricsUnit::events` for event rows.
-- If an operator emits `table_slice`s directly and it does not accept a parsing
-  (`chunk_ptr -> table_slice`) pipeline, increment the events counter by
-  `slice.rows()` immediately before pushing the slice downstream.
-- If an operator consumes `table_slice`s directly and it does not accept a
+- If a source operator emits `table_slice`s directly, increment the events
+  counter by `slice.rows()` immediately before pushing the slice downstream.
+- If a source operator accepts a parsing (`chunk_ptr -> table_slice`) pipeline,
+  increment the events counter in `process_sub()` by the rows that the operator
+  actually pushes downstream. This counts the rows entering the parent pipeline
+  after the full nested parsing pipeline has run.
+- If a sink operator consumes `table_slice`s directly or forwards them into a
   printing (`table_slice -> chunk_ptr`) pipeline, increment the events counter
   by `slice.rows()` when accepting the slice for output.
-- Operators that run parser or printer subpipelines should not count the rows
-  flowing through those subpipelines. The nested parser or printer operators own
-  those event counters.
 - Message-oriented connectors that produce or consume one event per message may
   increment the events counter by `1`; slice-oriented code should use
   `slice.rows()`.

--- a/.agents/references/executor.md
+++ b/.agents/references/executor.md
@@ -96,6 +96,35 @@ For timeout-driven flushes, let `await_task()` sleep until the earliest deadline
 and let `process_task()` flush expired buffers. Do not poll time while processing
 each input item. Guard `duration::max()` sentinels before time arithmetic.
 
+### Metrics counters
+
+Operators that form an external pipeline edge should report both byte and event
+throughput when both quantities are meaningful. Create counters in `start()` with
+`ctx.make_counter(label, direction, visibility, type)` and keep them as operator
+members.
+
+- Use `MetricsDirection::read` for ingress/source-side data and
+  `MetricsDirection::write` for egress/sink-side data.
+- Use `MetricsVisibility::external_` for data crossing the pipeline boundary
+  (network, files, stdin/stdout, databases, message brokers). Use internal
+  visibility only for executor-internal handoff accounting.
+- Use `MetricsUnit::bytes` for encoded bytes read or written and
+  `MetricsUnit::events` for event rows.
+- If an operator emits `table_slice`s directly, increment the events counter by
+  `slice.rows()` immediately before pushing the slice downstream.
+- If an operator consumes `table_slice`s directly, increment the events counter
+  by `slice.rows()` when accepting the slice for output.
+- Operators that run parser or printer subpipelines should not count the rows
+  flowing through those subpipelines. The nested parser or printer operators own
+  those event counters.
+- Message-oriented connectors that produce or consume one event per message may
+  increment the events counter by `1`; slice-oriented code should use
+  `slice.rows()`.
+
+Do not register only a byte counter for an operator that produces or consumes
+rows directly. That causes node-level event throughput to report zero for that
+operator even though data is flowing.
+
 ### Per-chunk parser flushes
 
 If a `chunk_ptr -> table_slice` parser scans an input chunk incrementally,

--- a/changelog/unreleased/event-throughput-metrics-for-the-new-executor.md
+++ b/changelog/unreleased/event-throughput-metrics-for-the-new-executor.md
@@ -1,0 +1,20 @@
+---
+title: Event throughput metrics for the new executor
+type: feature
+authors:
+  - mavam
+  - codex
+created: 2026-05-12T10:26:00.599424Z
+---
+
+Pipeline metrics now report event throughput alongside byte throughput for
+pipelines running on the new executor:
+
+```tql
+metrics "pipeline"
+summarize ingress_events=sum(ingress.events), ingress_bytes=sum(ingress.bytes), egress_events=sum(egress.events), pipeline_id
+sort -egress_events
+```
+
+This makes node metrics distinguish the amount of data transferred from the
+number of events processed.

--- a/libtenzir/builtins/operators/accept_http.cpp
+++ b/libtenzir/builtins/operators/accept_http.cpp
@@ -365,20 +365,14 @@ public:
           MetricsLabel{"client_ip", MetricsLabel::FixedString::truncate(
                                       msg.metadata.client_ip)},
           MetricsDirection::read, MetricsVisibility::external_,
-          MetricsType::bytes);
-        auto events_read = ctx.make_counter(
-          MetricsLabel{"client_ip", MetricsLabel::FixedString::truncate(
-                                      msg.metadata.client_ip)},
-          MetricsDirection::read, MetricsVisibility::external_,
-          MetricsType::events);
+          MetricsUnit::bytes);
         {
           auto active_requests = co_await active_requests_.lock();
           active_requests->emplace(
             request_id, ActiveRequest{.metadata = std::move(msg.metadata),
                                       .decompressor = std::move(decompressor),
                                       .finished = msg.response_signal,
-                                      .bytes_read = std::move(bytes_read),
-                                      .events_read = std::move(events_read)});
+                                      .bytes_read = std::move(bytes_read)});
         }
         co_await ctx.spawn_sub<chunk_ptr>(request_id, std::move(pipeline),
                                           DiagnosticBehavior::ErrorToWarning);
@@ -448,14 +442,8 @@ public:
   auto process_sub(SubKeyView key, table_slice slice, Push<table_slice>& push,
                    OpCtx& ctx) -> Task<void> override {
     TENZIR_UNUSED(ctx);
-    auto const request_id = as<uint64_t>(key);
-    auto const rows = slice.rows();
+    TENZIR_UNUSED(key);
     co_await push(std::move(slice));
-    auto active_requests = co_await active_requests_.lock();
-    if (auto it = active_requests->find(request_id);
-        it != active_requests->end()) {
-      it->second.events_read.add(rows);
-    }
   }
 
   auto finish_sub(SubKeyView key, Push<table_slice>&, OpCtx&)
@@ -505,7 +493,6 @@ private:
     bool drop_body = false;
     Arc<ResponseSignal> finished;
     MetricsCounter bytes_read;
-    MetricsCounter events_read;
   };
 
   void force_stop() {

--- a/libtenzir/builtins/operators/accept_http.cpp
+++ b/libtenzir/builtins/operators/accept_http.cpp
@@ -366,13 +366,19 @@ public:
                                       msg.metadata.client_ip)},
           MetricsDirection::read, MetricsVisibility::external_,
           MetricsType::bytes);
+        auto events_read = ctx.make_counter(
+          MetricsLabel{"client_ip", MetricsLabel::FixedString::truncate(
+                                      msg.metadata.client_ip)},
+          MetricsDirection::read, MetricsVisibility::external_,
+          MetricsType::events);
         {
           auto active_requests = co_await active_requests_.lock();
           active_requests->emplace(
             request_id, ActiveRequest{.metadata = std::move(msg.metadata),
                                       .decompressor = std::move(decompressor),
                                       .finished = msg.response_signal,
-                                      .bytes_read = std::move(bytes_read)});
+                                      .bytes_read = std::move(bytes_read),
+                                      .events_read = std::move(events_read)});
         }
         co_await ctx.spawn_sub<chunk_ptr>(request_id, std::move(pipeline),
                                           DiagnosticBehavior::ErrorToWarning);
@@ -441,8 +447,15 @@ public:
 
   auto process_sub(SubKeyView key, table_slice slice, Push<table_slice>& push,
                    OpCtx& ctx) -> Task<void> override {
-    TENZIR_UNUSED(key, ctx);
+    TENZIR_UNUSED(ctx);
+    auto const request_id = as<uint64_t>(key);
+    auto const rows = slice.rows();
     co_await push(std::move(slice));
+    auto active_requests = co_await active_requests_.lock();
+    if (auto it = active_requests->find(request_id);
+        it != active_requests->end()) {
+      it->second.events_read.add(rows);
+    }
   }
 
   auto finish_sub(SubKeyView key, Push<table_slice>&, OpCtx&)
@@ -492,6 +505,7 @@ private:
     bool drop_body = false;
     Arc<ResponseSignal> finished;
     MetricsCounter bytes_read;
+    MetricsCounter events_read;
   };
 
   void force_stop() {

--- a/libtenzir/builtins/operators/accept_http.cpp
+++ b/libtenzir/builtins/operators/accept_http.cpp
@@ -364,7 +364,8 @@ public:
         auto bytes_read = ctx.make_counter(
           MetricsLabel{"client_ip", MetricsLabel::FixedString::truncate(
                                       msg.metadata.client_ip)},
-          MetricsDirection::read, MetricsVisibility::external_);
+          MetricsDirection::read, MetricsVisibility::external_,
+          MetricsType::bytes);
         {
           auto active_requests = co_await active_requests_.lock();
           active_requests->emplace(

--- a/libtenzir/builtins/operators/accept_http.cpp
+++ b/libtenzir/builtins/operators/accept_http.cpp
@@ -327,6 +327,10 @@ public:
       co_await catch_cancellation(wait_forever());
       force_stop();
     });
+    events_read_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "accept_http"},
+                         MetricsDirection::read, MetricsVisibility::external_,
+                         MetricsUnit::events);
     co_return;
   }
 
@@ -441,9 +445,10 @@ public:
 
   auto process_sub(SubKeyView key, table_slice slice, Push<table_slice>& push,
                    OpCtx& ctx) -> Task<void> override {
-    TENZIR_UNUSED(ctx);
-    TENZIR_UNUSED(key);
+    TENZIR_UNUSED(ctx, key);
+    auto const rows = slice.rows();
     co_await push(std::move(slice));
+    events_read_counter_.add(rows);
   }
 
   auto finish_sub(SubKeyView key, Push<table_slice>&, OpCtx&)
@@ -494,6 +499,8 @@ private:
     Arc<ResponseSignal> finished;
     MetricsCounter bytes_read;
   };
+
+  MetricsCounter events_read_counter_;
 
   void force_stop() {
     if (server_) {

--- a/libtenzir/builtins/operators/accept_opensearch.cpp
+++ b/libtenzir/builtins/operators/accept_opensearch.cpp
@@ -352,6 +352,10 @@ public:
       = ctx.make_counter(MetricsLabel{"operator", "accept_opensearch"},
                          MetricsDirection::read, MetricsVisibility::external_,
                          MetricsType::bytes);
+    events_read_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "accept_opensearch"},
+                         MetricsDirection::read, MetricsVisibility::external_,
+                         MetricsType::events);
     co_return;
   }
 
@@ -447,11 +451,13 @@ public:
         for (auto& slice : slices) {
           auto filtered = handle_slice(is_action, slice);
           if (args_.keep_actions) {
-            if (slice.rows() > 0) {
+            if (auto rows = slice.rows(); rows > 0) {
+              events_read_counter_.add(rows);
               co_await push(std::move(slice));
             }
           } else {
-            if (filtered.rows() > 0) {
+            if (auto rows = filtered.rows(); rows > 0) {
+              events_read_counter_.add(rows);
               co_await push(std::move(filtered));
             }
           }
@@ -484,11 +490,13 @@ public:
         for (auto& slice : slices) {
           auto filtered = handle_slice(is_action, slice);
           if (args_.keep_actions) {
-            if (slice.rows() > 0) {
+            if (auto rows = slice.rows(); rows > 0) {
+              events_read_counter_.add(rows);
               co_await push(std::move(slice));
             }
           } else {
-            if (filtered.rows() > 0) {
+            if (auto rows = filtered.rows(); rows > 0) {
+              events_read_counter_.add(rows);
               co_await push(std::move(filtered));
             }
           }
@@ -596,6 +604,7 @@ private:
   Option<Arc<proxygen::coro::ScopedHTTPServer>> server_;
   std::unordered_map<uint64_t, InFlightRequest> active_requests_{{}};
   MetricsCounter bytes_read_counter_;
+  MetricsCounter events_read_counter_;
   mutable Arc<MessageQueue> message_queue_{std::in_place, uint32_t{64}};
 };
 

--- a/libtenzir/builtins/operators/accept_opensearch.cpp
+++ b/libtenzir/builtins/operators/accept_opensearch.cpp
@@ -350,7 +350,8 @@ public:
     });
     bytes_read_counter_
       = ctx.make_counter(MetricsLabel{"operator", "accept_opensearch"},
-                         MetricsDirection::read, MetricsVisibility::external_);
+                         MetricsDirection::read, MetricsVisibility::external_,
+                         MetricsType::bytes);
     co_return;
   }
 

--- a/libtenzir/builtins/operators/accept_opensearch.cpp
+++ b/libtenzir/builtins/operators/accept_opensearch.cpp
@@ -351,11 +351,11 @@ public:
     bytes_read_counter_
       = ctx.make_counter(MetricsLabel{"operator", "accept_opensearch"},
                          MetricsDirection::read, MetricsVisibility::external_,
-                         MetricsType::bytes);
+                         MetricsUnit::bytes);
     events_read_counter_
       = ctx.make_counter(MetricsLabel{"operator", "accept_opensearch"},
                          MetricsDirection::read, MetricsVisibility::external_,
-                         MetricsType::events);
+                         MetricsUnit::events);
     co_return;
   }
 

--- a/libtenzir/builtins/operators/accept_tcp.cpp
+++ b/libtenzir/builtins/operators/accept_tcp.cpp
@@ -280,7 +280,7 @@ public:
           MetricsLabel{"peer_ip", MetricsLabel::FixedString::truncate(
                                     fmt::to_string(accepted.peer_ip))},
           MetricsDirection::read, MetricsVisibility::external_,
-          MetricsType::bytes);
+          MetricsUnit::bytes);
         auto reg = global_registry();
         auto b_ctx = base_ctx{ctx, *reg};
         auto sub_result

--- a/libtenzir/builtins/operators/accept_tcp.cpp
+++ b/libtenzir/builtins/operators/accept_tcp.cpp
@@ -212,6 +212,10 @@ public:
     server_ = std::make_unique<folly::coro::ServerSocket>(
       std::move(socket), address_, listen_backlog);
     accept_loop_finished_ = false;
+    events_read_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "accept_tcp"},
+                         MetricsDirection::read, MetricsVisibility::external_,
+                         MetricsUnit::events);
     ctx.spawn_task([this, &ctx]() -> Task<void> {
       auto notify_finished = detail::scope_guard{[this, &ctx]() noexcept {
         ctx.spawn_task([this]() -> Task<void> {
@@ -345,6 +349,13 @@ public:
         maybe_finish_draining();
         co_return;
       });
+  }
+
+  auto process_sub(SubKeyView, table_slice slice, Push<table_slice>& push,
+                   OpCtx&) -> Task<void> override {
+    auto const rows = slice.rows();
+    co_await push(std::move(slice));
+    events_read_counter_.add(rows);
   }
 
   auto finish_sub(SubKeyView key, Push<table_slice>&, OpCtx&)
@@ -756,6 +767,7 @@ private:
                                            message_queue_capacity};
   Semaphore connection_slots_;
   std::unordered_map<uint64_t, Connection> connections_;
+  MetricsCounter events_read_counter_;
   Box<folly::CancellationSource> accept_cancel_{std::in_place};
   bool accept_loop_finished_ = true;
   bool peer_resolution_warning_emitted_ = false;

--- a/libtenzir/builtins/operators/accept_tcp.cpp
+++ b/libtenzir/builtins/operators/accept_tcp.cpp
@@ -279,7 +279,8 @@ public:
         auto bytes_read = ctx.make_counter(
           MetricsLabel{"peer_ip", MetricsLabel::FixedString::truncate(
                                     fmt::to_string(accepted.peer_ip))},
-          MetricsDirection::read, MetricsVisibility::external_);
+          MetricsDirection::read, MetricsVisibility::external_,
+          MetricsType::bytes);
         auto reg = global_registry();
         auto b_ctx = base_ctx{ctx, *reg};
         auto sub_result

--- a/libtenzir/builtins/operators/accept_udp.cpp
+++ b/libtenzir/builtins/operators/accept_udp.cpp
@@ -224,6 +224,10 @@ public:
       = ctx.make_counter(MetricsLabel{"operator", "accept_udp"},
                          MetricsDirection::read, MetricsVisibility::external_,
                          MetricsType::bytes);
+    events_read_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "accept_udp"},
+                         MetricsDirection::read, MetricsVisibility::external_,
+                         MetricsType::events);
     TENZIR_ASSERT(message_sender_);
     ctx.spawn_task(folly::coro::co_withExecutor(
       evb_, read_loop(*evb_, std::move(bind_address).unwrap(), *message_sender_,
@@ -475,7 +479,10 @@ private:
       co_return;
     }
     cancel_batch_flush();
-    co_await push(builder_.finish_assert_one_slice());
+    auto slice = builder_.finish_assert_one_slice();
+    auto const rows = slice.rows();
+    co_await push(std::move(slice));
+    events_read_counter_.add(rows);
   }
 
   AcceptUdpArgs args_;
@@ -486,6 +493,7 @@ private:
   Option<Sender<Message>> message_sender_;
   mutable Receiver<Message> message_receiver_;
   Option<folly::CancellationSource> batch_flush_cancel_;
+  MetricsCounter events_read_counter_;
   uint64_t batch_generation_ = 0;
   bool peer_resolution_warning_emitted_ = false;
 };

--- a/libtenzir/builtins/operators/accept_udp.cpp
+++ b/libtenzir/builtins/operators/accept_udp.cpp
@@ -223,11 +223,11 @@ public:
     auto bytes_read_counter
       = ctx.make_counter(MetricsLabel{"operator", "accept_udp"},
                          MetricsDirection::read, MetricsVisibility::external_,
-                         MetricsType::bytes);
+                         MetricsUnit::bytes);
     events_read_counter_
       = ctx.make_counter(MetricsLabel{"operator", "accept_udp"},
                          MetricsDirection::read, MetricsVisibility::external_,
-                         MetricsType::events);
+                         MetricsUnit::events);
     TENZIR_ASSERT(message_sender_);
     ctx.spawn_task(folly::coro::co_withExecutor(
       evb_, read_loop(*evb_, std::move(bind_address).unwrap(), *message_sender_,

--- a/libtenzir/builtins/operators/accept_udp.cpp
+++ b/libtenzir/builtins/operators/accept_udp.cpp
@@ -222,7 +222,8 @@ public:
     // `make_counter` always requires exactly one label pair.
     auto bytes_read_counter
       = ctx.make_counter(MetricsLabel{"operator", "accept_udp"},
-                         MetricsDirection::read, MetricsVisibility::external_);
+                         MetricsDirection::read, MetricsVisibility::external_,
+                         MetricsType::bytes);
     TENZIR_ASSERT(message_sender_);
     ctx.spawn_task(folly::coro::co_withExecutor(
       evb_, read_loop(*evb_, std::move(bind_address).unwrap(), *message_sender_,

--- a/libtenzir/builtins/operators/discard.cpp
+++ b/libtenzir/builtins/operators/discard.cpp
@@ -68,7 +68,17 @@ public:
         "operator",
         "discard",
       },
-      MetricsDirection::write, MetricsVisibility::internal_);
+      MetricsDirection::write, MetricsVisibility::internal_,
+      MetricsType::bytes);
+    if constexpr (std::same_as<Input, table_slice>) {
+      write_events_counter_ = ctx.make_counter(
+        MetricsLabel{
+          "operator",
+          "discard",
+        },
+        MetricsDirection::write, MetricsVisibility::internal_,
+        MetricsType::events);
+    }
     co_return;
   }
 
@@ -82,11 +92,15 @@ public:
       }
     }
     write_bytes_counter_.add(static_cast<uint64_t>(bytes));
+    if constexpr (std::same_as<Input, table_slice>) {
+      write_events_counter_.add(input.rows());
+    }
     co_return;
   }
 
 private:
   MetricsCounter write_bytes_counter_;
+  MetricsCounter write_events_counter_;
 };
 
 class plugin final : public virtual operator_plugin<discard_operator>,

--- a/libtenzir/builtins/operators/discard.cpp
+++ b/libtenzir/builtins/operators/discard.cpp
@@ -69,7 +69,7 @@ public:
         "discard",
       },
       MetricsDirection::write, MetricsVisibility::internal_,
-      MetricsType::bytes);
+      MetricsUnit::bytes);
     if constexpr (std::same_as<Input, table_slice>) {
       write_events_counter_ = ctx.make_counter(
         MetricsLabel{
@@ -77,7 +77,7 @@ public:
           "discard",
         },
         MetricsDirection::write, MetricsVisibility::internal_,
-        MetricsType::events);
+        MetricsUnit::events);
     }
     co_return;
   }

--- a/libtenzir/builtins/operators/export.cpp
+++ b/libtenzir/builtins/operators/export.cpp
@@ -86,7 +86,7 @@ public:
         "export",
       },
       MetricsDirection::read, MetricsVisibility::internal_,
-      MetricsType::events);
+      MetricsUnit::events);
     auto node = co_await fetch_node(ctx.actor_system(), ctx.dh());
     if (not node) {
       co_return;

--- a/libtenzir/builtins/operators/export.cpp
+++ b/libtenzir/builtins/operators/export.cpp
@@ -80,6 +80,13 @@ public:
   Export& operator=(Export&&) = default;
 
   auto start(OpCtx& ctx) -> Task<void> override {
+    read_events_counter_ = ctx.make_counter(
+      MetricsLabel{
+        "operator",
+        "export",
+      },
+      MetricsDirection::read, MetricsVisibility::internal_,
+      MetricsType::events);
     auto node = co_await fetch_node(ctx.actor_system(), ctx.dh());
     if (not node) {
       co_return;
@@ -181,12 +188,16 @@ public:
       co_return;
     }
     if (not remainder_) {
+      auto const rows = expected->rows();
       co_await push(std::move(*expected));
+      read_events_counter_.add(rows);
       co_return;
     }
     auto output = filter2(*expected, *remainder_, ctx, false);
     if (output.rows() > 0) {
+      auto const rows = output.rows();
       co_await push(std::move(output));
+      read_events_counter_.add(rows);
     }
   }
 
@@ -209,6 +220,7 @@ private:
   export_bridge_actor bridge_;
   std::shared_ptr<UnboundedQueue<diagnostic>> diag_queue_;
   std::optional<ast::expression> remainder_ = std::nullopt;
+  MetricsCounter read_events_counter_;
   bool done_ = false;
 };
 

--- a/libtenzir/builtins/operators/from_ftp.cpp
+++ b/libtenzir/builtins/operators/from_ftp.cpp
@@ -121,7 +121,8 @@ public:
     }
     bytes_read_counter_
       = ctx.make_counter(MetricsLabel{"operator", "from_ftp"},
-                         MetricsDirection::read, MetricsVisibility::external_);
+                         MetricsDirection::read, MetricsVisibility::external_,
+                         MetricsType::bytes);
     download_.emplace(session_->start_download(download_buffer_capacity));
     co_await ctx.spawn_sub<chunk_ptr>(caf::none, std::move(pipeline));
     co_return;

--- a/libtenzir/builtins/operators/from_ftp.cpp
+++ b/libtenzir/builtins/operators/from_ftp.cpp
@@ -123,6 +123,10 @@ public:
       = ctx.make_counter(MetricsLabel{"operator", "from_ftp"},
                          MetricsDirection::read, MetricsVisibility::external_,
                          MetricsUnit::bytes);
+    events_read_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "from_ftp"},
+                         MetricsDirection::read, MetricsVisibility::external_,
+                         MetricsUnit::events);
     download_.emplace(session_->start_download(download_buffer_capacity));
     co_await ctx.spawn_sub<chunk_ptr>(caf::none, std::move(pipeline));
     co_return;
@@ -207,7 +211,9 @@ public:
 
   auto process_sub(SubKeyView, table_slice slice, Push<table_slice>& push,
                    OpCtx&) -> Task<void> override {
+    auto const rows = slice.rows();
     co_await push(std::move(slice));
+    events_read_counter_.add(rows);
   }
 
   auto finish_sub(SubKeyView, Push<table_slice>&, OpCtx&)
@@ -243,6 +249,7 @@ private:
   Option<CurlSession> session_;
   Option<CurlDownloadTransfer> download_;
   MetricsCounter bytes_read_counter_;
+  MetricsCounter events_read_counter_;
   FromFtpArgs args_;
   std::string resolved_url_;
   Lifecycle lifecycle_ = Lifecycle::running;

--- a/libtenzir/builtins/operators/from_ftp.cpp
+++ b/libtenzir/builtins/operators/from_ftp.cpp
@@ -122,11 +122,7 @@ public:
     bytes_read_counter_
       = ctx.make_counter(MetricsLabel{"operator", "from_ftp"},
                          MetricsDirection::read, MetricsVisibility::external_,
-                         MetricsType::bytes);
-    events_read_counter_
-      = ctx.make_counter(MetricsLabel{"operator", "from_ftp"},
-                         MetricsDirection::read, MetricsVisibility::external_,
-                         MetricsType::events);
+                         MetricsUnit::bytes);
     download_.emplace(session_->start_download(download_buffer_capacity));
     co_await ctx.spawn_sub<chunk_ptr>(caf::none, std::move(pipeline));
     co_return;
@@ -211,9 +207,7 @@ public:
 
   auto process_sub(SubKeyView, table_slice slice, Push<table_slice>& push,
                    OpCtx&) -> Task<void> override {
-    auto const rows = slice.rows();
     co_await push(std::move(slice));
-    events_read_counter_.add(rows);
   }
 
   auto finish_sub(SubKeyView, Push<table_slice>&, OpCtx&)
@@ -249,7 +243,6 @@ private:
   Option<CurlSession> session_;
   Option<CurlDownloadTransfer> download_;
   MetricsCounter bytes_read_counter_;
-  MetricsCounter events_read_counter_;
   FromFtpArgs args_;
   std::string resolved_url_;
   Lifecycle lifecycle_ = Lifecycle::running;

--- a/libtenzir/builtins/operators/from_ftp.cpp
+++ b/libtenzir/builtins/operators/from_ftp.cpp
@@ -123,6 +123,10 @@ public:
       = ctx.make_counter(MetricsLabel{"operator", "from_ftp"},
                          MetricsDirection::read, MetricsVisibility::external_,
                          MetricsType::bytes);
+    events_read_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "from_ftp"},
+                         MetricsDirection::read, MetricsVisibility::external_,
+                         MetricsType::events);
     download_.emplace(session_->start_download(download_buffer_capacity));
     co_await ctx.spawn_sub<chunk_ptr>(caf::none, std::move(pipeline));
     co_return;
@@ -207,7 +211,9 @@ public:
 
   auto process_sub(SubKeyView, table_slice slice, Push<table_slice>& push,
                    OpCtx&) -> Task<void> override {
+    auto const rows = slice.rows();
     co_await push(std::move(slice));
+    events_read_counter_.add(rows);
   }
 
   auto finish_sub(SubKeyView, Push<table_slice>&, OpCtx&)
@@ -243,6 +249,7 @@ private:
   Option<CurlSession> session_;
   Option<CurlDownloadTransfer> download_;
   MetricsCounter bytes_read_counter_;
+  MetricsCounter events_read_counter_;
   FromFtpArgs args_;
   std::string resolved_url_;
   Lifecycle lifecycle_ = Lifecycle::running;

--- a/libtenzir/builtins/operators/from_http.cpp
+++ b/libtenzir/builtins/operators/from_http.cpp
@@ -951,7 +951,7 @@ private:
     bytes_read_ = ctx.make_counter(
       MetricsLabel{"host",
                    MetricsLabel::FixedString::truncate(parsed_url.getHost())},
-      MetricsDirection::read, MetricsVisibility::external_);
+      MetricsDirection::read, MetricsVisibility::external_, MetricsType::bytes);
     ctx.spawn_task(fetch(evb_, std::move(parsed_url), std::move(request),
                          fetch_config_, static_cast<bool>(args_.error_field),
                          message_queue_));

--- a/libtenzir/builtins/operators/from_http.cpp
+++ b/libtenzir/builtins/operators/from_http.cpp
@@ -877,7 +877,9 @@ public:
                                NextUrlSource::odata_next_link)
             : None{};
       for (auto& event_slice : page->events) {
+        auto const rows = event_slice.rows();
         co_await push(std::move(event_slice));
+        events_read_.add(rows);
       }
       co_return;
     }
@@ -887,7 +889,9 @@ public:
         pagination_.next_url = std::move(*next);
       }
     }
+    auto const rows = slice.rows();
     co_await push(std::move(slice));
+    events_read_.add(rows);
   }
 
   auto finish_sub(SubKeyView, Push<table_slice>&, OpCtx& ctx)

--- a/libtenzir/builtins/operators/from_http.cpp
+++ b/libtenzir/builtins/operators/from_http.cpp
@@ -1030,7 +1030,9 @@ private:
     error_sb.data(std::move(response_->error_body));
     auto slice = assign(*args_.error_field, error_sb.finish_assert_one_array(),
                         record_sb.finish_assert_one_slice(), ctx.dh());
+    auto const rows = slice.rows();
     co_await push(std::move(slice));
+    events_read_.add(rows);
   }
 
   auto response_body_needed() const -> bool {

--- a/libtenzir/builtins/operators/from_http.cpp
+++ b/libtenzir/builtins/operators/from_http.cpp
@@ -877,9 +877,7 @@ public:
                                NextUrlSource::odata_next_link)
             : None{};
       for (auto& event_slice : page->events) {
-        auto const rows = event_slice.rows();
         co_await push(std::move(event_slice));
-        events_read_.add(rows);
       }
       co_return;
     }
@@ -889,9 +887,7 @@ public:
         pagination_.next_url = std::move(*next);
       }
     }
-    auto const rows = slice.rows();
     co_await push(std::move(slice));
-    events_read_.add(rows);
   }
 
   auto finish_sub(SubKeyView, Push<table_slice>&, OpCtx& ctx)
@@ -955,12 +951,12 @@ private:
     bytes_read_ = ctx.make_counter(
       MetricsLabel{"host",
                    MetricsLabel::FixedString::truncate(parsed_url.getHost())},
-      MetricsDirection::read, MetricsVisibility::external_, MetricsType::bytes);
+      MetricsDirection::read, MetricsVisibility::external_, MetricsUnit::bytes);
     events_read_ = ctx.make_counter(
       MetricsLabel{"host",
                    MetricsLabel::FixedString::truncate(parsed_url.getHost())},
       MetricsDirection::read, MetricsVisibility::external_,
-      MetricsType::events);
+      MetricsUnit::events);
     ctx.spawn_task(fetch(evb_, std::move(parsed_url), std::move(request),
                          fetch_config_, static_cast<bool>(args_.error_field),
                          message_queue_));

--- a/libtenzir/builtins/operators/from_http.cpp
+++ b/libtenzir/builtins/operators/from_http.cpp
@@ -877,7 +877,9 @@ public:
                                NextUrlSource::odata_next_link)
             : None{};
       for (auto& event_slice : page->events) {
+        auto const rows = event_slice.rows();
         co_await push(std::move(event_slice));
+        events_read_.add(rows);
       }
       co_return;
     }
@@ -887,7 +889,9 @@ public:
         pagination_.next_url = std::move(*next);
       }
     }
+    auto const rows = slice.rows();
     co_await push(std::move(slice));
+    events_read_.add(rows);
   }
 
   auto finish_sub(SubKeyView, Push<table_slice>&, OpCtx& ctx)
@@ -952,6 +956,11 @@ private:
       MetricsLabel{"host",
                    MetricsLabel::FixedString::truncate(parsed_url.getHost())},
       MetricsDirection::read, MetricsVisibility::external_, MetricsType::bytes);
+    events_read_ = ctx.make_counter(
+      MetricsLabel{"host",
+                   MetricsLabel::FixedString::truncate(parsed_url.getHost())},
+      MetricsDirection::read, MetricsVisibility::external_,
+      MetricsType::events);
     ctx.spawn_task(fetch(evb_, std::move(parsed_url), std::move(request),
                          fetch_config_, static_cast<bool>(args_.error_field),
                          message_queue_));
@@ -1032,6 +1041,7 @@ private:
   mutable Arc<MessageQueue> message_queue_;
   folly::EventBase* evb_{};
   MetricsCounter bytes_read_;
+  MetricsCounter events_read_;
   // --- args ---
   FromHttpArgs args_;
   FetchConfig fetch_config_;

--- a/libtenzir/builtins/operators/from_mysql.cpp
+++ b/libtenzir/builtins/operators/from_mysql.cpp
@@ -2022,7 +2022,9 @@ private:
         emit_mysql_error(std::move(*slice_result).unwrap_err(), ctx);
         co_return false;
       }
-      co_await push(std::move(*slice_result).unwrap());
+      auto slice = std::move(*slice_result).unwrap();
+      events_read_counter_.add(slice.rows());
+      co_await push(std::move(slice));
     }
     co_return true;
   }
@@ -2143,6 +2145,10 @@ public:
       = ctx.make_counter(MetricsLabel{"operator", "from_mysql"},
                          MetricsDirection::read, MetricsVisibility::external_,
                          MetricsType::bytes);
+    events_read_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "from_mysql"},
+                         MetricsDirection::read, MetricsVisibility::external_,
+                         MetricsType::events);
     // Connect asynchronously.
     auto result = co_await async_client::make(evb, std::move(config),
                                               bytes_read_counter_);
@@ -2217,7 +2223,9 @@ public:
         emit_mysql_error(std::move(*slice_result).unwrap_err(), ctx);
         break;
       }
-      co_await push(std::move(*slice_result).unwrap());
+      auto slice = std::move(*slice_result).unwrap();
+      events_read_counter_.add(slice.rows());
+      co_await push(std::move(slice));
     }
     done_ = true;
     co_await close_client(ctx);
@@ -2256,6 +2264,7 @@ private:
   Box<async_client> client_;
   bool has_client_ = false;
   MetricsCounter bytes_read_counter_;
+  MetricsCounter events_read_counter_;
   std::string query_;
   std::string schema_name_;
   std::string table_name_;

--- a/libtenzir/builtins/operators/from_mysql.cpp
+++ b/libtenzir/builtins/operators/from_mysql.cpp
@@ -2141,7 +2141,8 @@ public:
     auto const tls_enabled = config.ssl_context != nullptr;
     bytes_read_counter_
       = ctx.make_counter(MetricsLabel{"operator", "from_mysql"},
-                         MetricsDirection::read, MetricsVisibility::external_);
+                         MetricsDirection::read, MetricsVisibility::external_,
+                         MetricsType::bytes);
     // Connect asynchronously.
     auto result = co_await async_client::make(evb, std::move(config),
                                               bytes_read_counter_);

--- a/libtenzir/builtins/operators/from_mysql.cpp
+++ b/libtenzir/builtins/operators/from_mysql.cpp
@@ -2144,11 +2144,11 @@ public:
     bytes_read_counter_
       = ctx.make_counter(MetricsLabel{"operator", "from_mysql"},
                          MetricsDirection::read, MetricsVisibility::external_,
-                         MetricsType::bytes);
+                         MetricsUnit::bytes);
     events_read_counter_
       = ctx.make_counter(MetricsLabel{"operator", "from_mysql"},
                          MetricsDirection::read, MetricsVisibility::external_,
-                         MetricsType::events);
+                         MetricsUnit::events);
     // Connect asynchronously.
     auto result = co_await async_client::make(evb, std::move(config),
                                               bytes_read_counter_);

--- a/libtenzir/builtins/operators/from_stdin.cpp
+++ b/libtenzir/builtins/operators/from_stdin.cpp
@@ -237,6 +237,10 @@ public:
       = ctx.make_counter(MetricsLabel{"operator", "from_stdin"},
                          MetricsDirection::read, MetricsVisibility::external_,
                          MetricsType::bytes);
+    events_read_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "from_stdin"},
+                         MetricsDirection::read, MetricsVisibility::external_,
+                         MetricsType::events);
     co_await ctx.spawn_sub<chunk_ptr>(caf::none, std::move(pipe));
     ctx.spawn_task(folly::coro::co_withExecutor(
       ctx.io_executor(), read_stdin(chunk_queue_, ctx.dh())));
@@ -292,6 +296,13 @@ public:
     co_return;
   }
 
+  auto process_sub(SubKeyView, table_slice slice, Push<table_slice>& push,
+                   OpCtx&) -> Task<void> override {
+    auto const rows = slice.rows();
+    co_await push(std::move(slice));
+    events_read_counter_.add(rows);
+  }
+
   auto state() -> OperatorState override {
     return done_ ? OperatorState::done : OperatorState::normal;
   }
@@ -301,6 +312,7 @@ private:
   bool done_ = false;
   bool stdin_closed_ = false;
   MetricsCounter bytes_read_counter_;
+  MetricsCounter events_read_counter_;
   mutable Arc<Notify> sub_finished_{std::in_place};
   mutable Arc<ChunkQueue> chunk_queue_{std::in_place, queue_capacity};
 };

--- a/libtenzir/builtins/operators/from_stdin.cpp
+++ b/libtenzir/builtins/operators/from_stdin.cpp
@@ -237,6 +237,10 @@ public:
       = ctx.make_counter(MetricsLabel{"operator", "from_stdin"},
                          MetricsDirection::read, MetricsVisibility::external_,
                          MetricsUnit::bytes);
+    events_read_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "from_stdin"},
+                         MetricsDirection::read, MetricsVisibility::external_,
+                         MetricsUnit::events);
     co_await ctx.spawn_sub<chunk_ptr>(caf::none, std::move(pipe));
     ctx.spawn_task(folly::coro::co_withExecutor(
       ctx.io_executor(), read_stdin(chunk_queue_, ctx.dh())));
@@ -294,7 +298,9 @@ public:
 
   auto process_sub(SubKeyView, table_slice slice, Push<table_slice>& push,
                    OpCtx&) -> Task<void> override {
+    auto const rows = slice.rows();
     co_await push(std::move(slice));
+    events_read_counter_.add(rows);
   }
 
   auto state() -> OperatorState override {
@@ -306,6 +312,7 @@ private:
   bool done_ = false;
   bool stdin_closed_ = false;
   MetricsCounter bytes_read_counter_;
+  MetricsCounter events_read_counter_;
   mutable Arc<Notify> sub_finished_{std::in_place};
   mutable Arc<ChunkQueue> chunk_queue_{std::in_place, queue_capacity};
 };

--- a/libtenzir/builtins/operators/from_stdin.cpp
+++ b/libtenzir/builtins/operators/from_stdin.cpp
@@ -181,7 +181,7 @@ public:
     bytes_read_counter_
       = ctx.make_counter(MetricsLabel{"operator", "load_stdin"},
                          MetricsDirection::read, MetricsVisibility::external_,
-                         MetricsType::bytes);
+                         MetricsUnit::bytes);
     ctx.spawn_task(folly::coro::co_withExecutor(
       ctx.io_executor(), read_stdin(chunk_queue_, ctx.dh())));
     co_return;
@@ -236,11 +236,7 @@ public:
     bytes_read_counter_
       = ctx.make_counter(MetricsLabel{"operator", "from_stdin"},
                          MetricsDirection::read, MetricsVisibility::external_,
-                         MetricsType::bytes);
-    events_read_counter_
-      = ctx.make_counter(MetricsLabel{"operator", "from_stdin"},
-                         MetricsDirection::read, MetricsVisibility::external_,
-                         MetricsType::events);
+                         MetricsUnit::bytes);
     co_await ctx.spawn_sub<chunk_ptr>(caf::none, std::move(pipe));
     ctx.spawn_task(folly::coro::co_withExecutor(
       ctx.io_executor(), read_stdin(chunk_queue_, ctx.dh())));
@@ -298,9 +294,7 @@ public:
 
   auto process_sub(SubKeyView, table_slice slice, Push<table_slice>& push,
                    OpCtx&) -> Task<void> override {
-    auto const rows = slice.rows();
     co_await push(std::move(slice));
-    events_read_counter_.add(rows);
   }
 
   auto state() -> OperatorState override {
@@ -312,7 +306,6 @@ private:
   bool done_ = false;
   bool stdin_closed_ = false;
   MetricsCounter bytes_read_counter_;
-  MetricsCounter events_read_counter_;
   mutable Arc<Notify> sub_finished_{std::in_place};
   mutable Arc<ChunkQueue> chunk_queue_{std::in_place, queue_capacity};
 };

--- a/libtenzir/builtins/operators/from_stdin.cpp
+++ b/libtenzir/builtins/operators/from_stdin.cpp
@@ -180,7 +180,8 @@ public:
   auto start(OpCtx& ctx) -> Task<void> override {
     bytes_read_counter_
       = ctx.make_counter(MetricsLabel{"operator", "load_stdin"},
-                         MetricsDirection::read, MetricsVisibility::external_);
+                         MetricsDirection::read, MetricsVisibility::external_,
+                         MetricsType::bytes);
     ctx.spawn_task(folly::coro::co_withExecutor(
       ctx.io_executor(), read_stdin(chunk_queue_, ctx.dh())));
     co_return;
@@ -234,7 +235,8 @@ public:
     }
     bytes_read_counter_
       = ctx.make_counter(MetricsLabel{"operator", "from_stdin"},
-                         MetricsDirection::read, MetricsVisibility::external_);
+                         MetricsDirection::read, MetricsVisibility::external_,
+                         MetricsType::bytes);
     co_await ctx.spawn_sub<chunk_ptr>(caf::none, std::move(pipe));
     ctx.spawn_task(folly::coro::co_withExecutor(
       ctx.io_executor(), read_stdin(chunk_queue_, ctx.dh())));

--- a/libtenzir/builtins/operators/from_tcp.cpp
+++ b/libtenzir/builtins/operators/from_tcp.cpp
@@ -168,6 +168,10 @@ public:
                            port_);
     evb_ = folly::getGlobalIOExecutor()->getEventBase();
     TENZIR_ASSERT(evb_);
+    events_read_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "from_tcp"},
+                         MetricsDirection::read, MetricsVisibility::external_,
+                         MetricsUnit::events);
     co_return;
   }
 
@@ -283,6 +287,13 @@ public:
       });
   }
 
+  auto process_sub(SubKeyView, table_slice slice, Push<table_slice>& push,
+                   OpCtx&) -> Task<void> override {
+    auto const rows = slice.rows();
+    co_await push(std::move(slice));
+    events_read_counter_.add(rows);
+  }
+
   auto finish_sub(SubKeyView key, Push<table_slice>&, OpCtx&)
     -> Task<void> override {
     auto conn_id = static_cast<uint64_t>(as<int64_t>(key));
@@ -358,6 +369,7 @@ private:
                                            message_queue_capacity};
   Option<Connection> current_connection_;
   Option<uint64_t> current_conn_id_;
+  MetricsCounter events_read_counter_;
   uint64_t next_conn_id_{0};
   bool startup_failed_ = false;
 };

--- a/libtenzir/builtins/operators/from_tcp.cpp
+++ b/libtenzir/builtins/operators/from_tcp.cpp
@@ -228,7 +228,7 @@ public:
           MetricsLabel{"peer_ip", MetricsLabel::FixedString::truncate(
                                     fmt::to_string(peer_ip))},
           MetricsDirection::read, MetricsVisibility::external_,
-          MetricsType::bytes);
+          MetricsUnit::bytes);
         auto conn_id = next_conn_id_++;
         auto pipeline_copy = args_.user_pipeline.inner;
         auto env = substitute_ctx::env_t{};

--- a/libtenzir/builtins/operators/from_tcp.cpp
+++ b/libtenzir/builtins/operators/from_tcp.cpp
@@ -227,7 +227,8 @@ public:
         auto bytes_read_counter = ctx.make_counter(
           MetricsLabel{"peer_ip", MetricsLabel::FixedString::truncate(
                                     fmt::to_string(peer_ip))},
-          MetricsDirection::read, MetricsVisibility::external_);
+          MetricsDirection::read, MetricsVisibility::external_,
+          MetricsType::bytes);
         auto conn_id = next_conn_id_++;
         auto pipeline_copy = args_.user_pipeline.inner;
         auto env = substitute_ctx::env_t{};

--- a/libtenzir/builtins/operators/from_to_2.cpp
+++ b/libtenzir/builtins/operators/from_to_2.cpp
@@ -100,7 +100,14 @@ public:
         "operator",
         "from_events",
       },
-      MetricsDirection::read, MetricsVisibility::internal_);
+      MetricsDirection::read, MetricsVisibility::internal_, MetricsType::bytes);
+    read_events_counter_ = ctx.make_counter(
+      MetricsLabel{
+        "operator",
+        "from_events",
+      },
+      MetricsDirection::read, MetricsVisibility::internal_,
+      MetricsType::events);
     co_return;
   }
 
@@ -121,8 +128,11 @@ public:
     auto slice = table_slice{
       record_batch_from_struct_array(schema.to_arrow_schema(), *cast->array),
       schema};
-    read_bytes_counter_.add(slice.approx_bytes());
+    auto const bytes = slice.approx_bytes();
+    auto const rows = slice.rows();
     co_await push(std::move(slice));
+    read_bytes_counter_.add(bytes);
+    read_events_counter_.add(rows);
     next_ += 1;
   }
 
@@ -141,6 +151,7 @@ private:
   size_t next_ = 0;
   std::vector<ast::expression> events_;
   MetricsCounter read_bytes_counter_;
+  MetricsCounter read_events_counter_;
 };
 
 class from_ir final : public ir::Operator {

--- a/libtenzir/builtins/operators/from_to_2.cpp
+++ b/libtenzir/builtins/operators/from_to_2.cpp
@@ -100,14 +100,14 @@ public:
         "operator",
         "from_events",
       },
-      MetricsDirection::read, MetricsVisibility::internal_, MetricsType::bytes);
+      MetricsDirection::read, MetricsVisibility::internal_, MetricsUnit::bytes);
     read_events_counter_ = ctx.make_counter(
       MetricsLabel{
         "operator",
         "from_events",
       },
       MetricsDirection::read, MetricsVisibility::internal_,
-      MetricsType::events);
+      MetricsUnit::events);
     co_return;
   }
 

--- a/libtenzir/builtins/operators/import.cpp
+++ b/libtenzir/builtins/operators/import.cpp
@@ -44,7 +44,15 @@ public:
         "operator",
         "import",
       },
-      MetricsDirection::write, MetricsVisibility::internal_);
+      MetricsDirection::write, MetricsVisibility::internal_,
+      MetricsType::bytes);
+    write_events_counter_ = ctx.make_counter(
+      MetricsLabel{
+        "operator",
+        "import",
+      },
+      MetricsDirection::write, MetricsVisibility::internal_,
+      MetricsType::events);
     auto node = co_await fetch_node(ctx.actor_system(), ctx.dh());
     if (not node) {
       co_return;
@@ -93,6 +101,7 @@ public:
       co_return;
     }
     write_bytes_counter_.add(input.approx_bytes());
+    write_events_counter_.add(input.rows());
     auto* diagnostics = &ctx.dh();
     inflight_.push_back(
       ctx.spawn_task([importer = importer_, slice = std::move(input),
@@ -132,6 +141,7 @@ private:
 
   importer_actor importer_;
   MetricsCounter write_bytes_counter_ = {};
+  MetricsCounter write_events_counter_ = {};
   std::deque<AsyncHandle<void>> inflight_ = {};
 };
 

--- a/libtenzir/builtins/operators/import.cpp
+++ b/libtenzir/builtins/operators/import.cpp
@@ -45,14 +45,14 @@ public:
         "import",
       },
       MetricsDirection::write, MetricsVisibility::internal_,
-      MetricsType::bytes);
+      MetricsUnit::bytes);
     write_events_counter_ = ctx.make_counter(
       MetricsLabel{
         "operator",
         "import",
       },
       MetricsDirection::write, MetricsVisibility::internal_,
-      MetricsType::events);
+      MetricsUnit::events);
     auto node = co_await fetch_node(ctx.actor_system(), ctx.dh());
     if (not node) {
       co_return;

--- a/libtenzir/builtins/operators/to_ftp.cpp
+++ b/libtenzir/builtins/operators/to_ftp.cpp
@@ -138,11 +138,11 @@ public:
     bytes_write_counter_
       = ctx.make_counter(MetricsLabel{"operator", "to_ftp"},
                          MetricsDirection::write, MetricsVisibility::external_,
-                         MetricsType::bytes);
+                         MetricsUnit::bytes);
     events_write_counter_
       = ctx.make_counter(MetricsLabel{"operator", "to_ftp"},
                          MetricsDirection::write, MetricsVisibility::external_,
-                         MetricsType::events);
+                         MetricsUnit::events);
     auto code = easy.set([](std::span<const std::byte>) {});
     if (code != curl::easy::code::ok) {
       diagnostic::error("failed to configure FTP upload")

--- a/libtenzir/builtins/operators/to_ftp.cpp
+++ b/libtenzir/builtins/operators/to_ftp.cpp
@@ -137,7 +137,8 @@ public:
     }
     bytes_write_counter_
       = ctx.make_counter(MetricsLabel{"operator", "to_ftp"},
-                         MetricsDirection::write, MetricsVisibility::external_);
+                         MetricsDirection::write, MetricsVisibility::external_,
+                         MetricsType::bytes);
     auto code = easy.set([](std::span<const std::byte>) {});
     if (code != curl::easy::code::ok) {
       diagnostic::error("failed to configure FTP upload")

--- a/libtenzir/builtins/operators/to_ftp.cpp
+++ b/libtenzir/builtins/operators/to_ftp.cpp
@@ -139,6 +139,10 @@ public:
       = ctx.make_counter(MetricsLabel{"operator", "to_ftp"},
                          MetricsDirection::write, MetricsVisibility::external_,
                          MetricsType::bytes);
+    events_write_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "to_ftp"},
+                         MetricsDirection::write, MetricsVisibility::external_,
+                         MetricsType::events);
     auto code = easy.set([](std::span<const std::byte>) {});
     if (code != curl::easy::code::ok) {
       diagnostic::error("failed to configure FTP upload")
@@ -164,6 +168,7 @@ public:
       co_await finish_upload_task();
       co_return;
     }
+    auto const rows = input.rows();
     auto& printer = as<SubHandle<table_slice>>(*sub);
     auto push_result = co_await printer.push(std::move(input));
     if (push_result.is_err()) {
@@ -171,7 +176,9 @@ public:
       // `head`. Let `finish_sub()` close the upload with EOF instead of
       // turning already-produced printer output into a local abort.
       lifecycle_ = Lifecycle::draining;
+      co_return;
     }
+    events_write_counter_.add(rows);
   }
 
   auto process_sub(SubKeyView, chunk_ptr chunk, OpCtx&) -> Task<void> override {
@@ -340,6 +347,7 @@ private:
   ToFtpArgs args_;
   std::string resolved_url_;
   MetricsCounter bytes_write_counter_;
+  MetricsCounter events_write_counter_;
   Lifecycle lifecycle_ = Lifecycle::running;
 };
 

--- a/libtenzir/builtins/operators/to_http.cpp
+++ b/libtenzir/builtins/operators/to_http.cpp
@@ -89,14 +89,14 @@ public:
         "to_http",
       },
       MetricsDirection::write, MetricsVisibility::external_,
-      MetricsType::bytes);
+      MetricsUnit::bytes);
     events_write_counter_ = ctx.make_counter(
       MetricsLabel{
         "operator",
         "to_http",
       },
       MetricsDirection::write, MetricsVisibility::external_,
-      MetricsType::events);
+      MetricsUnit::events);
     // setup url, headers & tls
     if (auto result = co_await resolve_secrets(ctx, args_, url_, headers_);
         result.is_error()) {

--- a/libtenzir/builtins/operators/to_http.cpp
+++ b/libtenzir/builtins/operators/to_http.cpp
@@ -90,6 +90,13 @@ public:
       },
       MetricsDirection::write, MetricsVisibility::external_,
       MetricsType::bytes);
+    events_write_counter_ = ctx.make_counter(
+      MetricsLabel{
+        "operator",
+        "to_http",
+      },
+      MetricsDirection::write, MetricsVisibility::external_,
+      MetricsType::events);
     // setup url, headers & tls
     if (auto result = co_await resolve_secrets(ctx, args_, url_, headers_);
         result.is_error()) {
@@ -136,11 +143,14 @@ public:
       lifecycle_ = Lifecycle::done;
       co_return;
     }
+    auto const rows = input.rows();
     auto& pipeline = as<SubHandle<table_slice>>(*sub);
     if (auto result = co_await pipeline.push(std::move(input));
         result.is_err()) {
       co_await begin_draining(ctx);
+      co_return;
     }
+    events_write_counter_.add(rows);
   }
 
   auto process_sub(SubKeyView, chunk_ptr chunk, OpCtx& ctx)
@@ -313,6 +323,7 @@ private:
   Option<Box<HttpPool>> http_pool_;
   mutable Arc<Oneshot<std::string>> error_signal_{std::in_place};
   MetricsCounter bytes_write_counter_;
+  MetricsCounter events_write_counter_;
 };
 
 class ToHttpPlugin final : public OperatorPlugin {

--- a/libtenzir/builtins/operators/to_http.cpp
+++ b/libtenzir/builtins/operators/to_http.cpp
@@ -88,7 +88,8 @@ public:
         "operator",
         "to_http",
       },
-      MetricsDirection::write, MetricsVisibility::external_);
+      MetricsDirection::write, MetricsVisibility::external_,
+      MetricsType::bytes);
     // setup url, headers & tls
     if (auto result = co_await resolve_secrets(ctx, args_, url_, headers_);
         result.is_error()) {

--- a/libtenzir/builtins/operators/to_opensearch2.cpp
+++ b/libtenzir/builtins/operators/to_opensearch2.cpp
@@ -293,7 +293,8 @@ public:
     }
     bytes_write_counter_
       = ctx.make_counter(MetricsLabel{"operator", "to_opensearch"},
-                         MetricsDirection::write, MetricsVisibility::external_);
+                         MetricsDirection::write, MetricsVisibility::external_,
+                         MetricsType::bytes);
   }
 
   auto process(table_slice input, OpCtx& ctx) -> Task<void> override {

--- a/libtenzir/builtins/operators/to_opensearch2.cpp
+++ b/libtenzir/builtins/operators/to_opensearch2.cpp
@@ -302,11 +302,11 @@ public:
     bytes_write_counter_
       = ctx.make_counter(MetricsLabel{"operator", "to_opensearch"},
                          MetricsDirection::write, MetricsVisibility::external_,
-                         MetricsType::bytes);
+                         MetricsUnit::bytes);
     events_write_counter_
       = ctx.make_counter(MetricsLabel{"operator", "to_opensearch"},
                          MetricsDirection::write, MetricsVisibility::external_,
-                         MetricsType::events);
+                         MetricsUnit::events);
   }
 
   auto process(table_slice input, OpCtx& ctx) -> Task<void> override {

--- a/libtenzir/builtins/operators/to_opensearch2.cpp
+++ b/libtenzir/builtins/operators/to_opensearch2.cpp
@@ -144,6 +144,7 @@ public:
         body_ += element_text_;
         element_text_.clear();
       }
+      event_count_ += 1;
       return state::ok;
     }
     return state::full;
@@ -157,8 +158,13 @@ public:
     return last_element_size_;
   }
 
+  auto event_count() const -> uint64_t {
+    return event_count_;
+  }
+
   auto yield(diagnostic_handler& dh) -> std::string_view {
     TENZIR_ASSERT(not body_.empty());
+    auto const pending_event = not element_text_.empty();
     if (not codec_) {
       std::swap(body_, result_);
     } else {
@@ -179,6 +185,7 @@ public:
     }
     std::swap(body_, element_text_);
     element_text_.clear();
+    event_count_ = pending_event ? 1 : 0;
     return result_;
   }
 
@@ -190,6 +197,7 @@ private:
   std::string result_;
   std::unique_ptr<arrow::util::Codec> codec_;
   uint64_t last_element_size_{};
+  uint64_t event_count_{};
 };
 
 auto to_option_string_view(
@@ -295,6 +303,10 @@ public:
       = ctx.make_counter(MetricsLabel{"operator", "to_opensearch"},
                          MetricsDirection::write, MetricsVisibility::external_,
                          MetricsType::bytes);
+    events_write_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "to_opensearch"},
+                         MetricsDirection::write, MetricsVisibility::external_,
+                         MetricsType::events);
   }
 
   auto process(table_slice input, OpCtx& ctx) -> Task<void> override {
@@ -425,6 +437,7 @@ private:
 
   auto send_request(OpCtx& ctx) -> Task<void> {
     TENZIR_ASSERT(pool_);
+    auto const events = builder_.event_count();
     auto body = builder_.yield(ctx.dh());
     if (body.empty()) {
       co_return;
@@ -468,6 +481,7 @@ private:
         .emit(ctx);
     }
     bytes_write_counter_.add(body.size());
+    events_write_counter_.add(events);
   }
 
   ToOpenSearchArgs args_;
@@ -476,6 +490,7 @@ private:
   std::string url_;
   std::map<std::string, std::string> headers_;
   MetricsCounter bytes_write_counter_;
+  MetricsCounter events_write_counter_;
   mutable Option<std::chrono::steady_clock::time_point> next_timeout_;
   mutable Box<Notify> buffer_ready_{std::in_place};
 };

--- a/libtenzir/builtins/operators/to_stdout.cpp
+++ b/libtenzir/builtins/operators/to_stdout.cpp
@@ -167,7 +167,12 @@ public:
     }
     bytes_write_counter_
       = ctx.make_counter(MetricsLabel{"operator", "to_stdout"},
-                         MetricsDirection::write, MetricsVisibility::external_);
+                         MetricsDirection::write, MetricsVisibility::external_,
+                         MetricsType::bytes);
+    events_write_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "to_stdout"},
+                         MetricsDirection::write, MetricsVisibility::external_,
+                         MetricsType::events);
     if (auto error = stdout_nonblocking_.activate()) {
       diagnostic::error("{}", *error).primary(args_.self).emit(ctx);
       done_ = true;
@@ -206,11 +211,14 @@ public:
       done_ = true;
       co_return;
     }
+    auto const rows = input.rows();
     auto& pipeline = as<SubHandle<table_slice>>(*sub);
     auto push_result = co_await pipeline.push(std::move(input));
     if (push_result.is_err()) {
       done_ = true;
+      co_return;
     }
+    events_write_counter_.add(rows);
   }
 
   auto process_sub(SubKeyView, chunk_ptr chunk, OpCtx&) -> Task<void> override {
@@ -266,6 +274,7 @@ private:
   // loop, which owns the operator lifecycle state.
   mutable Box<ErrorQueue> queue_{std::in_place, error_queue_capacity};
   MetricsCounter bytes_write_counter_;
+  MetricsCounter events_write_counter_;
   bool done_ = false;
 };
 
@@ -277,7 +286,8 @@ public:
   auto start(OpCtx& ctx) -> Task<void> override {
     bytes_write_counter_
       = ctx.make_counter(MetricsLabel{"operator", "save_stdout"},
-                         MetricsDirection::write, MetricsVisibility::external_);
+                         MetricsDirection::write, MetricsVisibility::external_,
+                         MetricsType::bytes);
     if (auto error = stdout_nonblocking_.activate()) {
       diagnostic::error("{}", *error).primary(args_.self).emit(ctx);
       done_ = true;

--- a/libtenzir/builtins/operators/to_stdout.cpp
+++ b/libtenzir/builtins/operators/to_stdout.cpp
@@ -168,11 +168,11 @@ public:
     bytes_write_counter_
       = ctx.make_counter(MetricsLabel{"operator", "to_stdout"},
                          MetricsDirection::write, MetricsVisibility::external_,
-                         MetricsType::bytes);
+                         MetricsUnit::bytes);
     events_write_counter_
       = ctx.make_counter(MetricsLabel{"operator", "to_stdout"},
                          MetricsDirection::write, MetricsVisibility::external_,
-                         MetricsType::events);
+                         MetricsUnit::events);
     if (auto error = stdout_nonblocking_.activate()) {
       diagnostic::error("{}", *error).primary(args_.self).emit(ctx);
       done_ = true;
@@ -287,7 +287,7 @@ public:
     bytes_write_counter_
       = ctx.make_counter(MetricsLabel{"operator", "save_stdout"},
                          MetricsDirection::write, MetricsVisibility::external_,
-                         MetricsType::bytes);
+                         MetricsUnit::bytes);
     if (auto error = stdout_nonblocking_.activate()) {
       diagnostic::error("{}", *error).primary(args_.self).emit(ctx);
       done_ = true;

--- a/libtenzir/builtins/operators/to_tcp.cpp
+++ b/libtenzir/builtins/operators/to_tcp.cpp
@@ -261,7 +261,8 @@ private:
     bytes_write_counter_ = ctx.make_counter(
       MetricsLabel{"peer_ip", MetricsLabel::FixedString::truncate(
                                 peer_addr.getAddressStr())},
-      MetricsDirection::write, MetricsVisibility::external_);
+      MetricsDirection::write, MetricsVisibility::external_,
+      MetricsType::bytes);
     TENZIR_DEBUG("to_tcp: connected to {}", address_.describe());
   }
 

--- a/libtenzir/builtins/operators/to_tcp.cpp
+++ b/libtenzir/builtins/operators/to_tcp.cpp
@@ -108,6 +108,10 @@ public:
       finish();
       co_return;
     }
+    events_write_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "to_tcp"},
+                         MetricsDirection::write, MetricsVisibility::external_,
+                         MetricsType::events);
     co_await ctx.spawn_sub<table_slice>(sub_key_, std::move(pipeline));
     co_return;
   }
@@ -121,11 +125,14 @@ public:
       finish();
       co_return;
     }
+    auto const rows = input.rows();
     auto& pipeline = as<SubHandle<table_slice>>(*sub);
     auto result = co_await pipeline.push(std::move(input));
     if (result.is_err()) {
       finish();
+      co_return;
     }
+    events_write_counter_.add(rows);
   }
 
   auto process_sub(SubKeyView, chunk_ptr chunk, OpCtx&) -> Task<void> override {
@@ -321,6 +328,7 @@ private:
   };
   Option<folly::coro::Transport> transport_;
   MetricsCounter bytes_write_counter_;
+  MetricsCounter events_write_counter_;
   Lifecycle lifecycle_ = Lifecycle::running;
 };
 

--- a/libtenzir/builtins/operators/to_tcp.cpp
+++ b/libtenzir/builtins/operators/to_tcp.cpp
@@ -111,7 +111,7 @@ public:
     events_write_counter_
       = ctx.make_counter(MetricsLabel{"operator", "to_tcp"},
                          MetricsDirection::write, MetricsVisibility::external_,
-                         MetricsType::events);
+                         MetricsUnit::events);
     co_await ctx.spawn_sub<table_slice>(sub_key_, std::move(pipeline));
     co_return;
   }
@@ -269,7 +269,7 @@ private:
       MetricsLabel{"peer_ip", MetricsLabel::FixedString::truncate(
                                 peer_addr.getAddressStr())},
       MetricsDirection::write, MetricsVisibility::external_,
-      MetricsType::bytes);
+      MetricsUnit::bytes);
     TENZIR_DEBUG("to_tcp: connected to {}", address_.describe());
   }
 

--- a/libtenzir/builtins/operators/to_udp.cpp
+++ b/libtenzir/builtins/operators/to_udp.cpp
@@ -74,11 +74,11 @@ public:
     bytes_write_counter_
       = ctx.make_counter(MetricsLabel{"operator", "to_udp"},
                          MetricsDirection::write, MetricsVisibility::external_,
-                         MetricsType::bytes);
+                         MetricsUnit::bytes);
     events_write_counter_
       = ctx.make_counter(MetricsLabel{"operator", "to_udp"},
                          MetricsDirection::write, MetricsVisibility::external_,
-                         MetricsType::events);
+                         MetricsUnit::events);
     auto [startup_sender, startup_receiver]
       = channel<diagnostic>(request_queue_capacity);
     TENZIR_ASSERT(write_sender_);

--- a/libtenzir/builtins/operators/to_udp.cpp
+++ b/libtenzir/builtins/operators/to_udp.cpp
@@ -75,13 +75,17 @@ public:
       = ctx.make_counter(MetricsLabel{"operator", "to_udp"},
                          MetricsDirection::write, MetricsVisibility::external_,
                          MetricsType::bytes);
+    events_write_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "to_udp"},
+                         MetricsDirection::write, MetricsVisibility::external_,
+                         MetricsType::events);
     auto [startup_sender, startup_receiver]
       = channel<diagnostic>(request_queue_capacity);
     TENZIR_ASSERT(write_sender_);
     ctx.spawn_task(folly::coro::co_withExecutor(
       evb_, write_loop(*evb_, std::move(address).unwrap(), args_.self,
                        std::move(write_receiver_), std::move(startup_sender),
-                       bytes_write_counter_)));
+                       bytes_write_counter_, events_write_counter_)));
     // Successful startup is signaled by closing the channel without errors.
     while (auto diagnostic = co_await startup_receiver.recv()) {
       std::move(*diagnostic).modify().emit(ctx);
@@ -179,7 +183,8 @@ private:
   static auto write_loop(folly::EventBase& evb, folly::SocketAddress address,
                          location self, Receiver<SendBatch> write_receiver,
                          Sender<diagnostic> startup_sender,
-                         MetricsCounter bytes_write_counter) -> Task<void> {
+                         MetricsCounter bytes_write_counter,
+                         MetricsCounter events_write_counter) -> Task<void> {
     auto socket = folly::AsyncUDPSocket{&evb};
     auto startup_diagnostics = collecting_diagnostic_handler{};
     try {
@@ -231,6 +236,7 @@ private:
           continue;
         }
         bytes_write_counter.add(payload->size());
+        events_write_counter.add(1);
       }
       // This single-shot channel of capacity 1 can always be written to since
       // we don't reuse it.
@@ -246,6 +252,7 @@ private:
   Option<Sender<SendBatch>> write_sender_;
   Receiver<SendBatch> write_receiver_;
   MetricsCounter bytes_write_counter_;
+  MetricsCounter events_write_counter_;
 };
 
 class ToUdpPlugin final : public OperatorPlugin {

--- a/libtenzir/builtins/operators/to_udp.cpp
+++ b/libtenzir/builtins/operators/to_udp.cpp
@@ -73,7 +73,8 @@ public:
     // `make_counter` always requires exactly one label pair.
     bytes_write_counter_
       = ctx.make_counter(MetricsLabel{"operator", "to_udp"},
-                         MetricsDirection::write, MetricsVisibility::external_);
+                         MetricsDirection::write, MetricsVisibility::external_,
+                         MetricsType::bytes);
     auto [startup_sender, startup_receiver]
       = channel<diagnostic>(request_queue_capacity);
     TENZIR_ASSERT(write_sender_);

--- a/libtenzir/include/tenzir/arrow_fs.hpp
+++ b/libtenzir/include/tenzir/arrow_fs.hpp
@@ -303,7 +303,6 @@ private:
     max_jobs + 1,
   };
   MetricsCounter bytes_read_counter_;
-  MetricsCounter events_read_counter_;
 };
 
 /// Common arguments for Arrow filesystem-based sink operators.
@@ -543,7 +542,6 @@ private:
 
   bool finalized_ = false;
   MetricsCounter bytes_written_counter_;
-  MetricsCounter events_written_counter_;
 };
 
 } // namespace tenzir

--- a/libtenzir/include/tenzir/arrow_fs.hpp
+++ b/libtenzir/include/tenzir/arrow_fs.hpp
@@ -232,6 +232,8 @@ public:
   auto await_task(diagnostic_handler& dh) const -> Task<Any> final;
   auto process_task(Any result, Push<table_slice>& push, OpCtx& ctx)
     -> Task<void> final;
+  auto process_sub(SubKeyView key, table_slice slice, Push<table_slice>& push,
+                   OpCtx& ctx) -> Task<void> final;
   auto finish_sub(SubKeyView key, Push<table_slice>& push, OpCtx& ctx)
     -> Task<void> final;
   auto finalize(Push<table_slice>& push, OpCtx& ctx)
@@ -301,6 +303,7 @@ private:
     max_jobs + 1,
   };
   MetricsCounter bytes_read_counter_;
+  MetricsCounter events_read_counter_;
 };
 
 /// Common arguments for Arrow filesystem-based sink operators.
@@ -540,6 +543,7 @@ private:
 
   bool finalized_ = false;
   MetricsCounter bytes_written_counter_;
+  MetricsCounter events_written_counter_;
 };
 
 } // namespace tenzir

--- a/libtenzir/include/tenzir/arrow_fs.hpp
+++ b/libtenzir/include/tenzir/arrow_fs.hpp
@@ -303,6 +303,7 @@ private:
     max_jobs + 1,
   };
   MetricsCounter bytes_read_counter_;
+  MetricsCounter events_read_counter_;
 };
 
 /// Common arguments for Arrow filesystem-based sink operators.

--- a/libtenzir/include/tenzir/arrow_fs.hpp
+++ b/libtenzir/include/tenzir/arrow_fs.hpp
@@ -543,6 +543,7 @@ private:
 
   bool finalized_ = false;
   MetricsCounter bytes_written_counter_;
+  MetricsCounter events_written_counter_;
 };
 
 } // namespace tenzir

--- a/libtenzir/include/tenzir/async.hpp
+++ b/libtenzir/include/tenzir/async.hpp
@@ -205,13 +205,13 @@ public:
 
   /// Create a throughput counter with the given label.
   virtual auto make_counter(MetricsLabel label, MetricsDirection direction,
-                            MetricsVisibility visibility, MetricsType type)
+                            MetricsVisibility visibility, MetricsUnit type)
     -> MetricsCounter
     = 0;
 
   /// Create a throughput gauge with the given label.
   virtual auto make_gauge(MetricsLabel label, MetricsDirection direction,
-                          MetricsVisibility visibility, MetricsType type)
+                          MetricsVisibility visibility, MetricsUnit type)
     -> MetricsGauge
     = delete;
 

--- a/libtenzir/include/tenzir/async.hpp
+++ b/libtenzir/include/tenzir/async.hpp
@@ -205,12 +205,14 @@ public:
 
   /// Create a throughput counter with the given label.
   virtual auto make_counter(MetricsLabel label, MetricsDirection direction,
-                            MetricsVisibility visibility) -> MetricsCounter
+                            MetricsVisibility visibility, MetricsType type)
+    -> MetricsCounter
     = 0;
 
   /// Create a throughput gauge with the given label.
   virtual auto make_gauge(MetricsLabel label, MetricsDirection direction,
-                          MetricsVisibility visibility) -> MetricsGauge
+                          MetricsVisibility visibility, MetricsType type)
+    -> MetricsGauge
     = delete;
 
   /// Returns the metrics receiver actor handle, if available.

--- a/libtenzir/include/tenzir/async/executor.hpp
+++ b/libtenzir/include/tenzir/async/executor.hpp
@@ -241,7 +241,7 @@ public:
 
   /// Create and register a new counter for the pipeline.
   virtual auto make_counter(MetricsLabel label, MetricsDirection direction,
-                            MetricsVisibility visibility, MetricsType type)
+                            MetricsVisibility visibility, MetricsUnit type)
     -> MetricsCounter
     = 0;
 

--- a/libtenzir/include/tenzir/async/executor.hpp
+++ b/libtenzir/include/tenzir/async/executor.hpp
@@ -241,7 +241,8 @@ public:
 
   /// Create and register a new counter for the pipeline.
   virtual auto make_counter(MetricsLabel label, MetricsDirection direction,
-                            MetricsVisibility visibility) -> MetricsCounter
+                            MetricsVisibility visibility, MetricsType type)
+    -> MetricsCounter
     = 0;
 
   /// Returns whether the pipeline is hidden.

--- a/libtenzir/include/tenzir/async/pusher.hpp
+++ b/libtenzir/include/tenzir/async/pusher.hpp
@@ -37,13 +37,13 @@ public:
   /// Pushes one ready slice and schedules the next timeout.
   auto push(series_builder::YieldReadyResult result,
             Push<table_slice>& push) const -> Task<void> {
-    co_await this->push(std::move(result), push, [](uint64_t) {});
+    co_await this->push(std::move(result), push, [](table_slice const&) {});
   }
 
   auto push(series_builder::YieldReadyResult result, Push<table_slice>& push,
             MetricsCounter& counter) const -> Task<void> {
-    co_await this->push(std::move(result), push, [&](uint64_t rows) {
-      counter.add(rows);
+    co_await this->push(std::move(result), push, [&](table_slice const& slice) {
+      counter.add(slice.rows());
     });
   }
 
@@ -51,14 +51,8 @@ public:
   auto push(series_builder::YieldReadyResult result, Push<table_slice>& push,
             OnSlice&& on_slice) const -> Task<void> {
     for (auto&& slice : result.slices) {
-      if constexpr (std::is_invocable_v<OnSlice, uint64_t>) {
-        auto rows = slice.rows();
-        co_await push(std::move(slice));
-        std::invoke(on_slice, rows);
-      } else {
-        std::invoke(on_slice, slice);
-        co_await push(std::move(slice));
-      }
+      std::invoke(on_slice, slice);
+      co_await push(std::move(slice));
     }
     if (result.wait_for) {
       set_wait_for(result.wait_for.unwrap());

--- a/libtenzir/include/tenzir/async/pusher.hpp
+++ b/libtenzir/include/tenzir/async/pusher.hpp
@@ -10,6 +10,7 @@
 
 #include "tenzir/async/push_pull.hpp"
 #include "tenzir/box.hpp"
+#include "tenzir/pipeline_metrics.hpp"
 #include "tenzir/series_builder.hpp"
 
 #include <folly/coro/BoundedQueue.h>
@@ -36,15 +37,28 @@ public:
   /// Pushes one ready slice and schedules the next timeout.
   auto push(series_builder::YieldReadyResult result,
             Push<table_slice>& push) const -> Task<void> {
-    co_await this->push(std::move(result), push, [](table_slice const&) {});
+    co_await this->push(std::move(result), push, [](uint64_t) {});
+  }
+
+  auto push(series_builder::YieldReadyResult result, Push<table_slice>& push,
+            MetricsCounter& counter) const -> Task<void> {
+    co_await this->push(std::move(result), push, [&](uint64_t rows) {
+      counter.add(rows);
+    });
   }
 
   template <class OnSlice>
   auto push(series_builder::YieldReadyResult result, Push<table_slice>& push,
             OnSlice&& on_slice) const -> Task<void> {
     for (auto&& slice : result.slices) {
-      std::invoke(on_slice, slice);
-      co_await push(std::move(slice));
+      if constexpr (std::is_invocable_v<OnSlice, uint64_t>) {
+        auto rows = slice.rows();
+        co_await push(std::move(slice));
+        std::invoke(on_slice, rows);
+      } else {
+        std::invoke(on_slice, slice);
+        co_await push(std::move(slice));
+      }
     }
     if (result.wait_for) {
       set_wait_for(result.wait_for.unwrap());

--- a/libtenzir/include/tenzir/pipeline_metrics.hpp
+++ b/libtenzir/include/tenzir/pipeline_metrics.hpp
@@ -25,7 +25,8 @@ namespace tenzir {
 
 enum class MetricsDirection : std::uint8_t { read, write };
 enum class MetricsVisibility : std::uint8_t { external_, internal_ };
-enum class MetricsType : std::uint8_t { counter, gauge };
+enum class MetricsInstrument : std::uint8_t { counter, gauge };
+enum class MetricsType : std::uint8_t { bytes, events };
 
 /// A (key, value) label attached to a counter.
 /// Key and value are bounded to `max_length` characters.
@@ -77,18 +78,18 @@ private:
   FixedString value_;
 };
 
-template <MetricsType Type>
+template <MetricsInstrument Instrument>
 class Metric {
 public:
-  constexpr static auto type = Type;
+  constexpr static auto instrument = Instrument;
   /// Constructs a null counter where `add()` is a no-op.
   Metric() = default;
 
-  void add(uint64_t bytes);
-  void remove(uint64_t bytes)
-    requires(Type == MetricsType::gauge);
-  void set(uint64_t bytes)
-    requires(Type == MetricsType::gauge);
+  void add(uint64_t value);
+  void remove(uint64_t value)
+    requires(Instrument == MetricsInstrument::gauge);
+  void set(uint64_t value)
+    requires(Instrument == MetricsInstrument::gauge);
 
   explicit operator bool() const;
 
@@ -100,14 +101,15 @@ private:
   std::shared_ptr<std::atomic<uint64_t>> value_;
 };
 
-using MetricsCounter = Metric<MetricsType::counter>;
-using MetricsGauge = Metric<MetricsType::gauge>;
+using MetricsCounter = Metric<MetricsInstrument::counter>;
+using MetricsGauge = Metric<MetricsInstrument::gauge>;
 
 /// Snapshot of a single counter (plain values, no atomics).
 struct MetricsSnapshotEntry {
   MetricsLabel label;
   MetricsDirection direction = {};
   MetricsVisibility visibility = {};
+  MetricsInstrument instrument = {};
   MetricsType type = {};
   uint64_t value = {};
 };
@@ -124,8 +126,9 @@ class PipelineMetrics {
 public:
   /// Create and register a new counter.
   auto make_counter(MetricsLabel label, MetricsDirection direction,
-                    MetricsVisibility visibility) -> MetricsCounter {
-    return make<MetricsType::counter>(label, direction, visibility);
+                    MetricsVisibility visibility, MetricsType type)
+    -> MetricsCounter {
+    return make<MetricsInstrument::counter>(label, direction, visibility, type);
   }
 
   /// Create and register a new gauge.
@@ -134,21 +137,24 @@ public:
   /// `direction` and `visibility`, which should probably be labels. And label
   /// values should be set in a step that is separate from the metric creation.
   auto make_gauge(MetricsLabel label, MetricsDirection direction,
-                  MetricsVisibility visibility) -> MetricsGauge
+                  MetricsVisibility visibility, MetricsType type)
+    -> MetricsGauge
     = delete;
 
   /// Read all counters into plain snapshots.
   auto take_snapshot() -> std::vector<MetricsSnapshotEntry>;
 
 private:
-  template <MetricsType Type>
+  template <MetricsInstrument Instrument>
   auto make(MetricsLabel label, MetricsDirection direction,
-            MetricsVisibility visibility) -> Metric<Type>;
+            MetricsVisibility visibility, MetricsType type)
+    -> Metric<Instrument>;
 
   struct Entry {
     MetricsLabel label;
     MetricsDirection direction;
     MetricsVisibility visibility;
+    MetricsInstrument instrument;
     MetricsType type;
     std::shared_ptr<std::atomic<uint64_t>> value;
 

--- a/libtenzir/include/tenzir/pipeline_metrics.hpp
+++ b/libtenzir/include/tenzir/pipeline_metrics.hpp
@@ -26,7 +26,7 @@ namespace tenzir {
 enum class MetricsDirection : std::uint8_t { read, write };
 enum class MetricsVisibility : std::uint8_t { external_, internal_ };
 enum class MetricsInstrument : std::uint8_t { counter, gauge };
-enum class MetricsType : std::uint8_t { bytes, events };
+enum class MetricsUnit : std::uint8_t { bytes, events };
 
 /// A (key, value) label attached to a counter.
 /// Key and value are bounded to `max_length` characters.
@@ -110,7 +110,7 @@ struct MetricsSnapshotEntry {
   MetricsDirection direction = {};
   MetricsVisibility visibility = {};
   MetricsInstrument instrument = {};
-  MetricsType type = {};
+  MetricsUnit type = {};
   uint64_t value = {};
 };
 
@@ -126,7 +126,7 @@ class PipelineMetrics {
 public:
   /// Create and register a new counter.
   auto make_counter(MetricsLabel label, MetricsDirection direction,
-                    MetricsVisibility visibility, MetricsType type)
+                    MetricsVisibility visibility, MetricsUnit type)
     -> MetricsCounter {
     return make<MetricsInstrument::counter>(label, direction, visibility, type);
   }
@@ -137,7 +137,7 @@ public:
   /// `direction` and `visibility`, which should probably be labels. And label
   /// values should be set in a step that is separate from the metric creation.
   auto make_gauge(MetricsLabel label, MetricsDirection direction,
-                  MetricsVisibility visibility, MetricsType type)
+                  MetricsVisibility visibility, MetricsUnit type)
     -> MetricsGauge
     = delete;
 
@@ -147,7 +147,7 @@ public:
 private:
   template <MetricsInstrument Instrument>
   auto make(MetricsLabel label, MetricsDirection direction,
-            MetricsVisibility visibility, MetricsType type)
+            MetricsVisibility visibility, MetricsUnit type)
     -> Metric<Instrument>;
 
   struct Entry {
@@ -155,7 +155,7 @@ private:
     MetricsDirection direction;
     MetricsVisibility visibility;
     MetricsInstrument instrument;
-    MetricsType type;
+    MetricsUnit type;
     std::shared_ptr<std::atomic<uint64_t>> value;
 
     auto snapshot() const -> MetricsSnapshotEntry;

--- a/libtenzir/src/arrow_fs.cpp
+++ b/libtenzir/src/arrow_fs.cpp
@@ -615,6 +615,10 @@ auto ToArrowFsOperator::start(OpCtx& ctx) -> Task<void> {
     = ctx.make_counter(MetricsLabel{"operator", "to_arrow_fs"},
                        MetricsDirection::write, MetricsVisibility::external_,
                        MetricsUnit::bytes);
+  events_written_counter_
+    = ctx.make_counter(MetricsLabel{"operator", "to_arrow_fs"},
+                       MetricsDirection::write, MetricsVisibility::external_,
+                       MetricsUnit::events);
 }
 
 auto ToArrowFsOperator::preprocess(table_slice input, OpCtx&)
@@ -705,6 +709,7 @@ auto ToArrowFsOperator::process(table_slice input, OpCtx& ctx) -> Task<void> {
       co_return;
     }
     auto slice = filter(input, arrow::BooleanArray{rows, bitmap});
+    auto const slice_rows = slice.rows();
     // `push` runs without the guard. If it suspends on a full input
     // channel and we still hold the guard, `process_sub` on the draining
     // side cannot acquire the guard to look up the partition, and
@@ -717,6 +722,7 @@ auto ToArrowFsOperator::process(table_slice input, OpCtx& ctx) -> Task<void> {
         .emit(ctx.dh());
       co_return;
     }
+    events_written_counter_.add(slice_rows);
   }
 }
 

--- a/libtenzir/src/arrow_fs.cpp
+++ b/libtenzir/src/arrow_fs.cpp
@@ -94,6 +94,10 @@ auto FromArrowFsOperator::start(OpCtx& ctx) -> Task<void> {
     = ctx.make_counter(MetricsLabel{"operator", "from_arrow_fs"},
                        MetricsDirection::read, MetricsVisibility::external_,
                        MetricsUnit::bytes);
+  events_read_counter_
+    = ctx.make_counter(MetricsLabel{"operator", "from_arrow_fs"},
+                       MetricsDirection::read, MetricsVisibility::external_,
+                       MetricsUnit::events);
   co_await restore(ctx);
   auto ndh = null_diagnostic_handler{};
   co_await cleanup_files(ndh);
@@ -251,7 +255,9 @@ auto FromArrowFsOperator::process_sub(SubKeyView key, table_slice slice,
                                       Push<table_slice>& push, OpCtx& ctx)
   -> Task<void> {
   TENZIR_UNUSED(key, ctx);
+  auto const rows = slice.rows();
   co_await push(std::move(slice));
+  events_read_counter_.add(rows);
 }
 
 auto FromArrowFsOperator::finish_sub(SubKeyView key, Push<table_slice>&, OpCtx&)

--- a/libtenzir/src/arrow_fs.cpp
+++ b/libtenzir/src/arrow_fs.cpp
@@ -93,11 +93,7 @@ auto FromArrowFsOperator::start(OpCtx& ctx) -> Task<void> {
   bytes_read_counter_
     = ctx.make_counter(MetricsLabel{"operator", "from_arrow_fs"},
                        MetricsDirection::read, MetricsVisibility::external_,
-                       MetricsType::bytes);
-  events_read_counter_
-    = ctx.make_counter(MetricsLabel{"operator", "from_arrow_fs"},
-                       MetricsDirection::read, MetricsVisibility::external_,
-                       MetricsType::events);
+                       MetricsUnit::bytes);
   co_await restore(ctx);
   auto ndh = null_diagnostic_handler{};
   co_await cleanup_files(ndh);
@@ -255,9 +251,7 @@ auto FromArrowFsOperator::process_sub(SubKeyView key, table_slice slice,
                                       Push<table_slice>& push, OpCtx& ctx)
   -> Task<void> {
   TENZIR_UNUSED(key, ctx);
-  auto const rows = slice.rows();
   co_await push(std::move(slice));
-  events_read_counter_.add(rows);
 }
 
 auto FromArrowFsOperator::finish_sub(SubKeyView key, Push<table_slice>&, OpCtx&)
@@ -614,11 +608,7 @@ auto ToArrowFsOperator::start(OpCtx& ctx) -> Task<void> {
   bytes_written_counter_
     = ctx.make_counter(MetricsLabel{"operator", "to_arrow_fs"},
                        MetricsDirection::write, MetricsVisibility::external_,
-                       MetricsType::bytes);
-  events_written_counter_
-    = ctx.make_counter(MetricsLabel{"operator", "to_arrow_fs"},
-                       MetricsDirection::write, MetricsVisibility::external_,
-                       MetricsType::events);
+                       MetricsUnit::bytes);
 }
 
 auto ToArrowFsOperator::preprocess(table_slice input, OpCtx&)
@@ -709,7 +699,6 @@ auto ToArrowFsOperator::process(table_slice input, OpCtx& ctx) -> Task<void> {
       co_return;
     }
     auto slice = filter(input, arrow::BooleanArray{rows, bitmap});
-    auto const slice_rows = slice.rows();
     // `push` runs without the guard. If it suspends on a full input
     // channel and we still hold the guard, `process_sub` on the draining
     // side cannot acquire the guard to look up the partition, and
@@ -722,7 +711,6 @@ auto ToArrowFsOperator::process(table_slice input, OpCtx& ctx) -> Task<void> {
         .emit(ctx.dh());
       co_return;
     }
-    events_written_counter_.add(slice_rows);
   }
 }
 

--- a/libtenzir/src/arrow_fs.cpp
+++ b/libtenzir/src/arrow_fs.cpp
@@ -92,7 +92,12 @@ auto FromArrowFsOperator::start(OpCtx& ctx) -> Task<void> {
   root_path_ = extract_root_path(glob_, fs->path);
   bytes_read_counter_
     = ctx.make_counter(MetricsLabel{"operator", "from_arrow_fs"},
-                       MetricsDirection::read, MetricsVisibility::external_);
+                       MetricsDirection::read, MetricsVisibility::external_,
+                       MetricsType::bytes);
+  events_read_counter_
+    = ctx.make_counter(MetricsLabel{"operator", "from_arrow_fs"},
+                       MetricsDirection::read, MetricsVisibility::external_,
+                       MetricsType::events);
   co_await restore(ctx);
   auto ndh = null_diagnostic_handler{};
   co_await cleanup_files(ndh);
@@ -244,6 +249,15 @@ auto FromArrowFsOperator::process_task(Any result, Push<table_slice>&,
         co_await cleanup_file(std::move(path), ctx.dh());
       }
     });
+}
+
+auto FromArrowFsOperator::process_sub(SubKeyView key, table_slice slice,
+                                      Push<table_slice>& push, OpCtx& ctx)
+  -> Task<void> {
+  TENZIR_UNUSED(key, ctx);
+  auto const rows = slice.rows();
+  co_await push(std::move(slice));
+  events_read_counter_.add(rows);
 }
 
 auto FromArrowFsOperator::finish_sub(SubKeyView key, Push<table_slice>&, OpCtx&)
@@ -599,7 +613,12 @@ auto ToArrowFsOperator::start(OpCtx& ctx) -> Task<void> {
   template_.set_path(std::move(fs->path), base_args_.url.source, ctx.dh());
   bytes_written_counter_
     = ctx.make_counter(MetricsLabel{"operator", "to_arrow_fs"},
-                       MetricsDirection::write, MetricsVisibility::external_);
+                       MetricsDirection::write, MetricsVisibility::external_,
+                       MetricsType::bytes);
+  events_written_counter_
+    = ctx.make_counter(MetricsLabel{"operator", "to_arrow_fs"},
+                       MetricsDirection::write, MetricsVisibility::external_,
+                       MetricsType::events);
 }
 
 auto ToArrowFsOperator::preprocess(table_slice input, OpCtx&)
@@ -690,6 +709,7 @@ auto ToArrowFsOperator::process(table_slice input, OpCtx& ctx) -> Task<void> {
       co_return;
     }
     auto slice = filter(input, arrow::BooleanArray{rows, bitmap});
+    auto const slice_rows = slice.rows();
     // `push` runs without the guard. If it suspends on a full input
     // channel and we still hold the guard, `process_sub` on the draining
     // side cannot acquire the guard to look up the partition, and
@@ -702,6 +722,7 @@ auto ToArrowFsOperator::process(table_slice input, OpCtx& ctx) -> Task<void> {
         .emit(ctx.dh());
       co_return;
     }
+    events_written_counter_.add(slice_rows);
   }
 }
 

--- a/libtenzir/src/async/executor.cpp
+++ b/libtenzir/src/async/executor.cpp
@@ -325,8 +325,9 @@ public:
   }
 
   auto make_counter(MetricsLabel label, MetricsDirection direction,
-                    MetricsVisibility visibility) -> MetricsCounter override {
-    return inner_.make_counter(label, direction, visibility);
+                    MetricsVisibility visibility, MetricsType type)
+    -> MetricsCounter override {
+    return inner_.make_counter(label, direction, visibility, type);
   }
 
   auto is_hidden() const -> bool override {
@@ -582,8 +583,9 @@ private:
   }
 
   auto make_counter(MetricsLabel label, MetricsDirection direction,
-                    MetricsVisibility visibility) -> MetricsCounter override {
-    return exec_ctx_.make_counter(label, direction, visibility);
+                    MetricsVisibility visibility, MetricsType type)
+    -> MetricsCounter override {
+    return exec_ctx_.make_counter(label, direction, visibility, type);
   }
 
   auto metrics_receiver() const -> metrics_receiver_actor override {

--- a/libtenzir/src/async/executor.cpp
+++ b/libtenzir/src/async/executor.cpp
@@ -325,7 +325,7 @@ public:
   }
 
   auto make_counter(MetricsLabel label, MetricsDirection direction,
-                    MetricsVisibility visibility, MetricsType type)
+                    MetricsVisibility visibility, MetricsUnit type)
     -> MetricsCounter override {
     return inner_.make_counter(label, direction, visibility, type);
   }
@@ -583,7 +583,7 @@ private:
   }
 
   auto make_counter(MetricsLabel label, MetricsDirection direction,
-                    MetricsVisibility visibility, MetricsType type)
+                    MetricsVisibility visibility, MetricsUnit type)
     -> MetricsCounter override {
     return exec_ctx_.make_counter(label, direction, visibility, type);
   }

--- a/libtenzir/src/pipeline_metrics.cpp
+++ b/libtenzir/src/pipeline_metrics.cpp
@@ -51,7 +51,7 @@ template class Metric<MetricsInstrument::gauge>;
 
 template <MetricsInstrument Instrument>
 auto PipelineMetrics::make(MetricsLabel label, MetricsDirection direction,
-                           MetricsVisibility visibility, MetricsType type)
+                           MetricsVisibility visibility, MetricsUnit type)
   -> Metric<Instrument> {
   auto lock = std::lock_guard{mutex_};
   for (auto& e : entries_) {
@@ -76,13 +76,13 @@ auto PipelineMetrics::make(MetricsLabel label, MetricsDirection direction,
 }
 
 template auto PipelineMetrics::make<MetricsInstrument::counter>(
-  MetricsLabel, MetricsDirection, MetricsVisibility, MetricsType)
+  MetricsLabel, MetricsDirection, MetricsVisibility, MetricsUnit)
   -> Metric<MetricsInstrument::counter>;
 
 template auto PipelineMetrics::make<MetricsInstrument::gauge>(MetricsLabel,
                                                               MetricsDirection,
                                                               MetricsVisibility,
-                                                              MetricsType)
+                                                              MetricsUnit)
   -> Metric<MetricsInstrument::gauge>;
 
 auto PipelineMetrics::Entry::snapshot() const -> MetricsSnapshotEntry {

--- a/libtenzir/src/pipeline_metrics.cpp
+++ b/libtenzir/src/pipeline_metrics.cpp
@@ -10,54 +10,57 @@
 
 namespace tenzir {
 
-template <MetricsType Type>
-Metric<Type>::Metric(std::shared_ptr<std::atomic<uint64_t>> value)
+template <MetricsInstrument Instrument>
+Metric<Instrument>::Metric(std::shared_ptr<std::atomic<uint64_t>> value)
   : value_{std::move(value)} {
 }
 
-template <MetricsType type>
-void Metric<type>::add(uint64_t bytes) {
+template <MetricsInstrument Instrument>
+void Metric<Instrument>::add(uint64_t value) {
   if (value_) {
-    value_->fetch_add(bytes, std::memory_order_relaxed);
+    value_->fetch_add(value, std::memory_order_relaxed);
   }
 }
 
-template <MetricsType Type>
-void Metric<Type>::remove(uint64_t bytes)
-  requires(Type == MetricsType::gauge)
+template <MetricsInstrument Instrument>
+void Metric<Instrument>::remove(uint64_t value)
+  requires(Instrument == MetricsInstrument::gauge)
 {
   if (value_) {
-    value_->fetch_sub(bytes, std::memory_order_relaxed);
+    value_->fetch_sub(value, std::memory_order_relaxed);
   }
 }
 
-template <MetricsType Type>
-void Metric<Type>::set(uint64_t bytes)
-  requires(Type == MetricsType::gauge)
+template <MetricsInstrument Instrument>
+void Metric<Instrument>::set(uint64_t value)
+  requires(Instrument == MetricsInstrument::gauge)
 {
   if (value_) {
-    value_->store(bytes, std::memory_order_relaxed);
+    value_->store(value, std::memory_order_relaxed);
   }
 }
 
-template <MetricsType type>
-Metric<type>::operator bool() const {
+template <MetricsInstrument Instrument>
+Metric<Instrument>::operator bool() const {
   return value_ != nullptr;
 }
 
-template class Metric<MetricsType::counter>;
+template class Metric<MetricsInstrument::counter>;
 
-template class Metric<MetricsType::gauge>;
+template class Metric<MetricsInstrument::gauge>;
 
-template <MetricsType Type>
+template <MetricsInstrument Instrument>
 auto PipelineMetrics::make(MetricsLabel label, MetricsDirection direction,
-                           MetricsVisibility visibility) -> Metric<Type> {
+                           MetricsVisibility visibility, MetricsType type)
+  -> Metric<Instrument> {
   auto lock = std::lock_guard{mutex_};
   for (auto& e : entries_) {
     // We currently ignore the labels and only store one entry per `(direction,
-    // visibility)` combination. This should be cleaned up together with gauges.
-    if (e.direction == direction and e.visibility == visibility) {
-      return Metric<Type>{e.value};
+    // visibility, type)` combination. This should be cleaned up together with
+    // gauges.
+    if (e.direction == direction and e.visibility == visibility
+        and e.type == type) {
+      return Metric<Instrument>{e.value};
     }
   }
   auto value = std::make_shared<std::atomic<uint64_t>>(0);
@@ -65,27 +68,29 @@ auto PipelineMetrics::make(MetricsLabel label, MetricsDirection direction,
     .label = label,
     .direction = direction,
     .visibility = visibility,
-    .type = Type,
+    .instrument = Instrument,
+    .type = type,
     .value = value,
   });
-  return Metric<Type>{std::move(value)};
+  return Metric<Instrument>{std::move(value)};
 }
 
-template auto
-  PipelineMetrics::make<MetricsType::counter>(MetricsLabel, MetricsDirection,
-                                              MetricsVisibility)
-    -> Metric<MetricsType::counter>;
+template auto PipelineMetrics::make<MetricsInstrument::counter>(
+  MetricsLabel, MetricsDirection, MetricsVisibility, MetricsType)
+  -> Metric<MetricsInstrument::counter>;
 
-template auto
-  PipelineMetrics::make<MetricsType::gauge>(MetricsLabel, MetricsDirection,
-                                            MetricsVisibility)
-    -> Metric<MetricsType::gauge>;
+template auto PipelineMetrics::make<MetricsInstrument::gauge>(MetricsLabel,
+                                                              MetricsDirection,
+                                                              MetricsVisibility,
+                                                              MetricsType)
+  -> Metric<MetricsInstrument::gauge>;
 
 auto PipelineMetrics::Entry::snapshot() const -> MetricsSnapshotEntry {
   return MetricsSnapshotEntry{
     .label = label,
     .direction = direction,
     .visibility = visibility,
+    .instrument = instrument,
     .type = type,
     .value = value->load(std::memory_order_relaxed),
   };

--- a/libtenzir/src/tql2/exec.cpp
+++ b/libtenzir/src/tql2/exec.cpp
@@ -1043,8 +1043,9 @@ public:
   }
 
   auto make_counter(MetricsLabel label, MetricsDirection direction,
-                    MetricsVisibility visibility) -> MetricsCounter override {
-    return metrics_->make_counter(label, direction, visibility);
+                    MetricsVisibility visibility, MetricsType type)
+    -> MetricsCounter override {
+    return metrics_->make_counter(label, direction, visibility, type);
   }
 
   auto metrics_receiver() const -> metrics_receiver_actor override {
@@ -1847,23 +1848,37 @@ void emit_node_metrics(NodeProfiler const& node, TestExecCtx& exec_ctx,
                        std::unordered_map<OpId, OpSnapshot>& prev_snapshots) {
   TENZIR_UNUSED(num_ops);
   auto entries = exec_ctx.take_metrics_snapshot();
-  auto external_read_bytes = uint64_t{0};
-  auto external_write_bytes = uint64_t{0};
-  auto internal_read_bytes = uint64_t{0};
-  auto internal_write_bytes = uint64_t{0};
+  struct TrafficMetrics {
+    uint64_t bytes = 0;
+    uint64_t events = 0;
+  };
+  auto external_read = TrafficMetrics{};
+  auto external_write = TrafficMetrics{};
+  auto internal_read = TrafficMetrics{};
+  auto internal_write = TrafficMetrics{};
+  auto add = [](TrafficMetrics& metrics, MetricsSnapshotEntry const& entry) {
+    switch (entry.type) {
+      case MetricsType::bytes:
+        metrics.bytes += entry.value;
+        break;
+      case MetricsType::events:
+        metrics.events += entry.value;
+        break;
+    }
+  };
   for (auto const& e : entries) {
-    TENZIR_ASSERT(e.type != MetricsType::gauge);
+    TENZIR_ASSERT(e.instrument != MetricsInstrument::gauge);
     if (e.visibility == MetricsVisibility::external_) {
       if (e.direction == MetricsDirection::read) {
-        external_read_bytes += e.value;
+        add(external_read, e);
       } else {
-        external_write_bytes += e.value;
+        add(external_write, e);
       }
     } else {
       if (e.direction == MetricsDirection::read) {
-        internal_read_bytes += e.value;
+        add(internal_read, e);
       } else {
-        internal_write_bytes += e.value;
+        add(internal_write, e);
       }
     }
   }
@@ -1873,50 +1888,64 @@ void emit_node_metrics(NodeProfiler const& node, TestExecCtx& exec_ctx,
   // external first and fall back to internal only if there is no external
   // traffic for that direction. This loses visibility into pipelines that mix
   // internal and external ingress or egress.
-  if (external_read_bytes > 0) {
-    auto m = operator_metric{};
-    m.operator_index = 0;
-    m.operator_name = "source";
-    m.internal = false;
-    m.outbound_measurement.unit = "bytes";
-    m.outbound_measurement.num_elements = external_read_bytes;
-    m.time_total = elapsed;
-    m.time_running = elapsed;
-    caf::anon_mail(std::move(m)).send(node.metrics);
-  } else if (internal_read_bytes > 0) {
-    auto m = operator_metric{};
-    m.operator_index = 0;
-    m.operator_name = "source";
-    m.internal = true;
-    m.outbound_measurement.unit = "bytes";
-    m.outbound_measurement.num_elements = internal_read_bytes;
-    m.time_total = elapsed;
-    m.time_running = elapsed;
-    caf::anon_mail(std::move(m)).send(node.metrics);
-  }
-  if (external_write_bytes > 0) {
-    auto m = operator_metric{};
+  auto send_source_metrics = [&](TrafficMetrics metrics, bool internal) {
+    if (metrics.bytes == 0 and metrics.events == 0) {
+      return;
+    }
+    auto bytes = operator_metric{};
+    bytes.operator_index = 0;
+    bytes.operator_name = "source";
+    bytes.internal = internal;
+    bytes.outbound_measurement.unit = "bytes";
+    bytes.outbound_measurement.num_elements = metrics.bytes;
+    bytes.time_total = elapsed;
+    bytes.time_running = elapsed;
+    caf::anon_mail(std::move(bytes)).send(node.metrics);
+    auto events = operator_metric{};
+    events.operator_index = 2;
+    events.operator_name = "source";
+    events.internal = internal;
+    events.outbound_measurement.unit = "events";
+    events.outbound_measurement.num_elements = metrics.events;
+    events.time_total = elapsed;
+    events.time_running = elapsed;
+    caf::anon_mail(std::move(events)).send(node.metrics);
+  };
+  auto send_sink_metrics = [&](TrafficMetrics metrics, bool internal) {
+    if (metrics.bytes == 0 and metrics.events == 0) {
+      return;
+    }
+    auto bytes = operator_metric{};
     // We use operator index 1 such that a pipeline with a single operator will
     // still use two different operator indices for ingress and egress. The code
     // in the pipeline manager cannot handle the case where it's the same.
-    m.operator_index = 1;
-    m.operator_name = "sink";
-    m.internal = false;
-    m.inbound_measurement.unit = "bytes";
-    m.inbound_measurement.num_elements = external_write_bytes;
-    m.time_total = elapsed;
-    m.time_running = elapsed;
-    caf::anon_mail(std::move(m)).send(node.metrics);
-  } else if (internal_write_bytes > 0) {
-    auto m = operator_metric{};
-    m.operator_index = 1;
-    m.operator_name = "sink";
-    m.internal = true;
-    m.inbound_measurement.unit = "bytes";
-    m.inbound_measurement.num_elements = internal_write_bytes;
-    m.time_total = elapsed;
-    m.time_running = elapsed;
-    caf::anon_mail(std::move(m)).send(node.metrics);
+    bytes.operator_index = 1;
+    bytes.operator_name = "sink";
+    bytes.internal = internal;
+    bytes.inbound_measurement.unit = "bytes";
+    bytes.inbound_measurement.num_elements = metrics.bytes;
+    bytes.time_total = elapsed;
+    bytes.time_running = elapsed;
+    caf::anon_mail(std::move(bytes)).send(node.metrics);
+    auto events = operator_metric{};
+    events.operator_index = 3;
+    events.operator_name = "sink";
+    events.internal = internal;
+    events.inbound_measurement.unit = "events";
+    events.inbound_measurement.num_elements = metrics.events;
+    events.time_total = elapsed;
+    events.time_running = elapsed;
+    caf::anon_mail(std::move(events)).send(node.metrics);
+  };
+  if (external_read.bytes > 0 or external_read.events > 0) {
+    send_source_metrics(external_read, false);
+  } else {
+    send_source_metrics(internal_read, true);
+  }
+  if (external_write.bytes > 0 or external_write.events > 0) {
+    send_sink_metrics(external_write, false);
+  } else {
+    send_sink_metrics(internal_write, true);
   }
   // Always drain profiles to prune dead channels/executors, even when there
   // is no importer to send snapshots to. Without this, the profile vectors

--- a/libtenzir/src/tql2/exec.cpp
+++ b/libtenzir/src/tql2/exec.cpp
@@ -1883,36 +1883,45 @@ void emit_node_metrics(NodeProfiler const& node, TestExecCtx& exec_ctx,
     }
   }
   auto elapsed = now - start_time;
-  // FIXME: The pipeline manager maintains a per-`operator_index` diff and
-  // cannot disambiguate two metrics at the same index. As a workaround, emit
-  // external first and fall back to internal only if there is no external
-  // traffic for that direction. This loses visibility into pipelines that mix
-  // internal and external ingress or egress.
-  auto send_source_metrics = [&](TrafficMetrics metrics, bool internal) {
-    if (metrics.bytes == 0 and metrics.events == 0) {
+  auto select_bytes = [](TrafficMetrics external, TrafficMetrics internal) {
+    return std::pair{external.bytes > 0 ? external.bytes : internal.bytes,
+                     external.bytes == 0};
+  };
+  auto select_events = [](TrafficMetrics external, TrafficMetrics internal) {
+    return std::pair{external.events > 0 ? external.events : internal.events,
+                     external.events == 0};
+  };
+  auto send_source_metrics = [&](TrafficMetrics external,
+                                 TrafficMetrics internal) {
+    auto [bytes_count, bytes_internal] = select_bytes(external, internal);
+    auto [events_count, events_internal] = select_events(external, internal);
+    if (bytes_count == 0 and events_count == 0) {
       return;
     }
     auto bytes = operator_metric{};
     bytes.operator_index = 0;
     bytes.operator_name = "source";
-    bytes.internal = internal;
+    bytes.internal = bytes_internal;
     bytes.outbound_measurement.unit = "bytes";
-    bytes.outbound_measurement.num_elements = metrics.bytes;
+    bytes.outbound_measurement.num_elements = bytes_count;
     bytes.time_total = elapsed;
     bytes.time_running = elapsed;
     caf::anon_mail(std::move(bytes)).send(node.metrics);
     auto events = operator_metric{};
     events.operator_index = 2;
     events.operator_name = "source";
-    events.internal = internal;
+    events.internal = events_internal;
     events.outbound_measurement.unit = "events";
-    events.outbound_measurement.num_elements = metrics.events;
+    events.outbound_measurement.num_elements = events_count;
     events.time_total = elapsed;
     events.time_running = elapsed;
     caf::anon_mail(std::move(events)).send(node.metrics);
   };
-  auto send_sink_metrics = [&](TrafficMetrics metrics, bool internal) {
-    if (metrics.bytes == 0 and metrics.events == 0) {
+  auto send_sink_metrics = [&](TrafficMetrics external,
+                               TrafficMetrics internal) {
+    auto [bytes_count, bytes_internal] = select_bytes(external, internal);
+    auto [events_count, events_internal] = select_events(external, internal);
+    if (bytes_count == 0 and events_count == 0) {
       return;
     }
     auto bytes = operator_metric{};
@@ -1921,32 +1930,24 @@ void emit_node_metrics(NodeProfiler const& node, TestExecCtx& exec_ctx,
     // in the pipeline manager cannot handle the case where it's the same.
     bytes.operator_index = 1;
     bytes.operator_name = "sink";
-    bytes.internal = internal;
+    bytes.internal = bytes_internal;
     bytes.inbound_measurement.unit = "bytes";
-    bytes.inbound_measurement.num_elements = metrics.bytes;
+    bytes.inbound_measurement.num_elements = bytes_count;
     bytes.time_total = elapsed;
     bytes.time_running = elapsed;
     caf::anon_mail(std::move(bytes)).send(node.metrics);
     auto events = operator_metric{};
     events.operator_index = 3;
     events.operator_name = "sink";
-    events.internal = internal;
+    events.internal = events_internal;
     events.inbound_measurement.unit = "events";
-    events.inbound_measurement.num_elements = metrics.events;
+    events.inbound_measurement.num_elements = events_count;
     events.time_total = elapsed;
     events.time_running = elapsed;
     caf::anon_mail(std::move(events)).send(node.metrics);
   };
-  if (external_read.bytes > 0 or external_read.events > 0) {
-    send_source_metrics(external_read, false);
-  } else {
-    send_source_metrics(internal_read, true);
-  }
-  if (external_write.bytes > 0 or external_write.events > 0) {
-    send_sink_metrics(external_write, false);
-  } else {
-    send_sink_metrics(internal_write, true);
-  }
+  send_source_metrics(external_read, internal_read);
+  send_sink_metrics(external_write, internal_write);
   // Always drain profiles to prune dead channels/executors, even when there
   // is no importer to send snapshots to. Without this, the profile vectors
   // would grow unboundedly for long-running pipelines with dynamic

--- a/libtenzir/src/tql2/exec.cpp
+++ b/libtenzir/src/tql2/exec.cpp
@@ -1043,7 +1043,7 @@ public:
   }
 
   auto make_counter(MetricsLabel label, MetricsDirection direction,
-                    MetricsVisibility visibility, MetricsType type)
+                    MetricsVisibility visibility, MetricsUnit type)
     -> MetricsCounter override {
     return metrics_->make_counter(label, direction, visibility, type);
   }
@@ -1858,10 +1858,10 @@ void emit_node_metrics(NodeProfiler const& node, TestExecCtx& exec_ctx,
   auto internal_write = TrafficMetrics{};
   auto add = [](TrafficMetrics& metrics, MetricsSnapshotEntry const& entry) {
     switch (entry.type) {
-      case MetricsType::bytes:
+      case MetricsUnit::bytes:
         metrics.bytes += entry.value;
         break;
-      case MetricsType::events:
+      case MetricsUnit::events:
         metrics.events += entry.value;
         break;
     }
@@ -1883,71 +1883,57 @@ void emit_node_metrics(NodeProfiler const& node, TestExecCtx& exec_ctx,
     }
   }
   auto elapsed = now - start_time;
-  auto select_bytes = [](TrafficMetrics external, TrafficMetrics internal) {
-    return std::pair{external.bytes > 0 ? external.bytes : internal.bytes,
-                     external.bytes == 0};
+  struct SelectedMetrics {
+    uint64_t count = 0;
+    bool internal = false;
   };
-  auto select_events = [](TrafficMetrics external, TrafficMetrics internal) {
-    return std::pair{external.events > 0 ? external.events : internal.events,
-                     external.events == 0};
+  auto select = [](uint64_t external, uint64_t internal) {
+    return external > 0 ? SelectedMetrics{external, false}
+                        : SelectedMetrics{internal, true};
   };
-  auto send_source_metrics = [&](TrafficMetrics external,
-                                 TrafficMetrics internal) {
-    auto [bytes_count, bytes_internal] = select_bytes(external, internal);
-    auto [events_count, events_internal] = select_events(external, internal);
-    if (bytes_count == 0 and events_count == 0) {
-      return;
+  auto make_metric
+    = [&](uint64_t index, std::string_view name, SelectedMetrics selected) {
+        auto metric = operator_metric{};
+        metric.operator_index = index;
+        metric.operator_name = name;
+        metric.internal = selected.internal;
+        metric.time_total = elapsed;
+        metric.time_running = elapsed;
+        return metric;
+      };
+  auto send_metric = [&](operator_metric metric, bool inbound,
+                         SelectedMetrics selected, std::string_view unit) {
+    if (inbound) {
+      metric.inbound_measurement.unit = unit;
+      metric.inbound_measurement.num_elements = selected.count;
+    } else {
+      metric.outbound_measurement.unit = unit;
+      metric.outbound_measurement.num_elements = selected.count;
     }
-    auto bytes = operator_metric{};
-    bytes.operator_index = 0;
-    bytes.operator_name = "source";
-    bytes.internal = bytes_internal;
-    bytes.outbound_measurement.unit = "bytes";
-    bytes.outbound_measurement.num_elements = bytes_count;
-    bytes.time_total = elapsed;
-    bytes.time_running = elapsed;
-    caf::anon_mail(std::move(bytes)).send(node.metrics);
-    auto events = operator_metric{};
-    events.operator_index = 2;
-    events.operator_name = "source";
-    events.internal = events_internal;
-    events.outbound_measurement.unit = "events";
-    events.outbound_measurement.num_elements = events_count;
-    events.time_total = elapsed;
-    events.time_running = elapsed;
-    caf::anon_mail(std::move(events)).send(node.metrics);
+    caf::anon_mail(std::move(metric)).send(node.metrics);
   };
-  auto send_sink_metrics = [&](TrafficMetrics external,
-                               TrafficMetrics internal) {
-    auto [bytes_count, bytes_internal] = select_bytes(external, internal);
-    auto [events_count, events_internal] = select_events(external, internal);
-    if (bytes_count == 0 and events_count == 0) {
-      return;
-    }
-    auto bytes = operator_metric{};
-    // We use operator index 1 such that a pipeline with a single operator will
-    // still use two different operator indices for ingress and egress. The code
-    // in the pipeline manager cannot handle the case where it's the same.
-    bytes.operator_index = 1;
-    bytes.operator_name = "sink";
-    bytes.internal = bytes_internal;
-    bytes.inbound_measurement.unit = "bytes";
-    bytes.inbound_measurement.num_elements = bytes_count;
-    bytes.time_total = elapsed;
-    bytes.time_running = elapsed;
-    caf::anon_mail(std::move(bytes)).send(node.metrics);
-    auto events = operator_metric{};
-    events.operator_index = 3;
-    events.operator_name = "sink";
-    events.internal = events_internal;
-    events.inbound_measurement.unit = "events";
-    events.inbound_measurement.num_elements = events_count;
-    events.time_total = elapsed;
-    events.time_running = elapsed;
-    caf::anon_mail(std::move(events)).send(node.metrics);
-  };
-  send_source_metrics(external_read, internal_read);
-  send_sink_metrics(external_write, internal_write);
+  auto send_edge_metrics
+    = [&](std::string_view name, uint64_t bytes_index, uint64_t events_index,
+          bool inbound, TrafficMetrics external, TrafficMetrics internal) {
+        auto bytes = select(external.bytes, internal.bytes);
+        auto events = select(external.events, internal.events);
+        if (bytes.count == 0 and events.count == 0) {
+          return;
+        }
+        if (bytes.count > 0) {
+          send_metric(make_metric(bytes_index, name, bytes), inbound, bytes,
+                      "bytes");
+        }
+        if (events.count > 0) {
+          send_metric(make_metric(events_index, name, events), inbound, events,
+                      "events");
+        }
+      };
+  send_edge_metrics("source", 0, 2, false, external_read, internal_read);
+  // We use operator index 1 such that a pipeline with a single operator will
+  // still use two different operator indices for ingress and egress. The code
+  // in the pipeline manager cannot handle the case where it's the same.
+  send_edge_metrics("sink", 1, 3, true, external_write, internal_write);
   // Always drain profiles to prune dead channels/executors, even when there
   // is no importer to send snapshots to. Without this, the profile vectors
   // would grow unboundedly for long-running pipelines with dynamic

--- a/plugins/amqp/builtins/from_amqp.cpp
+++ b/plugins/amqp/builtins/from_amqp.cpp
@@ -287,11 +287,11 @@ public:
     bytes_read_counter_
       = ctx.make_counter(MetricsLabel{"operator", "from_amqp"},
                          MetricsDirection::read, MetricsVisibility::external_,
-                         MetricsType::bytes);
+                         MetricsUnit::bytes);
     events_read_counter_
       = ctx.make_counter(MetricsLabel{"operator", "from_amqp"},
                          MetricsDirection::read, MetricsVisibility::external_,
-                         MetricsType::events);
+                         MetricsUnit::events);
     ctx.spawn_task(consume_loop(std::move(engine), queue_));
   }
 

--- a/plugins/amqp/builtins/from_amqp.cpp
+++ b/plugins/amqp/builtins/from_amqp.cpp
@@ -286,7 +286,12 @@ public:
     }
     bytes_read_counter_
       = ctx.make_counter(MetricsLabel{"operator", "from_amqp"},
-                         MetricsDirection::read, MetricsVisibility::external_);
+                         MetricsDirection::read, MetricsVisibility::external_,
+                         MetricsType::bytes);
+    events_read_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "from_amqp"},
+                         MetricsDirection::read, MetricsVisibility::external_,
+                         MetricsType::events);
     ctx.spawn_task(consume_loop(std::move(engine), queue_));
   }
 
@@ -305,7 +310,7 @@ public:
   auto process_task(Any result, Push<table_slice>& push, OpCtx& ctx)
     -> Task<void> override {
     if (result.try_as<PeriodicTick>()) {
-      co_await pusher_.push(builder_.yield_ready(), push);
+      co_await pusher_.push(builder_.yield_ready(), push, events_read_counter_);
       co_return;
     }
     auto* event = result.try_as<FromAmqpEvent>();
@@ -324,7 +329,8 @@ public:
         if (bytes > 0) {
           bytes_read_counter_.add(bytes);
         }
-        co_await pusher_.push(builder_.yield_ready(), push);
+        co_await pusher_.push(builder_.yield_ready(), push,
+                              events_read_counter_);
       },
       [&](AmqpError err) -> Task<void> {
         diagnostic::error("failed to consume AMQP message")
@@ -338,7 +344,9 @@ public:
   auto finalize(Push<table_slice>& push, OpCtx&)
     -> Task<FinalizeBehavior> override {
     for (auto&& slice : builder_.finish_as_table_slice()) {
+      auto const rows = slice.rows();
       co_await push(std::move(slice));
+      events_read_counter_.add(rows);
     }
     co_return FinalizeBehavior::done;
   }
@@ -372,6 +380,7 @@ private:
     type{"tenzir.amqp", record_type{{"message", blob_type{}}}}};
   SeriesPusher pusher_;
   MetricsCounter bytes_read_counter_;
+  MetricsCounter events_read_counter_;
 };
 
 class from_amqp_plugin final : public virtual OperatorPlugin {

--- a/plugins/amqp/builtins/to_amqp.cpp
+++ b/plugins/amqp/builtins/to_amqp.cpp
@@ -173,10 +173,15 @@ public:
     }};
     bytes_write_counter_
       = ctx.make_counter(MetricsLabel{"operator", "to_amqp"},
-                         MetricsDirection::write, MetricsVisibility::external_);
-    worker_handle_
-      = ctx.spawn_task(publish_loop(engine_, engine_mutex_, queue_, args_,
-                                    channel_, dh, bytes_write_counter_));
+                         MetricsDirection::write, MetricsVisibility::external_,
+                         MetricsType::bytes);
+    events_write_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "to_amqp"},
+                         MetricsDirection::write, MetricsVisibility::external_,
+                         MetricsType::events);
+    worker_handle_ = ctx.spawn_task(
+      publish_loop(engine_, engine_mutex_, queue_, args_, channel_, dh,
+                   bytes_write_counter_, events_write_counter_));
     if (hb_interval > std::chrono::seconds{0}) {
       ctx.spawn_task(heartbeat_loop(engine_, engine_mutex_, hb_interval,
                                     args_.url.source, dh));
@@ -221,7 +226,8 @@ private:
                            std::shared_ptr<std::mutex> engine_mutex,
                            std::shared_ptr<MessageQueue> queue, ToAmqpArgs args,
                            uint16_t channel, diagnostic_handler& dh,
-                           MetricsCounter bytes_write_counter) -> Task<void> {
+                           MetricsCounter bytes_write_counter,
+                           MetricsCounter events_write_counter) -> Task<void> {
     auto opts = amqp_engine::publish_options{
       .channel = channel,
       .exchange = args.exchange ? std::string_view{args.exchange->inner}
@@ -265,6 +271,7 @@ private:
           if (not bytes.empty()) {
             bytes_write_counter.add(bytes.size());
           }
+          events_write_counter.add(1);
         }
       };
       if (auto strings = item->template as<string_type>()) {
@@ -319,6 +326,7 @@ private:
   Option<json_printer2> printer_;
   bool is_default_printer_ = false;
   MetricsCounter bytes_write_counter_;
+  MetricsCounter events_write_counter_;
 };
 
 class to_amqp_plugin final : public virtual OperatorPlugin {

--- a/plugins/amqp/builtins/to_amqp.cpp
+++ b/plugins/amqp/builtins/to_amqp.cpp
@@ -174,11 +174,11 @@ public:
     bytes_write_counter_
       = ctx.make_counter(MetricsLabel{"operator", "to_amqp"},
                          MetricsDirection::write, MetricsVisibility::external_,
-                         MetricsType::bytes);
+                         MetricsUnit::bytes);
     events_write_counter_
       = ctx.make_counter(MetricsLabel{"operator", "to_amqp"},
                          MetricsDirection::write, MetricsVisibility::external_,
-                         MetricsType::events);
+                         MetricsUnit::events);
     worker_handle_ = ctx.spawn_task(
       publish_loop(engine_, engine_mutex_, queue_, args_, channel_, dh,
                    bytes_write_counter_, events_write_counter_));

--- a/plugins/clickhouse/builtins/to_clickhouse.cpp
+++ b/plugins/clickhouse/builtins/to_clickhouse.cpp
@@ -236,7 +236,8 @@ public:
     }
     state_->bytes_write_counter
       = ctx.make_counter(MetricsLabel{"operator", "to_clickhouse"},
-                         MetricsDirection::write, MetricsVisibility::external_);
+                         MetricsDirection::write, MetricsVisibility::external_,
+                         MetricsType::bytes);
     state_->worker_handles.reserve(args_.jobs);
     for (auto i = uint64_t{0}; i < args_.jobs; ++i) {
       auto client = std::shared_ptr<easy_client>{};

--- a/plugins/clickhouse/builtins/to_clickhouse.cpp
+++ b/plugins/clickhouse/builtins/to_clickhouse.cpp
@@ -238,11 +238,11 @@ public:
     state_->bytes_write_counter
       = ctx.make_counter(MetricsLabel{"operator", "to_clickhouse"},
                          MetricsDirection::write, MetricsVisibility::external_,
-                         MetricsType::bytes);
+                         MetricsUnit::bytes);
     state_->events_write_counter
       = ctx.make_counter(MetricsLabel{"operator", "to_clickhouse"},
                          MetricsDirection::write, MetricsVisibility::external_,
-                         MetricsType::events);
+                         MetricsUnit::events);
     state_->worker_handles.reserve(args_.jobs);
     for (auto i = uint64_t{0}; i < args_.jobs; ++i) {
       auto client = std::shared_ptr<easy_client>{};

--- a/plugins/clickhouse/builtins/to_clickhouse.cpp
+++ b/plugins/clickhouse/builtins/to_clickhouse.cpp
@@ -189,6 +189,7 @@ public:
     std::mutex pending_inserts_mutex;
     Atomic<bool> done{false};
     MetricsCounter bytes_write_counter;
+    MetricsCounter events_write_counter;
     std::vector<AsyncHandle<void>> worker_handles;
   };
 
@@ -238,6 +239,10 @@ public:
       = ctx.make_counter(MetricsLabel{"operator", "to_clickhouse"},
                          MetricsDirection::write, MetricsVisibility::external_,
                          MetricsType::bytes);
+    state_->events_write_counter
+      = ctx.make_counter(MetricsLabel{"operator", "to_clickhouse"},
+                         MetricsDirection::write, MetricsVisibility::external_,
+                         MetricsType::events);
     state_->worker_handles.reserve(args_.jobs);
     for (auto i = uint64_t{0}; i < args_.jobs; ++i) {
       auto client = std::shared_ptr<easy_client>{};
@@ -368,6 +373,7 @@ private:
       if (auto bytes = slice.approx_bytes(); bytes > 0) {
         shared_state->bytes_write_counter.add(bytes);
       }
+      shared_state->events_write_counter.add(slice.rows());
       // Remove the slice from the persisted state.
       auto const guard = std::scoped_lock{shared_state->pending_inserts_mutex};
       auto const erased = shared_state->pending_inserts.erase(*next);

--- a/plugins/fluent-bit/include/fluent-bit/fluent-bit_operator.hpp
+++ b/plugins/fluent-bit/include/fluent-bit/fluent-bit_operator.hpp
@@ -1115,7 +1115,14 @@ public:
         "operator",
         "from_fluent_bit",
       },
-      MetricsDirection::read, MetricsVisibility::external_);
+      MetricsDirection::read, MetricsVisibility::external_, MetricsType::bytes);
+    read_events_counter_ = ctx.make_counter(
+      MetricsLabel{
+        "operator",
+        "from_fluent_bit",
+      },
+      MetricsDirection::read, MetricsVisibility::external_,
+      MetricsType::events);
     builder_.emplace(args_.builder_options, ctx.dh());
     auto [sender, receiver]
       = channel<FluentBitSourceTaskResult>(source_channel_capacity);
@@ -1184,8 +1191,11 @@ public:
       [&](FluentBitSourceMessage& message) -> Task<void> {
         if (is<FluentBitSourceDone>(message)) {
           for (auto& slice : builder_->finalize_as_table_slice()) {
-            read_bytes_counter_.add(slice.approx_bytes());
+            auto const bytes = slice.approx_bytes();
+            auto const rows = slice.rows();
             co_await push(std::move(slice));
+            read_bytes_counter_.add(bytes);
+            read_events_counter_.add(rows);
           }
           source_exhausted_ = true;
           co_return;
@@ -1196,12 +1206,14 @@ public:
         co_await pusher_.push(builder_->yield_ready_as_table_slice(), push,
                               [this](table_slice const& slice) {
                                 read_bytes_counter_.add(slice.approx_bytes());
+                                read_events_counter_.add(slice.rows());
                               });
       },
       [&](FluentBitSourceTimeout&) -> Task<void> {
         co_await pusher_.push(builder_->yield_ready_as_table_slice(), push,
                               [this](table_slice const& slice) {
                                 read_bytes_counter_.add(slice.approx_bytes());
+                                read_events_counter_.add(slice.rows());
                               });
       });
   }
@@ -1211,8 +1223,11 @@ public:
     TENZIR_UNUSED(ctx);
     TENZIR_ASSERT(builder_);
     for (auto& slice : builder_->finalize_as_table_slice()) {
-      read_bytes_counter_.add(slice.approx_bytes());
+      auto const bytes = slice.approx_bytes();
+      auto const rows = slice.rows();
       co_await push(std::move(slice));
+      read_bytes_counter_.add(bytes);
+      read_events_counter_.add(rows);
     }
   }
 
@@ -1235,6 +1250,7 @@ private:
   SourceBridgeLifetime bridge_lifetime_;
   Arc<Atomic<bool>> stop_requested_{std::in_place, false};
   MetricsCounter read_bytes_counter_;
+  MetricsCounter read_events_counter_;
   bool source_exhausted_ = false;
 };
 
@@ -1249,7 +1265,15 @@ public:
         "operator",
         "to_fluent_bit",
       },
-      MetricsDirection::write, MetricsVisibility::external_);
+      MetricsDirection::write, MetricsVisibility::external_,
+      MetricsType::bytes);
+    write_events_counter_ = ctx.make_counter(
+      MetricsLabel{
+        "operator",
+        "to_fluent_bit",
+      },
+      MetricsDirection::write, MetricsVisibility::external_,
+      MetricsType::events);
     auto operator_args = make_operator_args(args_, ctx);
     if (not operator_args) {
       done_ = true;
@@ -1279,6 +1303,7 @@ public:
     auto array = check(to_record_batch(resolved_slice)->ToStructArray());
     auto failed = false;
     auto bytes = uint64_t{0};
+    auto events = uint64_t{0};
     auto printer = json_printer2{json_printer_options{
       .style = no_style(),
       .oneline = true,
@@ -1296,6 +1321,7 @@ public:
         failed = true;
       } else {
         bytes += message.size();
+        ++events;
       }
     }
     if (failed) {
@@ -1303,6 +1329,7 @@ public:
         .emit(ctx.dh());
     }
     write_bytes_counter_.add(bytes);
+    write_events_counter_.add(events);
   }
 
   auto prepare_snapshot(OpCtx& ctx) -> Task<void> override {
@@ -1332,6 +1359,7 @@ private:
   property_map plugin_args_;
   std::unique_ptr<engine> engine_;
   MetricsCounter write_bytes_counter_;
+  MetricsCounter write_events_counter_;
   bool done_ = false;
 };
 

--- a/plugins/fluent-bit/include/fluent-bit/fluent-bit_operator.hpp
+++ b/plugins/fluent-bit/include/fluent-bit/fluent-bit_operator.hpp
@@ -1115,14 +1115,14 @@ public:
         "operator",
         "from_fluent_bit",
       },
-      MetricsDirection::read, MetricsVisibility::external_, MetricsType::bytes);
+      MetricsDirection::read, MetricsVisibility::external_, MetricsUnit::bytes);
     read_events_counter_ = ctx.make_counter(
       MetricsLabel{
         "operator",
         "from_fluent_bit",
       },
       MetricsDirection::read, MetricsVisibility::external_,
-      MetricsType::events);
+      MetricsUnit::events);
     builder_.emplace(args_.builder_options, ctx.dh());
     auto [sender, receiver]
       = channel<FluentBitSourceTaskResult>(source_channel_capacity);
@@ -1266,14 +1266,14 @@ public:
         "to_fluent_bit",
       },
       MetricsDirection::write, MetricsVisibility::external_,
-      MetricsType::bytes);
+      MetricsUnit::bytes);
     write_events_counter_ = ctx.make_counter(
       MetricsLabel{
         "operator",
         "to_fluent_bit",
       },
       MetricsDirection::write, MetricsVisibility::external_,
-      MetricsType::events);
+      MetricsUnit::events);
     auto operator_args = make_operator_args(args_, ctx);
     if (not operator_args) {
       done_ = true;

--- a/plugins/from_velociraptor/builtins/from_velociraptor.cpp
+++ b/plugins/from_velociraptor/builtins/from_velociraptor.cpp
@@ -255,11 +255,11 @@ public:
     bytes_read_counter_
       = ctx.make_counter(MetricsLabel{"operator", "from_velociraptor"},
                          MetricsDirection::read, MetricsVisibility::external_,
-                         MetricsType::bytes);
+                         MetricsUnit::bytes);
     events_read_counter_
       = ctx.make_counter(MetricsLabel{"operator", "from_velociraptor"},
                          MetricsDirection::read, MetricsVisibility::external_,
-                         MetricsType::events);
+                         MetricsUnit::events);
     auto normalized = normalize_args(args_, ctx);
     TENZIR_ASSERT(normalized);
     auto config = select_client_config(args_, ctx.dh());

--- a/plugins/from_velociraptor/builtins/from_velociraptor.cpp
+++ b/plugins/from_velociraptor/builtins/from_velociraptor.cpp
@@ -254,7 +254,12 @@ public:
   auto start(OpCtx& ctx) -> Task<void> override {
     bytes_read_counter_
       = ctx.make_counter(MetricsLabel{"operator", "from_velociraptor"},
-                         MetricsDirection::read, MetricsVisibility::external_);
+                         MetricsDirection::read, MetricsVisibility::external_,
+                         MetricsType::bytes);
+    events_read_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "from_velociraptor"},
+                         MetricsDirection::read, MetricsVisibility::external_,
+                         MetricsType::events);
     auto normalized = normalize_args(args_, ctx);
     TENZIR_ASSERT(normalized);
     auto config = select_client_config(args_, ctx.dh());
@@ -303,7 +308,9 @@ public:
       }
       if (auto slices = parse(response)) {
         for (auto& slice : *slices) {
+          auto const rows = slice.rows();
           co_await push(std::move(slice));
+          events_read_counter_.add(rows);
         }
       } else {
         emit_parse_warning(response, ctx.dh(), slices.error(),
@@ -336,6 +343,7 @@ private:
   Option<Box<VelociraptorReadReactor>> reactor_;
   bool stream_finished_ = false;
   MetricsCounter bytes_read_counter_;
+  MetricsCounter events_read_counter_;
 };
 
 class FromVelociraptorPlugin final : public virtual OperatorPlugin {

--- a/plugins/google-cloud-pubsub/builtins/from_plugin.cpp
+++ b/plugins/google-cloud-pubsub/builtins/from_plugin.cpp
@@ -267,11 +267,11 @@ public:
     bytes_read_counter_
       = ctx.make_counter(MetricsLabel{"operator", "from_google_cloud_pubsub"},
                          MetricsDirection::read, MetricsVisibility::external_,
-                         MetricsType::bytes);
+                         MetricsUnit::bytes);
     events_read_counter_
       = ctx.make_counter(MetricsLabel{"operator", "from_google_cloud_pubsub"},
                          MetricsDirection::read, MetricsVisibility::external_,
-                         MetricsType::events);
+                         MetricsUnit::events);
     auto subscription = pubsub::Subscription(args_.project_id.inner,
                                              args_.subscription_id.inner);
     // Detect whether the subscription has message ordering enabled.

--- a/plugins/google-cloud-pubsub/builtins/from_plugin.cpp
+++ b/plugins/google-cloud-pubsub/builtins/from_plugin.cpp
@@ -266,7 +266,12 @@ public:
   auto start(OpCtx& ctx) -> Task<void> override {
     bytes_read_counter_
       = ctx.make_counter(MetricsLabel{"operator", "from_google_cloud_pubsub"},
-                         MetricsDirection::read, MetricsVisibility::external_);
+                         MetricsDirection::read, MetricsVisibility::external_,
+                         MetricsType::bytes);
+    events_read_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "from_google_cloud_pubsub"},
+                         MetricsDirection::read, MetricsVisibility::external_,
+                         MetricsType::events);
     auto subscription = pubsub::Subscription(args_.project_id.inner,
                                              args_.subscription_id.inner);
     // Detect whether the subscription has message ordering enabled.
@@ -371,7 +376,9 @@ public:
         }
       }
       for (auto&& slice : msb.finalize_as_table_slice()) {
+        auto const rows = slice.rows();
         co_await push(std::move(slice));
+        events_read_counter_.add(rows);
       }
     }
 
@@ -401,6 +408,7 @@ private:
   Option<SessionHandle> session_;
   std::shared_ptr<SharedState> shared_ = std::make_shared<SharedState>();
   MetricsCounter bytes_read_counter_;
+  MetricsCounter events_read_counter_;
 };
 
 } // namespace

--- a/plugins/google-cloud-pubsub/builtins/to_plugin.cpp
+++ b/plugins/google-cloud-pubsub/builtins/to_plugin.cpp
@@ -207,7 +207,12 @@ public:
   auto start(OpCtx& ctx) -> Task<void> override {
     bytes_write_counter_
       = ctx.make_counter(MetricsLabel{"operator", "to_google_cloud_pubsub"},
-                         MetricsDirection::write, MetricsVisibility::external_);
+                         MetricsDirection::write, MetricsVisibility::external_,
+                         MetricsType::bytes);
+    events_write_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "to_google_cloud_pubsub"},
+                         MetricsDirection::write, MetricsVisibility::external_,
+                         MetricsType::events);
     auto topic = pubsub::Topic(args_.project_id.inner, args_.topic_id.inner);
     publisher_.emplace(pubsub::MakePublisherConnection(std::move(topic)));
     co_return;
@@ -275,6 +280,7 @@ private:
     if (bytes > 0) {
       bytes_write_counter_.add(bytes);
     }
+    events_write_counter_.add(1);
   }
 
   auto drain_inflight(diagnostic_handler& dh) -> Task<void> {
@@ -293,6 +299,7 @@ private:
   Option<pubsub::Publisher> publisher_;
   std::deque<InflightPublish> inflight_;
   MetricsCounter bytes_write_counter_;
+  MetricsCounter events_write_counter_;
 };
 
 } // namespace

--- a/plugins/google-cloud-pubsub/builtins/to_plugin.cpp
+++ b/plugins/google-cloud-pubsub/builtins/to_plugin.cpp
@@ -208,11 +208,11 @@ public:
     bytes_write_counter_
       = ctx.make_counter(MetricsLabel{"operator", "to_google_cloud_pubsub"},
                          MetricsDirection::write, MetricsVisibility::external_,
-                         MetricsType::bytes);
+                         MetricsUnit::bytes);
     events_write_counter_
       = ctx.make_counter(MetricsLabel{"operator", "to_google_cloud_pubsub"},
                          MetricsDirection::write, MetricsVisibility::external_,
-                         MetricsType::events);
+                         MetricsUnit::events);
     auto topic = pubsub::Topic(args_.project_id.inner, args_.topic_id.inner);
     publisher_.emplace(pubsub::MakePublisherConnection(std::move(topic)));
     co_return;

--- a/plugins/kafka/builtins/from_kafka.cpp
+++ b/plugins/kafka/builtins/from_kafka.cpp
@@ -445,14 +445,14 @@ public:
         "operator",
         "from_kafka",
       },
-      MetricsDirection::read, MetricsVisibility::external_, MetricsType::bytes);
+      MetricsDirection::read, MetricsVisibility::external_, MetricsUnit::bytes);
     read_events_counter_ = ctx.make_counter(
       MetricsLabel{
         "operator",
         "from_kafka",
       },
       MetricsDirection::read, MetricsVisibility::external_,
-      MetricsType::events);
+      MetricsUnit::events);
     initialize_perf_tracking();
     auto aws_iam = args_.aws_iam
                      ? std::optional<located<record>>{*args_.aws_iam}

--- a/plugins/kafka/builtins/from_kafka.cpp
+++ b/plugins/kafka/builtins/from_kafka.cpp
@@ -445,7 +445,14 @@ public:
         "operator",
         "from_kafka",
       },
-      MetricsDirection::read, MetricsVisibility::external_);
+      MetricsDirection::read, MetricsVisibility::external_, MetricsType::bytes);
+    read_events_counter_ = ctx.make_counter(
+      MetricsLabel{
+        "operator",
+        "from_kafka",
+      },
+      MetricsDirection::read, MetricsVisibility::external_,
+      MetricsType::events);
     initialize_perf_tracking();
     auto aws_iam = args_.aws_iam
                      ? std::optional<located<record>>{*args_.aws_iam}
@@ -548,11 +555,13 @@ public:
       std::move(d).modify().emit(ctx);
     }
     for (auto& slice : frame.slices) {
+      auto const rows = slice.rows();
       auto push_started = std::chrono::steady_clock::time_point{};
       if (perf_enabled_) {
         push_started = std::chrono::steady_clock::now();
       }
       co_await push(std::move(slice));
+      read_events_counter_.add(rows);
       if (perf_enabled_) {
         add_perf_counter(
           perf_.push_wait_ns,
@@ -1725,6 +1734,7 @@ private:
   // Optional counters for benchmarking; enabled via env flag.
   mutable FromKafkaPerfCounters perf_;
   mutable MetricsCounter read_bytes_counter_;
+  mutable MetricsCounter read_events_counter_;
   mutable std::atomic<bool> perf_reported_ = false;
   bool perf_enabled_ = false;
   bool perf_started_ = false;

--- a/plugins/kafka/builtins/to_kafka.cpp
+++ b/plugins/kafka/builtins/to_kafka.cpp
@@ -162,14 +162,16 @@ public:
                      std::optional<ResolvedAwsIamAuth> auth,
                      producer_configuration cfg,
                      Box<RdKafka::Producer> producer,
-                     MetricsCounter write_bytes_counter)
+                     MetricsCounter write_bytes_counter,
+                     MetricsCounter write_events_counter)
     : topic_{std::move(topic)},
       message_expr_{std::move(message_expr)},
       auth_{std::move(auth)},
       cfg_{std::move(cfg)},
       producer_{std::move(producer)},
       printer_{try_make_json_printer(message_expr_)},
-      write_bytes_counter_{std::move(write_bytes_counter)} {
+      write_bytes_counter_{std::move(write_bytes_counter)},
+      write_events_counter_{std::move(write_events_counter)} {
   }
 
   /// Serializes and produces all rows from `input` as Kafka messages.
@@ -273,6 +275,7 @@ private:
       switch (result) {
         case RdKafka::ERR_NO_ERROR: {
           write_bytes_counter_.add(static_cast<uint64_t>(bytes.size()));
+          write_events_counter_.add(1);
           ++produced_since_poll_;
           if (produced_since_poll_ >= producer_poll_interval) {
             producer_->poll(0);
@@ -339,6 +342,7 @@ private:
   Box<RdKafka::Producer> producer_; // destroyed first (declared after cfg_)
   std::optional<json_printer2> printer_;
   MetricsCounter write_bytes_counter_;
+  MetricsCounter write_events_counter_;
   size_t produced_since_poll_ = 0;
 };
 
@@ -354,7 +358,15 @@ public:
         "operator",
         "to_kafka",
       },
-      MetricsDirection::write, MetricsVisibility::external_);
+      MetricsDirection::write, MetricsVisibility::external_,
+      MetricsType::bytes);
+    write_events_counter_ = ctx.make_counter(
+      MetricsLabel{
+        "operator",
+        "to_kafka",
+      },
+      MetricsDirection::write, MetricsVisibility::external_,
+      MetricsType::events);
     auto aws_iam = args_.aws_iam
                      ? std::optional<located<record>>{*args_.aws_iam}
                      : std::nullopt;
@@ -403,7 +415,7 @@ public:
       producer_.emplace(args_.topic, args_.message, auth_, std::move(*cfg),
                         Box<RdKafka::Producer>::from_non_null(
                           std::unique_ptr<RdKafka::Producer>{raw_producer}),
-                        write_bytes_counter_);
+                        write_bytes_counter_, write_events_counter_);
       co_return;
     }
     // Multi-worker path: feed a bounded queue from process() and drain it with
@@ -426,7 +438,7 @@ public:
         args_.topic, args_.message, auth_, std::move(worker_cfg),
         Box<RdKafka::Producer>::from_non_null(
           std::unique_ptr<RdKafka::Producer>{raw_producer}),
-        write_bytes_counter_})));
+        write_bytes_counter_, write_events_counter_})));
     }
   }
 
@@ -508,6 +520,7 @@ private:
   std::optional<ResolvedAwsIamAuth> auth_;
   std::optional<AsyncKafkaProducer> producer_;
   MetricsCounter write_bytes_counter_;
+  MetricsCounter write_events_counter_;
   std::shared_ptr<InputQueue> input_queue_;
   std::vector<AsyncHandle<void>> worker_handles_;
   OpCtx* ctx_ = nullptr;

--- a/plugins/kafka/builtins/to_kafka.cpp
+++ b/plugins/kafka/builtins/to_kafka.cpp
@@ -359,14 +359,14 @@ public:
         "to_kafka",
       },
       MetricsDirection::write, MetricsVisibility::external_,
-      MetricsType::bytes);
+      MetricsUnit::bytes);
     write_events_counter_ = ctx.make_counter(
       MetricsLabel{
         "operator",
         "to_kafka",
       },
       MetricsDirection::write, MetricsVisibility::external_,
-      MetricsType::events);
+      MetricsUnit::events);
     auto aws_iam = args_.aws_iam
                      ? std::optional<located<record>>{*args_.aws_iam}
                      : std::nullopt;

--- a/plugins/nats/builtins/from_nats.cpp
+++ b/plugins/nats/builtins/from_nats.cpp
@@ -422,11 +422,11 @@ public:
     read_bytes_counter_
       = ctx.make_counter(MetricsLabel{"operator", "from_nats"},
                          MetricsDirection::read, MetricsVisibility::external_,
-                         MetricsType::bytes);
+                         MetricsUnit::bytes);
     read_events_counter_
       = ctx.make_counter(MetricsLabel{"operator", "from_nats"},
                          MetricsDirection::read, MetricsVisibility::external_,
-                         MetricsType::events);
+                         MetricsUnit::events);
     auto resolved
       = co_await resolve_connection_config(ctx, args_.url, args_.auth);
     if (not resolved) {

--- a/plugins/nats/builtins/from_nats.cpp
+++ b/plugins/nats/builtins/from_nats.cpp
@@ -421,7 +421,12 @@ public:
   auto start(OpCtx& ctx) -> Task<void> override {
     read_bytes_counter_
       = ctx.make_counter(MetricsLabel{"operator", "from_nats"},
-                         MetricsDirection::read, MetricsVisibility::external_);
+                         MetricsDirection::read, MetricsVisibility::external_,
+                         MetricsType::bytes);
+    read_events_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "from_nats"},
+                         MetricsDirection::read, MetricsVisibility::external_,
+                         MetricsType::events);
     auto resolved
       = co_await resolve_connection_config(ctx, args_.url, args_.auth);
     if (not resolved) {
@@ -629,6 +634,7 @@ public:
         auto const rows = detail::narrow_cast<size_t>(slice.rows());
         TENZIR_ASSERT(message_index + rows <= accepted.size());
         co_await push(std::move(slice));
+        read_events_counter_.add(rows);
         mark_delivered(
           std::span<nats_msg_ptr>{accepted.data() + message_index, rows});
         for (auto i = size_t{0}; i < rows; ++i) {
@@ -951,6 +957,7 @@ private:
   nats_subscription_ptr subscription_;
   std::vector<nats_msg_ptr> pending_acks_;
   MetricsCounter read_bytes_counter_;
+  MetricsCounter read_events_counter_;
   uint64_t received_ = 0;
   bool needs_shutdown_flush_ = false;
   bool done_ = false;

--- a/plugins/nats/builtins/to_nats.cpp
+++ b/plugins/nats/builtins/to_nats.cpp
@@ -200,11 +200,11 @@ public:
     write_bytes_counter_
       = ctx.make_counter(MetricsLabel{"operator", "to_nats"},
                          MetricsDirection::write, MetricsVisibility::external_,
-                         MetricsType::bytes);
+                         MetricsUnit::bytes);
     write_events_counter_
       = ctx.make_counter(MetricsLabel{"operator", "to_nats"},
                          MetricsDirection::write, MetricsVisibility::external_,
-                         MetricsType::events);
+                         MetricsUnit::events);
     auto resolved
       = co_await resolve_connection_config(ctx, args_.url, args_.auth);
     if (not resolved) {

--- a/plugins/nats/builtins/to_nats.cpp
+++ b/plugins/nats/builtins/to_nats.cpp
@@ -199,7 +199,12 @@ public:
   auto start(OpCtx& ctx) -> Task<void> override {
     write_bytes_counter_
       = ctx.make_counter(MetricsLabel{"operator", "to_nats"},
-                         MetricsDirection::write, MetricsVisibility::external_);
+                         MetricsDirection::write, MetricsVisibility::external_,
+                         MetricsType::bytes);
+    write_events_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "to_nats"},
+                         MetricsDirection::write, MetricsVisibility::external_,
+                         MetricsType::events);
     auto resolved
       = co_await resolve_connection_config(ctx, args_.url, args_.auth);
     if (not resolved) {
@@ -313,6 +318,7 @@ private:
       return false;
     }
     written_bytes += bytes.size();
+    write_events_counter_.add(1);
     return true;
   }
 
@@ -349,6 +355,7 @@ private:
       return false;
     }
     written_bytes += bytes.size();
+    write_events_counter_.add(1);
     return true;
   }
 
@@ -462,6 +469,7 @@ private:
   nats_connection_ptr connection_;
   js_ctx_ptr js_;
   MetricsCounter write_bytes_counter_;
+  MetricsCounter write_events_counter_;
   bool done_ = false;
 };
 

--- a/plugins/nic/builtins/from_nic.cpp
+++ b/plugins/nic/builtins/from_nic.cpp
@@ -352,7 +352,8 @@ public:
     }
     bytes_read_counter_
       = ctx.make_counter(MetricsLabel{"operator", "from_nic"},
-                         MetricsDirection::read, MetricsVisibility::external_);
+                         MetricsDirection::read, MetricsVisibility::external_,
+                         MetricsType::bytes);
     co_await ctx.spawn_sub<chunk_ptr>(caf::none, std::move(parser));
     auto io_executor = ctx.io_executor();
     auto* evb = io_executor->getEventBase();

--- a/plugins/nic/builtins/from_nic.cpp
+++ b/plugins/nic/builtins/from_nic.cpp
@@ -353,11 +353,11 @@ public:
     bytes_read_counter_
       = ctx.make_counter(MetricsLabel{"operator", "from_nic"},
                          MetricsDirection::read, MetricsVisibility::external_,
-                         MetricsType::bytes);
+                         MetricsUnit::bytes);
     events_read_counter_
       = ctx.make_counter(MetricsLabel{"operator", "from_nic"},
                          MetricsDirection::read, MetricsVisibility::external_,
-                         MetricsType::events);
+                         MetricsUnit::events);
     co_await ctx.spawn_sub<chunk_ptr>(caf::none, std::move(parser));
     auto io_executor = ctx.io_executor();
     auto* evb = io_executor->getEventBase();

--- a/plugins/nic/builtins/from_nic.cpp
+++ b/plugins/nic/builtins/from_nic.cpp
@@ -354,6 +354,10 @@ public:
       = ctx.make_counter(MetricsLabel{"operator", "from_nic"},
                          MetricsDirection::read, MetricsVisibility::external_,
                          MetricsType::bytes);
+    events_read_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "from_nic"},
+                         MetricsDirection::read, MetricsVisibility::external_,
+                         MetricsType::events);
     co_await ctx.spawn_sub<chunk_ptr>(caf::none, std::move(parser));
     auto io_executor = ctx.io_executor();
     auto* evb = io_executor->getEventBase();
@@ -407,6 +411,13 @@ public:
     -> Task<void> override {
     sub_finished_->notify_one();
     co_return;
+  }
+
+  auto process_sub(SubKeyView, table_slice slice, Push<table_slice>& push,
+                   OpCtx&) -> Task<void> override {
+    auto const rows = slice.rows();
+    co_await push(std::move(slice));
+    events_read_counter_.add(rows);
   }
 
   auto state() -> OperatorState override {
@@ -477,6 +488,7 @@ private:
   bool done_ = false;
   bool capture_closed_ = false;
   MetricsCounter bytes_read_counter_;
+  MetricsCounter events_read_counter_;
   mutable std::shared_ptr<Notify> sub_finished_ = std::make_shared<Notify>();
   mutable std::shared_ptr<ChunkQueue> chunk_queue_
     = std::make_shared<ChunkQueue>(queue_capacity);

--- a/plugins/sqs/include/operators.hpp
+++ b/plugins/sqs/include/operators.hpp
@@ -60,6 +60,7 @@ private:
   Option<std::chrono::seconds> visibility_timeout_;
   std::shared_ptr<AsyncSqsQueue> queue_;
   MetricsCounter bytes_read_counter_;
+  MetricsCounter events_read_counter_;
 };
 
 class ToSqs final : public Operator<table_slice, void> {
@@ -74,6 +75,7 @@ private:
   ToSqsArgs args_;
   std::shared_ptr<AsyncSqsQueue> queue_;
   MetricsCounter bytes_write_counter_;
+  MetricsCounter events_write_counter_;
 };
 
 } // namespace tenzir::plugins::sqs

--- a/plugins/sqs/src/operators.cpp
+++ b/plugins/sqs/src/operators.cpp
@@ -125,7 +125,12 @@ auto FromSqs::start(OpCtx& ctx) -> Task<void> {
   queue_ = co_await make_async_sqs_queue(args_, ctx);
   bytes_read_counter_
     = ctx.make_counter(MetricsLabel{"operator", "from_sqs"},
-                       MetricsDirection::read, MetricsVisibility::external_);
+                       MetricsDirection::read, MetricsVisibility::external_,
+                       MetricsType::bytes);
+  events_read_counter_
+    = ctx.make_counter(MetricsLabel{"operator", "from_sqs"},
+                       MetricsDirection::read, MetricsVisibility::external_,
+                       MetricsType::events);
 }
 
 auto FromSqs::await_task(diagnostic_handler& dh) const -> Task<Any> {
@@ -241,7 +246,9 @@ auto FromSqs::process_task(Any result, Push<table_slice>& push, OpCtx& ctx)
     build_event(msb, message);
   }
   for (auto&& slice : msb.finalize_as_table_slice()) {
+    auto const rows = slice.rows();
     co_await push(std::move(slice));
+    events_read_counter_.add(rows);
   }
   if (args_.keep_messages) {
     co_return;
@@ -263,7 +270,12 @@ auto ToSqs::start(OpCtx& ctx) -> Task<void> {
   queue_ = co_await make_async_sqs_queue(args_, ctx);
   bytes_write_counter_
     = ctx.make_counter(MetricsLabel{"operator", "to_sqs"},
-                       MetricsDirection::write, MetricsVisibility::external_);
+                       MetricsDirection::write, MetricsVisibility::external_,
+                       MetricsType::bytes);
+  events_write_counter_
+    = ctx.make_counter(MetricsLabel{"operator", "to_sqs"},
+                       MetricsDirection::write, MetricsVisibility::external_,
+                       MetricsType::events);
 }
 
 auto ToSqs::process(table_slice input, OpCtx& ctx) -> Task<void> {
@@ -286,6 +298,7 @@ auto ToSqs::process(table_slice input, OpCtx& ctx) -> Task<void> {
         if (not bytes.empty()) {
           bytes_write_counter_.add(bytes.size());
         }
+        events_write_counter_.add(1);
       }
     };
     if (auto strings = messages.template as<string_type>()) {

--- a/plugins/sqs/src/operators.cpp
+++ b/plugins/sqs/src/operators.cpp
@@ -126,11 +126,11 @@ auto FromSqs::start(OpCtx& ctx) -> Task<void> {
   bytes_read_counter_
     = ctx.make_counter(MetricsLabel{"operator", "from_sqs"},
                        MetricsDirection::read, MetricsVisibility::external_,
-                       MetricsType::bytes);
+                       MetricsUnit::bytes);
   events_read_counter_
     = ctx.make_counter(MetricsLabel{"operator", "from_sqs"},
                        MetricsDirection::read, MetricsVisibility::external_,
-                       MetricsType::events);
+                       MetricsUnit::events);
 }
 
 auto FromSqs::await_task(diagnostic_handler& dh) const -> Task<Any> {
@@ -271,11 +271,11 @@ auto ToSqs::start(OpCtx& ctx) -> Task<void> {
   bytes_write_counter_
     = ctx.make_counter(MetricsLabel{"operator", "to_sqs"},
                        MetricsDirection::write, MetricsVisibility::external_,
-                       MetricsType::bytes);
+                       MetricsUnit::bytes);
   events_write_counter_
     = ctx.make_counter(MetricsLabel{"operator", "to_sqs"},
                        MetricsDirection::write, MetricsVisibility::external_,
-                       MetricsType::events);
+                       MetricsUnit::events);
 }
 
 auto ToSqs::process(table_slice input, OpCtx& ctx) -> Task<void> {

--- a/plugins/zmq/builtins/from_zmq.cpp
+++ b/plugins/zmq/builtins/from_zmq.cpp
@@ -90,13 +90,21 @@ public:
     if constexpr (Mode == transport::ConnectionMode::connect) {
       bytes_read_counter_
         = ctx.make_counter(MetricsLabel{"operator", "from_zmq"},
-                           MetricsDirection::read,
-                           MetricsVisibility::external_);
+                           MetricsDirection::read, MetricsVisibility::external_,
+                           MetricsType::bytes);
+      events_read_counter_
+        = ctx.make_counter(MetricsLabel{"operator", "from_zmq"},
+                           MetricsDirection::read, MetricsVisibility::external_,
+                           MetricsType::events);
     } else {
       bytes_read_counter_
         = ctx.make_counter(MetricsLabel{"operator", "accept_zmq"},
-                           MetricsDirection::read,
-                           MetricsVisibility::external_);
+                           MetricsDirection::read, MetricsVisibility::external_,
+                           MetricsType::bytes);
+      events_read_counter_
+        = ctx.make_counter(MetricsLabel{"operator", "accept_zmq"},
+                           MetricsDirection::read, MetricsVisibility::external_,
+                           MetricsType::events);
     }
     endpoint_ = transport::normalize_endpoint(args_.endpoint.inner);
     if (args_.prefix) {
@@ -214,7 +222,9 @@ public:
 
   auto process_sub(SubKeyView, table_slice slice, Push<table_slice>& push,
                    OpCtx&) -> Task<void> override {
+    auto const rows = slice.rows();
     co_await push(std::move(slice));
+    events_read_counter_.add(rows);
   }
 
   auto finish_sub(SubKeyView, Push<table_slice>&, OpCtx&)
@@ -295,6 +305,7 @@ private:
   size_t active_parsers_ = 0;
   uint64_t next_sub_id_ = 0;
   MetricsCounter bytes_read_counter_;
+  MetricsCounter events_read_counter_;
 };
 
 template <transport::ConnectionMode Mode>

--- a/plugins/zmq/builtins/from_zmq.cpp
+++ b/plugins/zmq/builtins/from_zmq.cpp
@@ -91,20 +91,20 @@ public:
       bytes_read_counter_
         = ctx.make_counter(MetricsLabel{"operator", "from_zmq"},
                            MetricsDirection::read, MetricsVisibility::external_,
-                           MetricsType::bytes);
+                           MetricsUnit::bytes);
       events_read_counter_
         = ctx.make_counter(MetricsLabel{"operator", "from_zmq"},
                            MetricsDirection::read, MetricsVisibility::external_,
-                           MetricsType::events);
+                           MetricsUnit::events);
     } else {
       bytes_read_counter_
         = ctx.make_counter(MetricsLabel{"operator", "accept_zmq"},
                            MetricsDirection::read, MetricsVisibility::external_,
-                           MetricsType::bytes);
+                           MetricsUnit::bytes);
       events_read_counter_
         = ctx.make_counter(MetricsLabel{"operator", "accept_zmq"},
                            MetricsDirection::read, MetricsVisibility::external_,
-                           MetricsType::events);
+                           MetricsUnit::events);
     }
     endpoint_ = transport::normalize_endpoint(args_.endpoint.inner);
     if (args_.prefix) {

--- a/plugins/zmq/builtins/to_zmq.cpp
+++ b/plugins/zmq/builtins/to_zmq.cpp
@@ -124,20 +124,20 @@ public:
       bytes_write_counter_
         = ctx.make_counter(MetricsLabel{"operator", "to_zmq"},
                            MetricsDirection::write,
-                           MetricsVisibility::external_, MetricsType::bytes);
+                           MetricsVisibility::external_, MetricsUnit::bytes);
       events_write_counter_
         = ctx.make_counter(MetricsLabel{"operator", "to_zmq"},
                            MetricsDirection::write,
-                           MetricsVisibility::external_, MetricsType::events);
+                           MetricsVisibility::external_, MetricsUnit::events);
     } else {
       bytes_write_counter_
         = ctx.make_counter(MetricsLabel{"operator", "serve_zmq"},
                            MetricsDirection::write,
-                           MetricsVisibility::external_, MetricsType::bytes);
+                           MetricsVisibility::external_, MetricsUnit::bytes);
       events_write_counter_
         = ctx.make_counter(MetricsLabel{"operator", "serve_zmq"},
                            MetricsDirection::write,
-                           MetricsVisibility::external_, MetricsType::events);
+                           MetricsVisibility::external_, MetricsUnit::events);
     }
     endpoint_ = transport::normalize_endpoint(args_.endpoint.inner);
     if (args_.monitor) {

--- a/plugins/zmq/builtins/to_zmq.cpp
+++ b/plugins/zmq/builtins/to_zmq.cpp
@@ -124,12 +124,20 @@ public:
       bytes_write_counter_
         = ctx.make_counter(MetricsLabel{"operator", "to_zmq"},
                            MetricsDirection::write,
-                           MetricsVisibility::external_);
+                           MetricsVisibility::external_, MetricsType::bytes);
+      events_write_counter_
+        = ctx.make_counter(MetricsLabel{"operator", "to_zmq"},
+                           MetricsDirection::write,
+                           MetricsVisibility::external_, MetricsType::events);
     } else {
       bytes_write_counter_
         = ctx.make_counter(MetricsLabel{"operator", "serve_zmq"},
                            MetricsDirection::write,
-                           MetricsVisibility::external_);
+                           MetricsVisibility::external_, MetricsType::bytes);
+      events_write_counter_
+        = ctx.make_counter(MetricsLabel{"operator", "serve_zmq"},
+                           MetricsDirection::write,
+                           MetricsVisibility::external_, MetricsType::events);
     }
     endpoint_ = transport::normalize_endpoint(args_.endpoint.inner);
     if (args_.monitor) {
@@ -211,6 +219,7 @@ public:
         if (framed->size() > 0) {
           bytes_write_counter_.add(framed->size());
         }
+        events_write_counter_.add(1);
         continue;
       }
       diagnostic::error("failed to send ZeroMQ message")
@@ -237,6 +246,7 @@ private:
   transport::Socket socket_{transport::SocketRole::publisher};
   bool done_ = false;
   MetricsCounter bytes_write_counter_;
+  MetricsCounter events_write_counter_;
 };
 
 template <transport::ConnectionMode Mode>


### PR DESCRIPTION
## 🔍 Problem

- New-executor pipeline metrics only distinguished counter/gauge instruments.
- Throughput metrics could not separately report bytes and events.
- Operators with event ingress/egress had no event-count counters for node metrics.

## 🛠️ Solution

- Split metric instrument from metric type, adding `bytes` and `events` as separate throughput units.
- Emit node metrics for both units while keeping the existing external/internal fallback behavior.
- Add event counters at new-executor source, sink, parser handoff, writer handoff, and internal handoff points across core and bundled plugins.
- Update the contrib plugin submodule for the extended counter API.

## 💬 Review

- The node metric emission still uses synthetic indices as a compatibility workaround for the pipeline manager.
- Tests are limited by the current lack of node-startable pipeline coverage for this executor path; verification was compile plus a local new-executor smoke run.

<sub>
📚 Docs PR: tenzir/docs#310<br>
📎 Companion: tenzir/tenzir-plugins#537<br>
✅ Closes TNZ-557
</sub>