### PR TITLE
Fix pre-push and CI formatter scoping

### DIFF
--- a/.agents/references/operator-review.md
+++ b/.agents/references/operator-review.md
@@ -20,7 +20,7 @@ Pay special attention to the following questions:
 - Do we support backpressure handling?
 
 - Are there any operators that were already ported to the new executor
-  framework that need to solve the same 
+  framework that need to solve the same
 
 # Backwards Compatibility
 
@@ -44,7 +44,7 @@ for destroying it and where/when that happens.
 # Source Operators
 
 - Walk through the operation in high-traffic and low-traffic mode:
-  -  In high-traffic mode, are there any unbounded buffers that could
+  - In high-traffic mode, are there any unbounded buffers that could
      kill our memory? Any blocking calls that
 
   - In low-traffic mode, are there any unbounded waits that could kill
@@ -59,4 +59,3 @@ for destroying it and where/when that happens.
   after all currently pending events are processed, to ensure correctness
   when the snapshot "flows back" along the pipeline. Is that already
   implemented correctly?
-    

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,29 +9,44 @@ pre-push:
   commands:
     ruff-format:
       env:
-        RUFF_VERSION: &ruff_version "0.15.6"
+        RUFF_VERSION: &ruff_version "0.15.12"
+      # {push_files} returns every tracked file when the branch is new
+      # (remote sha is all zeros); compute the actual branch diff instead.
+      files: &branch_files 'git diff --name-only --diff-filter=ACMR "$(git merge-base origin/main HEAD)" HEAD'
       glob: "**/*.py"
-      run: uvx ruff==$RUFF_VERSION format --check --diff {push_files}
+      exclude:
+        - "^scripts/splunk-search\\.py$"
+      run: uvx ruff==$RUFF_VERSION format --check --diff {files}
     clang-format:
       env:
         CLANG_FORMAT_VERSION: &clang_format_version "21.1.8"
-      glob: "**/*.{cpp,cpp.in,hpp,hpp.in}"
-      run: uvx clang-format@$CLANG_FORMAT_VERSION --dry-run --Werror {push_files}
+      files: *branch_files
+      # .cpp.in/.hpp.in are CMake templates with @VAR@ placeholders that
+      # clang-format mangles into "@VAR @"; skip them.
+      glob: "**/*.{cpp,hpp}"
+      exclude:
+        - "^libtenzir/aux/"
+      run: uvx clang-format@$CLANG_FORMAT_VERSION --dry-run --Werror {files}
     cmake-format:
       env:
         CMAKE_FORMAT_VERSION: &cmake_format_version "0.6.13"
+      files: *branch_files
       glob: "**/{CMakeLists.txt,*.cmake,*.cmake.in}"
-      run: uvx --from cmakelang==$CMAKE_FORMAT_VERSION cmake-format --check {push_files}
+      exclude:
+        - "^libtenzir/aux/"
+      run: uvx --from cmakelang==$CMAKE_FORMAT_VERSION cmake-format --check {files}
     shfmt:
       env:
         SHFMT_PY_VERSION: &shfmt_py_version "3.12.0.2"
+      files: *branch_files
       glob: "**/*.{sh,bash}"
-      run: uvx --from shfmt-py==$SHFMT_PY_VERSION shfmt -d {push_files}
+      run: uvx --from shfmt-py==$SHFMT_PY_VERSION shfmt -d {files}
     yamllint:
       env:
         YAMLLINT_VERSION: &yamllint_version "1.37.1"
+      files: *branch_files
       glob: "**/*.{yaml,yml}"
-      run: uvx yamllint==$YAMLLINT_VERSION {push_files}
+      run: uvx yamllint==$YAMLLINT_VERSION {files}
 
 # This hook is for automated local fixes with pinned non-Nix tools.
 # YAML remains check-only here; CI/treefmt is the broader style authority.
@@ -42,16 +57,22 @@ fix:
       env:
         RUFF_VERSION: *ruff_version
       glob: "**/*.py"
+      exclude:
+        - "^scripts/splunk-search\\.py$"
       run: uvx ruff==$RUFF_VERSION format {files}
     clang-format:
       env:
         CLANG_FORMAT_VERSION: *clang_format_version
