### PR TITLE
Fix macOS GCS upload hangs

### DIFF
--- a/.github/workflows/tenzir.yaml
+++ b/.github/workflows/tenzir.yaml
@@ -1060,8 +1060,14 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
       - name: Upload Artifact to GCS
         if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
+        timeout-minutes: 15
         run: |
-          gsutil -m cp "${{ env.BUILD_DIR }}/package/${{ env.PACKAGE_NAME }}.tar.gz" "gs://${{ vars.GCS_BUCKET }}/${{ env.PACKAGE_NAME }}.tar.gz"
+          artifact="${BUILD_DIR}/package/${PACKAGE_NAME}.tar.gz"
+          destination="gs://${{ vars.GCS_BUCKET }}/${PACKAGE_NAME}.tar.gz"
+          test -s "$artifact"
+          ls -lh "$artifact"
+          gcloud --quiet --verbosity=info storage cp "$artifact" "$destination"
+          gcloud --quiet storage ls "$destination"
 
   python:
     needs:


### PR DESCRIPTION
## 🔍 Problem

- The latest `main` macOS run builds, tests, packages, and uploads the GitHub artifact successfully.
- It then hangs in `Upload Artifact to GCS` while running `gsutil -m cp` until GitHub cancels the job at the 6-hour limit.
- The failing artifact was about 84 MB, so the multi-hour GCS step is not expected transfer time.

## 🛠️ Solution

- Replace the legacy `gsutil -m cp` invocation with `gcloud storage cp`.
- Add a 15-minute timeout so this publish step cannot consume the full runner limit again.
- Log the artifact size before upload and verify the copied destination object afterwards.

## 💬 Review

- Focus on the GCS upload command, destination path preservation, and the 15-minute timeout budget.
- Checked with `uvx yamllint==1.37.1 .github/workflows/tenzir.yaml` and `git diff --check`.
- `actionlint .github/workflows/tenzir.yaml` still reports pre-existing unrelated workflow issues, but none in the changed upload step.
