### PR TITLE
Retain operator profile metrics

### DIFF
--- a/libtenzir/include/tenzir/retention_policy.hpp
+++ b/libtenzir/include/tenzir/retention_policy.hpp
@@ -49,6 +49,8 @@ struct retention_policy {
     try_parse(result.diagnostics_period, "tenzir.retention.diagnostics");
     try_parse(result.operator_metrics_period,
               "tenzir.retention.operator-metrics");
+    try_parse(result.operator_profile_metrics_period,
+              "tenzir.retention.operator-profile-metrics");
     if (failed) {
       return failure::promise();
     }
@@ -76,6 +78,9 @@ struct retention_policy {
     if (schema.name() == "tenzir.metrics.operator") {
       return operator_metrics_period > duration::zero();
     }
+    if (schema.name() == "tenzir.metrics.operator_profile") {
+      return operator_profile_metrics_period > duration::zero();
+    }
     if (schema.name().starts_with("tenzir.metrics.")) {
       return metrics_period > duration::zero();
     }
@@ -87,12 +92,15 @@ struct retention_policy {
       .pretty_name("tenzir.retention_policy")
       .fields(f.field("metrics_period", x.metrics_period),
               f.field("diagnostics_period", x.diagnostics_period),
-              f.field("operator_metrics_period", x.operator_metrics_period));
+              f.field("operator_metrics_period", x.operator_metrics_period),
+              f.field("operator_profile_metrics_period",
+                      x.operator_profile_metrics_period));
   }
 
   duration metrics_period = days{16};
   duration diagnostics_period = days{30};
   duration operator_metrics_period = duration::zero();
+  duration operator_profile_metrics_period = days{1};
 };
 
 } // namespace tenzir

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -32,6 +32,14 @@ tenzir:
     # pipeline activity in the Tenzir Platform.
     #metrics: 7d
 
+    # How long to keep legacy operator metrics for. Set to 0s to avoid storing
+    # these heavy metrics while still making live metrics available.
+    #operator-metrics: 0s
+
+    # How long to keep operator profile metrics for. Set to 0s to avoid storing
+    # these heavy metrics while still making live metrics available.
+    #operator-profile-metrics: 1d
+
     # How long to keep diagnostics for. Set to 0s to disable diagnostics
     # retention entirely.
     # WARNING: A low retention period may negatively impact the usability of


### PR DESCRIPTION
## 🔍 Problem

- `operator_profile` metrics from the new executor use their own schema.
- They currently fall through to the general metrics retention default.
- Regular `tenzir.metrics.operator` events should remain disabled by default because they are heavy and legacy-oriented.
- The shipped example configuration should match the docs copy.

## 🛠️ Solution

- Add `tenzir.retention.operator-profile-metrics` for `tenzir.metrics.operator_profile`.
- Keep `tenzir.retention.operator-metrics` controlling only legacy `tenzir.metrics.operator` events, with its `0s` default unchanged.
- Use a one-day default for operator profile metrics.
- List both settings in `tenzir.yaml.example`.

## 💬 Review

- Check that the schema mapping is intentionally exact and does not affect other `tenzir.metrics.*` events.
- Check that the example configuration wording matches tenzir/docs#343.

<sub>
📚 Docs PRs: tenzir/docs#339, tenzir/docs#343<br>
✅ Closes TNZ-580
</sub>