### PR TITLE
Reject cron subpipelines that emit chunk_ptr

### DIFF
--- a/libtenzir/builtins/operators/cron.cpp
+++ b/libtenzir/builtins/operators/cron.cpp
@@ -99,8 +99,8 @@ public:
   auto describe() const -> Description override {
     auto d = Describer<CronArgs, Cron>{};
     auto schedule = d.positional("schedule", &CronArgs::schedule, "string");
-    d.pipeline(&CronArgs::pipe);
-    d.validate([schedule](DescribeCtx& ctx) -> Empty {
+    auto pipe_arg = d.pipeline(&CronArgs::pipe);
+    d.validate([schedule, pipe_arg](DescribeCtx& ctx) -> Empty {
       if (auto v = ctx.get(schedule)) {
         try {
           detail::cron::make_cron(v->inner);
@@ -114,6 +114,16 @@ public:
           } else {
             diagnostic::error("bad cron expression: {}", msg)
               .primary(v->source)
+              .emit(ctx);
+          }
+        }
+      }
+      if (auto pipe = ctx.get(pipe_arg)) {
+        auto output = pipe->inner.infer_type(tag_v<void>, ctx);
+        if (not output.is_error()) {
+          if (not *output or (*output)->is_not<table_slice>()) {
+            diagnostic::error("pipeline must return events")
+              .primary(pipe->source.subloc(0, 1))
               .emit(ctx);
           }
         }

--- a/test/tests/operators/cron/bytes_output.tql
+++ b/test/tests/operators/cron/bytes_output.tql
@@ -1,0 +1,7 @@
+---
+error: true
+---
+
+cron "* * * * * *", {
+  load_stdin
+}

--- a/test/tests/operators/cron/bytes_output.txt
+++ b/test/tests/operators/cron/bytes_output.txt
@@ -1,0 +1,6 @@
+error: pipeline must return events
+ --> tests/operators/cron/bytes_output.tql:5:21
+  |
+5 | cron "* * * * * *", {
+  |                     ^ 
+  |


### PR DESCRIPTION

Currently, this panics:
```
cron "*/4 * * * * *" {
  from {a: 1}
  write_lines
}
```

This PR changes that into an error diagnostic.

We might want to support this, but I'm not convinced.