### PR TITLE
Honor Retry-After in from_http

### DIFF
--- a/libtenzir/builtins/operators/from_http.cpp
+++ b/libtenzir/builtins/operators/from_http.cpp
@@ -501,14 +501,17 @@ auto find_content_encoding(
 struct retryable_http_response : std::runtime_error {
   retryable_http_response(
     uint16_t status_code,
-    std::vector<std::pair<std::string, std::string>> headers)
+    std::vector<std::pair<std::string, std::string>> headers,
+    Option<std::chrono::seconds> retry_after)
     : std::runtime_error{fmt::format("retryable HTTP status {}", status_code)},
       status_code{status_code},
-      headers{std::move(headers)} {
+      headers{std::move(headers)},
+      retry_after{retry_after} {
   }
 
   uint16_t status_code = 0;
   std::vector<std::pair<std::string, std::string>> headers;
+  Option<std::chrono::seconds> retry_after;
   blob body;
 };
 
@@ -584,8 +587,10 @@ auto fetch(folly::EventBase* evb, proxygen::URL url, RequestConfig request,
                 });
                 auto status = msg->getStatusCode();
                 if (http::is_retryable_http_status(status)) {
-                  retryable_response
-                    = retryable_http_response{status, std::move(hdrs)};
+                  auto retry_after = http::parse_retry_after(
+                    msg->getHeaders().getSingleOrEmpty("Retry-After"));
+                  retryable_response = retryable_http_response{
+                    status, std::move(hdrs), retry_after};
                   if (not buffer_retryable_body) {
                     throw std::move(*retryable_response);
                   }
@@ -648,22 +653,14 @@ auto fetch(folly::EventBase* evb, proxygen::URL url, RequestConfig request,
             if (not retryable or retries_done >= config.max_retry_count) {
               co_yield folly::coro::co_error(std::move(ew));
             }
-            // Compute exponential backoff (same schedule as the previous
-            // retryWithExponentialBackoff call, no jitter).
-            auto delay = config.retry_delay;
-            auto const max_delay = config.retry_delay * 16;
-            for (auto i = uint32_t{0}; i < retries_done; ++i) {
-              delay *= 2;
-              if (delay > max_delay) {
-                delay = max_delay;
-                break;
-              }
-            }
-            // Build the retry reason string.
+            auto retry_after = Option<std::chrono::seconds>{};
             auto reason = std::string{"connection error"};
             ew.with_exception([&](retryable_http_response const& e) {
               reason = fmt::format("HTTP error {}", e.status_code);
+              retry_after = e.retry_after;
             });
+            auto delay = http::retry_delay_for_attempt(
+              config.retry_delay, retries_done, retry_after);
             // Emit a warning diagnostic before sleeping.
             auto const delay_secs
               = std::chrono::duration_cast<std::chrono::seconds>(delay);

--- a/libtenzir/include/tenzir/http.hpp
+++ b/libtenzir/include/tenzir/http.hpp
@@ -42,6 +42,13 @@ auto is_retryable_http_error(proxygen::coro::HTTPErrorCode code) -> bool;
 
 auto is_retryable_http_status(uint16_t status_code) -> bool;
 
+auto parse_retry_after(std::string_view value) -> Option<std::chrono::seconds>;
+
+auto retry_delay_for_attempt(std::chrono::milliseconds retry_delay,
+                             uint32_t attempt,
+                             Option<std::chrono::seconds> retry_after)
+  -> std::chrono::milliseconds;
+
 inline constexpr auto default_timeout = std::chrono::seconds{90};
 inline constexpr auto default_connection_timeout = std::chrono::seconds{5};
 inline constexpr auto default_max_retry_count = 5;

--- a/libtenzir/src/http.cpp
+++ b/libtenzir/src/http.cpp
@@ -16,11 +16,15 @@
 
 #include <boost/url/parse.hpp>
 #include <boost/url/url.hpp>
+#include <folly/portability/Time.h>
 #include <proxygen/lib/http/coro/HTTPError.h>
 
 #include <algorithm>
 #include <cctype>
+#include <charconv>
+#include <chrono>
 #include <cstdint>
+#include <ctime>
 #include <string_view>
 
 namespace tenzir::http {
@@ -38,6 +42,26 @@ auto is_retryable_http_status(uint16_t status_code) -> bool {
 
 namespace {
 
+using std::chrono::system_clock;
+
+/// Parses an HTTP date and returns a `system_clock` time point.
+auto parse_http_date(std::string_view value)
+  -> Option<system_clock::time_point> {
+  if (value.empty()) {
+    return None{};
+  }
+  auto tm = std::tm{};
+  auto parsed = std::string{value};
+  if (::strptime(parsed.c_str(), "%a, %d %b %Y %H:%M:%S GMT", &tm) != nullptr
+      or ::strptime(parsed.c_str(), "%a, %d-%b-%y %H:%M:%S GMT", &tm) != nullptr
+      or ::strptime(parsed.c_str(), "%a %b %d %H:%M:%S %Y", &tm) != nullptr) {
+    return system_clock::time_point{
+      std::chrono::seconds{int64_t{timegm(&tm)}},
+    };
+  }
+  return None{};
+}
+
 auto normalize_content_encoding(std::string_view encoding) -> std::string {
   auto result = std::string{detail::trim(encoding)};
   std::transform(result.begin(), result.end(), result.begin(), [](char c) {
@@ -46,6 +70,52 @@ auto normalize_content_encoding(std::string_view encoding) -> std::string {
   });
   return result;
 }
+
+} // namespace
+
+auto parse_retry_after(std::string_view value) -> Option<std::chrono::seconds> {
+  if (value.empty()) {
+    return None{};
+  }
+  auto seconds = uint64_t{};
+  auto* begin = value.data();
+  auto* end = value.data() + value.size();
+  if (auto [ptr, ec] = std::from_chars(begin, end, seconds);
+      ec == std::errc{} and ptr == end) {
+    return std::chrono::seconds{seconds};
+  }
+  auto retry_at = parse_http_date(value);
+  if (not retry_at) {
+    return None{};
+  }
+  auto now = system_clock::now();
+  return std::chrono::duration_cast<std::chrono::seconds>(
+    retry_at <= now ? system_clock::duration::zero() : *retry_at - now);
+}
+
+auto retry_delay_for_attempt(std::chrono::milliseconds retry_delay,
+                             uint32_t attempt,
+                             Option<std::chrono::seconds> retry_after)
+  -> std::chrono::milliseconds {
+  if (retry_after) {
+    return *retry_after;
+  }
+  auto delay = retry_delay;
+  auto max_delay = retry_delay * 16;
+  for (auto i = uint32_t{0}; i < attempt; ++i) {
+    auto next_delay = delay * 2;
+    if (next_delay <= delay) {
+      return max_delay;
+    }
+    delay = next_delay;
+    if (delay > max_delay) {
+      return max_delay;
+    }
+  }
+  return delay;
+}
+
+namespace {
 
 // Splits a raw HTTP Link header value into individual link-value items at
 // top-level commas (not inside <...> or quoted strings).

--- a/libtenzir/src/http_pool.cpp
+++ b/libtenzir/src/http_pool.cpp
@@ -16,7 +16,6 @@
 #include <folly/ScopeGuard.h>
 #include <folly/coro/Sleep.h>
 #include <folly/io/async/AsyncSocketException.h>
-#include <folly/portability/Time.h>
 #include <proxygen/lib/http/HTTPMethod.h>
 #include <proxygen/lib/http/coro/HTTPFixedSource.h>
 #include <proxygen/lib/http/coro/client/HTTPClient.h>
@@ -24,7 +23,6 @@
 #include <proxygen/lib/utils/URL.h>
 
 #include <algorithm>
-#include <charconv>
 #include <chrono>
 #include <filesystem>
 #include <mutex>
@@ -100,71 +98,6 @@ auto make_request_source(proxygen::URL const& host_url, std::string path,
   return source;
 }
 
-using std::chrono::system_clock;
-
-/// Parses an HTTP date and returns a `system_clock` time point.
-auto parse_http_date(std::string_view value)
-  -> Option<system_clock::time_point> {
-  if (value.empty()) {
-    return None{};
-  }
-  auto tm = std::tm{};
-  auto parsed = std::string{value};
-  if (::strptime(parsed.c_str(), "%a, %d %b %Y %H:%M:%S GMT", &tm) != nullptr
-      or ::strptime(parsed.c_str(), "%a, %d-%b-%y %H:%M:%S GMT", &tm) != nullptr
-      or ::strptime(parsed.c_str(), "%a %b %d %H:%M:%S %Y", &tm) != nullptr) {
-    return system_clock::time_point{
-      std::chrono::seconds{int64_t{timegm(&tm)}},
-    };
-  }
-  return None{};
-}
-
-auto parse_retry_after(std::string_view value) -> Option<std::chrono::seconds> {
-  if (value.empty()) {
-    return None{};
-  }
-  // try parse a number of seconds
-  auto seconds = uint64_t{};
-  auto* begin = value.data();
-  auto* end = value.data() + value.size();
-  if (auto [ptr, ec] = std::from_chars(begin, end, seconds);
-      ec == std::errc{} and ptr == end) {
-    return std::chrono::seconds{seconds};
-  }
-  // try parse as HTTP date
-  auto retry_at = parse_http_date(value);
-  if (not retry_at) {
-    return None{};
-  }
-  auto now = system_clock::now();
-  return std::chrono::duration_cast<std::chrono::seconds>(
-    retry_at <= now ? system_clock::duration::zero() : *retry_at - now);
-}
-
-auto retry_delay_for_attempt(HttpPoolConfig const& config, uint32_t attempt,
-                             Option<std::chrono::seconds> retry_after)
-  -> std::chrono::milliseconds {
-  if (retry_after) {
-    // explict Retry-After header
-    return *retry_after;
-  }
-  // exponential backoff with upper bound
-  auto delay = config.retry_delay;
-  auto max_delay = config.retry_delay * 16;
-  for (auto i = uint32_t{0}; i < attempt; ++i) {
-    auto next_delay = delay * 2;
-    if (next_delay <= delay) {
-      return max_delay;
-    }
-    delay = next_delay;
-    if (delay > max_delay) {
-      return max_delay;
-    }
-  }
-  return delay;
-}
-
 template <class F>
 auto retry_request(HttpPoolConfig const& config, F&& f)
   -> Task<Result<HttpResponse, std::string>> {
@@ -188,7 +121,7 @@ auto retry_request(HttpPoolConfig const& config, F&& f)
       }
       // retryable HTTP status
       retry_reason = fmt::format("HTTP error {}", status);
-      retry_after = parse_retry_after(
+      retry_after = http::parse_retry_after(
         resp.headers->getHeaders().getSingleOrEmpty("Retry-After"));
     } else {
       // transport error
@@ -207,7 +140,8 @@ auto retry_request(HttpPoolConfig const& config, F&& f)
       retry_reason = "connection error";
     }
     // will retry, compute delay and notify caller
-    auto delay = retry_delay_for_attempt(config, attempt, retry_after);
+    auto delay
+      = http::retry_delay_for_attempt(config.retry_delay, attempt, retry_after);
     ++attempt;
     if (config.on_retry) {
       auto const delay_secs

--- a/test/tests/operators/from_http/retry_status_429_retry_after.tql
+++ b/test/tests/operators/from_http/retry_status_429_retry_after.tql
@@ -1,0 +1,13 @@
+---
+fixtures:
+  - http_server:
+      expected_request:
+        count: 2
+        method: GET
+        path: /status/retry-429-after
+timeout: 60
+---
+
+from_http env("HTTP_FIXTURE_RETRY_429_AFTER_URL"), max_retry_count=1, retry_delay=1ms {
+  read_json
+}

--- a/test/tests/operators/from_http/retry_status_429_retry_after.txt
+++ b/test/tests/operators/from_http/retry_status_429_retry_after.txt
@@ -1,0 +1,9 @@
+{
+  ok: true,
+}
+warning: HTTP error 429, attempt 1/2, retrying after 1s
+  --> tests/operators/from_http/retry_status_429_retry_after.tql:11:1
+   |
+11 | from_http env("HTTP_FIXTURE_RETRY_429_AFTER_URL"), max_retry_count=1, retry_delay=1ms {
+   | ~~~~~~~~~ 
+   |


### PR DESCRIPTION
## 🔍 Problem

- `from_http` still ignores `Retry-After` on retryable HTTP responses.

## 🛠️ Solution

- Reuse the shared `Retry-After` parsing and backoff helpers in `from_http`.
- Carry the parsed retry delay through the retryable response path.
- Add regression coverage for `429` with `Retry-After`.

## 💬 Review

- Focus on the `from_http` retry path and the extracted HTTP retry-delay helpers.
- This PR is stacked on top of tenzir/tenzir#6172.
- I did not run tests locally because this checkout has no configured build.

<sub>
📎 Related: tenzir/tenzir#6172
</br>
Resolves TNZ-590
</sub>
