### PR TITLE
Fix to_tcp retry exhaustion

### DIFF
--- a/.github/workflows/nix-build.py
+++ b/.github/workflows/nix-build.py
@@ -29,6 +29,7 @@ import json
 import os
 import platform
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -57,9 +58,16 @@ def error(msg: str) -> None:
     print(f"::error::{msg}")
 
 
+def format_command(cmd: object) -> str:
+    """Format a subprocess command for logs."""
+    if isinstance(cmd, list | tuple):
+        return shlex.join(str(arg) for arg in cmd)
+    return str(cmd)
+
+
 def run(cmd: list[str], check: bool = True) -> subprocess.CompletedProcess[str]:
     """Run a command, optionally capturing output."""
-    notice(f"Running: {' '.join(cmd)}")
+    notice(f"Running: {format_command(cmd)}")
     return subprocess.run(cmd, check=check, stdout=subprocess.PIPE, text=True)
 
 
@@ -1296,7 +1304,21 @@ def main() -> int:
     print_pkgutil_identifier_parser.set_defaults(func=cmd_print_pkgutil_identifier)
 
     args = parser.parse_args()
-    return args.func(args)
+    try:
+        return args.func(args)
+    except subprocess.CalledProcessError as exc:
+        error(
+            f"Command failed with exit code {exc.returncode}: {format_command(exc.cmd)}"
+        )
+        if exc.stdout:
+            print(exc.stdout, end="" if exc.stdout.endswith("\n") else "\n")
+        if exc.stderr:
+            print(
+                exc.stderr,
+                end="" if exc.stderr.endswith("\n") else "\n",
+                file=sys.stderr,
+            )
+        return exc.returncode
 
 
 if __name__ == "__main__":

--- a/libtenzir/builtins/formats/bitz.cpp
+++ b/libtenzir/builtins/formats/bitz.cpp
@@ -64,6 +64,7 @@ public:
                  .note("expected {}",
                        std::string_view{BITZ_MAGIC.data(), BITZ_MAGIC.size()}),
                ctx.dh());
+          co_return;
         }
         state_ = State::header;
       }
@@ -384,6 +385,7 @@ public:
               .note("expected {}",
                     std::string_view{BITZ_MAGIC.data(), BITZ_MAGIC.size()})
               .emit(ctrl.diagnostics());
