### PR TITLE
Add request records for from_http pagination

### DIFF
--- a/.github/workflows/tenzir.yaml
+++ b/.github/workflows/tenzir.yaml
@@ -1298,9 +1298,7 @@ jobs:
       - update-homebrew-tap
       # TODO: Re-enable this after v4.26 was released.
       # - regression-tests
-      # TODO: Re-enable this when homebrew is fixed (aws-sdk-cpp issue).
-      # See: https://github.com/apache/arrow/issues/49347
-      # - tenzir
+      - tenzir
       - tenzir-static-arm64-darwin
       - tenzir-static-aarch64-linux
       - tenzir-static-x86_64-linux

--- a/changelog/unreleased/from-http-pagination-request-records.md
+++ b/changelog/unreleased/from-http-pagination-request-records.md
@@ -1,0 +1,31 @@
+---
+title: Request records for `from_http` pagination
+type: feature
+authors:
+  - mavam
+  - codex
+created: 2026-05-17T13:45:00Z
+---
+
+The `from_http` operator now supports returning request records from
+`paginate` lambdas. This lets APIs keep pagination state in the next request
+body or headers instead of only in the next URL:
+
+```tql
+from_http "https://opensearch.example.com/logs/_search",
+  method="post",
+  body={size: 500, query: {match_all: {}}},
+  paginate=(x => {
+    body: {
+      size: 500,
+      query: {match_all: {}},
+      search_after: x.hits.hits[-1].sort,
+    },
+  } if x.hits.hits != []) {
+  read_json
+}
+```
+
+Returned request records can patch `url`, `method`, `headers`, and `body`.
+Missing fields inherit from the current request, and `body: null` clears the
+body.

--- a/libtenzir/builtins/connectors/curl.cpp
+++ b/libtenzir/builtins/connectors/curl.cpp
@@ -64,17 +64,17 @@ struct connector_args {
 };
 
 auto make_items_wo_secrets(const connector_args& args, diagnostic_handler& dh)
