### PR TITLE
Fix changelog PR metadata

### DIFF
--- a/changelog/releases/v5.22.0/entries/parent-truth-cotton.md
+++ b/changelog/releases/v5.22.0/entries/parent-truth-cotton.md
@@ -3,7 +3,10 @@ title: "Run pipelines with uvx tenzir"
 type: feature
 author: tobim
 created: 2025-10-27T19:05:00Z
-pr: 5482, 5588, 5589
+prs:
+  - 5482
+  - 5588
+  - 5589
 ---
 
 The `tenzir` binary is now bundled directly with the `tenzir` Python wheel.


### PR DESCRIPTION
## 🔍 Problem

- One changelog entry used `pr` with multiple values, which does not match the changelog schema.

## 🛠️ Solution

- Switch the entry to the multi-value `prs` field.

## 💬 Review

- Internal changelog metadata fix only.