### PR TITLE
Improve SQS region resolution and error logging

### DIFF
--- a/changelog/unreleased/region-derivation-and-endpoint-logging-for-sqs.md
+++ b/changelog/unreleased/region-derivation-and-endpoint-logging-for-sqs.md
@@ -1,0 +1,27 @@
+---
+title: Region derivation and endpoint logging for SQS
+type: change
+authors:
+  - lava
+prs:
+  - 6168
+created: 2026-05-13T09:08:28.12779Z
+---
+
+The `from_sqs` and `to_sqs` operators now derive the AWS region from a queue
+URL when `aws_region` is not set, so passing a full URL such as
+`https://sqs.us-west-2.amazonaws.com/123456789012/my-queue` works without
+having to specify the region again:
+
+```tql
+from_sqs "https://sqs.us-west-2.amazonaws.com/123456789012/my-queue"
+```
+
+Previously, this would fall back to the SDK default region and fail with a
+SigV4 signature mismatch. Explicit `aws_region`, resolved IAM credentials, and
+the SDK default still apply in that order when the URL has no region (for
+example VPC endpoints, LocalStack, or an `AWS_ENDPOINT_URL` override).
+
+SQS API errors and HTTP failures now also include the endpoint URL in their
+log lines and diagnostic notes, which makes it easier to tell which queue
+produced an error when multiple SQS pipelines run side by side.

