### PR TITLE
Restore Elasticsearch operator aliases

### DIFF
--- a/libtenzir/builtins/operators/accept_opensearch.cpp
+++ b/libtenzir/builtins/operators/accept_opensearch.cpp
@@ -598,7 +598,7 @@ private:
   mutable Arc<MessageQueue> message_queue_{std::in_place, uint32_t{64}};
 };
 
-class AcceptOpenSearchPlugin final : public virtual OperatorPlugin {
+class AcceptOpenSearchPlugin : public virtual OperatorPlugin {
 public:
   auto name() const -> std::string override {
     return "accept_opensearch";
@@ -639,9 +639,18 @@ public:
   }
 };
 
+class AcceptElasticsearchPlugin final : public AcceptOpenSearchPlugin {
+public:
+  auto name() const -> std::string override {
+    return "accept_elasticsearch";
+  }
+};
+
 } // namespace
 
 } // namespace tenzir::plugins::accept_opensearch
 
 TENZIR_REGISTER_PLUGIN(
   tenzir::plugins::accept_opensearch::AcceptOpenSearchPlugin)
+TENZIR_REGISTER_PLUGIN(
+  tenzir::plugins::accept_opensearch::AcceptElasticsearchPlugin)

--- a/libtenzir/builtins/operators/to_opensearch2.cpp
+++ b/libtenzir/builtins/operators/to_opensearch2.cpp
@@ -479,7 +479,7 @@ private:
   mutable Box<Notify> buffer_ready_{std::in_place};
 };
 
-class ToOpenSearchPlugin final : public virtual OperatorPlugin {
+class ToOpenSearchPlugin : public virtual OperatorPlugin {
 public:
   auto name() const -> std::string override {
     return "tql2.to_opensearch";
@@ -525,7 +525,15 @@ public:
   }
 };
 
+class ToElasticsearchPlugin final : public ToOpenSearchPlugin {
+public:
+  auto name() const -> std::string override {
+    return "tql2.to_elasticsearch";
+  }
+};
+
 } // namespace
 } // namespace tenzir::plugins::opensearch2
 
 TENZIR_REGISTER_PLUGIN(tenzir::plugins::opensearch2::ToOpenSearchPlugin)
+TENZIR_REGISTER_PLUGIN(tenzir::plugins::opensearch2::ToElasticsearchPlugin)

--- a/test/tests/operators/plugins/elasticsearch_aliases.tql
+++ b/test/tests/operators/plugins/elasticsearch_aliases.tql
@@ -1,0 +1,4 @@
+plugins
+where name in ["accept_elasticsearch", "tql2.to_elasticsearch"]
+sort name
+select name

--- a/test/tests/operators/plugins/elasticsearch_aliases.txt
+++ b/test/tests/operators/plugins/elasticsearch_aliases.txt
@@ -1,0 +1,6 @@
+{
+  name: "accept_elasticsearch",
+}
+{
+  name: "tql2.to_elasticsearch",
+}


### PR DESCRIPTION
## 🔍 Problem

- The port to the neo executor dropped the `accept_elasticsearch` and `to_elasticsearch` operator names.
- Existing Elasticsearch-oriented pipelines could no longer use those aliases.

## 🛠️ Solution

- Register alias plugins that reuse the OpenSearch operator implementations and describers.
- Add a single plugin-registry smoke test for the restored names.

## 💬 Review

- Check the alias registration pattern and the exposed operator names.

<sub>
📚 Docs PR: tenzir/docs#334
</sub>