### PR TITLE
Remove duplicate symlink to AGENTS.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,1 +1,0 @@
-../AGENTS.md

--- a/.gitignore
+++ b/.gitignore
@@ -45,8 +45,8 @@ venv/
 .cmake/
 
 # Claude
+.claude/
 CLAUDE.local.md
-.claude/settings.local.json
 CLAUDE-TODOS.md
 .docs/
 


### PR DESCRIPTION
## 🔍 Problem

- `.claude/CLAUDE.md` was a symlink to `../AGENTS.md`, duplicating the symlink from the top-level `CLAUDE.md` to `AGENTS.md`. The instructions were actually loaded twice into memory, there is no deduplication.
- After this change we don't have any file in `.claude`, so we can `.gitignore` the whole directory to allow local skill and settings plumbing

## 🛠️ Solution

- Drop the redundant `.claude/CLAUDE.md` symlink.
- Ignore the whole `.claude/` directory in `.gitignore`.

## 💬 Review

- Pure repo-tooling cleanup; no user-facing or runtime impact.
- Confirm no other path expects `.claude/CLAUDE.md` to exist (none found).