### PR TITLE
Track to_splunk HEC queue selection

### DIFF
--- a/changelog/unreleased/to-splunk-hec-queue-selection.md
+++ b/changelog/unreleased/to-splunk-hec-queue-selection.md
@@ -1,0 +1,18 @@
+---
+title: HEC queue selection in `to_splunk`
+type: feature
+authors:
+  - mavam
+  - codex
+created: 2026-05-18T00:00:00Z
+---
+
+The neo `to_splunk` implementation now accepts `queue="indexing"` and
+`queue="typing"` for selecting the Splunk HEC processing queue. The default
+`indexing` path keeps Splunk's regular HEC behavior, while `typing` sends the
+Splunk `parsingQueue` hint in HEC event envelopes for receivers that support
+this non-standard HEC metadata.
+
+The default is `queue="indexing"`. The `typing` queue is rejected with
+`raw=...`, because Splunk's raw HEC endpoint sends raw requests to the indexer
+queue.


### PR DESCRIPTION
## 🔍 Problem

- The contrib neo `to_splunk` queue-selection change needs to be pulled into the root repo.
- The release notes need to describe the new user-facing option.

## 🛠️ Solution

- Advance `contrib/tenzir-plugins` to the neo queue-selection implementation.
- Add a changelog entry for `queue="indexing" | "typing"`.
- Leave receiver-specific behavior covered by the contrib implementation and docs instead of pinning a live Splunk rejection fixture.

## 💬 Review

- Focus on the changelog wording and submodule pointer. The implementation diff is in `tenzir/tenzir-plugins#545`.

<sub>
📚 Docs PR: tenzir/docs#336<br>
📎 Related: tenzir/tenzir-plugins#545
</sub>