### PR TITLE
Add diagnostics for HTTP retries

### DIFF
--- a/libtenzir/builtins/operators/from_http.cpp
+++ b/libtenzir/builtins/operators/from_http.cpp
@@ -94,8 +94,12 @@ struct FetchError {
   std::string message;
 };
 struct FetchDone {};
+struct RetryWarning {
+  std::string message;
+};
 
-using Message = variant<ResponseHeader, ResponseBody, FetchError, FetchDone>;
+using Message
+  = variant<ResponseHeader, ResponseBody, FetchError, FetchDone, RetryWarning>;
 using MessageQueue = folly::coro::BoundedQueue<Message>;
 
 // Builds a Proxygen request source, working around a bug in Proxygen's
@@ -533,12 +537,11 @@ auto fetch(folly::EventBase* evb, proxygen::URL url, RequestConfig request,
         }
         auto sess_params = proxygen::coro::HTTPClient::getSessionParams(
           config.request_timeout);
-        // Retry only on socket-level failures (connect refused, reset, …).
-        // HTTP-level errors (non-2xx) are not retried.
+        // Retry on socket-level failures and retryable HTTP status codes.
+        // A diagnostic warning is emitted before each retry attempt.
         auto emitted_messages = false;
-        co_await folly::coro::retryWithExponentialBackoff(
-          config.max_retry_count, config.retry_delay, config.retry_delay * 16,
-          0.0 /* no jitter */,
+        auto retries_done = uint32_t{0};
+        co_await folly::coro::retryWhen(
           [&]() -> Task<void> {
             emitted_messages = false;
             // Resolve DNS and establish the TCP connection.
@@ -625,24 +628,51 @@ auto fetch(folly::EventBase* evb, proxygen::URL url, RequestConfig request,
               throw std::move(*retryable_response);
             }
           },
-          [&](folly::exception_wrapper const& ew) {
+          [&](folly::exception_wrapper&& ew) -> Task<void> {
             // Once an attempt emitted response messages, do not retry.
             // Retrying after partial output can duplicate/corrupt downstream
             // parser and pagination state.
             if (emitted_messages) {
-              return false;
+              co_yield folly::coro::co_error(std::move(ew));
             }
+            auto retryable = false;
             if (ew.is_compatible_with<folly::AsyncSocketException>()) {
-              return true;
+              retryable = true;
             }
             if (ew.is_compatible_with<retryable_http_response>()) {
-              return true;
+              retryable = true;
             }
-            auto retryable_http_error = false;
             ew.with_exception([&](proxygen::coro::HTTPError const& err) {
-              retryable_http_error = http::is_retryable_http_error(err.code);
+              retryable = http::is_retryable_http_error(err.code);
             });
-            return retryable_http_error;
+            if (not retryable or retries_done >= config.max_retry_count) {
+              co_yield folly::coro::co_error(std::move(ew));
+            }
+            // Compute exponential backoff (same schedule as the previous
+            // retryWithExponentialBackoff call, no jitter).
+            auto delay = config.retry_delay;
+            auto const max_delay = config.retry_delay * 16;
+            for (auto i = uint32_t{0}; i < retries_done; ++i) {
+              delay *= 2;
+              if (delay > max_delay) {
+                delay = max_delay;
+                break;
+              }
+            }
+            // Build the retry reason string.
+            auto reason = std::string{"connection error"};
+            ew.with_exception([&](retryable_http_response const& e) {
+              reason = fmt::format("HTTP error {}", e.status_code);
+            });
+            // Emit a warning diagnostic before sleeping.
+            auto const delay_secs
+              = std::chrono::duration_cast<std::chrono::seconds>(delay);
+            co_await mq->enqueue(RetryWarning{
+              fmt::format("{}, attempt {}/{}, retrying after {}s", reason,
+                          retries_done + 1u, config.max_retry_count + 1u,
+                          delay_secs.count())});
+            co_await folly::coro::sleep(delay);
+            ++retries_done;
           });
       }());
       if (result.hasException()) {
@@ -792,6 +822,13 @@ public:
           .emit(ctx);
         pagination_.next_url = None{};
         lifecycle_ = Lifecycle::done;
+        co_return;
+      },
+      // --- RetryWarning ---
+      [&](RetryWarning warn) -> Task<void> {
+        diagnostic::warning("{}", warn.message)
+          .primary(args_.operator_location)
+          .emit(ctx);
         co_return;
       },
       // --- FetchDone ---

--- a/libtenzir/builtins/operators/to_http.cpp
+++ b/libtenzir/builtins/operators/to_http.cpp
@@ -102,6 +102,11 @@ public:
       config->connection_timeout = get_connection_timeout();
       config->max_retry_count = get_max_retry_count();
       config->retry_delay = get_retry_delay();
