### PR TITLE
Reduce disk I/O of time-based compaction

### DIFF
--- a/changelog/unreleased/avoid-redundant-partition-rewrites-during-compaction.md
+++ b/changelog/unreleased/avoid-redundant-partition-rewrites-during-compaction.md
@@ -1,0 +1,10 @@
+---
+title: Reduce disk I/O of time-based compaction
+type: bugfix
+authors:
+  - lava
+created: 2026-05-12T13:32:50.629468Z
+---
+
+Time-based compaction rules no longer cause the node to reprocess data that
+has already been compacted in a previous run.

--- a/libtenzir/src/partition_transformer.cpp
+++ b/libtenzir/src/partition_transformer.cpp
@@ -397,8 +397,10 @@ auto partition_transformer(
           if (slice.import_time() == time{}) {
             slice.import_time(self->state().min_import_time);
           }
-          unshared_synopsis->min_import_time = self->state().min_import_time;
-          unshared_synopsis->max_import_time = self->state().max_import_time;
+          unshared_synopsis->min_import_time
+            = std::min(unshared_synopsis->min_import_time, slice.import_time());
+          unshared_synopsis->max_import_time
+            = std::max(unshared_synopsis->max_import_time, slice.import_time());
           partition_data.events += slice.rows();
           self->state().events += slice.rows();
           self->state().partition_buildup[partition_data.id].slices.push_back(


### PR DESCRIPTION
## 🔍 Problem

When a time-based compaction rule deletes part of a partition's data, the
output partition's synopsis should reflect the time range of the slices that
survived. Instead, the old code copied the *input* partition's full
`min_import_time` / `max_import_time` onto the output synopsis.

So an input partition spanning a wide time range that's been trimmed by
compaction kept advertising the original wide range. Time-based compaction
rules use that range to pick eligible partitions, so the same partition got
selected and rewritten again on every run, even though there was nothing
left to do.

## 🛠️ Solution

- Aggregate `min`/`max` import time from the slices that actually end up in
  each output partition with `std::min` / `std::max`.
- The default `partition_synopsis` sentinels (`min_import_time = time::max()`,
  `max_import_time = time::min()`) make the first slice seed the range
  correctly.

## 💬 Review

- Side fix discovered while investigating TNZ-527; should not close that
  ticket.
- No new test — the existing transformer/compaction tests don't assert on
  per-partition import-time ranges. Happy to add one if you want.

<sub>
🎫 References TNZ-527
</sub>