-      glob: "**/*.{cpp,cpp.in,hpp,hpp.in}"
+      glob: "**/*.{cpp,hpp}"
+      exclude:
+        - "^libtenzir/aux/"
       run: uvx clang-format@$CLANG_FORMAT_VERSION -i {files}
     cmake-format:
       env:
         CMAKE_FORMAT_VERSION: *cmake_format_version
       glob: "**/{CMakeLists.txt,*.cmake,*.cmake.in}"
+      exclude:
+        - "^libtenzir/aux/"
       run: uvx --from cmakelang==$CMAKE_FORMAT_VERSION cmake-format -i {files}
     shfmt:
       env:

--- a/libtenzir/include/tenzir/detail/syslog.hpp
+++ b/libtenzir/include/tenzir/detail/syslog.hpp
@@ -667,8 +667,7 @@ struct cisco_datetime_parser : parser_base<cisco_datetime_parser> {
 /// Parser for Cisco date-time fields like:
 /// `Apr 14 08:45:52.113 UTC`
 /// `Apr 14 08:45:52.113`
-struct cisco_short_datetime_parser
-  : parser_base<cisco_short_datetime_parser> {
+struct cisco_short_datetime_parser : parser_base<cisco_short_datetime_parser> {
   using attribute = cisco_short_datetime;
 
   template <class Iterator, class Attribute>
@@ -952,8 +951,7 @@ struct cisco_legacy_message_parser : parser_base<cisco_legacy_message_parser> {
         auto save = it2;
         if (cisco_datetime_parser{}(it2, l, ts)) {
           out = fmt::format("{} {} {} {:02}:{:02}:{:02} {}", ts.year, ts.month,
-                            ts.day, ts.hour, ts.minute, ts.second,
-                            ts.timezone);
+                            ts.day, ts.hour, ts.minute, ts.second, ts.timezone);
           cursor = it2;
           return true;
         }
@@ -966,11 +964,10 @@ struct cisco_legacy_message_parser : parser_base<cisco_legacy_message_parser> {
           auto const subsecond = ts.subsecond.empty()
                                    ? std::string{}
                                    : fmt::format(".{}", ts.subsecond);
-          auto const timezone = ts.timezone ? fmt::format(" {}", *ts.timezone)
-                                            : std::string{};
+          auto const timezone
+            = ts.timezone ? fmt::format(" {}", *ts.timezone) : std::string{};
           out = fmt::format("{} {} {:02}:{:02}:{:02}{}{}", ts.month, ts.day,
-                            ts.hour, ts.minute, ts.second, subsecond,
-                            timezone);
+                            ts.hour, ts.minute, ts.second, subsecond, timezone);
           cursor = it2;
           return true;
         }
@@ -991,8 +988,7 @@ struct cisco_legacy_message_parser : parser_base<cisco_legacy_message_parser> {
         auto ts = cisco_uptime_short_datetime{};
         auto save = it2;
         if (cisco_uptime_short_datetime_parser{}(it2, l, ts)) {
-          out = fmt::format("{:02}:{:02}:{:02}", ts.hour, ts.minute,
-                            ts.second);
+          out = fmt::format("{:02}:{:02}:{:02}", ts.hour, ts.minute, ts.second);
           cursor = it2;
           return true;
         }

--- a/libtenzir/test/CMakeLists.txt
+++ b/libtenzir/test/CMakeLists.txt
@@ -25,7 +25,8 @@ TenzirTargetEnableTooling(tenzir-unit-test)
 target_link_libraries(
   tenzir-unit-test PRIVATE tenzir::test tenzir::libtenzir tenzir::internal
                            ${CMAKE_THREAD_LIBS_INIT})
-TenzirTargetLinkWholeArchive(tenzir-unit-test PRIVATE tenzir::libtenzir_builtins)
+TenzirTargetLinkWholeArchive(tenzir-unit-test PRIVATE
+                             tenzir::libtenzir_builtins)
 
 add_test(NAME build-tenzir-unit-test
          COMMAND "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" --config

--- a/nix/overrides/libnats-c.nix
+++ b/nix/overrides/libnats-c.nix
@@ -4,11 +4,9 @@
   stdenv,
 }:
 libnats-c.overrideAttrs (orig: {
-  cmakeFlags =
-    (orig.cmakeFlags or [ ])
-    ++ [
-      (lib.cmakeBool "NATS_BUILD_EXAMPLES" false)
-      (lib.cmakeBool "NATS_BUILD_LIB_SHARED" (!stdenv.hostPlatform.isStatic))
-      (lib.cmakeBool "NATS_BUILD_LIB_STATIC" stdenv.hostPlatform.isStatic)
-    ];
+  cmakeFlags = (orig.cmakeFlags or [ ]) ++ [
+    (lib.cmakeBool "NATS_BUILD_EXAMPLES" false)
+    (lib.cmakeBool "NATS_BUILD_LIB_SHARED" (!stdenv.hostPlatform.isStatic))
+    (lib.cmakeBool "NATS_BUILD_LIB_STATIC" stdenv.hostPlatform.isStatic)
+  ];
 })

--- a/nix/overrides/ngtcp2.nix
+++ b/nix/overrides/ngtcp2.nix
@@ -16,7 +16,12 @@ ngtcp2.overrideAttrs (orig: {
   # ngtcp2's CMake only looks for libev and nghttp3 when building examples.
   # nixpkgs still injects them for lib-only static builds, which leaks libev's
   # headers into downstream consumers.
-  buildInputs = lib.subtractLists (lib.optionals enableLibOnly [ libev nghttp3 ]) (orig.buildInputs or [ ]);
-  propagatedBuildInputs =
-    lib.subtractLists (lib.optionals enableLibOnly [ libev nghttp3 ]) (orig.propagatedBuildInputs or [ ]);
+  buildInputs = lib.subtractLists (lib.optionals enableLibOnly [
+    libev
+    nghttp3
+  ]) (orig.buildInputs or [ ]);
+  propagatedBuildInputs = lib.subtractLists (lib.optionals enableLibOnly [
+    libev
+    nghttp3
+  ]) (orig.propagatedBuildInputs or [ ]);
 })

--- a/nix/tenzir/plugins/source.nix
+++ b/nix/tenzir/plugins/source.nix
@@ -6,10 +6,12 @@ let
   source = builtins.fromJSON (builtins.readFile ./source.json);
   tenzir-plugins-tarball = import <nix/fetchurl.nix> source;
 in
-runCommand "tenzir-plugins-source" {
-  allowSubstitutes = false;
-  preferLocalBuild = true;
-} ''
-  mkdir -p $out
-  tar --strip-components=1 -C $out -xf ${tenzir-plugins-tarball}
-''
+runCommand "tenzir-plugins-source"
+  {
+    allowSubstitutes = false;
+    preferLocalBuild = true;
+  }
+  ''
+    mkdir -p $out
+    tar --strip-components=1 -C $out -xf ${tenzir-plugins-tarball}
+  ''

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -15,6 +15,14 @@
 
   # CMake
   programs.cmake-format.enable = true;
+  # treefmt-nix's default includes ["*.cmake", "CMakeLists.txt"] silently
+  # skip every nested CMakeLists.txt because patterns without wildcards
+  # are anchored at the project root.
+  programs.cmake-format.includes = [
+    "CMakeLists.txt"
+    "**/CMakeLists.txt"
+    "*.cmake"
+  ];
 
   # Markdown
   settings.formatter.markdownlint = {

--- a/plugins/clickhouse/CMakeLists.txt
+++ b/plugins/clickhouse/CMakeLists.txt
@@ -68,8 +68,7 @@ else ()
 
   set(DEBUG_DEPENDENCIES
       OFF
-      CACHE BOOL "Disable bundled clickhouse-cpp debug helper targets"
-      FORCE)
+      CACHE BOOL "Disable bundled clickhouse-cpp debug helper targets" FORCE)
   set(_build_shared_libs_before "${BUILD_SHARED_LIBS}")
   set(BUILD_SHARED_LIBS OFF)
   add_subdirectory(aux/clickhouse-cpp)

--- a/plugins/gcs/CMakeLists.txt
+++ b/plugins/gcs/CMakeLists.txt
@@ -7,9 +7,12 @@ project(
 
 find_package(Arrow QUIET REQUIRED CONFIG)
 if (NOT ARROW_GCS OR NOT ${ARROW_GCS} STREQUAL "ON")
-  message(WARNING "Disabling gcs plugin because the ARROW_GCS flag is not found/enabled. You probably need to enable ARROW_GCS when installing Apache Arrow.")
+  message(
+    WARNING
+      "Disabling gcs plugin because the ARROW_GCS flag is not found/enabled. You probably need to enable ARROW_GCS when installing Apache Arrow."
+  )
   return()
-endif()
+endif ()
 
 include(CTest)
 

--- a/plugins/google-cloud-pubsub/CMakeLists.txt
+++ b/plugins/google-cloud-pubsub/CMakeLists.txt
@@ -2,14 +2,17 @@ cmake_minimum_required(VERSION 3.30...4.0 FATAL_ERROR)
 
 project(
   google-cloud-pubsub
-   DESCRIPTION "Google Cloud Pub/Sub plugin for Tenzir"
+  DESCRIPTION "Google Cloud Pub/Sub plugin for Tenzir"
   LANGUAGES CXX)
 
 find_package(google_cloud_cpp_pubsub CONFIG)
 if (NOT google_cloud_cpp_pubsub_FOUND)
-  message(WARNING "Disabling Google Cloud Pub/Sub plugin because the google-could-cpp library was not found")
+  message(
+    WARNING
+      "Disabling Google Cloud Pub/Sub plugin because the google-could-cpp library was not found"
+  )
   return()
-endif()
+endif ()
 
 include(CTest)
 

--- a/plugins/nats/CMakeLists.txt
+++ b/plugins/nats/CMakeLists.txt
@@ -9,7 +9,8 @@ find_package(Threads REQUIRED)
 find_package(OpenSSL REQUIRED)
 find_package(cnats CONFIG QUIET)
 if (NOT cnats_FOUND)
-  message(WARNING "Disabling NATS plugin because the nats.c library was not found")
+  message(
+    WARNING "Disabling NATS plugin because the nats.c library was not found")
   return()
 endif ()
 if (TARGET cnats::nats)
@@ -62,6 +63,6 @@ TenzirRegisterPlugin(
   INCLUDE_DIRECTORIES include)
 
 target_link_libraries(nats PUBLIC ${nats_library})
-target_include_directories(nats BEFORE
-                           PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/compat/libevent2")
+target_include_directories(
+  nats BEFORE PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/compat/libevent2")
 target_link_libraries(nats PUBLIC PkgConfig::Libevent)

--- a/plugins/s3/CMakeLists.txt
+++ b/plugins/s3/CMakeLists.txt
@@ -7,14 +7,20 @@ project(
 
 find_package(Arrow QUIET REQUIRED CONFIG)
 if (NOT ARROW_S3)
-  message(WARNING "Disabling S3 plugin because the ARROW_S3 flag is not found/enabled. You probably need to enable ARROW_S3 when installing Apache Arrow.")
+  message(
+    WARNING
+      "Disabling S3 plugin because the ARROW_S3 flag is not found/enabled. You probably need to enable ARROW_S3 when installing Apache Arrow."
+  )
   return()
-endif()
+endif ()
 
 include(CTest)
 
 find_package(Tenzir REQUIRED)
-find_package(AWSSDK COMPONENTS s3 sts REQUIRED CONFIG)
+find_package(
+  AWSSDK
+  COMPONENTS s3 sts
+  REQUIRED CONFIG)
 
 TenzirRegisterPlugin(
   TARGET s3

--- a/plugins/sqs/CMakeLists.txt
+++ b/plugins/sqs/CMakeLists.txt
@@ -7,7 +7,10 @@ project(
 
 include(CTest)
 
-find_package(AWSSDK COMPONENTS sqs REQUIRED CONFIG)
+find_package(
+  AWSSDK
+  COMPONENTS sqs
+  REQUIRED CONFIG)
 find_package(Tenzir REQUIRED)
 
 TenzirRegisterPlugin(

--- a/plugins/web/aux/CMakeLists.txt
+++ b/plugins/web/aux/CMakeLists.txt
@@ -49,7 +49,9 @@ find_package(fmt REQUIRED)
 
 # Set CMAKE_CONFIGURATION_TYPES to bypass llhttp's build type validation
 set(CMAKE_CONFIGURATION_TYPES_BACKUP "${CMAKE_CONFIGURATION_TYPES}")
-set(CMAKE_CONFIGURATION_TYPES "${CMAKE_BUILD_TYPE}" CACHE STRING "" FORCE)
+set(CMAKE_CONFIGURATION_TYPES
+    "${CMAKE_BUILD_TYPE}"
+    CACHE STRING "" FORCE)
 # Force llhttp to build as static library to avoid runtime dependency issues
 set(BUILD_SHARED_LIBS_BACKUP "${BUILD_SHARED_LIBS}")
 set(BUILD_STATIC_LIBS_BACKUP "${BUILD_STATIC_LIBS}")
@@ -63,13 +65,14 @@ add_subdirectory(llhttp EXCLUDE_FROM_ALL)
 set(CMAKE_POSITION_INDEPENDENT_CODE "${CMAKE_POSITION_INDEPENDENT_CODE_BACKUP}")
 set(BUILD_SHARED_LIBS "${BUILD_SHARED_LIBS_BACKUP}")
 set(BUILD_STATIC_LIBS "${BUILD_STATIC_LIBS_BACKUP}")
-set(CMAKE_CONFIGURATION_TYPES "${CMAKE_CONFIGURATION_TYPES_BACKUP}" CACHE STRING "" FORCE)
+set(CMAKE_CONFIGURATION_TYPES
+    "${CMAKE_CONFIGURATION_TYPES_BACKUP}"
+    CACHE STRING "" FORCE)
 
 # Create an interface library for the modified restinio sources.
 target_include_directories(
   restinio INTERFACE "${CMAKE_CURRENT_BINARY_DIR}/patched-restinio")
-target_link_libraries(
-  restinio INTERFACE fmt::fmt Boost::headers OpenSSL::SSL OpenSSL::Crypto
-                     llhttp::llhttp)
+target_link_libraries(restinio INTERFACE fmt::fmt Boost::headers OpenSSL::SSL
+                                         OpenSSL::Crypto llhttp::llhttp)
 
 add_library(restinio::restinio ALIAS restinio)

--- a/plugins/yara/CMakeLists.txt
+++ b/plugins/yara/CMakeLists.txt
@@ -12,9 +12,7 @@ project(
 include(CTest)
 
 find_package(Tenzir REQUIRED)
-TenzirRegisterPlugin(
-  TARGET yara ENTRYPOINT src/plugin.cpp
-)
+TenzirRegisterPlugin(TARGET yara ENTRYPOINT src/plugin.cpp)
 
 find_package(PkgConfig REQUIRED QUIET)
 pkg_check_modules(yara REQUIRED IMPORTED_TARGET yara)

--- a/test/fixtures/mock_s3.py
+++ b/test/fixtures/mock_s3.py
@@ -163,9 +163,7 @@ class _Handler(BaseHTTPRequestHandler):
 
         if is_dir_marker:
             # Create the directory; do not write a file.
-            (self.state.data_dir / bucket / key).mkdir(
-                parents=True, exist_ok=True
-            )
+            (self.state.data_dir / bucket / key).mkdir(parents=True, exist_ok=True)
             self.send_response(200)
             self.end_headers()
             return
@@ -230,9 +228,9 @@ class _Handler(BaseHTTPRequestHandler):
                 resp = (
                     f'<?xml version="1.0"?>'
                     f"<CompleteMultipartUploadResult>"
-                    f'<Location>http://localhost/{upload["bucket"]}/{upload["key"]}</Location>'
-                    f'<Bucket>{upload["bucket"]}</Bucket>'
-                    f'<Key>{upload["key"]}</Key>'
+                    f"<Location>http://localhost/{upload['bucket']}/{upload['key']}</Location>"
+                    f"<Bucket>{upload['bucket']}</Bucket>"
+                    f"<Key>{upload['key']}</Key>"
                     f"</CompleteMultipartUploadResult>"
                 )
                 self.send_response(200)
@@ -302,18 +300,12 @@ def mock_s3() -> FixtureHandle:
             journal = {
                 "completed": list(state.completed),
                 "aborted": list(state.aborted),
-                "pending": {
-                    uid: info["key"]
-                    for uid, info in state.uploads.items()
-                },
+                "pending": {uid: info["key"] for uid, info in state.uploads.items()},
             }
         journal_path.write_text(json.dumps(journal, indent=2))
         if assertions.all_uploads_completed:
             with state.lock:
-                pending = {
-                    uid: info["key"]
-                    for uid, info in state.uploads.items()
-                }
+                pending = {uid: info["key"] for uid, info in state.uploads.items()}
                 aborted = list(state.aborted)
             problems = []
             if pending:
@@ -336,6 +328,7 @@ def mock_s3() -> FixtureHandle:
         server.shutdown()
         thread.join(timeout=5)
         import shutil
+
         shutil.rmtree(data_dir, ignore_errors=True)
         logger.info("mock_s3 shut down")
 

--- a/test/fixtures/s3_proxy.py
+++ b/test/fixtures/s3_proxy.py
@@ -147,7 +147,9 @@ def s3_fail_complete() -> FixtureHandle:
     """LocalStack behind a proxy that fails CompleteMultipartUpload."""
     runtime = detect_runtime()
     if runtime is None:
-        raise FixtureUnavailable("container runtime (docker/podman) required but not found")
+        raise FixtureUnavailable(
+            "container runtime (docker/podman) required but not found"
+        )
     upstream_port = find_free_port()
     container = _start_localstack(runtime, upstream_port)
     try:

--- a/test/tests/operators/to_amazon_security_lake/basic_write/01_partition_by_day.py
+++ b/test/tests/operators/to_amazon_security_lake/basic_write/01_partition_by_day.py
@@ -37,12 +37,12 @@ def main() -> None:
     )
     pipeline = (
         "from "
-        "{time: 2024-01-01T00:00:00, msg: \"a\"}, "
-        "{time: 2024-01-02T00:00:00, msg: \"b\"}, "
-        "{time: 2024-01-03T00:00:00, msg: \"c\"}\n"
+        '{time: 2024-01-01T00:00:00, msg: "a"}, '
+        '{time: 2024-01-02T00:00:00, msg: "b"}, '
+        '{time: 2024-01-03T00:00:00, msg: "c"}\n'
         f"to_amazon_security_lake {json.dumps(url)},\n"
-        "  region=\"us-east-1\",\n"
-        "  account_id=\"123456789012\",\n"
+        '  region="us-east-1",\n'
+        '  account_id="123456789012",\n'
         "  role=null"
     )
     # Disable IMDS to avoid the 7s hang on non-EC2 hosts (see SESSION.md).

--- a/test/tests/operators/to_amazon_security_lake/null_time/01_null_time_dropped.py
+++ b/test/tests/operators/to_amazon_security_lake/null_time/01_null_time_dropped.py
@@ -35,8 +35,8 @@ def main() -> None:
     pipeline = (
         "from {x: 1}, {x: 2}\n"
         f"to_amazon_security_lake {json.dumps(url)},\n"
-        "  region=\"us-east-1\",\n"
-        "  account_id=\"123456789012\",\n"
+        '  region="us-east-1",\n'
+        '  account_id="123456789012",\n'
         "  role=null"
     )
     env = os.environ.copy()

--- a/test/tests/operators/to_s3/close_failure_warning/01_warn_on_complete_multipart_error.py
+++ b/test/tests/operators/to_s3/close_failure_warning/01_warn_on_complete_multipart_error.py
@@ -67,7 +67,14 @@ def main() -> None:
         pipeline = Path(tmpdir) / "close_failure.tql"
         _write_pipeline(pipeline)
         result = subprocess.run(
-            [*tenzir, "--bare-mode", "--console-verbosity=warning", "--multi", "-f", str(pipeline)],
+            [
+                *tenzir,
+                "--bare-mode",
+                "--console-verbosity=warning",
+                "--multi",
+                "-f",
+                str(pipeline),
+            ],
             capture_output=True,
             text=True,
             timeout=180,

--- a/test/tests/operators/to_s3/uuid_in_query_warning/01_warn_uuid_in_query.py
+++ b/test/tests/operators/to_s3/uuid_in_query_warning/01_warn_uuid_in_query.py
@@ -38,10 +38,10 @@ def main() -> None:
         f"&tls_ca_file_path={{uuid}}"
     )
     pipeline = (
-        "from {msg: \"hello\"}\n"
-        f"to_s3 \"{url}\",\n"
-        "  aws_iam={access_key_id: \"test\", secret_access_key: \"test\","
-        " region: \"us-east-1\"} {\n"
+        'from {msg: "hello"}\n'
+        f'to_s3 "{url}",\n'
+        '  aws_iam={access_key_id: "test", secret_access_key: "test",'
+        ' region: "us-east-1"} {\n'
         "  write_ndjson\n"
         "}\n"
     )


### PR DESCRIPTION
Three related fixes to the style-check tooling that landed in #6156, plus a submodule bump that pulls in the matching cleanup in the plugins repo.

### Review

- The `nix/treefmt.nix` change (`657473b6585`) is the one with potential cross-cutting impact: previously CI silently never ran `cmake-format` against any nested `CMakeLists.txt`, so the third commit (`6b2f26f1974`) sweeps up the accumulated drift in eight `plugins/*/CMakeLists.txt` files plus `libtenzir/test/CMakeLists.txt`. The submodule bump (`fd05089304f`) pulls in the equivalent sweep for `contrib/tenzir-plugins` (tenzir/tenzir-plugins#541). The reformat commits are pure formatter output.
- The lefthook fix (`d791478020d`) bumps the pinned `ruff` version from `0.15.6` to `0.15.12` to match nixpkgs; please double-check that's still current when this lands.
- The lefthook fix also routes file-selection through a `git merge-base origin/main HEAD` diff, which assumes the default branch is named `main`. That matches our convention but worth a sanity check.
- This PR can't merge until tenzir/tenzir-plugins#541 is merged, because the submodule bump points at that PR's branch tip.

### Details

<details>
<summary>⁉️ Motivation</summary>

Tried to push a one-file branch and watched lefthook check 1158 unrelated C++ files. Pulled the thread and found three independent bugs:

- `lefthook.yml` uses `{push_files}`, which expands to every tracked file when the branch is new on the remote (remote SHA is `0000…`). Also feeds CMake template files to `clang-format` (which mangles `@VAR@`), doesn't exclude `libtenzir/aux/**` from formatting like treefmt does, and pins `ruff` one patch version behind nixpkgs/CI.
- `nix/treefmt.nix` accepts treefmt-nix's default `programs.cmake-format.includes`, which is `["*.cmake", "CMakeLists.txt"]`. Wildcard-free patterns are root-anchored in treefmt, so every nested `CMakeLists.txt` falls through with no formatter assigned. cmake-format has been a tree-wide no-op on most CMake files since the treefmt move.
- The actual drift this exposes: nine `CMakeLists.txt` files plus `libtenzir/include/tenzir/detail/syslog.hpp` (legacy from the pre-2026-05-11 diff-only `clang-format-diff.py` workflow), six Python files under `test/`, three Nix files, and one Markdown file in this repo, plus eight more files in `contrib/tenzir-plugins` covered by the companion PR.

</details>

<details>
<summary>🧪 Testing</summary>

- Simulated `git push` of a new branch with `0000…` remote SHA against the original `lefthook.yml`: 1158 files checked, 11.93s total.
- Same simulation against the fixed `lefthook.yml`: only the one actually-modified file is checked.
- `nix run .#format -- --fail-on-change` on the whole tree before the third commit: 12 files flagged. After: clean.
- The push that opened this PR itself exercised the lefthook fix end-to-end — all five checks completed in well under a second each.

</details>

<details>
<summary>📌 References</summary>

- tenzir/tenzir-plugins#541 — companion submodule PR with the equivalent reformat.
- #6156 *Move style checks to lefthook and treefmt* — introduced the affected config.
- #6054 *Disable treefmt checks in CI and restore regular style checks* — created the diff-only-checking window in which `syslog.hpp` slipped through.
- treefmt-nix `programs.cmake-format` upstream default is the source of the matching gap, worth fixing there too if anyone wants to send a patch.

</details>