### PR TITLE
Demote pipeline thread log

### DIFF
--- a/libtenzir/src/tql2/exec.cpp
+++ b/libtenzir/src/tql2/exec.cpp
@@ -2107,11 +2107,11 @@ auto run_plan_blocking(OperatorChain<void, void> chain, caf::actor_system& sys,
                has_terminal, false)));
   });
 #if 0
-  TENZIR_INFO("running pipeline on a single thread");
+  TENZIR_DEBUG("running pipeline on a single thread");
   auto result = folly::coro::blockingWait(std::move(task));
 #else
-  TENZIR_INFO("running pipeline on {} threads",
-              folly::getGlobalCPUExecutorCounters().numThreads);
+  TENZIR_DEBUG("running pipeline on {} threads",
+               folly::getGlobalCPUExecutorCounters().numThreads);
   auto result = folly::coro::blockingWait(folly::coro::co_withExecutor(
     folly::getGlobalCPUExecutor(), std::move(task)));
 #endif


### PR DESCRIPTION
## Problem

The pipeline executor reports its worker thread count at info level, which makes routine pipeline startup noisy in default logs.

## Solution

Emit the single-threaded and multi-threaded variants of that message at debug level instead.

## Review

This is limited to log verbosity; there is no behavior change beyond the emitted level.