+      auto* dh = &ctx.dh();
+      auto loc = args_.operator_location;
+      config->on_retry = [dh, loc](std::string_view message) {
+        diagnostic::warning("{}", message).primary(loc).emit(*dh);
+      };
     }
     if (config.is_error()) {
       lifecycle_ = Lifecycle::done;

--- a/libtenzir/builtins/operators/to_opensearch2.cpp
+++ b/libtenzir/builtins/operators/to_opensearch2.cpp
@@ -257,13 +257,12 @@ public:
     if (tls_needed.is_error()) {
       co_return;
     }
-    auto* dh = &ctx.dh();
     auto loc = args_.operator_location;
     auto config = HttpPoolConfig{
       .tls = *tls_needed,
       .ssl_context = nullptr,
       .on_retry =
-        [dh, loc](std::string_view message) {
+        [dh = &ctx.dh(), loc](std::string_view message) {
           diagnostic::warning("{}", message).primary(loc).emit(*dh);
         },
     };

--- a/libtenzir/builtins/operators/to_opensearch2.cpp
+++ b/libtenzir/builtins/operators/to_opensearch2.cpp
@@ -257,9 +257,15 @@ public:
     if (tls_needed.is_error()) {
       co_return;
     }
+    auto* dh = &ctx.dh();
+    auto loc = args_.operator_location;
     auto config = HttpPoolConfig{
       .tls = *tls_needed,
       .ssl_context = nullptr,
+      .on_retry =
+        [dh, loc](std::string_view message) {
+          diagnostic::warning("{}", message).primary(loc).emit(*dh);
+        },
     };
     if (*tls_needed) {
       auto tls_opts = tls_options::from_optional(args_.tls);

--- a/libtenzir/include/tenzir/http_pool.hpp
+++ b/libtenzir/include/tenzir/http_pool.hpp
@@ -17,9 +17,11 @@
 
 #include <chrono>
 #include <cstdint>
+#include <functional>
 #include <map>
 #include <memory>
 #include <string>
+#include <string_view>
 
 namespace folly {
 class EventBase;
@@ -51,6 +53,8 @@ struct HttpPoolConfig {
   std::chrono::milliseconds connection_timeout = std::chrono::seconds{5};
   uint32_t max_retry_count = 0;
   std::chrono::milliseconds retry_delay = std::chrono::seconds{1};
+  /// callback invoked before each retry sleep with a preformatted message
+  std::function<void(std::string_view message)> on_retry;
 };
 
 /// Registers well-known system CA bundle paths for Proxygen HTTPS clients.

--- a/libtenzir/src/http.cpp
+++ b/libtenzir/src/http.cpp
@@ -246,6 +246,7 @@ auto make_http_pool_config(Option<located<data>> const& tls, std::string& url,
     .tls = tls_enabled,
     .ssl_context = nullptr,
     .request_timeout = request_timeout,
+    .on_retry = {},
   };
   if (tls_enabled) {
     auto tls_opts = tls_options::from_optional(tls, options);

--- a/libtenzir/src/http_pool.cpp
+++ b/libtenzir/src/http_pool.cpp
@@ -171,6 +171,7 @@ auto retry_request(HttpPoolConfig const& config, F&& f)
   auto attempt = uint32_t{0};
   while (true) {
     auto retry_after = Option<std::chrono::seconds>{};
+    auto retry_reason = std::string{};
     auto attempt_res
       = co_await async_try([&]() -> Task<proxygen::coro::HTTPClient::Response> {
           co_return co_await f();
@@ -179,13 +180,14 @@ auto retry_request(HttpPoolConfig const& config, F&& f)
       // got response
       proxygen::coro::HTTPClient::Response resp
         = std::move(attempt_res).unwrap();
+      auto const status = resp.headers->getStatusCode();
       if (attempt >= config.max_retry_count
-          or (not http::is_retryable_http_status(
-            resp.headers->getStatusCode()))) {
+          or not http::is_retryable_http_status(status)) {
         // not retryable
         co_return to_http_response(resp);
       }
-      // retryable
+      // retryable HTTP status
+      retry_reason = fmt::format("HTTP error {}", status);
       retry_after = parse_retry_after(
         resp.headers->getHeaders().getSingleOrEmpty("Retry-After"));
     } else {
@@ -202,10 +204,18 @@ auto retry_request(HttpPoolConfig const& config, F&& f)
         // will not retry, return error
         co_return Err{std::move(attempt_err).what().toStdString()};
       }
+      retry_reason = "connection error";
     }
-    // will retry, compute delay
+    // will retry, compute delay and notify caller
     auto delay = retry_delay_for_attempt(config, attempt, retry_after);
     ++attempt;
+    if (config.on_retry) {
+      auto const delay_secs
+        = std::chrono::duration_cast<std::chrono::seconds>(delay);
+      config.on_retry(
+        fmt::format("{}, attempt {}/{}, retrying after {}s", retry_reason,
+                    attempt, config.max_retry_count + 1u, delay_secs.count()));
+    }
     co_await folly::coro::sleep(delay);
   }
 }

--- a/test/tests/operators/from_http/error_field_retry_exhausted_503.txt
+++ b/test/tests/operators/from_http/error_field_retry_exhausted_503.txt
@@ -1,3 +1,9 @@
 {
   error: b"{\"error\":\"service-unavailable\"}\n",
 }
+warning: HTTP error 503, attempt 1/2, retrying after 0s
+  --> tests/operators/from_http/error_field_retry_exhausted_503.tql:11:1
+   |
+11 | from_http env("HTTP_FIXTURE_RETRY_EXHAUSTED_503_URL"), error_field=error, max_retry_count=1, retry_delay=1ms, tls=false { read_json }
+   | ~~~~~~~~~
+   |

--- a/test/tests/operators/from_http/error_field_retry_exhausted_503.txt
+++ b/test/tests/operators/from_http/error_field_retry_exhausted_503.txt
@@ -5,5 +5,5 @@ warning: HTTP error 503, attempt 1/2, retrying after 0s
   --> tests/operators/from_http/error_field_retry_exhausted_503.tql:11:1
    |
 11 | from_http env("HTTP_FIXTURE_RETRY_EXHAUSTED_503_URL"), error_field=error, max_retry_count=1, retry_delay=1ms, tls=false { read_json }
-   | ~~~~~~~~~
+   | ~~~~~~~~~ 
    |

--- a/test/tests/operators/from_http/retry_status_503.tql
+++ b/test/tests/operators/from_http/retry_status_503.tql
@@ -8,6 +8,6 @@ fixtures:
 timeout: 60
 ---
 
-from_http env("HTTP_FIXTURE_RETRY_503_URL"), max_retry_count=2, retry_delay=1ms {
+from_http env("HTTP_FIXTURE_RETRY_503_URL"), max_retry_count=2, retry_delay=1s {
   read_json
 }

--- a/test/tests/operators/from_http/retry_status_503.txt
+++ b/test/tests/operators/from_http/retry_status_503.txt
@@ -1,3 +1,16 @@
 {
   ok: true,
 }
+warning: HTTP error 503, attempt 1/3, retrying after 1s
+  --> tests/operators/from_http/retry_status_503.tql:11:1
+   |
+11 | from_http env("HTTP_FIXTURE_RETRY_503_URL"), max_retry_count=2, retry_delay=1s {
+   | ~~~~~~~~~
+   |
+
+warning: HTTP error 503, attempt 2/3, retrying after 2s
+  --> tests/operators/from_http/retry_status_503.tql:11:1
+   |
+11 | from_http env("HTTP_FIXTURE_RETRY_503_URL"), max_retry_count=2, retry_delay=1s {
+   | ~~~~~~~~~
+   |

--- a/test/tests/operators/from_http/retry_status_503.txt
+++ b/test/tests/operators/from_http/retry_status_503.txt
@@ -5,12 +5,12 @@ warning: HTTP error 503, attempt 1/3, retrying after 1s
   --> tests/operators/from_http/retry_status_503.tql:11:1
    |
 11 | from_http env("HTTP_FIXTURE_RETRY_503_URL"), max_retry_count=2, retry_delay=1s {
-   | ~~~~~~~~~
+   | ~~~~~~~~~ 
    |
 
 warning: HTTP error 503, attempt 2/3, retrying after 2s
   --> tests/operators/from_http/retry_status_503.tql:11:1
    |
 11 | from_http env("HTTP_FIXTURE_RETRY_503_URL"), max_retry_count=2, retry_delay=1s {
-   | ~~~~~~~~~
+   | ~~~~~~~~~ 
    |

--- a/test/tests/operators/from_http/retry_success.txt
+++ b/test/tests/operators/from_http/retry_success.txt
@@ -5,12 +5,12 @@ warning: connection error, attempt 1/3, retrying after 0s
  --> tests/operators/from_http/retry_success.tql:5:1
   |
 5 | from_http env("HTTP_FIXTURE_RETRY_FLAKY_URL"), max_retry_count=2, retry_delay=1ms, connection_timeout=200ms, tls=false { read_json }
-  | ~~~~~~~~~
+  | ~~~~~~~~~ 
   |
 
 warning: connection error, attempt 2/3, retrying after 0s
  --> tests/operators/from_http/retry_success.tql:5:1
   |
 5 | from_http env("HTTP_FIXTURE_RETRY_FLAKY_URL"), max_retry_count=2, retry_delay=1ms, connection_timeout=200ms, tls=false { read_json }
-  | ~~~~~~~~~
+  | ~~~~~~~~~ 
   |

--- a/test/tests/operators/from_http/retry_success.txt
+++ b/test/tests/operators/from_http/retry_success.txt
@@ -1,3 +1,16 @@
 {
   attempt: 3,
 }
+warning: connection error, attempt 1/3, retrying after 0s
+ --> tests/operators/from_http/retry_success.tql:5:1
+  |
+5 | from_http env("HTTP_FIXTURE_RETRY_FLAKY_URL"), max_retry_count=2, retry_delay=1ms, connection_timeout=200ms, tls=false { read_json }
+  | ~~~~~~~~~
+  |
+
+warning: connection error, attempt 2/3, retrying after 0s
+ --> tests/operators/from_http/retry_success.tql:5:1
+  |
+5 | from_http env("HTTP_FIXTURE_RETRY_FLAKY_URL"), max_retry_count=2, retry_delay=1ms, connection_timeout=200ms, tls=false { read_json }
+  | ~~~~~~~~~
+  |

--- a/test/tests/operators/to_http/options/retry_connection_error.tql
+++ b/test/tests/operators/to_http/options/retry_connection_error.tql
@@ -1,0 +1,14 @@
+---
+fixtures: [http_paginate]
+---
+
+from {
+  value: 42,
+}
+to_http env("HTTP_FIXTURE_RETRY_FLAKY_URL"),
+        max_retry_count=2,
+        retry_delay=1ms,
+        connection_timeout=200ms,
+        tls=false {
+  write_ndjson
+}

--- a/test/tests/operators/to_http/options/retry_connection_error.tql
+++ b/test/tests/operators/to_http/options/retry_connection_error.tql
@@ -6,8 +6,9 @@ from {
   value: 42,
 }
 to_http env("HTTP_FIXTURE_RETRY_FLAKY_URL"),
+        method="GET",
         max_retry_count=2,
-        retry_delay=1ms,
+        retry_delay=1s,
         connection_timeout=200ms,
         tls=false {
   write_ndjson

--- a/test/tests/operators/to_http/options/retry_connection_error.txt
+++ b/test/tests/operators/to_http/options/retry_connection_error.txt
@@ -1,0 +1,13 @@
+warning: connection error, attempt 1/3, retrying after 0s
+  --> tests/operators/to_http/options/retry_connection_error.tql:8:1
+   |
+ 8 | to_http env("HTTP_FIXTURE_RETRY_FLAKY_URL"),
+   | ~~~~~~~
+   |
+
+warning: connection error, attempt 2/3, retrying after 0s
+  --> tests/operators/to_http/options/retry_connection_error.tql:8:1
+   |
+ 8 | to_http env("HTTP_FIXTURE_RETRY_FLAKY_URL"),
+   | ~~~~~~~
+   |

--- a/test/tests/operators/to_http/options/retry_connection_error.txt
+++ b/test/tests/operators/to_http/options/retry_connection_error.txt
@@ -1,13 +1,13 @@
-warning: connection error, attempt 1/3, retrying after 0s
-  --> tests/operators/to_http/options/retry_connection_error.tql:8:1
-   |
- 8 | to_http env("HTTP_FIXTURE_RETRY_FLAKY_URL"),
-   | ~~~~~~~
-   |
+warning: connection error, attempt 1/3, retrying after 1s
+ --> tests/operators/to_http/options/retry_connection_error.tql:8:1
+  |
+8 | to_http env("HTTP_FIXTURE_RETRY_FLAKY_URL"),
+  | ~~~~~~~ 
+  |
 
-warning: connection error, attempt 2/3, retrying after 0s
-  --> tests/operators/to_http/options/retry_connection_error.tql:8:1
-   |
- 8 | to_http env("HTTP_FIXTURE_RETRY_FLAKY_URL"),
-   | ~~~~~~~
-   |
+warning: connection error, attempt 2/3, retrying after 2s
+ --> tests/operators/to_http/options/retry_connection_error.tql:8:1
+  |
+8 | to_http env("HTTP_FIXTURE_RETRY_FLAKY_URL"),
+  | ~~~~~~~ 
+  |

--- a/test/tests/operators/to_http/options/retry_status_429_retry_after.txt
+++ b/test/tests/operators/to_http/options/retry_status_429_retry_after.txt
@@ -1,0 +1,6 @@
+warning: HTTP error 429, attempt 1/2, retrying after 1s
+  --> tests/operators/to_http/options/retry_status_429_retry_after.tql:14:1
+   |
+14 | to_http env("HTTP_FIXTURE_RETRY_429_AFTER_URL"),
+   | ~~~~~~~
+   |

--- a/test/tests/operators/to_http/options/retry_status_429_retry_after.txt
+++ b/test/tests/operators/to_http/options/retry_status_429_retry_after.txt
@@ -2,5 +2,5 @@ warning: HTTP error 429, attempt 1/2, retrying after 1s
   --> tests/operators/to_http/options/retry_status_429_retry_after.tql:14:1
    |
 14 | to_http env("HTTP_FIXTURE_RETRY_429_AFTER_URL"),
-   | ~~~~~~~
+   | ~~~~~~~ 
    |

--- a/test/tests/operators/to_http/options/retry_status_503.txt
+++ b/test/tests/operators/to_http/options/retry_status_503.txt
@@ -2,12 +2,12 @@ warning: HTTP error 503, attempt 1/3, retrying after 0s
   --> tests/operators/to_http/options/retry_status_503.tql:14:1
    |
 14 | to_http env("HTTP_FIXTURE_RETRY_503_URL"),
-   | ~~~~~~~
+   | ~~~~~~~ 
    |
 
 warning: HTTP error 503, attempt 2/3, retrying after 0s
   --> tests/operators/to_http/options/retry_status_503.tql:14:1
    |
 14 | to_http env("HTTP_FIXTURE_RETRY_503_URL"),
-   | ~~~~~~~
+   | ~~~~~~~ 
    |

--- a/test/tests/operators/to_http/options/retry_status_503.txt
+++ b/test/tests/operators/to_http/options/retry_status_503.txt
@@ -1,0 +1,13 @@
+warning: HTTP error 503, attempt 1/3, retrying after 0s
+  --> tests/operators/to_http/options/retry_status_503.tql:14:1
+   |
+14 | to_http env("HTTP_FIXTURE_RETRY_503_URL"),
+   | ~~~~~~~
+   |
+
+warning: HTTP error 503, attempt 2/3, retrying after 0s
+  --> tests/operators/to_http/options/retry_status_503.tql:14:1
+   |
+14 | to_http env("HTTP_FIXTURE_RETRY_503_URL"),
+   | ~~~~~~~
+   |

--- a/test/tests/operators/to_http/options/retry_status_503_backoff.txt
+++ b/test/tests/operators/to_http/options/retry_status_503_backoff.txt
@@ -2,12 +2,12 @@ warning: HTTP error 503, attempt 1/3, retrying after 0s
   --> tests/operators/to_http/options/retry_status_503_backoff.tql:14:1
    |
 14 | to_http env("HTTP_FIXTURE_RETRY_503_BACKOFF_URL"),
-   | ~~~~~~~
+   | ~~~~~~~ 
    |
 
 warning: HTTP error 503, attempt 2/3, retrying after 1s
   --> tests/operators/to_http/options/retry_status_503_backoff.tql:14:1
    |
 14 | to_http env("HTTP_FIXTURE_RETRY_503_BACKOFF_URL"),
-   | ~~~~~~~
+   | ~~~~~~~ 
    |

--- a/test/tests/operators/to_http/options/retry_status_503_backoff.txt
+++ b/test/tests/operators/to_http/options/retry_status_503_backoff.txt
@@ -1,0 +1,13 @@
+warning: HTTP error 503, attempt 1/3, retrying after 0s
+  --> tests/operators/to_http/options/retry_status_503_backoff.tql:14:1
+   |
+14 | to_http env("HTTP_FIXTURE_RETRY_503_BACKOFF_URL"),
+   | ~~~~~~~
+   |
+
+warning: HTTP error 503, attempt 2/3, retrying after 1s
+  --> tests/operators/to_http/options/retry_status_503_backoff.tql:14:1
+   |
+14 | to_http env("HTTP_FIXTURE_RETRY_503_BACKOFF_URL"),
+   | ~~~~~~~
+   |


### PR DESCRIPTION
Emit operator warnings before HTTP client retries so users can see the
retry reason and backoff delay while pipelines keep running.

This adds retry diagnostics for from_http, to_http, and to_opensearch2,
and adds regression coverage for HTTP-status and transport retry paths.

Resolves TNZ-581
Docs PR: tenzir/docs#318
plugins-contrib PR: https://github.com/tenzir/tenzir-plugins/pull/540
