### PR TITLE
Fix async_mail cancellation

### DIFF
--- a/libtenzir/include/tenzir/async/mail.hpp
+++ b/libtenzir/include/tenzir/async/mail.hpp
@@ -16,57 +16,67 @@
 #include <caf/event_based_actor.hpp>
 #include <caf/message.hpp>
 #include <caf/response_type.hpp>
+#include <caf/send.hpp>
 #include <caf/timespan.hpp>
 #include <caf/unit.hpp>
+#include <folly/ExceptionWrapper.h>
 #include <folly/futures/Future.h>
 
 #include <atomic>
-#include <functional>
 #include <memory>
-#include <source_location>
 #include <tuple>
 #include <type_traits>
 #include <utility>
 
 namespace tenzir {
 
-template <class Result, class Handle, class F, class... Ts>
-void mail_with_callback(Handle receiver, caf::timespan timeout,
-                        std::source_location location, F f, Ts&&... xs) {
-  struct state_t {
-    explicit state_t(F fn) : callback{std::move(fn)} {
-    }
+template <class Result>
+struct AsyncMailRequestState {
+  using FutureResult = caf::expected<Result>;
 
-    auto finish(caf::expected<Result> result) -> void {
-      auto expected = false;
-      if (not completed.compare_exchange_strong(expected, true,
-                                                std::memory_order_relaxed)) {
-        return;
-      }
-      std::invoke(callback, std::move(result));
-    }
-
-    std::atomic<bool> completed = false;
-    F callback;
-  };
-  if (not receiver) {
-    std::invoke(f, caf::expected<Result>{caf::make_error(
-                     ec::remote_node_down, "async_mail receiver down")});
-    return;
+  explicit AsyncMailRequestState(folly::Promise<FutureResult> promise)
+    : promise{std::move(promise)} {
   }
-  auto state = std::make_shared<state_t>(std::move(f));
-  receiver->home_system().template spawn<caf::hidden>(
-    [receiver = std::move(receiver), timeout, location,
-     state = std::move(state), args = std::make_tuple(std::forward<Ts>(xs)...)](
+
+  auto finish(FutureResult result) -> void {
+    auto expected = false;
+    if (not completed.compare_exchange_strong(expected, true,
+                                              std::memory_order_relaxed)) {
+      return;
+    }
+    promise.setValue(std::move(result));
+  }
+
+  auto cancel(folly::exception_wrapper const& exception) -> void {
+    auto expected = false;
+    if (not completed.compare_exchange_strong(expected, true,
+                                              std::memory_order_relaxed)) {
+      return;
+    }
+    promise.setException(exception);
+    if (helper) {
+      caf::anon_send_exit(helper, caf::exit_reason::user_shutdown);
+    }
+  }
+
+  std::atomic<bool> completed = false;
+  folly::Promise<FutureResult> promise;
+  caf::actor helper;
+};
+
+template <class Result, class Handle, class... Ts>
+auto mail_with_callback(Handle receiver, caf::timespan timeout,
+                        std::shared_ptr<AsyncMailRequestState<Result>> state,
+                        Ts&&... xs) -> caf::actor {
+  if (not receiver) {
+    state->finish(caf::expected<Result>{
+      caf::make_error(ec::remote_node_down, "async_mail receiver down")});
+    return {};
+  }
+  return receiver->home_system().template spawn<caf::hidden>(
+    [receiver = std::move(receiver), timeout, state = std::move(state),
+     args = std::make_tuple(std::forward<Ts>(xs)...)](
       caf::event_based_actor* self) mutable -> caf::behavior {
-      self->attach_functor([location, state] {
-        state->finish(caf::expected<Result>{
-          caf::make_error(ec::logic_error,
-                          fmt::format("async_mail helper terminated before "
-                                      "producing a response for request at "
-                                      "{}:{}",
-                                      location.file_name(), location.line()))});
-      });
       std::apply(
         [self, &receiver, &state, timeout](auto&&... ys) mutable {
           if constexpr (std::is_void_v<Result>) {
@@ -112,18 +122,23 @@ public:
 
   template <class Handle, class Result = AsyncMailResult<Handle, Args...>>
   auto
-  request(Handle receiver, caf::timespan timeout = caf::infinite,
-          std::source_location location
-          = std::source_location::current()) && -> folly::coro::Task<Result> {
+  request(Handle receiver, caf::timespan timeout
+                           = caf::infinite) && -> folly::coro::Task<Result> {
     auto [promise, future] = folly::makePromiseContract<Result>();
+    auto state
+      = std::make_shared<AsyncMailRequestState<typename Result::value_type>>(
+        std::move(promise));
+    state->promise.setInterruptHandler(
+      [weak_state = std::weak_ptr{state}](
+        folly::exception_wrapper const& exception) mutable {
+        if (auto state = weak_state.lock()) {
+          state->cancel(exception);
+        }
+      });
     std::apply(
       [&](auto&&... xs) mutable {
-        mail_with_callback<typename Result::value_type>(
-          receiver, timeout, location,
-          [promise = std::move(promise)](Result result) mutable {
-            promise.setValue(std::move(result));
-          },
-          std::move(xs)...);
+        state->helper = mail_with_callback<typename Result::value_type>(
+          receiver, timeout, state, std::move(xs)...);
       },
       std::move(args_));
     return to_task_interrupt_on_cancel(std::move(future));

--- a/libtenzir/test/async/mail.cpp
+++ b/libtenzir/test/async/mail.cpp
@@ -1,0 +1,133 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "tenzir/async/mail.hpp"
+
+#include "tenzir/test/test.hpp"
+
+#include <caf/actor_from_state.hpp>
+#include <caf/actor_system.hpp>
+#include <caf/actor_system_config.hpp>
+#include <caf/send.hpp>
+#include <caf/typed_response_promise.hpp>
+#include <folly/CancellationToken.h>
+#include <folly/OperationCancelled.h>
+#include <folly/coro/BlockingWait.h>
+#include <folly/coro/WithCancellation.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <future>
+#include <memory>
+#include <thread>
+
+namespace tenzir {
+
+namespace {
+
+using MailTestActor = caf::typed_actor<caf::result<int32_t>(int32_t)>;
+
+struct DelayedResponderControl {
+  std::promise<void> received;
+};
+
+struct DelayedResponderState {
+  [[maybe_unused]] static constexpr auto name = "delayed-mail-responder";
+
+  DelayedResponderState(MailTestActor::pointer self,
+                        std::shared_ptr<DelayedResponderControl> control)
+    : self{self}, control{std::move(control)} {
+  }
+
+  auto make_behavior() -> MailTestActor::behavior_type {
+    return {
+      [this](int32_t) -> caf::result<int32_t> {
+        response = self->make_response_promise<int32_t>();
+        control->received.set_value();
+        return response;
+      },
+    };
+  }
+
+  MailTestActor::pointer self;
+  std::shared_ptr<DelayedResponderControl> control;
+  caf::typed_response_promise<int32_t> response;
+};
+
+struct TestSystem {
+  caf::actor_system_config config;
+  caf::actor_system system{config};
+
+  TestSystem() = default;
+  TestSystem(const TestSystem&) = delete;
+  TestSystem(TestSystem&&) = delete;
+  TestSystem& operator=(const TestSystem&) = delete;
+  TestSystem& operator=(TestSystem&&) = delete;
+  ~TestSystem() = default;
+};
+
+} // namespace
+
+TEST("async_mail returns response") {
+  auto ts = TestSystem{};
+  auto& system = ts.system;
+  auto responder
+    = system.spawn([](MailTestActor::pointer) -> MailTestActor::behavior_type {
+        return {
+          [](int32_t value) -> caf::result<int32_t> {
+            return value + 1;
+          },
+        };
+      });
+  auto result = folly::coro::blockingWait(
+    async_mail(int32_t{41}).request(responder, caf::infinite));
+  require(result.has_value());
+  check_eq(*result, int32_t{42});
+  caf::anon_send_exit(responder, caf::exit_reason::user_shutdown);
+}
+
+TEST("async_mail cancellation wakes without response") {
+  using namespace std::chrono_literals;
+  auto ts = TestSystem{};
+  auto& system = ts.system;
+  auto control = std::make_shared<DelayedResponderControl>();
+  auto received = control->received.get_future();
+  auto responder
+    = system.spawn(caf::actor_from_state<DelayedResponderState>, control);
+  auto cancel = folly::CancellationSource{};
+  auto cancelled = std::atomic<bool>{false};
+  auto unexpected = std::atomic<bool>{false};
+  auto done = std::promise<void>{};
+  auto done_future = done.get_future();
+  auto waiter = std::thread{[&] {
+    try {
+      std::ignore = folly::coro::blockingWait(folly::coro::co_withCancellation(
+        cancel.getToken(),
+        async_mail(int32_t{42}).request(responder, caf::infinite)));
+    } catch (folly::OperationCancelled const&) {
+      cancelled.store(true, std::memory_order_relaxed);
+    } catch (...) {
+      unexpected.store(true, std::memory_order_relaxed);
+    }
+    done.set_value();
+  }};
+  check_eq(received.wait_for(1s), std::future_status::ready);
+  cancel.requestCancellation();
+  auto status = done_future.wait_for(250ms);
+  check_eq(status, std::future_status::ready);
+  caf::anon_send_exit(responder, caf::exit_reason::user_shutdown);
+  if (status != std::future_status::ready) {
+    check_eq(done_future.wait_for(1s), std::future_status::ready);
+  }
+  waiter.join();
+  check(cancelled.load(std::memory_order_relaxed));
+  check(not unexpected.load(std::memory_order_relaxed));
+}
+
+} // namespace tenzir


### PR DESCRIPTION
## Problem

`async_mail` was not cancellation-aware. When a Folly coroutine awaiting an `async_mail` request was cancelled, the cancellation signal had nowhere to go: the helper CAF actor kept running and the promise was never resolved, so the coroutine would hang indefinitely.

## Solution

- Register a `setInterruptHandler` on the promise so that Folly's cancellation mechanism (`toTaskInterruptOnCancel`) drives `state->cancel()`, which resolves the promise with the cancellation exception and immediately exits the helper actor via `caf::anon_send_exit`.
- Introduce `AsyncMailRequestState` to hold both the `folly::Promise` and the helper actor handle together, enabling clean cancellation.
- Add unit tests covering the normal response path and the cancellation path.

The submodule bump also pulls in the pipeline-manager request inspection fix from tenzir-plugins#538, but this should be inconsequential.

## Review

Focus on `libtenzir/include/tenzir/async/mail.hpp`: the `cancel` method, the `setInterruptHandler` registration, and whether the `completed` flag correctly prevents double-resolution across the normal and cancellation paths.