-  -> std::vector<http::request_item> {
-  auto items = std::vector<http::request_item>{};
+  -> std::vector<http::RequestItem> {
+  auto items = std::vector<http::RequestItem>{};
   for (auto& [key, value] : args.http_opts.body.inner) {
     auto str = to_json(value);
     TENZIR_ASSERT(str);
-    items.emplace_back(tenzir::http::request_item::data_json, std::move(key),
+    items.emplace_back(tenzir::http::RequestItem::data_json, std::move(key),
                        std::move(*str));
   }
   for (auto& [key, value] : args.http_opts.params.inner) {
     if (auto* str = try_as<std::string>(value)) {
-      items.emplace_back(tenzir::http::request_item::url_param, std::move(key),
+      items.emplace_back(tenzir::http::RequestItem::url_param, std::move(key),
                          std::move(*str));
       continue;
     }
@@ -89,7 +89,7 @@ auto make_items_wo_secrets(const connector_args& args, diagnostic_handler& dh)
   }
   for (auto& [key, value] : args.http_opts.headers.inner) {
     if (auto* str = try_as<std::string>(value)) {
-      items.emplace_back(tenzir::http::request_item::header, std::move(key),
+      items.emplace_back(tenzir::http::RequestItem::header, std::move(key),
                          std::move(*str));
       continue;
     }
@@ -106,9 +106,9 @@ auto make_items_wo_secrets(const connector_args& args, diagnostic_handler& dh)
 }
 
 auto make_request(const connector_args& args, std::string_view url,
-                  std::vector<http::request_item> items)
-  -> caf::expected<http::request> {
-  auto result = http::request{};
+                  std::vector<http::RequestItem> items)
+  -> caf::expected<http::Request> {
+  auto result = http::Request{};
   // Set URL.
   result.uri = url;
   // Set method.
@@ -136,9 +136,9 @@ auto make_request(const connector_args& args, std::string_view url,
 }
 
 auto make_record_param_request(std::string name,
-                               http::request_item::item_type type,
+                               http::RequestItem::ItemType type,
                                const located<record>& r,
-                               std::vector<http::request_item>& items,
+                               std::vector<http::RequestItem>& items,
                                diagnostic_handler& dh) {
   return make_secret_request(
     r.inner, r.source,
@@ -172,9 +172,9 @@ public:
       ctrl,
       {
         make_secret_request("url", args_.url, url, dh),
-        make_record_param_request("parameter", http::request_item::url_param,
+        make_record_param_request("parameter", http::RequestItem::url_param,
                                   args_.http_opts.params, items, dh),
-        make_record_param_request("header", http::request_item::header,
+        make_record_param_request("header", http::RequestItem::header,
                                   args_.http_opts.headers, items, dh),
       });
     co_yield std::move(x);
@@ -284,9 +284,9 @@ public:
       ctrl,
       {
         make_secret_request("url", args_.url, url, dh),
-        make_record_param_request("parameter", http::request_item::url_param,
+        make_record_param_request("parameter", http::RequestItem::url_param,
                                   args_.http_opts.params, items, dh),
-        make_record_param_request("header", http::request_item::header,
+        make_record_param_request("header", http::RequestItem::header,
                                   args_.http_opts.headers, items, dh),
       });
     co_yield std::move(x);

--- a/libtenzir/builtins/operators/from_http.cpp
+++ b/libtenzir/builtins/operators/from_http.cpp
@@ -413,6 +413,23 @@ struct NextRequest {
   RequestConfig request;
 };
 
+struct PaginationState {
+  Option<pagination_spec> spec;
+  int64_t page_count = 0;
+  std::string current_url;
+  RequestConfig current_request;
+  Option<NextRequest> next_request;
+  bool odata_envelope_seen = false;
+};
+
+struct PaginationRequestContext {
+  pagination_spec const& spec;
+  std::string const& current_url;
+  RequestConfig const& current_request;
+  std::vector<std::pair<std::string, std::string>> const& paginated_headers;
+  Option<located<std::string>> const& encode;
+};
+
 auto emit_paginate_record_warning(std::string message, location paginate_loc,
                                   diagnostic_handler& dh) -> void {
   diagnostic::warning("{}", message)
@@ -426,35 +443,35 @@ auto is_paginate_request_field(std::string_view field) -> bool {
          or field == "body";
 }
 
-auto next_request_from_record(record const& patch, std::string const& base_url,
-                              RequestConfig const& current_request,
-                              Option<located<std::string>> const& encode,
-                              location paginate_loc, diagnostic_handler& dh)
-  -> Option<NextRequest> {
+auto next_request_from_record(record const& patch,
+                              PaginationRequestContext const& context,
+                              diagnostic_handler& dh) -> Option<NextRequest> {
   if (patch.empty()) {
     emit_paginate_record_warning("`paginate` request record must not be empty",
-                                 paginate_loc, dh);
+                                 context.spec.source, dh);
     return None{};
   }
   for (auto const& [field, _] : patch) {
     if (not is_paginate_request_field(field)) {
       emit_paginate_record_warning(
         fmt::format("unknown field `{}` in `paginate` request record", field),
-        paginate_loc, dh);
+        context.spec.source, dh);
       return None{};
     }
   }
-  auto url = base_url;
-  auto request = current_request;
+  auto url = context.current_url;
+  auto request = context.current_request;
   if (auto it = patch.find("url"); it != patch.end()) {
     auto const* next_url = try_as<std::string>(&it->second);
     if (not next_url) {
-      emit_paginate_record_warning(
-        "`paginate` request field `url` must be `string`", paginate_loc, dh);
+      emit_paginate_record_warning("`paginate` request field `url` must be "
+                                   "`string`",
+                                   context.spec.source, dh);
       return None{};
     }
-    if (auto resolved = resolve_next_url(*next_url, base_url, paginate_loc, dh,
-                                         NextUrlSource::paginate_lambda)) {
+    if (auto resolved
+        = resolve_next_url(*next_url, context.current_url, context.spec.source,
+                           dh, NextUrlSource::paginate_lambda)) {
       url = std::move(*resolved);
     } else {
       return None{};
@@ -463,8 +480,9 @@ auto next_request_from_record(record const& patch, std::string const& base_url,
   if (auto it = patch.find("method"); it != patch.end()) {
     auto const* method_str = try_as<std::string>(&it->second);
     if (not method_str) {
-      emit_paginate_record_warning(
-        "`paginate` request field `method` must be `string`", paginate_loc, dh);
+      emit_paginate_record_warning("`paginate` request field `method` must be "
+                                   "`string`",
+                                   context.spec.source, dh);
       return None{};
     }
     auto method = parse_http_method(*method_str);
@@ -472,7 +490,7 @@ auto next_request_from_record(record const& patch, std::string const& base_url,
       emit_paginate_record_warning(
         fmt::format("invalid HTTP method in `paginate` request record: `{}`",
                     *method_str),
-        paginate_loc, dh);
+        context.spec.source, dh);
       return None{};
     }
     request.method = *method;
@@ -480,7 +498,7 @@ auto next_request_from_record(record const& patch, std::string const& base_url,
   if (auto it = patch.find("body"); it != patch.end()) {
     if (is<caf::none_t>(it->second)) {
       request.body.clear();
-    } else if (auto serialized = serialize_body(it->second, encode)) {
+    } else if (auto serialized = serialize_body(it->second, context.encode)) {
       request.body = std::move(serialized->body);
       add_default_content_type(request.headers,
                                std::move(serialized->content_type));
@@ -488,7 +506,7 @@ auto next_request_from_record(record const& patch, std::string const& base_url,
       emit_paginate_record_warning("`paginate` request field `body` must be "
                                    "`blob`, `record`, `string`, "
                                    "or `null`",
-                                   paginate_loc, dh);
+                                   context.spec.source, dh);
       return None{};
     }
   }
@@ -497,7 +515,7 @@ auto next_request_from_record(record const& patch, std::string const& base_url,
     if (not headers) {
       emit_paginate_record_warning("`paginate` request field `headers` must be "
                                    "`record`",
-                                   paginate_loc, dh);
+                                   context.spec.source, dh);
       return None{};
     }
     for (auto const& [name, value] : *headers) {
@@ -508,7 +526,7 @@ auto next_request_from_record(record const& patch, std::string const& base_url,
       } else {
         emit_paginate_record_warning("`paginate` request header values must be "
                                      "`string` or `null`",
-                                     paginate_loc, dh);
+                                     context.spec.source, dh);
         return None{};
       }
     }
@@ -516,36 +534,30 @@ auto next_request_from_record(record const& patch, std::string const& base_url,
   return NextRequest{.url = std::move(url), .request = std::move(request)};
 }
 
-auto next_request_from_url(
-  std::string_view url, std::string const& base_url,
-  std::vector<std::pair<std::string, std::string>> const& headers,
-  location paginate_loc, diagnostic_handler& dh) -> Option<NextRequest> {
-  if (auto resolved = resolve_next_url(url, base_url, paginate_loc, dh,
-                                       NextUrlSource::paginate_lambda)) {
+auto next_request_from_url(std::string_view url,
+                           PaginationRequestContext const& context,
+                           diagnostic_handler& dh) -> Option<NextRequest> {
+  if (auto resolved
+      = resolve_next_url(url, context.current_url, context.spec.source, dh,
+                         NextUrlSource::paginate_lambda)) {
     return NextRequest{
       .url = std::move(*resolved),
-      .request = make_paginated_request_config(headers),
+      .request = make_paginated_request_config(context.paginated_headers),
     };
   }
   return None{};
 }
 
-auto next_request_from_lambda(
-  Option<pagination_spec> const& paginate, table_slice const& slice,
-  std::string const& base_url, RequestConfig const& current_request,
-  std::vector<std::pair<std::string, std::string>> const& paginated_headers,
-  Option<located<std::string>> const& encode, diagnostic_handler& dh)
+auto next_request_from_lambda(PaginationRequestContext const& context,
+                              table_slice const& slice, diagnostic_handler& dh)
   -> Option<NextRequest> {
-  if (not paginate) {
-    return None{};
-  }
-  auto const* lambda = try_as<ast::lambda_expr>(&paginate->inner);
+  auto const* lambda = try_as<ast::lambda_expr>(&context.spec.inner);
   if (not lambda) {
     return None{};
   }
   if (slice.rows() != 1) {
     diagnostic::warning("cannot paginate over multiple events")
-      .primary(*paginate)
+      .primary(context.spec)
       .note("stopping pagination")
       .emit(dh);
     return None{};
@@ -558,19 +570,16 @@ auto next_request_from_lambda(
       return None{};
     },
     [&](std::string_view url) -> Option<NextRequest> {
-      return next_request_from_url(url, base_url, paginated_headers,
-                                   paginate->source, dh);
+      return next_request_from_url(url, context, dh);
     },
     [&](view3<record> req) -> Option<NextRequest> {
-      return next_request_from_record(materialize(req), base_url,
-                                      current_request, encode, paginate->source,
-                                      dh);
+      return next_request_from_record(materialize(req), context, dh);
     },
     [&](auto const&) -> Option<NextRequest> {
       diagnostic::error("expected `paginate` to be `string`, `record`, or "
                         "`null`, got `{}`",
                         ms.parts().front().type.kind())
-        .primary(*paginate)
+        .primary(context.spec)
         .emit(dh);
       return None{};
     });
@@ -622,12 +631,6 @@ auto make_fetch_config(FromHttpArgs const& args) -> FetchConfig {
   }
   return config;
 }
-
-struct PaginationState {
-  int64_t page_count = 0;
-  std::string current_url;
-  Option<NextRequest> next_request;
-};
 
 struct ResponseState {
   uint16_t status;
@@ -896,7 +899,7 @@ public:
       lifecycle_ = Lifecycle::done;
       co_return;
     }
-    paginate_ = std::move(*paginate);
+    pagination_.spec = std::move(*paginate);
     // resolve secrets
     std::string resolved_url;
     auto secret_resolution = co_await resolve_http_secrets(
@@ -910,8 +913,8 @@ public:
     fetch_config_ = make_fetch_config(args_);
     // ensure system CA paths are registered
     ensure_http_default_ca_paths();
-    current_request_ = make_request_config(args_, resolved_headers_);
-    co_await start_fetch(ctx, current_request_);
+    pagination_.current_request = make_request_config(args_, resolved_headers_);
+    co_await start_fetch(ctx, pagination_.current_request);
   }
 
   auto await_task(diagnostic_handler&) const -> Task<Any> override {
@@ -954,13 +957,13 @@ public:
           if (lifecycle_ == Lifecycle::done) {
             co_return;
           }
-          if (auto mode = builtin_pagination_mode(paginate_);
+          if (auto mode = builtin_pagination_mode(pagination_.spec);
               mode and *mode == http::PaginationMode::link) {
-            TENZIR_ASSERT(paginate_);
+            TENZIR_ASSERT(pagination_.spec);
             // Extract the rel=next URL for link pagination.
             if (auto next_url = http::next_url_from_link_headers(
                   response_->headers, pagination_.current_url,
-                  paginate_->source, ctx.dh())) {
+                  pagination_.spec->source, ctx.dh())) {
               pagination_.next_request = NextRequest{
                 .url = std::move(*next_url),
                 .request = make_paginated_request_config(resolved_headers_),
@@ -1047,19 +1050,21 @@ public:
 
   auto process_sub(SubKeyView, table_slice slice, Push<table_slice>& push,
                    OpCtx& ctx) -> Task<void> override {
-    if (auto mode = builtin_pagination_mode(paginate_);
+    if (auto mode = builtin_pagination_mode(pagination_.spec);
         mode and *mode == http::PaginationMode::odata) {
-      TENZIR_ASSERT(paginate_);
-      auto page = http::extract_odata_page(slice, paginate_->source, ctx.dh());
+      TENZIR_ASSERT(pagination_.spec);
+      auto page
+        = http::extract_odata_page(slice, pagination_.spec->source, ctx.dh());
       if (not page) {
         lifecycle_ = Lifecycle::done;
         co_return;
       }
-      odata_envelope_seen_ = true;
+      pagination_.odata_envelope_seen = true;
       if (page->next_url) {
-        if (auto next_url = resolve_next_url(
-              *page->next_url, pagination_.current_url, paginate_->source,
-              ctx.dh(), NextUrlSource::odata_next_link)) {
+        if (auto next_url
+            = resolve_next_url(*page->next_url, pagination_.current_url,
+                               pagination_.spec->source, ctx.dh(),
+                               NextUrlSource::odata_next_link)) {
           pagination_.next_request = NextRequest{
             .url = std::move(*next_url),
             .request = make_paginated_request_config(resolved_headers_),
@@ -1071,10 +1076,15 @@ public:
       }
       co_return;
     }
-    if (not pagination_.next_request) {
-      if (auto next = next_request_from_lambda(
-            paginate_, slice, pagination_.current_url, current_request_,
-            resolved_headers_, args_.encode, ctx.dh())) {
+    if (not pagination_.next_request and pagination_.spec) {
+      auto context = PaginationRequestContext{
+        .spec = *pagination_.spec,
+        .current_url = pagination_.current_url,
+        .current_request = pagination_.current_request,
+        .paginated_headers = resolved_headers_,
+        .encode = args_.encode,
+      };
+      if (auto next = next_request_from_lambda(context, slice, ctx.dh())) {
         pagination_.next_request = std::move(*next);
       }
     }
@@ -1083,14 +1093,14 @@ public:
 
   auto finish_sub(SubKeyView, Push<table_slice>&, OpCtx& ctx)
     -> Task<void> override {
-    if (auto mode = builtin_pagination_mode(paginate_);
+    if (auto mode = builtin_pagination_mode(pagination_.spec);
         mode and *mode == http::PaginationMode::odata
-        and not odata_envelope_seen_ and response_
+        and not pagination_.odata_envelope_seen and response_
         and response_->is_success()) {
-      TENZIR_ASSERT(paginate_);
+      TENZIR_ASSERT(pagination_.spec);
       diagnostic::error(
         "expected OData response body to contain a top-level `value` array")
-        .primary(paginate_->source)
+        .primary(pagination_.spec->source)
         .emit(ctx);
       lifecycle_ = Lifecycle::done;
       co_return;
@@ -1099,7 +1109,7 @@ public:
       // next page
       auto next = std::move(*pagination_.next_request);
       pagination_.current_url = std::move(next.url);
-      current_request_ = std::move(next.request);
+      pagination_.current_request = std::move(next.request);
       pagination_.next_request = None{};
       pagination_.page_count += 1;
       if (args_.paginate_delay
@@ -1108,7 +1118,7 @@ public:
           std::chrono::duration_cast<std::chrono::steady_clock::duration>(
             args_.paginate_delay->inner));
       }
-      co_await start_fetch(ctx, current_request_);
+      co_await start_fetch(ctx, pagination_.current_request);
     } else {
       lifecycle_ = Lifecycle::done;
     }
@@ -1126,7 +1136,7 @@ private:
   // Requires pagination_.current_url and pagination_.page_count to be set.
   auto start_fetch(OpCtx& ctx, RequestConfig request) -> Task<void> {
     response_ = None{};
-    odata_envelope_seen_ = false;
+    pagination_.odata_envelope_seen = false;
     auto parsed_url = proxygen::URL{pagination_.current_url};
     if (parsed_url.isSecure() and not fetch_config_.tls_context) {
       auto tls_opts
@@ -1228,14 +1238,11 @@ private:
   FromHttpArgs args_;
   FetchConfig fetch_config_;
   std::vector<std::pair<std::string, std::string>> resolved_headers_;
-  RequestConfig current_request_;
-  Option<pagination_spec> paginate_;
   // --- state ---
   Lifecycle lifecycle_{};
   PaginationState pagination_;
   // State collected per response page; absent before first response header.
   Option<ResponseState> response_;
-  bool odata_envelope_seen_ = false;
 };
 
 class from_http_plugin final : public virtual OperatorPlugin {

--- a/libtenzir/builtins/operators/from_http.cpp
+++ b/libtenzir/builtins/operators/from_http.cpp
@@ -33,6 +33,7 @@
 #include <tenzir/tql2/set.hpp>
 #include <tenzir/try.hpp>
 #include <tenzir/variant.hpp>
+#include <tenzir/view3.hpp>
 
 #include <boost/url/parse.hpp>
 #include <boost/url/url.hpp>
@@ -52,6 +53,7 @@
 #include <proxygen/lib/utils/URL.h>
 
 #include <algorithm>
+#include <cctype>
 #include <chrono>
 #include <iterator>
 #include <limits>
@@ -128,7 +130,7 @@ auto build_request_source(
 }
 
 struct RequestConfig {
-  proxygen::HTTPMethod method;
+  proxygen::HTTPMethod method = proxygen::HTTPMethod::GET;
   std::vector<std::pair<std::string, std::string>> headers;
   std::vector<std::byte> body;
 };
@@ -143,6 +145,84 @@ auto find_header(std::span<const std::pair<std::string, std::string>> headers,
   return None{};
 }
 
+auto erase_header(std::vector<std::pair<std::string, std::string>>& headers,
+                  std::string_view name) -> void {
+  std::erase_if(headers, [&](auto const& kv) {
+    return detail::ascii_icase_equal(kv.first, name);
+  });
+}
+
+auto set_header(std::vector<std::pair<std::string, std::string>>& headers,
+                std::string name, std::string value) -> void {
+  erase_header(headers, name);
+  headers.emplace_back(std::move(name), std::move(value));
+}
+
+auto parse_http_method(std::string method_str) -> Option<proxygen::HTTPMethod> {
+  std::transform(method_str.begin(), method_str.end(), method_str.begin(),
+                 [](unsigned char c) {
+                   return static_cast<char>(std::toupper(c));
+                 });
+  if (auto method = proxygen::stringToMethod(method_str)) {
+    return *method;
+  }
+  return None{};
+}
+
+struct BodySerialization {
+  std::vector<std::byte> body;
+  Option<std::string> content_type;
+};
+
+auto serialize_body(data const& value,
+                    Option<located<std::string>> const& encode)
+  -> Option<BodySerialization> {
+  auto result = BodySerialization{};
+  auto valid = match(
+    value,
+    [&](std::string const& s) {
+      auto const* p = reinterpret_cast<std::byte const*>(s.data());
+      result.body.insert(result.body.end(), p, p + s.size());
+      return true;
+    },
+    [&](blob const& b) {
+      result.body.insert(result.body.end(), b.begin(), b.end());
+      return true;
+    },
+    [&](record const& r) {
+      if (encode and encode->inner == "form") {
+        auto buf = curl::escape(flatten(r));
+        auto const* p = reinterpret_cast<std::byte const*>(buf.data());
+        result.body.insert(result.body.end(), p, p + buf.size());
+        result.content_type = "application/x-www-form-urlencoded";
+      } else {
+        auto buf = std::string{};
+        auto printer = json_printer{{}};
+        auto out = std::back_inserter(buf);
+        printer.print(out, r);
+        auto const* p = reinterpret_cast<std::byte const*>(buf.data());
+        result.body.insert(result.body.end(), p, p + buf.size());
+        result.content_type = "application/json";
+      }
+      return true;
+    },
+    [](auto const&) {
+      return false;
+    });
+  if (not valid) {
+    return None{};
+  }
+  return result;
+}
+
+auto add_default_content_type(
+  std::vector<std::pair<std::string, std::string>>& headers,
+  Option<std::string> content_type) -> void {
+  if (content_type and not find_header(headers, "content-type")) {
+    headers.emplace_back("Content-Type", content_type.unwrap());
+  }
+}
+
 // Builds the initial request configuration from the operator arguments.
 // Resolves method, serializes the body (records become JSON, blobs are sent
 // verbatim), and assembles request headers.
@@ -154,46 +234,16 @@ auto make_request_config(
   auto method_str = args.method ? args.method->inner
                     : args.body ? "POST"
                                 : "GET";
-  std::transform(method_str.begin(), method_str.end(), method_str.begin(),
-                 ::toupper);
-  auto method = proxygen::stringToMethod(method_str);
+  auto method = parse_http_method(method_str);
   TENZIR_ASSERT(method);
   // Serialize the optional body. Records become JSON; blobs and strings are
   // sent verbatim.
   auto body = std::vector<std::byte>{};
-  Option<std::string> content_type;
   if (args.body) {
-    match(
-      args.body->inner,
-      [&](std::string const& s) {
-        auto const* p = reinterpret_cast<std::byte const*>(s.data());
-        body.insert(body.end(), p, p + s.size());
-      },
-      [&](blob const& b) {
-        body.insert(body.end(), b.begin(), b.end());
-      },
-      [&](record const& r) {
-        if (args.encode and args.encode->inner == "form") {
-          auto buf = curl::escape(flatten(r));
-          auto const* p = reinterpret_cast<std::byte const*>(buf.data());
-          body.insert(body.end(), p, p + buf.size());
-          content_type = "application/x-www-form-urlencoded";
-        } else {
-          auto buf = std::string{};
-          auto p = json_printer{{}};
-          auto it = std::back_inserter(buf);
-          p.print(it, r);
-          auto const* p2 = reinterpret_cast<std::byte const*>(buf.data());
-          body.insert(body.end(), p2, p2 + buf.size());
-          content_type = "application/json";
-        }
-      },
-      [](auto const&) {
-        // Other data types are rejected at describe() time.
-      });
-  }
-  if (content_type and not find_header(headers, "content-type")) {
-    headers.emplace_back("Content-Type", content_type.unwrap());
+    auto serialized = serialize_body(args.body->inner, args.encode);
+    TENZIR_ASSERT(serialized);
+    body = std::move(serialized->body);
+    add_default_content_type(headers, std::move(serialized->content_type));
   }
   if (not find_header(headers, "accept")) {
     headers.emplace_back("Accept", "application/json, */*;q=0.5");
@@ -358,9 +408,134 @@ auto resolve_next_url(std::string_view next_url, std::string const& base_url,
   return Option<std::string>{std::string{resolved.buffer()}};
 }
 
-auto next_url_from_lambda(Option<pagination_spec> const& paginate,
-                          table_slice const& slice, std::string const& base_url,
-                          diagnostic_handler& dh) -> Option<std::string> {
+struct NextRequest {
+  std::string url;
+  RequestConfig request;
+};
+
+auto emit_paginate_record_warning(std::string message, location paginate_loc,
+                                  diagnostic_handler& dh) -> void {
+  diagnostic::warning("{}", message)
+    .primary(paginate_loc)
+    .note("stopping pagination")
+    .emit(dh);
+}
+
+auto is_paginate_request_field(std::string_view field) -> bool {
+  return field == "url" or field == "method" or field == "headers"
+         or field == "body";
+}
+
+auto next_request_from_record(record const& patch, std::string const& base_url,
+                              RequestConfig const& current_request,
+                              Option<located<std::string>> const& encode,
+                              location paginate_loc, diagnostic_handler& dh)
+  -> Option<NextRequest> {
+  if (patch.empty()) {
+    emit_paginate_record_warning("`paginate` request record must not be empty",
+                                 paginate_loc, dh);
+    return None{};
+  }
+  for (auto const& [field, _] : patch) {
+    if (not is_paginate_request_field(field)) {
+      emit_paginate_record_warning(
+        fmt::format("unknown field `{}` in `paginate` request record", field),
+        paginate_loc, dh);
+      return None{};
+    }
+  }
+  auto url = base_url;
+  auto request = current_request;
+  if (auto it = patch.find("url"); it != patch.end()) {
+    auto const* next_url = try_as<std::string>(&it->second);
+    if (not next_url) {
+      emit_paginate_record_warning(
+        "`paginate` request field `url` must be `string`", paginate_loc, dh);
+      return None{};
+    }
+    if (auto resolved = resolve_next_url(*next_url, base_url, paginate_loc, dh,
+                                         NextUrlSource::paginate_lambda)) {
+      url = std::move(*resolved);
+    } else {
+      return None{};
+    }
+  }
+  if (auto it = patch.find("method"); it != patch.end()) {
+    auto const* method_str = try_as<std::string>(&it->second);
+    if (not method_str) {
+      emit_paginate_record_warning(
+        "`paginate` request field `method` must be `string`", paginate_loc, dh);
+      return None{};
+    }
+    auto method = parse_http_method(*method_str);
+    if (not method) {
+      emit_paginate_record_warning(
+        fmt::format("invalid HTTP method in `paginate` request record: `{}`",
+                    *method_str),
+        paginate_loc, dh);
+      return None{};
+    }
+    request.method = *method;
+  }
+  if (auto it = patch.find("body"); it != patch.end()) {
+    if (is<caf::none_t>(it->second)) {
+      request.body.clear();
+    } else if (auto serialized = serialize_body(it->second, encode)) {
+      request.body = std::move(serialized->body);
+      add_default_content_type(request.headers,
+                               std::move(serialized->content_type));
+    } else {
+      emit_paginate_record_warning("`paginate` request field `body` must be "
+                                   "`blob`, `record`, `string`, "
+                                   "or `null`",
+                                   paginate_loc, dh);
+      return None{};
+    }
+  }
+  if (auto it = patch.find("headers"); it != patch.end()) {
+    auto const* headers = try_as<record>(&it->second);
+    if (not headers) {
+      emit_paginate_record_warning("`paginate` request field `headers` must be "
+                                   "`record`",
+                                   paginate_loc, dh);
+      return None{};
+    }
+    for (auto const& [name, value] : *headers) {
+      if (is<caf::none_t>(value)) {
+        erase_header(request.headers, name);
+      } else if (auto const* str = try_as<std::string>(&value)) {
+        set_header(request.headers, name, *str);
+      } else {
+        emit_paginate_record_warning("`paginate` request header values must be "
+                                     "`string` or `null`",
+                                     paginate_loc, dh);
+        return None{};
+      }
+    }
+  }
+  return NextRequest{.url = std::move(url), .request = std::move(request)};
+}
+
+auto next_request_from_url(
+  std::string_view url, std::string const& base_url,
+  std::vector<std::pair<std::string, std::string>> const& headers,
+  location paginate_loc, diagnostic_handler& dh) -> Option<NextRequest> {
+  if (auto resolved = resolve_next_url(url, base_url, paginate_loc, dh,
+                                       NextUrlSource::paginate_lambda)) {
+    return NextRequest{
+      .url = std::move(*resolved),
+      .request = make_paginated_request_config(headers),
+    };
+  }
+  return None{};
+}
+
+auto next_request_from_lambda(
+  Option<pagination_spec> const& paginate, table_slice const& slice,
+  std::string const& base_url, RequestConfig const& current_request,
+  std::vector<std::pair<std::string, std::string>> const& paginated_headers,
+  Option<located<std::string>> const& encode, diagnostic_handler& dh)
+  -> Option<NextRequest> {
   if (not paginate) {
     return None{};
   }
@@ -379,15 +554,21 @@ auto next_url_from_lambda(Option<pagination_spec> const& paginate,
   auto value = ms.view3_at(0);
   return match(
     value,
-    [](caf::none_t const&) -> Option<std::string> {
+    [](caf::none_t const&) -> Option<NextRequest> {
       return None{};
     },
-    [&](std::string_view url) -> Option<std::string> {
-      return resolve_next_url(url, base_url, paginate->source, dh,
-                              NextUrlSource::paginate_lambda);
+    [&](std::string_view url) -> Option<NextRequest> {
+      return next_request_from_url(url, base_url, paginated_headers,
+                                   paginate->source, dh);
     },
-    [&](auto const&) -> Option<std::string> {
-      diagnostic::error("expected `paginate` to be `string`, got `{}`",
+    [&](view3<record> req) -> Option<NextRequest> {
+      return next_request_from_record(materialize(req), base_url,
+                                      current_request, encode, paginate->source,
+                                      dh);
+    },
+    [&](auto const&) -> Option<NextRequest> {
+      diagnostic::error("expected `paginate` to be `string`, `record`, or "
+                        "`null`, got `{}`",
                         ms.parts().front().type.kind())
         .primary(*paginate)
         .emit(dh);
@@ -445,7 +626,7 @@ auto make_fetch_config(FromHttpArgs const& args) -> FetchConfig {
 struct PaginationState {
   int64_t page_count = 0;
   std::string current_url;
-  Option<std::string> next_url;
+  Option<NextRequest> next_request;
 };
 
 struct ResponseState {
@@ -729,7 +910,8 @@ public:
     fetch_config_ = make_fetch_config(args_);
     // ensure system CA paths are registered
     ensure_http_default_ca_paths();
-    co_await start_fetch(ctx, make_request_config(args_, resolved_headers_));
+    current_request_ = make_request_config(args_, resolved_headers_);
+    co_await start_fetch(ctx, current_request_);
   }
 
   auto await_task(diagnostic_handler&) const -> Task<Any> override {
@@ -776,10 +958,14 @@ public:
               mode and *mode == http::PaginationMode::link) {
             TENZIR_ASSERT(paginate_);
             // Extract the rel=next URL for link pagination.
-            pagination_.next_url
-              = http::next_url_from_link_headers(response_->headers,
-                                                 pagination_.current_url,
-                                                 paginate_->source, ctx.dh());
+            if (auto next_url = http::next_url_from_link_headers(
+                  response_->headers, pagination_.current_url,
+                  paginate_->source, ctx.dh())) {
+              pagination_.next_request = NextRequest{
+                .url = std::move(*next_url),
+                .request = make_paginated_request_config(resolved_headers_),
+              };
+            }
           }
         } else {
           if (not args_.error_field) {
@@ -832,7 +1018,7 @@ public:
           strip_errno_from_error_message(std::move(err.message)))
           .primary(args_.operator_location)
           .emit(ctx);
-        pagination_.next_url = None{};
+        pagination_.next_request = None{};
         lifecycle_ = Lifecycle::done;
         co_return;
       },
@@ -870,21 +1056,26 @@ public:
         co_return;
       }
       odata_envelope_seen_ = true;
-      pagination_.next_url
-        = page->next_url
-            ? resolve_next_url(*page->next_url, pagination_.current_url,
-                               paginate_->source, ctx.dh(),
-                               NextUrlSource::odata_next_link)
-            : None{};
+      if (page->next_url) {
+        if (auto next_url = resolve_next_url(
+              *page->next_url, pagination_.current_url, paginate_->source,
+              ctx.dh(), NextUrlSource::odata_next_link)) {
+          pagination_.next_request = NextRequest{
+            .url = std::move(*next_url),
+            .request = make_paginated_request_config(resolved_headers_),
+          };
+        }
+      }
       for (auto& event_slice : page->events) {
         co_await push(std::move(event_slice));
       }
       co_return;
     }
-    if (not pagination_.next_url) {
-      if (auto next = next_url_from_lambda(paginate_, slice,
-                                           pagination_.current_url, ctx.dh())) {
-        pagination_.next_url = std::move(*next);
+    if (not pagination_.next_request) {
+      if (auto next = next_request_from_lambda(
+            paginate_, slice, pagination_.current_url, current_request_,
+            resolved_headers_, args_.encode, ctx.dh())) {
+        pagination_.next_request = std::move(*next);
       }
     }
     co_await push(std::move(slice));
@@ -904,10 +1095,12 @@ public:
       lifecycle_ = Lifecycle::done;
       co_return;
     }
-    if (pagination_.next_url) {
+    if (pagination_.next_request) {
       // next page
-      pagination_.current_url = std::move(*pagination_.next_url);
-      pagination_.next_url = None{};
+      auto next = std::move(*pagination_.next_request);
+      pagination_.current_url = std::move(next.url);
+      current_request_ = std::move(next.request);
+      pagination_.next_request = None{};
       pagination_.page_count += 1;
       if (args_.paginate_delay
           and args_.paginate_delay->inner > duration::zero()) {
@@ -915,8 +1108,7 @@ public:
           std::chrono::duration_cast<std::chrono::steady_clock::duration>(
             args_.paginate_delay->inner));
       }
-      co_await start_fetch(ctx,
-                           make_paginated_request_config(resolved_headers_));
+      co_await start_fetch(ctx, current_request_);
     } else {
       lifecycle_ = Lifecycle::done;
     }
@@ -1036,6 +1228,7 @@ private:
   FromHttpArgs args_;
   FetchConfig fetch_config_;
   std::vector<std::pair<std::string, std::string>> resolved_headers_;
+  RequestConfig current_request_;
   Option<pagination_spec> paginate_;
   // --- state ---
   Lifecycle lifecycle_{};

--- a/libtenzir/builtins/operators/from_http.cpp
+++ b/libtenzir/builtins/operators/from_http.cpp
@@ -91,7 +91,7 @@ struct FromHttpArgs {
 // Messages from the fetch task to the operator.
 struct ResponseHeader {
   uint16_t status;
-  std::vector<http::header> headers;
+  std::vector<http::Header> headers;
 };
 struct ResponseBody {
   chunk_ptr data;
@@ -112,7 +112,7 @@ using MessageQueue = folly::coro::BoundedQueue<Message>;
 // internal makeHTTPRequestSource where IOBuf::takeOwnership arguments are
 // evaluated in unspecified order.
 auto build_request_source(proxygen::URL const& url, proxygen::HTTPMethod method,
-                          const std::vector<http::header>& headers,
+                          const std::vector<http::Header>& headers,
                           std::unique_ptr<folly::IOBuf> body_buf)
   -> proxygen::coro::HTTPSourceHolder {
   auto* source = proxygen::coro::HTTPFixedSource::makeFixedRequest(
@@ -132,7 +132,7 @@ auto build_request_source(proxygen::URL const& url, proxygen::HTTPMethod method,
 
 struct RequestConfig {
   proxygen::HTTPMethod method = proxygen::HTTPMethod::GET;
-  std::vector<http::header> headers;
+  std::vector<http::Header> headers;
   std::vector<std::byte> body;
 };
 
@@ -193,7 +193,7 @@ auto serialize_body(data const& value,
   return result;
 }
 
-auto add_default_content_type(std::vector<http::header>& headers,
+auto add_default_content_type(std::vector<http::Header>& headers,
                               Option<std::string> content_type) -> void {
   if (content_type and not http::find_header(headers, "content-type")) {
     headers.emplace_back("Content-Type", content_type.unwrap());
@@ -204,7 +204,7 @@ auto add_default_content_type(std::vector<http::header>& headers,
 // Resolves method, serializes the body (records become JSON, blobs are sent
 // verbatim), and assembles request headers.
 auto make_request_config(FromHttpArgs const& args,
-                         std::vector<http::header> headers) -> RequestConfig {
+                         std::vector<http::Header> headers) -> RequestConfig {
   // Resolve HTTP method (validated at describe time).
   // Default to POST when a body is present, GET otherwise.
   auto method_str = args.method ? args.method->inner
@@ -233,7 +233,7 @@ auto make_request_config(FromHttpArgs const& args,
 
 // Builds the request configuration for a paginated follow-up request.
 // Always uses GET with the same headers as the original but no body.
-auto make_paginated_request_config(std::vector<http::header> headers)
+auto make_paginated_request_config(std::vector<http::Header> headers)
   -> RequestConfig {
   if (not http::find_header(headers, "accept")) {
     headers.emplace_back("Accept", "application/json, */*;q=0.5");
@@ -247,7 +247,7 @@ auto make_paginated_request_config(std::vector<http::header> headers)
 
 auto resolve_http_secrets(OpCtx& ctx, FromHttpArgs const& args,
                           std::string& resolved_url,
-                          std::vector<http::header>& resolved_headers)
+                          std::vector<http::Header>& resolved_headers)
   -> Task<failure_or<bool>> {
   resolved_url.clear();
   auto requests = std::vector<secret_request>{};
@@ -402,7 +402,7 @@ struct PaginationRequestContext {
   pagination_spec const& spec;
   std::string const& current_url;
   RequestConfig const& current_request;
-  std::vector<http::header> const& paginated_headers;
+  std::vector<http::Header> const& paginated_headers;
   Option<located<std::string>> const& encode;
 };
 
@@ -610,7 +610,7 @@ auto make_fetch_config(FromHttpArgs const& args) -> FetchConfig {
 
 struct ResponseState {
   uint16_t status;
-  std::vector<http::header> headers;
+  std::vector<http::Header> headers;
   Option<std::string> content_encoding;
   std::shared_ptr<arrow::util::Decompressor> decompressor;
   blob error_body;
@@ -665,7 +665,7 @@ auto make_parser_pipeline(operator_factory_plugin const& plugin, location loc,
 
 struct retryable_http_response : std::runtime_error {
   retryable_http_response(uint16_t status_code,
-                          std::vector<http::header> headers,
+                          std::vector<http::Header> headers,
                           Option<std::chrono::seconds> retry_after)
     : std::runtime_error{fmt::format("retryable HTTP status {}", status_code)},
       status_code{status_code},
@@ -674,7 +674,7 @@ struct retryable_http_response : std::runtime_error {
   }
 
   uint16_t status_code = 0;
-  std::vector<http::header> headers;
+  std::vector<http::Header> headers;
   Option<std::chrono::seconds> retry_after;
   blob body;
 };
@@ -745,7 +745,7 @@ auto fetch(folly::EventBase* evb, proxygen::URL url, RequestConfig request,
                   // response headers.
                   co_return proxygen::coro::HTTPSourceReader::Continue;
                 }
-                auto hdrs = std::vector<http::header>{};
+                auto hdrs = std::vector<http::Header>{};
                 msg->getHeaders().forEach([&](std::string& k, std::string& v) {
                   hdrs.emplace_back(k, v);
                 });
@@ -1207,7 +1207,7 @@ private:
   // --- args ---
   FromHttpArgs args_;
   FetchConfig fetch_config_;
-  std::vector<http::header> resolved_headers_;
+  std::vector<http::Header> resolved_headers_;
   // --- state ---
   Lifecycle lifecycle_{};
   PaginationState pagination_;

--- a/libtenzir/builtins/operators/from_http.cpp
+++ b/libtenzir/builtins/operators/from_http.cpp
@@ -38,6 +38,7 @@
 #include <boost/url/parse.hpp>
 #include <boost/url/url.hpp>
 #include <folly/ScopeGuard.h>
+#include <folly/String.h>
 #include <folly/coro/BoundedQueue.h>
 #include <folly/coro/Retry.h>
 #include <folly/executors/GlobalExecutor.h>
@@ -90,7 +91,7 @@ struct FromHttpArgs {
 // Messages from the fetch task to the operator.
 struct ResponseHeader {
   uint16_t status;
-  std::vector<std::pair<std::string, std::string>> headers;
+  std::vector<http::header> headers;
 };
 struct ResponseBody {
   chunk_ptr data;
@@ -110,10 +111,10 @@ using MessageQueue = folly::coro::BoundedQueue<Message>;
 // Builds a Proxygen request source, working around a bug in Proxygen's
 // internal makeHTTPRequestSource where IOBuf::takeOwnership arguments are
 // evaluated in unspecified order.
-auto build_request_source(
-  proxygen::URL const& url, proxygen::HTTPMethod method,
-  const std::vector<std::pair<std::string, std::string>>& headers,
-  std::unique_ptr<folly::IOBuf> body_buf) -> proxygen::coro::HTTPSourceHolder {
+auto build_request_source(proxygen::URL const& url, proxygen::HTTPMethod method,
+                          const std::vector<http::header>& headers,
+                          std::unique_ptr<folly::IOBuf> body_buf)
+  -> proxygen::coro::HTTPSourceHolder {
   auto* source = proxygen::coro::HTTPFixedSource::makeFixedRequest(
     url.makeRelativeURL(), method, std::move(body_buf));
   for (auto const& [k, v] : headers) {
@@ -131,32 +132,9 @@ auto build_request_source(
 
 struct RequestConfig {
   proxygen::HTTPMethod method = proxygen::HTTPMethod::GET;
-  std::vector<std::pair<std::string, std::string>> headers;
+  std::vector<http::header> headers;
   std::vector<std::byte> body;
 };
-
-auto find_header(std::span<const std::pair<std::string, std::string>> headers,
-                 std::string_view name) -> Option<std::string> {
-  for (auto const& [header_name, value] : headers) {
-    if (detail::ascii_icase_equal(header_name, name)) {
-      return value;
-    }
-  }
-  return None{};
-}
-
-auto erase_header(std::vector<std::pair<std::string, std::string>>& headers,
-                  std::string_view name) -> void {
-  std::erase_if(headers, [&](auto const& kv) {
-    return detail::ascii_icase_equal(kv.first, name);
-  });
-}
-
-auto set_header(std::vector<std::pair<std::string, std::string>>& headers,
-                std::string name, std::string value) -> void {
-  erase_header(headers, name);
-  headers.emplace_back(std::move(name), std::move(value));
-}
 
 auto parse_http_method(std::string method_str) -> Option<proxygen::HTTPMethod> {
   std::transform(method_str.begin(), method_str.end(), method_str.begin(),
@@ -215,10 +193,9 @@ auto serialize_body(data const& value,
   return result;
 }
 
-auto add_default_content_type(
-  std::vector<std::pair<std::string, std::string>>& headers,
-  Option<std::string> content_type) -> void {
-  if (content_type and not find_header(headers, "content-type")) {
+auto add_default_content_type(std::vector<http::header>& headers,
+                              Option<std::string> content_type) -> void {
+  if (content_type and not http::find_header(headers, "content-type")) {
     headers.emplace_back("Content-Type", content_type.unwrap());
   }
 }
@@ -226,9 +203,8 @@ auto add_default_content_type(
 // Builds the initial request configuration from the operator arguments.
 // Resolves method, serializes the body (records become JSON, blobs are sent
 // verbatim), and assembles request headers.
-auto make_request_config(
-  FromHttpArgs const& args,
-  std::vector<std::pair<std::string, std::string>> headers) -> RequestConfig {
+auto make_request_config(FromHttpArgs const& args,
+                         std::vector<http::header> headers) -> RequestConfig {
   // Resolve HTTP method (validated at describe time).
   // Default to POST when a body is present, GET otherwise.
   auto method_str = args.method ? args.method->inner
@@ -245,7 +221,7 @@ auto make_request_config(
     body = std::move(serialized->body);
     add_default_content_type(headers, std::move(serialized->content_type));
   }
-  if (not find_header(headers, "accept")) {
+  if (not http::find_header(headers, "accept")) {
     headers.emplace_back("Accept", "application/json, */*;q=0.5");
   }
   return RequestConfig{
@@ -257,9 +233,9 @@ auto make_request_config(
 
 // Builds the request configuration for a paginated follow-up request.
 // Always uses GET with the same headers as the original but no body.
-auto make_paginated_request_config(
-  std::vector<std::pair<std::string, std::string>> headers) -> RequestConfig {
-  if (not find_header(headers, "accept")) {
+auto make_paginated_request_config(std::vector<http::header> headers)
+  -> RequestConfig {
+  if (not http::find_header(headers, "accept")) {
     headers.emplace_back("Accept", "application/json, */*;q=0.5");
   }
   return RequestConfig{
@@ -269,9 +245,9 @@ auto make_paginated_request_config(
   };
 }
 
-auto resolve_http_secrets(
-  OpCtx& ctx, FromHttpArgs const& args, std::string& resolved_url,
-  std::vector<std::pair<std::string, std::string>>& resolved_headers)
+auto resolve_http_secrets(OpCtx& ctx, FromHttpArgs const& args,
+                          std::string& resolved_url,
+                          std::vector<http::header>& resolved_headers)
   -> Task<failure_or<bool>> {
   resolved_url.clear();
   auto requests = std::vector<secret_request>{};
@@ -426,7 +402,7 @@ struct PaginationRequestContext {
   pagination_spec const& spec;
   std::string const& current_url;
   RequestConfig const& current_request;
-  std::vector<std::pair<std::string, std::string>> const& paginated_headers;
+  std::vector<http::header> const& paginated_headers;
   Option<located<std::string>> const& encode;
 };
 
@@ -520,9 +496,9 @@ auto next_request_from_record(record const& patch,
     }
     for (auto const& [name, value] : *headers) {
       if (is<caf::none_t>(value)) {
-        erase_header(request.headers, name);
+        http::erase_header(request.headers, name);
       } else if (auto const* str = try_as<std::string>(&value)) {
-        set_header(request.headers, name, *str);
+        http::set_header(request.headers, name, *str);
       } else {
         emit_paginate_record_warning("`paginate` request header values must be "
                                      "`string` or `null`",
@@ -634,7 +610,7 @@ auto make_fetch_config(FromHttpArgs const& args) -> FetchConfig {
 
 struct ResponseState {
   uint16_t status;
-  std::vector<std::pair<std::string, std::string>> headers;
+  std::vector<http::header> headers;
   Option<std::string> content_encoding;
   std::shared_ptr<arrow::util::Decompressor> decompressor;
   blob error_body;
@@ -655,23 +631,19 @@ auto make_response_context(ResponseState const& response) -> record {
   };
 }
 
-// Normalizes platform-specific socket error text for user-facing diagnostics.
-// In particular, `AsyncSocketException` embeds OS-dependent errno values
-// (e.g., 111 on Linux vs. 61 on macOS) that make error messages noisy and
-// non-portable in tests.
-auto strip_errno_from_error_message(std::string message) -> std::string {
-  auto needle = std::string_view{"errno = "};
-  auto pos = message.find(needle);
-  if (pos == std::string::npos) {
-    return message;
+auto describe_socket_error(folly::AsyncSocketException const& ex)
+  -> std::string {
+  if (auto err = ex.getErrno(); err > 0) {
+    return folly::errnoStr(err);
   }
-  auto end = message.find('(', pos);
-  if (end == std::string::npos) {
-    return message;
+  return ex.what();
+}
+
+auto describe_fetch_error(folly::exception_wrapper const& ew) -> std::string {
+  if (auto const* ex = ew.get_exception<folly::AsyncSocketException>()) {
+    return describe_socket_error(*ex);
   }
-  auto start = pos + needle.length();
-  message.erase(start, end - start);
-  return message;
+  return ew.what().toStdString();
 }
 
 auto path_from_url(std::string_view url) -> std::string {
@@ -692,10 +664,9 @@ auto make_parser_pipeline(operator_factory_plugin const& plugin, location loc,
 }
 
 struct retryable_http_response : std::runtime_error {
-  retryable_http_response(
-    uint16_t status_code,
-    std::vector<std::pair<std::string, std::string>> headers,
-    Option<std::chrono::seconds> retry_after)
+  retryable_http_response(uint16_t status_code,
+                          std::vector<http::header> headers,
+                          Option<std::chrono::seconds> retry_after)
     : std::runtime_error{fmt::format("retryable HTTP status {}", status_code)},
       status_code{status_code},
       headers{std::move(headers)},
@@ -703,7 +674,7 @@ struct retryable_http_response : std::runtime_error {
   }
 
   uint16_t status_code = 0;
-  std::vector<std::pair<std::string, std::string>> headers;
+  std::vector<http::header> headers;
   Option<std::chrono::seconds> retry_after;
   blob body;
 };
@@ -774,7 +745,7 @@ auto fetch(folly::EventBase* evb, proxygen::URL url, RequestConfig request,
                   // response headers.
                   co_return proxygen::coro::HTTPSourceReader::Continue;
                 }
-                auto hdrs = std::vector<std::pair<std::string, std::string>>{};
+                auto hdrs = std::vector<http::header>{};
                 msg->getHeaders().forEach([&](std::string& k, std::string& v) {
                   hdrs.emplace_back(k, v);
                 });
@@ -875,7 +846,7 @@ auto fetch(folly::EventBase* evb, proxygen::URL url, RequestConfig request,
           }
         } else {
           co_await mq->enqueue(
-            FetchError{result.exception().what().toStdString()});
+            FetchError{describe_fetch_error(result.exception())});
         }
       }
       co_await mq->enqueue(FetchDone{});
@@ -932,7 +903,7 @@ public:
       [&](ResponseHeader hdr) -> Task<void> {
         auto headers = std::move(hdr.headers);
         auto content_encoding = Option<std::string>{};
-        if (auto value = find_header(headers, "content-encoding")) {
+        if (auto value = http::find_header(headers, "content-encoding")) {
           auto trimmed = std::string{detail::trim(*value)};
           if (not trimmed.empty()) {
             content_encoding = std::move(trimmed);
@@ -1016,9 +987,8 @@ public:
       },
       // --- FetchError ---
       [&](FetchError err) -> Task<void> {
-        diagnostic::error(
-          "HTTP request to `{}` failed: {}", pagination_.current_url,
-          strip_errno_from_error_message(std::move(err.message)))
+        diagnostic::error("HTTP request to `{}` failed: {}",
+                          pagination_.current_url, err.message)
           .primary(args_.operator_location)
           .emit(ctx);
         pagination_.next_request = None{};
@@ -1178,7 +1148,7 @@ private:
       }
     } else {
       auto const* plugin = static_cast<const operator_factory_plugin*>(nullptr);
-      if (auto value = find_header(response_->headers, "content-type");
+      if (auto value = http::find_header(response_->headers, "content-type");
           value and not detail::trim(*value).empty()) {
         auto content_type = std::string{detail::trim(*value)};
         plugin = read_plugin_for_content_type(content_type);
@@ -1237,7 +1207,7 @@ private:
   // --- args ---
   FromHttpArgs args_;
   FetchConfig fetch_config_;
-  std::vector<std::pair<std::string, std::string>> resolved_headers_;
+  std::vector<http::header> resolved_headers_;
   // --- state ---
   Lifecycle lifecycle_{};
   PaginationState pagination_;

--- a/libtenzir/builtins/operators/from_http.cpp
+++ b/libtenzir/builtins/operators/from_http.cpp
@@ -1287,12 +1287,16 @@ public:
       }
       // Validate encode: requires a body and must be "json" or "form".
       auto body_loc = ctx.get_location(body_arg);
+      auto paginate_expr = ctx.get(paginate_arg);
+      auto paginate_is_lambda
+        = paginate_expr and try_as<ast::lambda_expr>(*paginate_expr);
       if (auto encode_loc = ctx.get_location(encode_arg)) {
-        if (not body_loc) {
+        if (not body_loc and not paginate_is_lambda) {
           diagnostic::error("`encode` requires a `body`")
             .primary(*encode_loc)
             .emit(ctx);
-        } else if (auto encode = ctx.get(encode_arg)) {
+        }
+        if (auto encode = ctx.get(encode_arg)) {
           if (encode->inner != "json" and encode->inner != "form") {
             diagnostic::error("unsupported encoding: `{}`", encode->inner)
               .hint(R"(`encode` must be `"json"` or `"form"`)")
@@ -1382,7 +1386,7 @@ public:
             .emit(ctx);
         }
       }
-      if (auto paginate_expr = ctx.get(paginate_arg)) {
+      if (paginate_expr) {
         auto validated
           = validate_paginate(Option<ast::expression>{*paginate_expr}, ctx);
         if (not validated) {

--- a/libtenzir/builtins/operators/to_http.cpp
+++ b/libtenzir/builtins/operators/to_http.cpp
@@ -42,7 +42,7 @@ namespace {
 
 constexpr auto default_parallel = 1;
 
-using Headers = std::vector<std::pair<std::string, std::string>>;
+using Headers = std::vector<http::header>;
 
 struct ToHttpArgs {
   located<secret> url;

--- a/libtenzir/builtins/operators/to_http.cpp
+++ b/libtenzir/builtins/operators/to_http.cpp
@@ -42,7 +42,7 @@ namespace {
 
 constexpr auto default_parallel = 1;
 
-using Headers = std::vector<http::header>;
+using Headers = std::vector<http::Header>;
 
 struct ToHttpArgs {
   located<secret> url;

--- a/libtenzir/builtins/operators/to_tcp.cpp
+++ b/libtenzir/builtins/operators/to_tcp.cpp
@@ -64,6 +64,25 @@ constexpr auto should_retry_connect = [](folly::exception_wrapper const& ew) {
   return ew.is_compatible_with<folly::AsyncSocketException>();
 };
 
+// Normalizes platform-specific socket error text for user-facing diagnostics.
+// In particular, `AsyncSocketException` embeds OS-dependent errno values
+// (e.g., 111 on Linux vs. 61 on macOS) that make error messages noisy and
+// non-portable in tests.
+auto strip_errno_from_error_message(std::string message) -> std::string {
+  auto needle = std::string_view{"errno = "};
+  auto pos = message.find(needle);
+  if (pos == std::string::npos) {
+    return message;
+  }
+  auto end = message.find('(', pos);
+  if (end == std::string::npos) {
+    return message;
+  }
+  auto start = pos + needle.length();
+  message.erase(start, end - start);
+  return message;
+}
+
 struct ToTcpArgs {
   located<std::string> endpoint;
   Option<located<data>> tls;
@@ -238,7 +257,8 @@ private:
             // follow-up that covers all TCP operators.
             auto diag
               = diagnostic::warning("failed to connect to {}: {}",
-                                    address_.describe(), ex.what())
+                                    address_.describe(),
+                                    strip_errno_from_error_message(ex.what()))
                   .primary(args_.endpoint.source)
                   .hint("ensure a TCP server is listening on this endpoint");
             add_tls_client_diagnostic_hints(std::move(diag),
@@ -249,7 +269,7 @@ private:
         },
         should_retry_connect);
     } catch (folly::AsyncSocketException const& ex) {
-      diagnostic::error("{}", ex.what())
+      diagnostic::error("{}", strip_errno_from_error_message(ex.what()))
         .primary(args_.endpoint.source)
         .note("gave up after {} {}", max_retry_count,
               max_retry_count == 1 ? "retry" : "retries")

--- a/libtenzir/builtins/operators/to_tcp.cpp
+++ b/libtenzir/builtins/operators/to_tcp.cpp
@@ -26,9 +26,11 @@
 #include <tenzir/tql2/plugin.hpp>
 
 #include <folly/SocketAddress.h>
+#include <folly/String.h>
 #include <folly/coro/BoundedQueue.h>
 #include <folly/coro/Retry.h>
 #include <folly/executors/GlobalExecutor.h>
+#include <folly/io/async/AsyncSocketException.h>
 #include <folly/io/coro/Transport.h>
 
 #include <limits>
@@ -64,23 +66,12 @@ constexpr auto should_retry_connect = [](folly::exception_wrapper const& ew) {
   return ew.is_compatible_with<folly::AsyncSocketException>();
 };
 
-// Normalizes platform-specific socket error text for user-facing diagnostics.
-// In particular, `AsyncSocketException` embeds OS-dependent errno values
-// (e.g., 111 on Linux vs. 61 on macOS) that make error messages noisy and
-// non-portable in tests.
-auto strip_errno_from_error_message(std::string message) -> std::string {
-  auto needle = std::string_view{"errno = "};
-  auto pos = message.find(needle);
-  if (pos == std::string::npos) {
-    return message;
+auto describe_socket_error(folly::AsyncSocketException const& ex)
+  -> std::string {
+  if (auto err = ex.getErrno(); err > 0) {
+    return folly::errnoStr(err);
   }
-  auto end = message.find('(', pos);
-  if (end == std::string::npos) {
-    return message;
-  }
-  auto start = pos + needle.length();
-  message.erase(start, end - start);
-  return message;
+  return ex.what();
 }
 
 struct ToTcpArgs {
@@ -258,7 +249,7 @@ private:
             auto diag
               = diagnostic::warning("failed to connect to {}: {}",
                                     address_.describe(),
-                                    strip_errno_from_error_message(ex.what()))
+                                    describe_socket_error(ex))
                   .primary(args_.endpoint.source)
                   .hint("ensure a TCP server is listening on this endpoint");
             add_tls_client_diagnostic_hints(std::move(diag),
@@ -269,7 +260,8 @@ private:
         },
         should_retry_connect);
     } catch (folly::AsyncSocketException const& ex) {
-      diagnostic::error("{}", strip_errno_from_error_message(ex.what()))
+      diagnostic::error("failed to connect to {}: {}", address_.describe(),
+                        describe_socket_error(ex))
         .primary(args_.endpoint.source)
         .note("gave up after {} {}", max_retry_count,
               max_retry_count == 1 ? "retry" : "retries")

--- a/libtenzir/include/tenzir/concept/parseable/tenzir/http.hpp
+++ b/libtenzir/include/tenzir/concept/parseable/tenzir/http.hpp
@@ -19,7 +19,7 @@
 namespace tenzir {
 
 struct http_header_parser : parser_base<http_header_parser> {
-  using attribute = http::header;
+  using attribute = http::Header;
 
   static auto make() {
     using namespace parser_literals;
@@ -40,7 +40,7 @@ struct http_header_parser : parser_base<http_header_parser> {
   }
 
   template <class Iterator>
-  auto parse(Iterator& f, const Iterator& l, http::header& a) const -> bool {
+  auto parse(Iterator& f, const Iterator& l, http::Header& a) const -> bool {
     static auto p = make();
     a.name.clear();
     a.value.clear();
@@ -49,7 +49,7 @@ struct http_header_parser : parser_base<http_header_parser> {
 };
 
 template <>
-struct parser_registry<http::header> {
+struct parser_registry<http::Header> {
   using type = http_header_parser;
 };
 

--- a/libtenzir/include/tenzir/concept/printable/tenzir/http.hpp
+++ b/libtenzir/include/tenzir/concept/printable/tenzir/http.hpp
@@ -20,10 +20,10 @@
 namespace tenzir {
 
 struct http_header_printer : printer_base<http_header_printer> {
-  using attribute = http::header;
+  using attribute = http::Header;
 
   template <class Iterator>
-  bool print(Iterator& out, const http::header& hdr) const {
+  bool print(Iterator& out, const http::Header& hdr) const {
     using namespace printers;
     auto p = str << ": " << str;
     return p(out, hdr.name, hdr.value);
@@ -31,15 +31,15 @@ struct http_header_printer : printer_base<http_header_printer> {
 };
 
 template <>
-struct printer_registry<http::header> {
+struct printer_registry<http::Header> {
   using type = http_header_printer;
 };
 
-struct http_response_printer : printer_base<http::response> {
-  using attribute = http::response;
+struct http_response_printer : printer_base<http::Response> {
+  using attribute = http::Response;
 
   template <class Iterator>
-  bool print(Iterator& out, const http::response& res) const {
+  bool print(Iterator& out, const http::Response& res) const {
     using namespace printers;
     auto version = real_printer<double, 1>{};
     auto p = str                             // proto
@@ -55,7 +55,7 @@ struct http_response_printer : printer_base<http::response> {
 };
 
 template <>
-struct printer_registry<http::response> {
+struct printer_registry<http::Response> {
   using type = http_response_printer;
 };
 

--- a/libtenzir/include/tenzir/http.hpp
+++ b/libtenzir/include/tenzir/http.hpp
@@ -26,7 +26,7 @@
 #include <chrono>
 #include <cstdint>
 #include <map>
-#include <optional>
+#include <memory>
 #include <span>
 #include <string>
 #include <string_view>
@@ -74,59 +74,59 @@ auto make_http_pool_config(Option<located<data>> const& tls, std::string& url,
                            tls_options::options options = {.is_server = false})
   -> failure_or<HttpPoolConfig>;
 
-struct header {
+struct Header {
   std::string name;
   std::string value;
 };
 
 auto make_header_secret_requests(Option<located<data>> const& headers,
-                                 std::vector<header>& resolved_headers,
+                                 std::vector<Header>& resolved_headers,
                                  diagnostic_handler& dh)
   -> std::vector<secret_request>;
 
 /// Finds the first header by case-insensitive name.
-auto find_header(std::span<header const> headers, std::string_view name)
+auto find_header(std::span<Header const> headers, std::string_view name)
   -> Option<std::string>;
 
 /// Removes all headers matching the case-insensitive name.
-auto erase_header(std::vector<header>& headers, std::string_view name) -> void;
+auto erase_header(std::vector<Header>& headers, std::string_view name) -> void;
 
 /// Replaces all headers matching the case-insensitive name with one value.
-auto set_header(std::vector<header>& headers, std::string name,
+auto set_header(std::vector<Header>& headers, std::string name,
                 std::string value) -> void;
 
 /// Base for HTTP messages.
-struct message {
+struct Message {
   std::string protocol;
   double version;
-  std::vector<http::header> headers;
+  std::vector<http::Header> headers;
   std::string body;
 
   /// Retrieve a header with a case-insensitive lookup.
-  [[nodiscard]] auto header(const std::string& name) -> http::header*;
+  [[nodiscard]] auto header(const std::string& name) -> http::Header*;
 
   [[nodiscard]] auto header(const std::string& name) const
-    -> const http::header*;
+    -> const http::Header*;
 };
 
 /// A HTTP request message.
-struct request : message {
+struct Request : Message {
   std::string method;
   std::string uri;
 };
 
 /// A HTTP response message.
-struct response : message {
+struct Response : Message {
   uint32_t status_code;
   std::string status_text;
 };
 
 /// A HTTPie-inspired request item.
-struct request_item {
+struct RequestItem {
   /// Parses a request item like HTTPie.
-  static auto parse(std::string_view str) -> std::optional<request_item>;
+  static auto parse(std::string_view str) -> Option<RequestItem>;
 
-  enum item_type : uint8_t {
+  enum ItemType : uint8_t {
     file_data_json,
     data_json,
     url_param,
@@ -136,24 +136,24 @@ struct request_item {
     header,
   };
 
-  friend auto inspect(auto& f, request_item& x) -> bool {
-    using enum_type = std::underlying_type_t<item_type>;
+  friend auto inspect(auto& f, RequestItem& x) -> bool {
+    using EnumType = std::underlying_type_t<ItemType>;
     return f.object(x)
-      .pretty_name("tenzir.http.request_item")
-      .fields(f.field("type", reinterpret_cast<enum_type&>(x.type)),
+      .pretty_name("tenzir.http.RequestItem")
+      .fields(f.field("type", reinterpret_cast<EnumType&>(x.type)),
               f.field("key", x.key), f.field("value", x.value));
   }
 
-  item_type type;
+  ItemType type;
   std::string key;
   std::string value;
 };
 
 /// Applies a list of request items to a given HTTP request.
 /// We mimic HTTPie's behavior in processing request items.
-auto apply(std::vector<request_item> items, request& req) -> caf::error;
+auto apply(std::vector<RequestItem> items, Request& req) -> caf::error;
 
-struct encoded_request_body {
+struct EncodedRequestBody {
   std::string body;
   Option<std::string> content_encoding = None{};
 };
@@ -165,11 +165,11 @@ struct encoded_request_body {
 auto compress_request_body(std::string body, std::string_view encoding,
                            diagnostic_handler& dh,
                            location loc = location::unknown)
-  -> encoded_request_body;
+  -> EncodedRequestBody;
 
 /// Adds Content-Length and, when present, Content-Encoding headers.
 auto add_request_body_headers(std::map<std::string, std::string>& headers,
-                              encoded_request_body const& body) -> void;
+                              EncodedRequestBody const& body) -> void;
 
 /// Creates a streaming decompressor for the given Content-Encoding value.
 /// Emits a warning and returns None for unknown or unsupported encodings.
@@ -206,7 +206,7 @@ auto parse_pagination_mode(std::string_view mode) -> Option<PaginationMode>;
 /// URL, or None if no such link is present. Emits a warning on malformed
 /// headers.
 auto next_url_from_link_headers(
-  std::vector<http::header> const& response_headers,
+  std::vector<Header> const& response_headers,
   std::string const& base_url, location paginate_loc, diagnostic_handler& dh)
   -> Option<std::string>;
 

--- a/libtenzir/include/tenzir/http.hpp
+++ b/libtenzir/include/tenzir/http.hpp
@@ -205,9 +205,9 @@ auto parse_pagination_mode(std::string_view mode) -> Option<PaginationMode>;
 /// Scans all Link response headers and returns the first resolved `rel=next`
 /// URL, or None if no such link is present. Emits a warning on malformed
 /// headers.
-auto next_url_from_link_headers(
-  std::vector<Header> const& response_headers,
-  std::string const& base_url, location paginate_loc, diagnostic_handler& dh)
+auto next_url_from_link_headers(std::vector<Header> const& response_headers,
+                                std::string const& base_url,
+                                location paginate_loc, diagnostic_handler& dh)
   -> Option<std::string>;
 
 struct OdataPage {

--- a/libtenzir/include/tenzir/http.hpp
+++ b/libtenzir/include/tenzir/http.hpp
@@ -27,6 +27,7 @@
 #include <cstdint>
 #include <map>
 #include <optional>
+#include <span>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -73,15 +74,26 @@ auto make_http_pool_config(Option<located<data>> const& tls, std::string& url,
                            tls_options::options options = {.is_server = false})
   -> failure_or<HttpPoolConfig>;
 
-auto make_header_secret_requests(
-  Option<located<data>> const& headers,
-  std::vector<std::pair<std::string, std::string>>& resolved_headers,
-  diagnostic_handler& dh) -> std::vector<secret_request>;
-
 struct header {
   std::string name;
   std::string value;
 };
+
+auto make_header_secret_requests(Option<located<data>> const& headers,
+                                 std::vector<header>& resolved_headers,
+                                 diagnostic_handler& dh)
+  -> std::vector<secret_request>;
+
+/// Finds the first header by case-insensitive name.
+auto find_header(std::span<header const> headers, std::string_view name)
+  -> Option<std::string>;
+
+/// Removes all headers matching the case-insensitive name.
+auto erase_header(std::vector<header>& headers, std::string_view name) -> void;
+
+/// Replaces all headers matching the case-insensitive name with one value.
+auto set_header(std::vector<header>& headers, std::string name,
+                std::string value) -> void;
 
 /// Base for HTTP messages.
 struct message {
@@ -194,7 +206,7 @@ auto parse_pagination_mode(std::string_view mode) -> Option<PaginationMode>;
 /// URL, or None if no such link is present. Emits a warning on malformed
 /// headers.
 auto next_url_from_link_headers(
-  std::vector<std::pair<std::string, std::string>> const& response_headers,
+  std::vector<http::header> const& response_headers,
   std::string const& base_url, location paginate_loc, diagnostic_handler& dh)
   -> Option<std::string>;
 

--- a/libtenzir/include/tenzir/transfer.hpp
+++ b/libtenzir/include/tenzir/transfer.hpp
@@ -52,7 +52,7 @@ public:
 
   /// Prepares a transfer with an HTTP request.
   /// @note resets the transfer.
-  auto prepare(http::request req) -> caf::error;
+  auto prepare(http::Request req) -> caf::error;
 
   /// Prepares a transfer with an URL.
   /// @param url The URL to use.

--- a/libtenzir/src/aws_credentials.cpp
+++ b/libtenzir/src/aws_credentials.cpp
@@ -350,7 +350,7 @@ auto fetch_web_identity_token(const resolved_web_identity& web_identity)
     const auto& te = *web_identity.token_endpoint;
     TENZIR_VERBOSE("fetching web identity token from endpoint");
     auto xfer = transfer{};
-    auto req = http::request{};
+    auto req = http::Request{};
     req.uri = te.url;
     req.method = "GET";
     // Add custom headers.

--- a/libtenzir/src/http.cpp
+++ b/libtenzir/src/http.cpp
@@ -714,9 +714,9 @@ auto parse_pagination_mode(std::string_view mode) -> Option<PaginationMode> {
   return None{};
 }
 
-auto next_url_from_link_headers(
-  std::vector<Header> const& response_headers,
-  std::string const& base_url, location paginate_loc, diagnostic_handler& dh)
+auto next_url_from_link_headers(std::vector<Header> const& response_headers,
+                                std::string const& base_url,
+                                location paginate_loc, diagnostic_handler& dh)
   -> Option<std::string> {
   auto base = boost::urls::parse_uri_reference(base_url);
   if (not base) {

--- a/libtenzir/src/http.cpp
+++ b/libtenzir/src/http.cpp
@@ -327,7 +327,7 @@ auto make_http_pool_config(Option<located<data>> const& tls, std::string& url,
 }
 
 auto make_header_secret_requests(Option<located<data>> const& headers,
-                                 std::vector<http::header>& resolved_headers,
+                                 std::vector<http::Header>& resolved_headers,
                                  diagnostic_handler& dh)
   -> std::vector<secret_request> {
   resolved_headers.clear();
@@ -357,7 +357,7 @@ auto make_header_secret_requests(Option<located<data>> const& headers,
   return result;
 }
 
-auto find_header(std::span<http::header const> headers, std::string_view name)
+auto find_header(std::span<http::Header const> headers, std::string_view name)
   -> Option<std::string> {
   for (auto const& [header_name, value] : headers) {
     if (detail::ascii_icase_equal(header_name, name)) {
@@ -367,20 +367,20 @@ auto find_header(std::span<http::header const> headers, std::string_view name)
   return None{};
 }
 
-auto erase_header(std::vector<http::header>& headers, std::string_view name)
+auto erase_header(std::vector<http::Header>& headers, std::string_view name)
   -> void {
   std::erase_if(headers, [&](auto const& kv) {
     return detail::ascii_icase_equal(kv.name, name);
   });
 }
 
-auto set_header(std::vector<http::header>& headers, std::string name,
+auto set_header(std::vector<http::Header>& headers, std::string name,
                 std::string value) -> void {
   erase_header(headers, name);
   headers.push_back({std::move(name), std::move(value)});
 }
 
-auto message::header(const std::string& name) -> struct header* {
+auto Message::header(const std::string& name) -> Header* {
   auto pred = [&](auto& x) -> bool {
     if (x.name.size() != name.size()) {
       return false;
@@ -396,13 +396,13 @@ auto message::header(const std::string& name) -> struct header* {
   return i == headers.end() ? nullptr : &*i;
 }
 
-auto message::header(const std::string& name) const -> const struct header* {
+auto Message::header(const std::string& name) const -> Header const* {
   // We use a const_cast to avoid duplicating logic.
-  auto* self = const_cast<message*>(this);
+  auto* self = const_cast<Message*>(this);
   return self->header(name);
 }
 
-auto request_item::parse(std::string_view str) -> std::optional<request_item> {
+auto RequestItem::parse(std::string_view str) -> Option<RequestItem> {
   auto is_valid_header_name = [](std::string_view name) {
     for (char c : name) {
       if (std::isalnum(static_cast<unsigned char>(c)) == 0 and c != '-'
@@ -414,51 +414,51 @@ auto request_item::parse(std::string_view str) -> std::optional<request_item> {
   };
   auto xs = detail::split_escaped(str, ":=@", "\\", 1);
   if (xs.size() == 2) {
-    return request_item{.type = file_data_json, .key = xs[0], .value = xs[1]};
+    return RequestItem{.type = file_data_json, .key = xs[0], .value = xs[1]};
   }
   xs = detail::split_escaped(str, ":=", "\\", 1);
   if (xs.size() == 2) {
-    return request_item{.type = data_json, .key = xs[0], .value = xs[1]};
+    return RequestItem{.type = data_json, .key = xs[0], .value = xs[1]};
   }
   xs = detail::split_escaped(str, ":", "\\", 1);
   if (xs.size() == 2 and is_valid_header_name(xs[0])) {
-    return request_item{.type = header, .key = xs[0], .value = xs[1]};
+    return RequestItem{.type = header, .key = xs[0], .value = xs[1]};
   }
   xs = detail::split_escaped(str, "==", "\\", 1);
   if (xs.size() == 2) {
-    return request_item{.type = url_param, .key = xs[0], .value = xs[1]};
+    return RequestItem{.type = url_param, .key = xs[0], .value = xs[1]};
   }
   xs = detail::split_escaped(str, "=@", "\\", 1);
   if (xs.size() == 2) {
-    return request_item{.type = file_data, .key = xs[0], .value = xs[1]};
+    return RequestItem{.type = file_data, .key = xs[0], .value = xs[1]};
   }
   xs = detail::split_escaped(str, "@", "\\", 1);
   if (xs.size() == 2) {
-    return request_item{.type = file_form, .key = xs[0], .value = xs[1]};
+    return RequestItem{.type = file_form, .key = xs[0], .value = xs[1]};
   }
   xs = detail::split_escaped(str, "=", "\\", 1);
   if (xs.size() == 2) {
-    return request_item{.type = data, .key = xs[0], .value = xs[1]};
+    return RequestItem{.type = data, .key = xs[0], .value = xs[1]};
   }
   return {};
 }
 
-auto apply(std::vector<request_item> items, request& req) -> caf::error {
+auto apply(std::vector<RequestItem> items, Request& req) -> caf::error {
   auto body = record{};
   for (auto& item : items) {
     switch (item.type) {
-      case request_item::header: {
+      case RequestItem::header: {
         req.headers.emplace_back(std::move(item.key), std::move(item.value));
         break;
       }
-      case request_item::data: {
+      case RequestItem::data: {
         if (req.method.empty()) {
           req.method = "POST";
         }
         body.emplace(std::move(item.key), std::move(item.value));
         break;
       }
-      case request_item::data_json: {
+      case RequestItem::data_json: {
         if (req.method.empty()) {
           req.method = "POST";
         }
@@ -469,7 +469,7 @@ auto apply(std::vector<request_item> items, request& req) -> caf::error {
         body.emplace(std::move(item.key), std::move(*data));
         break;
       }
-      case request_item::url_param: {
+      case RequestItem::url_param: {
         auto pos = req.uri.find('?');
         if (pos == std::string::npos) {
           req.uri += '?';
@@ -494,9 +494,9 @@ auto apply(std::vector<request_item> items, request& req) -> caf::error {
   };
 
   // We assemble an Accept header as we go, unless we have one already.
-  auto accept = std::optional<std::vector<std::string>>{};
+  auto accept = Option<std::vector<std::string>>{};
   if (req.header("Accept") == nullptr) {
-    accept = {"*/*"};
+    accept = std::vector<std::string>{"*/*"};
   }
   // If the user provided any request body data, we default to JSON encoding.
   // The user can override this behavior by setting a Content-Type header.
@@ -542,7 +542,7 @@ auto apply(std::vector<request_item> items, request& req) -> caf::error {
 
 auto compress_request_body(std::string body, std::string_view encoding,
                            diagnostic_handler& dh, location loc)
-  -> encoded_request_body {
+  -> EncodedRequestBody {
   auto normalized_encoding = normalize_content_encoding(encoding);
   if (normalized_encoding.empty()) {
     return {.body = std::move(body)};
@@ -590,7 +590,7 @@ auto compress_request_body(std::string body, std::string_view encoding,
 }
 
 auto add_request_body_headers(std::map<std::string, std::string>& headers,
-                              encoded_request_body const& body) -> void {
+                              EncodedRequestBody const& body) -> void {
   headers["Content-Length"] = fmt::to_string(body.body.size());
   if (body.content_encoding) {
     headers["Content-Encoding"] = *body.content_encoding;
@@ -715,7 +715,7 @@ auto parse_pagination_mode(std::string_view mode) -> Option<PaginationMode> {
 }
 
 auto next_url_from_link_headers(
-  std::vector<http::header> const& response_headers,
+  std::vector<Header> const& response_headers,
   std::string const& base_url, location paginate_loc, diagnostic_handler& dh)
   -> Option<std::string> {
   auto base = boost::urls::parse_uri_reference(base_url);

--- a/libtenzir/src/http.cpp
+++ b/libtenzir/src/http.cpp
@@ -326,10 +326,10 @@ auto make_http_pool_config(Option<located<data>> const& tls, std::string& url,
   return config;
 }
 
-auto make_header_secret_requests(
-  Option<located<data>> const& headers,
-  std::vector<std::pair<std::string, std::string>>& resolved_headers,
-  diagnostic_handler& dh) -> std::vector<secret_request> {
+auto make_header_secret_requests(Option<located<data>> const& headers,
+                                 std::vector<http::header>& resolved_headers,
+                                 diagnostic_handler& dh)
+  -> std::vector<secret_request> {
   resolved_headers.clear();
   auto result = std::vector<secret_request>{};
   if (not headers) {
@@ -342,11 +342,11 @@ auto make_header_secret_requests(
     match(
       value,
       [&](std::string const& literal) {
-        resolved_headers.emplace_back(header_name, literal);
+        resolved_headers.push_back({header_name, literal});
       },
       [&](secret const& sec) {
-        auto& out
-          = resolved_headers.emplace_back(header_name, std::string{}).second;
+        resolved_headers.push_back({header_name, std::string{}});
+        auto& out = resolved_headers.back().value;
         result.emplace_back(
           make_secret_request(header_name, sec, headers->source, out, dh));
       },
@@ -355,6 +355,29 @@ auto make_header_secret_requests(
       });
   }
   return result;
+}
+
+auto find_header(std::span<http::header const> headers, std::string_view name)
+  -> Option<std::string> {
+  for (auto const& [header_name, value] : headers) {
+    if (detail::ascii_icase_equal(header_name, name)) {
+      return value;
+    }
+  }
+  return None{};
+}
+
+auto erase_header(std::vector<http::header>& headers, std::string_view name)
+  -> void {
+  std::erase_if(headers, [&](auto const& kv) {
+    return detail::ascii_icase_equal(kv.name, name);
+  });
+}
+
+auto set_header(std::vector<http::header>& headers, std::string name,
+                std::string value) -> void {
+  erase_header(headers, name);
+  headers.push_back({std::move(name), std::move(value)});
 }
 
 auto message::header(const std::string& name) -> struct header* {
@@ -692,7 +715,7 @@ auto parse_pagination_mode(std::string_view mode) -> Option<PaginationMode> {
 }
 
 auto next_url_from_link_headers(
-  std::vector<std::pair<std::string, std::string>> const& response_headers,
+  std::vector<http::header> const& response_headers,
   std::string const& base_url, location paginate_loc, diagnostic_handler& dh)
   -> Option<std::string> {
   auto base = boost::urls::parse_uri_reference(base_url);

--- a/libtenzir/src/transfer.cpp
+++ b/libtenzir/src/transfer.cpp
@@ -20,7 +20,7 @@ namespace tenzir {
 transfer::transfer(transfer_options opts) : options{std::move(opts)} {
 }
 
-auto transfer::prepare(http::request req) -> caf::error {
+auto transfer::prepare(http::Request req) -> caf::error {
   TENZIR_DEBUG("preparing HTTP request");
   if (auto err = reset(); err.valid()) {
     return err;

--- a/libtenzir/test/http.cpp
+++ b/libtenzir/test/http.cpp
@@ -23,8 +23,8 @@ using namespace std::string_literals;
 namespace {
 
 auto make_item = [](std::string_view str) {
-  auto result = http::request_item::parse(str);
-  REQUIRE_NOT_EQUAL(result, std::nullopt);
+  auto result = http::RequestItem::parse(str);
+  REQUIRE(result);
   return *result;
 };
 
@@ -33,22 +33,22 @@ auto make_item = [](std::string_view str) {
 TEST("parse HTTP request item") {
   auto separators = std::array{":=@", ":=", "==", "=@", "@", "=", ":"};
   auto types = std::array{
-    http::request_item::file_data_json, http::request_item::data_json,
-    http::request_item::url_param,      http::request_item::file_data,
-    http::request_item::file_form,      http::request_item::data,
-    http::request_item::header,
+    http::RequestItem::file_data_json, http::RequestItem::data_json,
+    http::RequestItem::url_param,      http::RequestItem::file_data,
+    http::RequestItem::file_form,      http::RequestItem::data,
+    http::RequestItem::header,
   };
   static_assert(separators.size() == types.size());
   for (auto i = 0u; i < types.size(); ++i) {
     auto sep = separators[i];
     auto str = fmt::format("foo{}bar", sep);
-    auto item = http::request_item::parse(str);
+    auto item = http::RequestItem::parse(str);
     REQUIRE(item);
     CHECK_EQUAL(item->key, "foo");
     CHECK_EQUAL(item->value, "bar");
     CHECK_EQUAL(item->type, types[i]);
     str = fmt::format("foo{}bar\\{}", sep, sep);
-    item = http::request_item::parse(str);
+    item = http::RequestItem::parse(str);
     REQUIRE(item);
     CHECK_EQUAL(item->key, "foo");
     auto value = fmt::format("bar\\{}", sep);
@@ -57,8 +57,8 @@ TEST("parse HTTP request item") {
 }
 
 TEST("HTTP request items - JSON") {
-  auto request = http::request{};
-  auto items = std::vector<http::request_item>{
+  auto request = http::Request{};
+  auto items = std::vector<http::RequestItem>{
     make_item("Content-Type:application/json"),
     make_item("foo:=42"),
   };
@@ -77,8 +77,8 @@ TEST("HTTP request items - JSON") {
 }
 
 TEST("HTTP request items - JSON without content type") {
-  auto request = http::request{};
-  auto items = std::vector<http::request_item>{
+  auto request = http::Request{};
+  auto items = std::vector<http::RequestItem>{
     make_item("foo:=42"),
   };
   auto err = apply(items, request);
@@ -95,8 +95,8 @@ TEST("HTTP request items - JSON without content type") {
 }
 
 TEST("HTTP request items - urlencoded") {
-  auto request = http::request{};
-  auto items = std::vector<http::request_item>{
+  auto request = http::Request{};
+  auto items = std::vector<http::RequestItem>{
     make_item("Content-Type:application/x-www-form-urlencoded"),
     make_item("foo:=42"),
     make_item("bar:=true"),
@@ -112,8 +112,8 @@ TEST("HTTP request items - urlencoded") {
 }
 
 TEST("HTTP request items - URL param") {
-  auto request = http::request{};
-  auto items = std::vector<http::request_item>{
+  auto request = http::Request{};
+  auto items = std::vector<http::RequestItem>{
     make_item("foo==42"),
     make_item("bar==true"),
   };
@@ -128,7 +128,7 @@ TEST("HTTP request items - URL param") {
 }
 
 TEST("HTTP response") {
-  http::response r;
+  http::Response r;
   r.status_code = 200;
   r.status_text = "OK";
   r.protocol = "HTTP";
@@ -142,11 +142,11 @@ TEST("HTTP response") {
 }
 
 TEST("HTTP header") {
-  auto p = make_parser<http::header>();
+  auto p = make_parser<http::Header>();
   auto str = "foo: bar"s;
   auto f = str.begin();
   auto l = str.end();
-  http::header hdr;
+  http::Header hdr;
   CHECK(p(f, l, hdr));
   CHECK(hdr.name == "FOO");
   CHECK(hdr.value == "bar");

--- a/test/fixtures/http_paginate.py
+++ b/test/fixtures/http_paginate.py
@@ -217,7 +217,7 @@ class _Handler(BaseHTTPRequestHandler):
         if path == _RECORD_GET_BODY_PAGE_1:
             next_value = {
                 "url": _RECORD_GET_BODY_PAGE_2,
-                "body": "hello-from-get",
+                "body": {"hello": "from-get"},
             }
             self._reply(self._observed_event(1, None, next_value))
             return

--- a/test/fixtures/http_paginate.py
+++ b/test/fixtures/http_paginate.py
@@ -11,7 +11,14 @@ Exports:
   HTTP_FIXTURE_LINK_UNREACHABLE_URL  — 204 with Link pointing to port 9 (always refused)
   HTTP_FIXTURE_RETRY_FLAKY_URL       — drops first 2 connections, then returns JSON
   HTTP_FIXTURE_LAMBDA_URL            — page chain where body carries `next` URL
+  HTTP_FIXTURE_RECORD_URL            — page chain where body carries next request records
+  HTTP_FIXTURE_RECORD_GET_BODY_URL   — next request record body inherits GET method
+  HTTP_FIXTURE_RECORD_METHOD_URL     — next request record explicitly changes method
   HTTP_FIXTURE_LARGE_ERROR_URL       — HTTP 500 with large streaming response body
+  HTTP_FIXTURE_RECORD_UNKNOWN_URL    — next request record with an unknown field
+  HTTP_FIXTURE_RECORD_TYPE_URL       — next request record with an invalid field type
+  HTTP_FIXTURE_RECORD_EMPTY_URL      — empty next request record
+  HTTP_FIXTURE_MULTI_EVENT_URL       — page body with multiple parsed events
   HTTP_FIXTURE_META_LAMBDA_URL        — next URL carried in X-Next-Page header (tests
                                         that pagination lambdas can read metadata_field)
   HTTP_FIXTURE_ODATA_USERS_URL        — Microsoft Graph-shaped OData collection pages
@@ -44,6 +51,17 @@ _UNREACHABLE_PAGE = "/paginate/unreachable/1"
 _RETRY_FLAKY_PAGE = "/paginate/retry/flaky"
 _LAMBDA_PAGE_1 = "/paginate/lambda/1"
 _LAMBDA_PAGE_2 = "/paginate/lambda/2"
+_RECORD_PAGE_1 = "/paginate/record/1"
+_RECORD_PAGE_2 = "/paginate/record/2"
+_RECORD_PAGE_3 = "/paginate/record/3"
+_RECORD_GET_BODY_PAGE_1 = "/paginate/record-get-body/1"
+_RECORD_GET_BODY_PAGE_2 = "/paginate/record-get-body/2"
+_RECORD_METHOD_PAGE_1 = "/paginate/record-method/1"
+_RECORD_METHOD_PAGE_2 = "/paginate/record-method/2"
+_RECORD_UNKNOWN_PAGE = "/paginate/record-bad/unknown"
+_RECORD_TYPE_PAGE = "/paginate/record-bad/type"
+_RECORD_EMPTY_PAGE = "/paginate/record-bad/empty"
+_MULTI_EVENT_PAGE = "/paginate/multi-event"
 _LARGE_ERROR_PAGE = "/paginate/error/large"
 _META_LAMBDA_PAGE_1 = "/paginate/meta-lambda/1"
 _META_LAMBDA_PAGE_2 = "/paginate/meta-lambda/2"
@@ -106,11 +124,132 @@ class _Handler(BaseHTTPRequestHandler):
         if body:
             self.wfile.write(body)
 
+    def _read_body(self) -> bytes:
+        length = int(self.headers.get("Content-Length", "0") or "0")
+        if length == 0:
+            return b""
+        return self.rfile.read(length)
+
+    def _read_json_body(self) -> object:
+        body = self._read_body()
+        if not body:
+            return None
+        try:
+            return json.loads(body.decode())
+        except json.JSONDecodeError:
+            return body.decode(errors="replace")
+
+    def _observed_event(self, page: int, body: object, next_value: object) -> bytes:
+        event = {
+            "page": page,
+            "method": self.command,
+            "path": self.path.split("?", 1)[0],
+            "body": body,
+            "headers": {
+                "x_secret": self.headers.get("X-Secret"),
+                "x_override": self.headers.get("X-Override"),
+                "x_delete": self.headers.get("X-Delete"),
+                "x_added": self.headers.get("X-Added"),
+            },
+            "next": next_value,
+        }
+        return json.dumps(event).encode()
+
+    def _handle_record_page(self, path: str) -> bool:
+        if path == _RECORD_PAGE_1:
+            body = self._read_json_body()
+            next_value = {
+                "url": _RECORD_PAGE_2,
+                "body": {"page": 2},
+                "headers": {
+                    "x-override": "new",
+                    "X-Added": "yes",
+                    "X-Delete": None,
+                },
+            }
+            self._reply(self._observed_event(1, body, next_value))
+            return True
+        if path == _RECORD_PAGE_2:
+            body = self._read_json_body()
+            if body == {"page": 2}:
+                next_value = {
+                    "url": _RECORD_PAGE_3,
+                    "headers": {
+                        "x-added": None,
+                    },
+                }
+                self._reply(self._observed_event(2, body, next_value))
+                return True
+        if path == _RECORD_PAGE_3:
+            body = self._read_json_body()
+            if body == {"page": 2}:
+                next_value = {
+                    "body": None,
+                }
+                self._reply(self._observed_event(3, body, next_value))
+                return True
+            if body is None:
+                self._reply(self._observed_event(4, body, None))
+                return True
+        return False
+
+    def _handle_record_method_page(self, path: str) -> bool:
+        if path == _RECORD_METHOD_PAGE_1:
+            body = self._read_json_body()
+            next_value = {
+                "url": _RECORD_METHOD_PAGE_2,
+                "method": "post",
+                "body": "hello-from-post",
+            }
+            self._reply(self._observed_event(1, body, next_value))
+            return True
+        if path == _RECORD_METHOD_PAGE_2:
+            body = self._read_json_body()
+            self._reply(self._observed_event(2, body, None))
+            return True
+        return False
+
     def do_GET(self) -> None:  # noqa: N802
         from urllib.parse import parse_qs, urlsplit
 
         parts = urlsplit(self.path)
         path = parts.path
+        if path == _RECORD_GET_BODY_PAGE_1:
+            next_value = {
+                "url": _RECORD_GET_BODY_PAGE_2,
+                "body": "hello-from-get",
+            }
+            self._reply(self._observed_event(1, None, next_value))
+            return
+        if path == _RECORD_GET_BODY_PAGE_2:
+            self._reply(self._observed_event(2, self._read_json_body(), None))
+            return
+        if self._handle_record_method_page(path):
+            return
+        if path == _RECORD_UNKNOWN_PAGE:
+            next_value = {
+                "url": _RECORD_PAGE_2,
+                "unexpected": "field",
+            }
+            self._reply(self._observed_event(1, None, next_value))
+            return
+        if path == _RECORD_TYPE_PAGE:
+            next_value = {
+                "url": 42,
+            }
+            self._reply(self._observed_event(1, None, next_value))
+            return
+        if path == _RECORD_EMPTY_PAGE:
+            self._reply(self._observed_event(1, None, {}))
+            return
+        if path == _MULTI_EVENT_PAGE:
+            self._reply(
+                (
+                    f'{{"page":1,"next":"{_LAMBDA_PAGE_2}"}}\n'
+                    f'{{"page":2,"next":"{_LAMBDA_PAGE_2}"}}\n'
+                ).encode()
+            )
+            return
         # Chain pagination: /paginate/chain/<n>
         if path.startswith(_CHAIN_PREFIX):
             page_str = path.removeprefix(_CHAIN_PREFIX)
@@ -272,6 +411,16 @@ class _Handler(BaseHTTPRequestHandler):
             return
         self.send_error(404)
 
+    def do_POST(self) -> None:  # noqa: N802
+        from urllib.parse import urlsplit
+
+        path = urlsplit(self.path).path
+        if self._handle_record_page(path):
+            return
+        if self._handle_record_method_page(path):
+            return
+        self.send_error(404)
+
     def log_message(self, *_: object) -> None:  # noqa: D401
         return
 
@@ -294,7 +443,14 @@ def run() -> Iterator[dict[str, str]]:
             "HTTP_FIXTURE_LINK_UNREACHABLE_URL": f"{base}{_UNREACHABLE_PAGE}",
             "HTTP_FIXTURE_RETRY_FLAKY_URL": f"{base}{_RETRY_FLAKY_PAGE}",
             "HTTP_FIXTURE_LAMBDA_URL": f"{base}{_LAMBDA_PAGE_1}",
+            "HTTP_FIXTURE_RECORD_URL": f"{base}{_RECORD_PAGE_1}",
+            "HTTP_FIXTURE_RECORD_GET_BODY_URL": f"{base}{_RECORD_GET_BODY_PAGE_1}",
+            "HTTP_FIXTURE_RECORD_METHOD_URL": f"{base}{_RECORD_METHOD_PAGE_1}",
             "HTTP_FIXTURE_LARGE_ERROR_URL": f"{base}{_LARGE_ERROR_PAGE}",
+            "HTTP_FIXTURE_RECORD_UNKNOWN_URL": f"{base}{_RECORD_UNKNOWN_PAGE}",
+            "HTTP_FIXTURE_RECORD_TYPE_URL": f"{base}{_RECORD_TYPE_PAGE}",
+            "HTTP_FIXTURE_RECORD_EMPTY_URL": f"{base}{_RECORD_EMPTY_PAGE}",
+            "HTTP_FIXTURE_MULTI_EVENT_URL": f"{base}{_MULTI_EVENT_PAGE}",
             "HTTP_FIXTURE_META_LAMBDA_URL": f"{base}{_META_LAMBDA_PAGE_1}",
             "HTTP_FIXTURE_ODATA_USERS_URL": f"{base}{_ODATA_PAGE_1}",
             "HTTP_FIXTURE_ODATA_RELATIVE_USERS_URL": (

--- a/test/tests/operators/from_http/paginate_lambda_multi_event.tql
+++ b/test/tests/operators/from_http/paginate_lambda_multi_event.tql
@@ -1,0 +1,9 @@
+---
+fixtures: [http_paginate]
+---
+
+from_http env("HTTP_FIXTURE_MULTI_EVENT_URL"),
+  paginate=(x => x.next),
+  tls=false {
+  read_json
+}

--- a/test/tests/operators/from_http/paginate_lambda_multi_event.txt
+++ b/test/tests/operators/from_http/paginate_lambda_multi_event.txt
@@ -1,0 +1,15 @@
+{
+  page: 1,
+  next: "/paginate/lambda/2",
+}
+{
+  page: 2,
+  next: "/paginate/lambda/2",
+}
+warning: cannot paginate over multiple events
+ --> tests/operators/from_http/paginate_lambda_multi_event.tql:6:13
+  |
+6 |   paginate=(x => x.next),
+  |             ~~~~~~~~~~~ 
+  |
+  = note: stopping pagination

--- a/test/tests/operators/from_http/paginate_lambda_record_empty.tql
+++ b/test/tests/operators/from_http/paginate_lambda_record_empty.tql
@@ -1,0 +1,9 @@
+---
+fixtures: [http_paginate]
+---
+
+from_http env("HTTP_FIXTURE_RECORD_EMPTY_URL"),
+  paginate=(x => x.next),
+  tls=false {
+  read_json
+}

--- a/test/tests/operators/from_http/paginate_lambda_record_empty.txt
+++ b/test/tests/operators/from_http/paginate_lambda_record_empty.txt
@@ -1,0 +1,20 @@
+{
+  page: 1,
+  method: "GET",
+  path: "/paginate/record-bad/empty",
+  body: null,
+  headers: {
+    x_secret: null,
+    x_override: null,
+    x_delete: null,
+    x_added: null,
+  },
+  next: {},
+}
+warning: `paginate` request record must not be empty
+ --> tests/operators/from_http/paginate_lambda_record_empty.tql:6:13
+  |
+6 |   paginate=(x => x.next),
+  |             ~~~~~~~~~~~ 
+  |
+  = note: stopping pagination

--- a/test/tests/operators/from_http/paginate_lambda_record_get_body_inherits_method.tql
+++ b/test/tests/operators/from_http/paginate_lambda_record_get_body_inherits_method.tql
@@ -5,6 +5,7 @@ timeout: 60
 
 from_http env("HTTP_FIXTURE_RECORD_GET_BODY_URL"),
   paginate=(x => x.next),
+  encode="form",
   tls=false {
   read_json
 }

--- a/test/tests/operators/from_http/paginate_lambda_record_get_body_inherits_method.tql
+++ b/test/tests/operators/from_http/paginate_lambda_record_get_body_inherits_method.tql
@@ -1,0 +1,10 @@
+---
+fixtures: [http_paginate]
+timeout: 60
+---
+
+from_http env("HTTP_FIXTURE_RECORD_GET_BODY_URL"),
+  paginate=(x => x.next),
+  tls=false {
+  read_json
+}

--- a/test/tests/operators/from_http/paginate_lambda_record_get_body_inherits_method.txt
+++ b/test/tests/operators/from_http/paginate_lambda_record_get_body_inherits_method.txt
@@ -11,14 +11,16 @@
   },
   next: {
     url: "/paginate/record-get-body/2",
-    body: "hello-from-get",
+    body: {
+      hello: "from-get",
+    },
   },
 }
 {
   page: 2,
   method: "GET",
   path: "/paginate/record-get-body/2",
-  body: "hello-from-get",
+  body: "hello=from-get",
   headers: {
     x_secret: null,
     x_override: null,

--- a/test/tests/operators/from_http/paginate_lambda_record_get_body_inherits_method.txt
+++ b/test/tests/operators/from_http/paginate_lambda_record_get_body_inherits_method.txt
@@ -1,0 +1,29 @@
+{
+  page: 1,
+  method: "GET",
+  path: "/paginate/record-get-body/1",
+  body: null,
+  headers: {
+    x_secret: null,
+    x_override: null,
+    x_delete: null,
+    x_added: null,
+  },
+  next: {
+    url: "/paginate/record-get-body/2",
+    body: "hello-from-get",
+  },
+}
+{
+  page: 2,
+  method: "GET",
+  path: "/paginate/record-get-body/2",
+  body: "hello-from-get",
+  headers: {
+    x_secret: null,
+    x_override: null,
+    x_delete: null,
+    x_added: null,
+  },
+  next: null,
+}

--- a/test/tests/operators/from_http/paginate_lambda_record_method.tql
+++ b/test/tests/operators/from_http/paginate_lambda_record_method.tql
@@ -1,0 +1,10 @@
+---
+fixtures: [http_paginate]
+timeout: 60
+---
+
+from_http env("HTTP_FIXTURE_RECORD_METHOD_URL"),
+  paginate=(x => x.next),
+  tls=false {
+  read_json
+}

--- a/test/tests/operators/from_http/paginate_lambda_record_method.txt
+++ b/test/tests/operators/from_http/paginate_lambda_record_method.txt
@@ -1,0 +1,30 @@
+{
+  page: 1,
+  method: "GET",
+  path: "/paginate/record-method/1",
+  body: null,
+  headers: {
+    x_secret: null,
+    x_override: null,
+    x_delete: null,
+    x_added: null,
+  },
+  next: {
+    url: "/paginate/record-method/2",
+    method: "post",
+    body: "hello-from-post",
+  },
+}
+{
+  page: 2,
+  method: "POST",
+  path: "/paginate/record-method/2",
+  body: "hello-from-post",
+  headers: {
+    x_secret: null,
+    x_override: null,
+    x_delete: null,
+    x_added: null,
+  },
+  next: null,
+}

--- a/test/tests/operators/from_http/paginate_lambda_record_request.tql
+++ b/test/tests/operators/from_http/paginate_lambda_record_request.tql
@@ -1,0 +1,18 @@
+---
+fixtures: [http_paginate]
+timeout: 60
+---
+
+from_http env("HTTP_FIXTURE_RECORD_URL"),
+  method="post",
+  body={page: 1},
+  encode="json",
+  headers={
+    "X-Secret": secret("keep", _literal=true),
+    "X-Override": "old",
+    "X-Delete": "gone",
+  },
+  paginate=(x => x.next),
+  tls=false {
+  read_json
+}

--- a/test/tests/operators/from_http/paginate_lambda_record_request.txt
+++ b/test/tests/operators/from_http/paginate_lambda_record_request.txt
@@ -1,0 +1,75 @@
+{
+  page: 1,
+  method: "POST",
+  path: "/paginate/record/1",
+  body: {
+    page: 1,
+  },
+  headers: {
+    x_secret: "keep",
+    x_override: "old",
+    x_delete: "gone",
+    x_added: null,
+  },
+  next: {
+    url: "/paginate/record/2",
+    body: {
+      page: 2,
+    },
+    headers: {
+      "x-override": "new",
+      "X-Added": "yes",
+      "X-Delete": null,
+    },
+  },
+}
+{
+  page: 2,
+  method: "POST",
+  path: "/paginate/record/2",
+  body: {
+    page: 2,
+  },
+  headers: {
+    x_secret: "keep",
+    x_override: "new",
+    x_delete: null,
+    x_added: "yes",
+  },
+  next: {
+    url: "/paginate/record/3",
+    headers: {
+      "x-added": null,
+    },
+  },
+}
+{
+  page: 3,
+  method: "POST",
+  path: "/paginate/record/3",
+  body: {
+    page: 2,
+  },
+  headers: {
+    x_secret: "keep",
+    x_override: "new",
+    x_delete: null,
+    x_added: null,
+  },
+  next: {
+    body: null,
+  },
+}
+{
+  page: 4,
+  method: "POST",
+  path: "/paginate/record/3",
+  body: null,
+  headers: {
+    x_secret: "keep",
+    x_override: "new",
+    x_delete: null,
+    x_added: null,
+  },
+  next: null,
+}

--- a/test/tests/operators/from_http/paginate_lambda_record_unknown_field.tql
+++ b/test/tests/operators/from_http/paginate_lambda_record_unknown_field.tql
@@ -1,0 +1,9 @@
+---
+fixtures: [http_paginate]
+---
+
+from_http env("HTTP_FIXTURE_RECORD_UNKNOWN_URL"),
+  paginate=(x => x.next),
+  tls=false {
+  read_json
+}

--- a/test/tests/operators/from_http/paginate_lambda_record_unknown_field.txt
+++ b/test/tests/operators/from_http/paginate_lambda_record_unknown_field.txt
@@ -1,0 +1,23 @@
+{
+  page: 1,
+  method: "GET",
+  path: "/paginate/record-bad/unknown",
+  body: null,
+  headers: {
+    x_secret: null,
+    x_override: null,
+    x_delete: null,
+    x_added: null,
+  },
+  next: {
+    url: "/paginate/record/2",
+    unexpected: "field",
+  },
+}
+warning: unknown field `unexpected` in `paginate` request record
+ --> tests/operators/from_http/paginate_lambda_record_unknown_field.tql:6:13
+  |
+6 |   paginate=(x => x.next),
+  |             ~~~~~~~~~~~ 
+  |
+  = note: stopping pagination

--- a/test/tests/operators/from_http/paginate_lambda_record_wrong_type.tql
+++ b/test/tests/operators/from_http/paginate_lambda_record_wrong_type.tql
@@ -1,0 +1,9 @@
+---
+fixtures: [http_paginate]
+---
+
+from_http env("HTTP_FIXTURE_RECORD_TYPE_URL"),
+  paginate=(x => x.next),
+  tls=false {
+  read_json
+}

--- a/test/tests/operators/from_http/paginate_lambda_record_wrong_type.txt
+++ b/test/tests/operators/from_http/paginate_lambda_record_wrong_type.txt
@@ -1,0 +1,22 @@
+{
+  page: 1,
+  method: "GET",
+  path: "/paginate/record-bad/type",
+  body: null,
+  headers: {
+    x_secret: null,
+    x_override: null,
+    x_delete: null,
+    x_added: null,
+  },
+  next: {
+    url: 42,
+  },
+}
+warning: `paginate` request field `url` must be `string`
+ --> tests/operators/from_http/paginate_lambda_record_wrong_type.tql:6:13
+  |
+6 |   paginate=(x => x.next),
+  |             ~~~~~~~~~~~ 
+  |
+  = note: stopping pagination

--- a/test/tests/operators/from_http/paginate_link_unreachable.txt
+++ b/test/tests/operators/from_http/paginate_link_unreachable.txt
@@ -1,4 +1,4 @@
-error: HTTP request to `http://127.0.0.1:9/paginate/unreachable/next` failed: folly::AsyncSocketException: AsyncSocketException: connect failed, type = Socket not open, errno = (Connection refused)
+error: HTTP request to `http://127.0.0.1:9/paginate/unreachable/next` failed: Connection refused
  --> tests/operators/from_http/paginate_link_unreachable.tql:7:1
   |
 7 | from_http env("HTTP_FIXTURE_LINK_UNREACHABLE_URL"), paginate="link", connection_timeout=200ms, max_retry_count=0, retry_delay=0s, tls=false { read_json }

--- a/test/tests/operators/to_tcp/error_connect_max_retry_count.txt
+++ b/test/tests/operators/to_tcp/error_connect_max_retry_count.txt
@@ -1,4 +1,4 @@
-warning: failed to connect to 127.0.0.1:9: AsyncSocketException: connect failed, type = Socket not open, errno = (Connection refused)
+warning: failed to connect to 127.0.0.1:9: Connection refused
  --> tests/operators/to_tcp/error_connect_max_retry_count.tql:9:8
   |
 9 | to_tcp "127.0.0.1:9", max_retry_count=1 {
@@ -8,7 +8,7 @@ warning: failed to connect to 127.0.0.1:9: AsyncSocketException: connect failed,
   = note: `tls` is disabled for this connection
   = hint: if the server requires TLS, set `tls=true`
 
-error: AsyncSocketException: connect failed, type = Socket not open, errno = (Connection refused)
+error: failed to connect to 127.0.0.1:9: Connection refused
  --> tests/operators/to_tcp/error_connect_max_retry_count.tql:9:8
   |
 9 | to_tcp "127.0.0.1:9", max_retry_count=1 {

--- a/test/tests/operators/to_tcp/error_connect_max_retry_count.txt
+++ b/test/tests/operators/to_tcp/error_connect_max_retry_count.txt
@@ -1,4 +1,4 @@
-warning: failed to connect to 127.0.0.1:9: AsyncSocketException: connect failed, type = Socket not open, errno = 111 (Connection refused)
+warning: failed to connect to 127.0.0.1:9: AsyncSocketException: connect failed, type = Socket not open, errno = (Connection refused)
  --> tests/operators/to_tcp/error_connect_max_retry_count.tql:9:8
   |
 9 | to_tcp "127.0.0.1:9", max_retry_count=1 {
@@ -8,7 +8,7 @@ warning: failed to connect to 127.0.0.1:9: AsyncSocketException: connect failed,
   = note: `tls` is disabled for this connection
   = hint: if the server requires TLS, set `tls=true`
 
-error: AsyncSocketException: connect failed, type = Socket not open, errno = 111 (Connection refused)
+error: AsyncSocketException: connect failed, type = Socket not open, errno = (Connection refused)
  --> tests/operators/to_tcp/error_connect_max_retry_count.tql:9:8
   |
 9 | to_tcp "127.0.0.1:9", max_retry_count=1 {


### PR DESCRIPTION
## 🔍 Problem

- Some APIs, such as OpenSearch, keep pagination state in the next request body or headers rather than only in a next URL.
- `from_http` lambda pagination could only return URL strings, which made those APIs awkward to ingest without external orchestration.

## 🛠️ Solution

- Allow `from_http` pagination lambdas to return request records that patch `url`, `method`, `headers`, and `body` for the next request.
- Preserve existing string-return, `paginate="link"`, and `paginate="odata"` behavior.
- Validate malformed request records with diagnostics and stop pagination after the current page.
- Add fixture and integration coverage for body inheritance, `body: null`, method inheritance, relative URLs, header merge/delete, secret header preservation, and multi-event parser output.

## 💬 Review

- Focus on request inheritance semantics and the compatibility path for existing pagination modes.
- `encode` remains an operator-level setting and applies to record bodies on paginated requests.

<sub>
📚 Docs PR: tenzir/docs#335
</sub>