### PR TITLE
Remove obsolete Pi formatter config

### DIFF
--- a/.pi/npm/.gitignore
+++ b/.pi/npm/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,5 +1,0 @@
-{
-  "packages": [
-    "npm:pi-formatter"
-  ]
-}


### PR DESCRIPTION
## 🔍 Problem

- `.pi` still configures `pi-formatter`, but formatting now runs through pre-push hooks.
- Keeping the old Pi package config around makes the formatter setup look split across two systems.

## 🛠️ Solution

- Remove the obsolete Pi formatter configuration.

## 💬 Review

- This is intentionally limited to deleting the stale `.pi` setup.
- No changelog entry: internal tooling cleanup only.