--- a/plugins/sqs/include/async_sqs_queue.hpp
+++ b/plugins/sqs/include/async_sqs_queue.hpp
@@ -24,6 +24,12 @@ namespace tenzir::plugins::sqs {
 /// `https://`) rather than a queue name.
 auto is_sqs_queue_url(std::string_view s) -> bool;
 
+/// Extracts the AWS region from a standard SQS queue URL of the form
+/// `https://sqs.<region>.amazonaws.com[.cn]/<account>/<queue>`. Returns
+/// `None` for non-URLs and for endpoints that do not encode a region
+/// (VPC endpoints, LocalStack, custom `AWS_ENDPOINT_URL` overrides).
+auto region_from_sqs_url(std::string_view url) -> Option<std::string>;
+
 /// Async SQS client using proxygen for HTTP transport.
 ///
 /// We use proxygen instead of the AWS SDK's built-in HTTP client because

--- a/plugins/sqs/include/async_sqs_queue.hpp
+++ b/plugins/sqs/include/async_sqs_queue.hpp
@@ -24,6 +24,12 @@ namespace tenzir::plugins::sqs {
 /// `https://`) rather than a queue name.
 auto is_sqs_queue_url(std::string_view s) -> bool;
 
+/// Returns whether `s` satisfies the AWS SQS queue naming rules.
+///
+/// See:
+/// https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_CreateQueue.html#API_CreateQueue_RequestParameters
+auto is_valid_sqs_queue_name(std::string_view s) -> bool;
+
 /// Extracts the AWS region from a standard SQS queue URL of the form
 /// `https://sqs.<region>.amazonaws.com[.cn]/<account>/<queue>`. Returns
 /// `None` for non-URLs and for endpoints that do not encode a region

--- a/plugins/sqs/src/async_sqs_queue.cpp
+++ b/plugins/sqs/src/async_sqs_queue.cpp
@@ -198,6 +198,34 @@ auto is_sqs_queue_url(std::string_view s) -> bool {
   return s.starts_with("http://") or s.starts_with("https://");
 }
 
+auto region_from_sqs_url(std::string_view url) -> Option<std::string> {
+  auto scheme_end = url.find("://");
+  if (scheme_end == std::string_view::npos) {
+    return None{};
+  }
+  auto host_start = scheme_end + 3;
+  auto host_end = url.find('/', host_start);
+  auto host = url.substr(host_start, host_end - host_start);
+  if (auto colon = host.find(':'); colon != std::string_view::npos) {
+    host = host.substr(0, colon);
+  }
+  constexpr auto prefix = std::string_view{"sqs."};
+  if (not host.starts_with(prefix)) {
+    return None{};
+  }
+  host.remove_prefix(prefix.size());
+  for (auto suffix : {std::string_view{".amazonaws.com.cn"},
+                      std::string_view{".amazonaws.com"}}) {
+    if (host.ends_with(suffix)) {
+      auto region = host.substr(0, host.size() - suffix.size());
+      if (not region.empty()) {
+        return std::string{region};
+      }
+    }
+  }
+  return None{};
+}
+
 // --- AsyncSqsQueue ---
 
 AsyncSqsQueue::AsyncSqsQueue(

--- a/plugins/sqs/src/async_sqs_queue.cpp
+++ b/plugins/sqs/src/async_sqs_queue.cpp
@@ -149,11 +149,12 @@ auto sqs_api_call(HttpPool& pool, Aws::Client::AWSAuthV4Signer& signer,
         if (resp.status_code < 200 or resp.status_code >= 300) {
           auto error_msg = extract_sqs_error_message(resp.body);
           if (is_retriable_status(resp.status_code)) {
-            TENZIR_WARN("SQS API returned HTTP {} (retrying): {}",
-                        resp.status_code, error_msg);
+            TENZIR_WARN("SQS API at {} returned HTTP {} (retrying): {}",
+                        endpoint_url, resp.status_code, error_msg);
             throw sqs_retriable_error{resp.status_code, std::move(error_msg)};
           }
           diagnostic::error("SQS API returned HTTP {}", resp.status_code)
+            .note("endpoint: {}", endpoint_url)
             .note("{}", error_msg)
             .throw_();
         }
@@ -177,11 +178,13 @@ auto sqs_api_call(HttpPool& pool, Aws::Client::AWSAuthV4Signer& signer,
     if (e.status_code != 0) {
       diagnostic::error("SQS API returned HTTP {} after {} retries",
                         e.status_code, retry_max_retries)
+        .note("endpoint {}", endpoint_url)
         .note("{}", e.detail)
         .throw_();
     }
     diagnostic::error("SQS HTTP request failed after {} retries",
                       retry_max_retries)
+      .note("endpoint {}", endpoint_url)
       .note("{}", e.detail)
       .throw_();
   }

--- a/plugins/sqs/src/async_sqs_queue.cpp
+++ b/plugins/sqs/src/async_sqs_queue.cpp
@@ -27,6 +27,8 @@
 #include <aws/sqs/model/SendMessageResult.h>
 #include <folly/coro/Retry.h>
 
+#include <algorithm>
+
 namespace tenzir::plugins::sqs {
 
 namespace {
@@ -196,6 +198,27 @@ auto sqs_api_call(HttpPool& pool, Aws::Client::AWSAuthV4Signer& signer,
 
 auto is_sqs_queue_url(std::string_view s) -> bool {
   return s.starts_with("http://") or s.starts_with("https://");
+}
+
+auto is_valid_sqs_queue_name(std::string_view s) -> bool {
+  // AWS rules: up to 80 characters; alphanumeric, `-`, and `_`; FIFO queues
+  // additionally end with `.fifo` (the suffix counts toward the 80 chars).
+  // See:
+  // https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_CreateQueue.html#API_CreateQueue_RequestParameters
+  if (s.empty() or s.size() > 80) {
+    return false;
+  }
+  auto base = s;
+  if (base.ends_with(".fifo")) {
+    base.remove_suffix(5);
+  }
+  if (base.empty()) {
+    return false;
+  }
+  return std::ranges::all_of(base, [](char c) {
+    return (c >= 'a' and c <= 'z') or (c >= 'A' and c <= 'Z')
+           or (c >= '0' and c <= '9') or c == '-' or c == '_';
+  });
 }
 
 auto region_from_sqs_url(std::string_view url) -> Option<std::string> {

--- a/plugins/sqs/src/operators.cpp
+++ b/plugins/sqs/src/operators.cpp
@@ -52,15 +52,21 @@ auto make_async_sqs_queue(const Args& args, OpCtx& ctx)
   if (queue_name.inner.starts_with("sqs://")) {
     queue_name.inner.erase(0, 6);
   }
-  // Resolve the effective region: explicit `aws_region` wins, then the region
-  // from resolved AWS IAM credentials, then the AWS SDK's default resolution
-  // (AWS_REGION / AWS_DEFAULT_REGION env vars, the configured profile in
-  // `~/.aws/config`, and finally the SDK default of "us-east-1"). When a full
-  // queue URL is supplied for a non-default region, `aws_region` must be set
-  // explicitly so SigV4 signing matches the queue's region.
+  // Resolve the effective region in priority order:
+  //   1. Explicit `aws_region` (user override).
+  //   2. Region parsed from a full queue URL (e.g. the `us-west-2` in
+  //      `https://sqs.us-west-2.amazonaws.com/...`) — keeps SigV4 signing
+  //      aligned with the queue's region without forcing the user to set
+  //      `aws_region` redundantly.
+  //   3. Region from resolved AWS IAM credentials.
+  //   4. AWS SDK default resolution (AWS_REGION / AWS_DEFAULT_REGION env vars,
+  //      the configured profile in `~/.aws/config`, and finally the SDK
+  //      default of "us-east-1").
   auto region = std::string{};
   if (args.aws_region) {
     region = args.aws_region->inner;
+  } else if (auto url_region = region_from_sqs_url(args.queue.inner)) {
+    region = std::move(*url_region);
   } else if (resolved_creds and not resolved_creds->region.empty()) {
     region = resolved_creds->region;
   } else {

--- a/plugins/sqs/src/operators.cpp
+++ b/plugins/sqs/src/operators.cpp
@@ -52,6 +52,16 @@ auto make_async_sqs_queue(const Args& args, OpCtx& ctx)
   if (queue_name.inner.starts_with("sqs://")) {
     queue_name.inner.erase(0, 6);
   }
+  // Reject anything that isn't either a valid AWS SQS queue name or an HTTP(S)
+  // queue URL — this catches malformed inputs like `sqs://https://...` that
+  // would otherwise silently break region detection and SigV4 signing.
+  if (not is_sqs_queue_url(queue_name.inner)
+      and not is_valid_sqs_queue_name(queue_name.inner)) {
+    diagnostic::error("invalid SQS queue `{}`", args.queue.inner)
+      .primary(args.queue.source)
+      .hint("expected a queue name, `sqs://<name>`, or a full queue URL")
+      .throw_();
+  }
   // Resolve the effective region in priority order:
   //   1. Explicit `aws_region` (user override).
   //   2. Region parsed from a full queue URL (e.g. the `us-west-2` in
@@ -65,7 +75,7 @@ auto make_async_sqs_queue(const Args& args, OpCtx& ctx)
   auto region = std::string{};
   if (args.aws_region) {
     region = args.aws_region->inner;
-  } else if (auto url_region = region_from_sqs_url(args.queue.inner)) {
+  } else if (auto url_region = region_from_sqs_url(queue_name.inner)) {
     region = std::move(*url_region);
   } else if (resolved_creds and not resolved_creds->region.empty()) {
     region = resolved_creds->region;


### PR DESCRIPTION
## 🔍 Problem

- When users supplied a full SQS queue URL (e.g. `https://sqs.us-west-2.amazonaws.com/...`) without setting `aws_region`, signing fell back to the SDK default region and requests failed with opaque signature errors.
- SQS API failures logged status codes and bodies without naming the endpoint, making it hard to tell which queue/region produced the error when multiple SQS calls were in flight.

## 🛠️ Solution

- Parse the region out of standard SQS queue URLs (`sqs.<region>.amazonaws.com[.cn]`) and use it as a fallback when `aws_region` is not set, slotting between the explicit user override and resolved IAM credentials.
- Include the endpoint URL in retryable `TENZIR_WARN` logs and as a `.note()` on terminal `diagnostic::error`s for SQS API responses and HTTP failures.

## 💬 Review

- The URL parser intentionally returns `None` for VPC endpoints, LocalStack, and `AWS_ENDPOINT_URL` overrides — those still fall through to credentials/SDK resolution.
- Priority order is now: explicit `aws_region` → URL-encoded region → credential region → SDK default. The comment on `make_async_sqs_queue` documents this.

<sub>
✅ Closes TNZ-543
</sub>