+            co_return;
           }
           auto header = byte_reader(sizeof(uint64_t));
           while (not header) {

--- a/libtenzir/builtins/operators/to_tcp.cpp
+++ b/libtenzir/builtins/operators/to_tcp.cpp
@@ -230,43 +230,11 @@ private:
     if (lifecycle_ == Lifecycle::done or transport_) {
       co_return;
     }
-    // `retryWithExponentialBackoff` rethrows the last attempt's exception once
-    // the configured retry budget is exhausted. With the default (unset)
-    // `max_retry_count`, the budget is effectively infinite so the catch only
-    // ever fires when the user opted into a finite retry count.
     auto const max_retry_count
       = args_.max_retry_count
           ? detail::narrow<uint32_t>(args_.max_retry_count->inner)
           : default_connect_max_retry_count;
-    try {
-      transport_ = co_await folly::coro::retryWithExponentialBackoff(
-        max_retry_count, connect_initial_backoff, connect_max_backoff,
-        connect_retry_jitter,
-        [this, &ctx]() -> Task<folly::coro::Transport> {
-          TENZIR_DEBUG("to_tcp: connecting to {}", address_.describe());
-          try {
-            co_return co_await connect_tcp_client(
-              evb_, address_,
-              std::chrono::duration_cast<std::chrono::milliseconds>(
-                connect_timeout),
-              tls_context_, host_);
-          } catch (folly::AsyncSocketException const& ex) {
-            // TODO: Surface connect retries and failures as metrics in a
-            // follow-up that covers all TCP operators.
-            auto diag
-              = diagnostic::warning("failed to connect to {}: {}",
-                                    address_.describe(),
-                                    describe_socket_error(ex))
-                  .primary(args_.endpoint.source)
-                  .hint("ensure a TCP server is listening on this endpoint");
-            add_tls_client_diagnostic_hints(std::move(diag),
-                                            is_tls_enabled(ctx))
-              .emit(ctx.dh());
-            throw;
-          }
-        },
-        should_retry_connect);
-    } catch (folly::AsyncSocketException const& ex) {
+    auto emit_final_error = [&](folly::AsyncSocketException const& ex) {
       diagnostic::error("failed to connect to {}: {}", address_.describe(),
                         describe_socket_error(ex))
         .primary(args_.endpoint.source)
@@ -274,6 +242,44 @@ private:
               max_retry_count == 1 ? "retry" : "retries")
         .emit(ctx.dh());
       finish();
+    };
+    auto emit_retry_warning = [&](folly::AsyncSocketException const& ex) {
+      // TODO: Surface connect retries and failures as metrics in a follow-up
+      // that covers all TCP operators.
+      auto diag
+        = diagnostic::warning("failed to connect to {}: {}",
+                              address_.describe(), describe_socket_error(ex))
+            .primary(args_.endpoint.source)
+            .hint("ensure a TCP server is listening on this endpoint");
+      ctx.dh().emit(
+        add_tls_client_diagnostic_hints(std::move(diag), is_tls_enabled(ctx))
+          .done());
+    };
+    auto connect = [this]() -> Task<folly::coro::Transport> {
+      TENZIR_DEBUG("to_tcp: connecting to {}", address_.describe());
+      co_return co_await connect_tcp_client(
+        evb_, address_,
+        std::chrono::duration_cast<std::chrono::milliseconds>(connect_timeout),
+        tls_context_, host_);
+    };
+    try {
+      transport_ = co_await folly::coro::retryWithExponentialBackoff(
+        max_retry_count, connect_initial_backoff, connect_max_backoff,
+        connect_retry_jitter,
+        [this, &connect,
+         &emit_retry_warning]() -> Task<folly::coro::Transport> {
+          try {
+            co_return co_await connect();
+          } catch (folly::AsyncSocketException const& ex) {
+            if (not args_.max_retry_count) {
+              emit_retry_warning(ex);
+            }
+            throw;
+          }
+        },
+        should_retry_connect);
+    } catch (folly::AsyncSocketException const& ex) {
+      emit_final_error(ex);
       co_return;
     }
     auto peer_addr = transport_->getPeerAddress();

--- a/libtenzir/builtins/operators/to_tcp.cpp
+++ b/libtenzir/builtins/operators/to_tcp.cpp
@@ -235,11 +235,14 @@ private:
           ? detail::narrow<uint32_t>(args_.max_retry_count->inner)
           : default_connect_max_retry_count;
     auto emit_final_error = [&](folly::AsyncSocketException const& ex) {
-      diagnostic::error("failed to connect to {}: {}", address_.describe(),
-                        describe_socket_error(ex))
-        .primary(args_.endpoint.source)
-        .note("gave up after {} {}", max_retry_count,
-              max_retry_count == 1 ? "retry" : "retries")
+      auto diag
+        = diagnostic::error("failed to connect to {}: {}", address_.describe(),
+                            describe_socket_error(ex))
+            .primary(args_.endpoint.source)
+            .note("gave up after {} {}", max_retry_count,
+                  max_retry_count == 1 ? "retry" : "retries")
+            .hint("ensure a TCP server is listening on this endpoint");
+      add_tls_client_diagnostic_hints(std::move(diag), is_tls_enabled(ctx))
         .emit(ctx.dh());
       finish();
     };

--- a/test/tests/operators/to_tcp/error_connect_max_retry_count.txt
+++ b/test/tests/operators/to_tcp/error_connect_max_retry_count.txt
@@ -5,3 +5,6 @@ error: failed to connect to 127.0.0.1:9: Connection refused
   |        ^^^^^^^^^^^^^ 
   |
   = note: gave up after 1 retry
+  = hint: ensure a TCP server is listening on this endpoint
+  = note: `tls` is disabled for this connection
+  = hint: if the server requires TLS, set `tls=true`

--- a/test/tests/operators/to_tcp/error_connect_max_retry_count.txt
+++ b/test/tests/operators/to_tcp/error_connect_max_retry_count.txt
@@ -1,13 +1,3 @@
-warning: failed to connect to 127.0.0.1:9: Connection refused
- --> tests/operators/to_tcp/error_connect_max_retry_count.tql:9:8
-  |
-9 | to_tcp "127.0.0.1:9", max_retry_count=1 {
-  |        ~~~~~~~~~~~~~ 
-  |
-  = hint: ensure a TCP server is listening on this endpoint
-  = note: `tls` is disabled for this connection
-  = hint: if the server requires TLS, set `tls=true`
-
 error: failed to connect to 127.0.0.1:9: Connection refused
  --> tests/operators/to_tcp/error_connect_max_retry_count.tql:9:8
   |

--- a/test/tests/operators/to_tcp/no_output_no_connect.tql
+++ b/test/tests/operators/to_tcp/no_output_no_connect.tql
@@ -1,0 +1,11 @@
+---
+timeout: 30
+---
+
+from {
+  line: "hello-from-to_tcp",
+}
+to_tcp "127.0.0.1:9", max_retry_count=0 {
+  where false
+  write_ndjson
+}


### PR DESCRIPTION
## 🔍 Problem

- `to_tcp ..., max_retry_count=1` could stop after a refused connection warning and still let the pipeline exit successfully.
- The retry-exhaustion fixture expected the sink to fail the pipeline instead.

## 🛠️ Solution

- Keep bounded connection retries tied to the sink lifecycle so upstream completion cannot turn a failed TCP write into a clean shutdown.
- Emit the terminal connection error when the explicit retry budget is exhausted.
- Add a bugfix changelog entry.

## 💬 Review

- Focus on the `to_tcp` connection/finalization lifecycle and the updated retry-exhaustion reference output.