### PR TITLE
Add `max_retry_count` to `to_tcp`

### DIFF
--- a/libtenzir/builtins/operators/to_tcp.cpp
+++ b/libtenzir/builtins/operators/to_tcp.cpp
@@ -54,7 +54,7 @@ constexpr auto connect_retry_jitter = 0.0;
 constexpr auto connect_max_retries = std::numeric_limits<uint32_t>::max();
 // Leave room for many queued payloads while still applying backpressure when
 // the remote peer falls behind or reconnects take time.
-constexpr auto message_queue_capacity = uint32_t{1_Ki};
+constexpr auto message_queue_capacity = uint32_t{10};
 
 constexpr auto should_retry_connect = [](folly::exception_wrapper const& ew) {
   return ew.is_compatible_with<folly::AsyncSocketException>();

--- a/libtenzir/builtins/operators/to_tcp.cpp
+++ b/libtenzir/builtins/operators/to_tcp.cpp
@@ -12,6 +12,7 @@
 #include <tenzir/compile_ctx.hpp>
 #include <tenzir/concept/parseable/tenzir/endpoint.hpp>
 #include <tenzir/concept/parseable/to.hpp>
+#include <tenzir/detail/narrow.hpp>
 #include <tenzir/endpoint.hpp>
 #include <tenzir/ir.hpp>
 #include <tenzir/operator_plugin.hpp>
@@ -47,12 +48,15 @@ constexpr auto connect_timeout = std::chrono::seconds{5};
 constexpr auto connect_initial_backoff = std::chrono::milliseconds{100};
 // Cap retries at five seconds to avoid hammering broken endpoints while still
 // keeping recovery reasonably quick once the peer comes back.
-constexpr auto connect_max_backoff = std::chrono::milliseconds{5_k};
+constexpr auto connect_max_backoff = std::chrono::seconds{5};
 // Preserve the current deterministic reconnect timing; if many sinks are
 // expected to flap together, revisit this and add jitter.
 constexpr auto connect_retry_jitter = 0.0;
-constexpr auto connect_max_retries = std::numeric_limits<uint32_t>::max();
-// Leave room for many queued payloads while still applying backpressure when
+// Used when the user does not set `max_retry_count`; effectively unbounded so
+// the operator keeps trying to reach the peer until the pipeline is shut down.
+constexpr auto default_connect_max_retry_count
+  = std::numeric_limits<uint32_t>::max();
+// Leave room for some queued payloads while still applying backpressure when
 // the remote peer falls behind or reconnects take time.
 constexpr auto message_queue_capacity = uint32_t{10};
 
@@ -63,6 +67,7 @@ constexpr auto should_retry_connect = [](folly::exception_wrapper const& ew) {
 struct ToTcpArgs {
   located<std::string> endpoint;
   Option<located<data>> tls;
+  Option<located<uint64_t>> max_retry_count;
   located<ir::pipeline> printer;
 };
 
@@ -208,33 +213,50 @@ private:
     if (lifecycle_ == Lifecycle::done or transport_) {
       co_return;
     }
-    transport_ = co_await folly::coro::retryWithExponentialBackoff(
-      connect_max_retries, connect_initial_backoff, connect_max_backoff,
-      connect_retry_jitter,
-      [this, &ctx]() -> Task<folly::coro::Transport> {
-        TENZIR_DEBUG("to_tcp: connecting to {}", address_.describe());
-        try {
-          co_return co_await connect_tcp_client(
-            evb_, address_,
-            std::chrono::duration_cast<std::chrono::milliseconds>(
-              connect_timeout),
-            tls_context_, host_);
-        } catch (folly::AsyncSocketException const& ex) {
-          // TODO: Surface connect retries and failures as metrics in a
-          // follow-up that covers all TCP operators.
-          auto diag
-            = diagnostic::warning("failed to connect to {}",
-                                  address_.describe())
-                .primary(args_.endpoint.source)
-                .note("reason: {}", ex.what())
-                .hint("ensure a TCP server is listening on this endpoint");
-
-          add_tls_client_diagnostic_hints(std::move(diag), is_tls_enabled(ctx))
-            .emit(ctx.dh());
-          throw;
-        }
-      },
-      should_retry_connect);
+    // `retryWithExponentialBackoff` rethrows the last attempt's exception once
+    // the configured retry budget is exhausted. With the default (unset)
+    // `max_retry_count`, the budget is effectively infinite so the catch only
+    // ever fires when the user opted into a finite retry count.
+    auto const max_retry_count
+      = args_.max_retry_count
+          ? detail::narrow<uint32_t>(args_.max_retry_count->inner)
+          : default_connect_max_retry_count;
+    try {
+      transport_ = co_await folly::coro::retryWithExponentialBackoff(
+        max_retry_count, connect_initial_backoff, connect_max_backoff,
+        connect_retry_jitter,
+        [this, &ctx]() -> Task<folly::coro::Transport> {
+          TENZIR_DEBUG("to_tcp: connecting to {}", address_.describe());
+          try {
+            co_return co_await connect_tcp_client(
+              evb_, address_,
+              std::chrono::duration_cast<std::chrono::milliseconds>(
+                connect_timeout),
+              tls_context_, host_);
+          } catch (folly::AsyncSocketException const& ex) {
+            // TODO: Surface connect retries and failures as metrics in a
+            // follow-up that covers all TCP operators.
+            auto diag
+              = diagnostic::warning("failed to connect to {}: {}",
+                                    address_.describe(), ex.what())
+                  .primary(args_.endpoint.source)
+                  .hint("ensure a TCP server is listening on this endpoint");
+            add_tls_client_diagnostic_hints(std::move(diag),
+                                            is_tls_enabled(ctx))
+              .emit(ctx.dh());
+            throw;
+          }
+        },
+        should_retry_connect);
+    } catch (folly::AsyncSocketException const& ex) {
+      diagnostic::error("{}", ex.what())
+        .primary(args_.endpoint.source)
+        .note("gave up after {} {}", max_retry_count,
+              max_retry_count == 1 ? "retry" : "retries")
+        .emit(ctx.dh());
+      finish();
+      co_return;
+    }
     auto peer_addr = transport_->getPeerAddress();
     bytes_write_counter_ = ctx.make_counter(
       MetricsLabel{"peer_ip", MetricsLabel::FixedString::truncate(
@@ -292,10 +314,12 @@ private:
   Option<tls_options> tls_;
   std::shared_ptr<folly::SSLContext> tls_context_;
   folly::EventBase* evb_ = nullptr;
-  mutable Box<MessageQueue> message_queue_{std::in_place,
-                                           message_queue_capacity};
+  mutable Box<MessageQueue> message_queue_{
+    std::in_place,
+    message_queue_capacity,
+  };
   Option<folly::coro::Transport> transport_;
-  MetricsCounter bytes_write_counter_ = {};
+  MetricsCounter bytes_write_counter_;
   Lifecycle lifecycle_ = Lifecycle::running;
 };
 
@@ -309,6 +333,8 @@ public:
     auto d = Describer<ToTcpArgs, ToTcp>{};
     auto endpoint_arg = d.positional("endpoint", &ToTcpArgs::endpoint);
     auto tls_arg = d.named("tls", &ToTcpArgs::tls);
+    auto max_retry_count_arg
+      = d.named("max_retry_count", &ToTcpArgs::max_retry_count);
     auto printer_arg = d.pipeline(&ToTcpArgs::printer);
     d.validate([=](DescribeCtx& ctx) -> Empty {
       TRY(auto endpoint_str, ctx.get(endpoint_arg));
@@ -325,6 +351,14 @@ public:
         auto tls_opts = tls_options{*tls_val, {.is_server = false}};
         if (auto valid = tls_opts.validate(ctx); not valid) {
           return {};
+        }
+      }
+      if (auto max_retry_count = ctx.get(max_retry_count_arg)) {
+        if (max_retry_count->inner > std::numeric_limits<uint32_t>::max()) {
+          diagnostic::error("`max_retry_count` must be <= {}",
+                            std::numeric_limits<uint32_t>::max())
+            .primary(max_retry_count->source)
+            .emit(ctx);
         }
       }
       TRY(auto printer, ctx.get(printer_arg));

--- a/test/tests/operators/to_tcp/error_connect_max_retry_count.tql
+++ b/test/tests/operators/to_tcp/error_connect_max_retry_count.tql
@@ -1,0 +1,11 @@
+---
+timeout: 30
+error: true
+---
+
+from {
+  line: "hello-from-to_tcp",
+}
+to_tcp "127.0.0.1:9", max_retry_count=1 {
+  write_ndjson
+}

--- a/test/tests/operators/to_tcp/error_connect_max_retry_count.txt
+++ b/test/tests/operators/to_tcp/error_connect_max_retry_count.txt
@@ -1,0 +1,17 @@
+warning: failed to connect to 127.0.0.1:9: AsyncSocketException: connect failed, type = Socket not open, errno = 111 (Connection refused)
+ --> tests/operators/to_tcp/error_connect_max_retry_count.tql:9:8
+  |
+9 | to_tcp "127.0.0.1:9", max_retry_count=1 {
+  |        ~~~~~~~~~~~~~ 
+  |
+  = hint: ensure a TCP server is listening on this endpoint
+  = note: `tls` is disabled for this connection
+  = hint: if the server requires TLS, set `tls=true`
+
+error: AsyncSocketException: connect failed, type = Socket not open, errno = 111 (Connection refused)
+ --> tests/operators/to_tcp/error_connect_max_retry_count.tql:9:8
+  |
+9 | to_tcp "127.0.0.1:9", max_retry_count=1 {
+  |        ^^^^^^^^^^^^^ 
+  |
+  = note: gave up after 1 retry


### PR DESCRIPTION
Adds a `max_retry_count` option to the `to_tcp` operator. When set, the operator stops retrying and emits an error diagnostic after exhausting the budget instead of looping until pipeline shutdown.

Resolves TNZ-595.