### PR TITLE
Optimize filters through operators with variables

### DIFF
--- a/libtenzir/builtins/operators/dns_lookup.cpp
+++ b/libtenzir/builtins/operators/dns_lookup.cpp
@@ -600,8 +600,9 @@ public:
       auto touched_fields = std::vector<ast::field_path>{};
       touched_fields.push_back(
         ctx.get(result).value_or(default_result_field()));
+      auto touched = ast::ExprRefs{.field_paths = std::move(touched_fields)};
       auto [f_upstream, f_self]
-        = ir::split_filter_by_dependents(std::move(filter), touched_fields);
+        = ir::split_filter_by_dependents(std::move(filter), touched);
       return {
         .order = order,
         .filter_upstream = std::move(f_upstream),

--- a/libtenzir/builtins/operators/drop.cpp
+++ b/libtenzir/builtins/operators/drop.cpp
@@ -241,8 +241,9 @@ public:
         TENZIR_ASSERT(field);
         touched_fields.push_back(std::move(*field));
       }
+      auto touched = ast::ExprRefs{.field_paths = std::move(touched_fields)};
       auto [f_upstream, f_self]
-        = ir::split_filter_by_dependents(std::move(filter), touched_fields);
+        = ir::split_filter_by_dependents(std::move(filter), touched);
       return {
         // invariant order
         .order = order,

--- a/libtenzir/builtins/operators/each.cpp
+++ b/libtenzir/builtins/operators/each.cpp
@@ -181,7 +181,7 @@ public:
         return failure::promise();
       }
     });
-    return d.without_optimize();
+    return d.invariant_filter();
   }
 };
 

--- a/libtenzir/builtins/operators/load_balance.cpp
+++ b/libtenzir/builtins/operators/load_balance.cpp
@@ -8,6 +8,7 @@
 
 #include "tenzir/async.hpp"
 #include "tenzir/detail/narrow.hpp"
+#include "tenzir/ir.hpp"
 #include "tenzir/operator_plugin.hpp"
 #include "tenzir/option.hpp"
 #include "tenzir/pipeline.hpp"
@@ -555,7 +556,17 @@ public:
       }
       return {};
     });
-    return d.unordered();
+    return d.optimize([](DescribeCtx& ctx, event_order,
+                         ir::optimize_filter filter) -> Optimization {
+      auto touched = ast::ExprRefs{.let_ids = ctx.pipeline_let_ids()};
+      auto [independent, dependent]
+        = ir::split_filter_by_dependents(std::move(filter), touched);
+      return {
+        .order = event_order::unordered,
+        .filter_upstream = std::move(independent),
+        .filter_self = std::move(dependent),
+      };
+    });
   }
 };
 

--- a/libtenzir/include/tenzir/ir.hpp
+++ b/libtenzir/include/tenzir/ir.hpp
@@ -173,10 +173,12 @@ struct split_filter_result {
   ir::optimize_filter dependent;
 };
 
-/// Splits a filter chain by dependency on a set of fields.
-/// Returns independent and dependent filters.
+/// Splits a filter chain into independent and dependent parts.
+/// A filter expression is dependent if its references overlap with `touched`.
+/// If refs of a filter cannot be determined (ambiguous), it is conservatively
+/// placed into the dependent set.
 auto split_filter_by_dependents(ir::optimize_filter filter,
-                                std::span<const ast::field_path> fields)
+                                const ast::ExprRefs& touched)
   -> split_filter_result;
 
 class SetIr final : public Operator {

--- a/libtenzir/include/tenzir/operator_plugin.hpp
+++ b/libtenzir/include/tenzir/operator_plugin.hpp
@@ -499,6 +499,22 @@ public:
     return operator_location_;
   }
 
+  /// Returns the let_ids bound by the pipeline's let bindings, in declaration
+  /// order. Empty if there is no pipeline or no let bindings.
+  auto pipeline_let_ids() const -> std::vector<let_id> {
+    if (not pipeline_ or not desc_->pipeline) {
+      return {};
+    }
+    auto result = std::vector<let_id>{};
+    for (const auto& [_, id] : pipeline_->let_ids) {
+      result.push_back(id);
+    }
+    for (const auto& let : pipeline_->pipeline.inner.lets) {
+      result.push_back(let.id);
+    }
+    return result;
+  }
+
   explicit(false) operator diagnostic_handler&() {
     return *dh_;
   }
@@ -1005,22 +1021,30 @@ public:
   /// Filter from downstream will be pushed upstream.
   /// Upstream is required to produce ordered events.
   auto invariant_filter() -> Description {
-    return optimize([](DescribeCtx&, event_order,
+    return optimize([](DescribeCtx& ctx, event_order,
                        ir::optimize_filter filter) -> Optimization {
+      auto touched = ast::ExprRefs{.let_ids = ctx.pipeline_let_ids()};
+      auto [independent, dependent]
+        = ir::split_filter_by_dependents(std::move(filter), touched);
       return {
         .order = event_order::ordered,
-        .filter_upstream = std::move(filter),
+        .filter_upstream = std::move(independent),
+        .filter_self = std::move(dependent),
       };
     });
   }
 
   /// Declares that the operator is invariant to ordering and filtering.
   auto invariant_order_filter() -> Description {
-    return optimize([](DescribeCtx&, event_order order,
+    return optimize([](DescribeCtx& ctx, event_order order,
                        ir::optimize_filter filter) -> Optimization {
+      auto touched = ast::ExprRefs{.let_ids = ctx.pipeline_let_ids()};
+      auto [independent, dependent]
+        = ir::split_filter_by_dependents(std::move(filter), touched);
       return {
         .order = order,
-        .filter_upstream = std::move(filter),
+        .filter_upstream = std::move(independent),
+        .filter_self = std::move(dependent),
       };
     });
   }

--- a/libtenzir/include/tenzir/tql2/ast.hpp
+++ b/libtenzir/include/tenzir/tql2/ast.hpp
@@ -15,6 +15,7 @@
 #include "tenzir/diagnostics.hpp"
 #include "tenzir/let_id.hpp"
 #include "tenzir/location.hpp"
+#include "tenzir/option.hpp"
 #include "tenzir/tql2/entity_path.hpp"
 #include "tenzir/variant.hpp"
 
@@ -298,13 +299,19 @@ private:
   std::vector<segment> path_;
 };
 
-/// Returns all field paths referenced by an expression.
-auto referenced_field_paths(const expression& expr) -> std::vector<field_path>;
+/// A set of references (field paths and let bindings) found in an expression.
+struct ExprRefs {
+  std::vector<field_path> field_paths = {};
+  std::vector<let_id> let_ids = {};
 
-/// Returns whether an expression may reference any of the given field paths.
-/// This is conservative and returns true for ambiguous field accesses.
-auto references_any_field_path(const expression& expr,
-                               std::span<const field_path> paths) -> bool;
+  /// Returns `true` if any reference in `*this` overlaps with `other`.
+  /// Field-path overlap uses prefix matching; let-id overlap is exact.
+  auto overlaps(const ExprRefs& other) const -> bool;
+};
+
+/// Collect all references (field paths and let bindings) from an expression.
+/// Returns `None` when the expression contains ambiguous field accesses.
+auto collect_refs(const expression& expr) -> Option<ExprRefs>;
 
 /// A selector is something that can be assigned.
 ///

--- a/libtenzir/src/ir.cpp
+++ b/libtenzir/src/ir.cpp
@@ -28,11 +28,16 @@
 namespace tenzir {
 
 auto ir::split_filter_by_dependents(ir::optimize_filter filter,
-                                    std::span<const ast::field_path> fields)
+                                    const ast::ExprRefs& touched)
   -> ir::split_filter_result {
   auto result = ir::split_filter_result{};
+  if (touched.let_ids.empty() and touched.field_paths.empty()) {
+    result.independent = std::move(filter);
+    return result;
+  }
   for (auto& expr : filter) {
-    if (references_any_field_path(expr, fields)) {
+    auto refs = ast::collect_refs(expr);
+    if (not refs or refs->overlaps(touched)) {
       result.dependent.push_back(std::move(expr));
     } else {
       result.independent.push_back(std::move(expr));
@@ -247,9 +252,11 @@ auto touched_fields_for_set(const std::vector<ast::assignment>& assignments)
 auto ir::SetIr::optimize(ir::optimize_filter filter,
                          event_order order) && -> ir::optimize_result {
   order_ = weaker_event_order(order_, order);
-  auto touched = touched_fields_for_set(assignments_);
-  auto split = touched
-                 ? ir::split_filter_by_dependents(std::move(filter), *touched)
+  auto touched_paths = touched_fields_for_set(assignments_);
+  auto split = touched_paths
+                 ? ir::split_filter_by_dependents(
+                     std::move(filter),
+                     ast::ExprRefs{.field_paths = std::move(*touched_paths)})
                  : ir::split_filter_result{{}, std::move(filter)};
   auto [filter_upstream, filter_self] = std::move(split);
   auto ops = std::vector<Box<ir::Operator>>{};

--- a/libtenzir/src/tql2/ast.cpp
+++ b/libtenzir/src/tql2/ast.cpp
@@ -19,6 +19,7 @@
 #include <caf/binary_serializer.hpp>
 #include <caf/detail/type_list.hpp>
 
+#include <algorithm>
 #include <type_traits>
 #include <unordered_set>
 #include <vector>
@@ -201,7 +202,7 @@ auto selector::try_from(ast::expression expr) -> std::optional<selector> {
 
 namespace {
 
-class field_path_extractor final : public ast::visitor<field_path_extractor> {
+class ref_collector final : public ast::visitor<ref_collector> {
 public:
   template <class T>
   void visit(const T& x) {
@@ -215,7 +216,7 @@ public:
                               ast::index_expr, ast::this_>
   {
     if (auto path = ast::field_path::try_from(x)) {
-      paths_.push_back(std::move(*path));
+      refs_.field_paths.push_back(std::move(*path));
       return;
     }
     ambiguous_ = true;
@@ -223,16 +224,23 @@ public:
     enter(const_cast<T&>(x));
   }
 
+  void visit(const ast::dollar_var& x) {
+    if (x.let
+        and std::ranges::find(refs_.let_ids, x.let) == refs_.let_ids.end()) {
+      refs_.let_ids.push_back(x.let);
+    }
+  }
+
   auto ambiguous() const -> bool {
     return ambiguous_;
   }
 
-  auto result() && -> std::vector<ast::field_path> {
-    return std::move(paths_);
+  auto result() && -> ast::ExprRefs {
+    return std::move(refs_);
   }
 
 private:
-  std::vector<ast::field_path> paths_;
+  ast::ExprRefs refs_;
   bool ambiguous_ = false;
 };
 
@@ -255,28 +263,28 @@ auto field_paths_overlap(const field_path& lhs, const field_path& rhs) -> bool {
 
 } // namespace
 
-auto referenced_field_paths(const expression& expr) -> std::vector<field_path> {
-  auto visitor = field_path_extractor{};
-  visitor.visit(expr);
-  return std::move(visitor).result();
+auto ExprRefs::overlaps(const ExprRefs& other) const -> bool {
+  // field paths
+  for (const auto& lhs : field_paths) {
+    for (const auto& rhs : other.field_paths) {
+      if (field_paths_overlap(lhs, rhs)) {
+        return true;
+      }
+    }
+  }
+  // let ids
+  return std::ranges::any_of(let_ids, [&other](auto& lhs) {
+    return std::ranges::contains(other.let_ids, lhs);
+  });
 }
 
-auto references_any_field_path(const expression& expr,
-                               std::span<const field_path> paths) -> bool {
-  if (paths.empty()) {
-    return false;
-  }
-  auto visitor = field_path_extractor{};
+auto collect_refs(const expression& expr) -> Option<ExprRefs> {
+  auto visitor = ref_collector{};
   visitor.visit(expr);
   if (visitor.ambiguous()) {
-    return true;
+    return None{};
   }
-  auto references = std::move(visitor).result();
-  return std::ranges::any_of(references, [&](const auto& reference) {
-    return std::ranges::any_of(paths, [&](const auto& path) {
-      return field_paths_overlap(reference, path);
-    });
-  });
+  return std::move(visitor).result();
 }
 
 auto expression::get_location() const -> location {

--- a/test/tests/compiler/opt/each_filter_dependent.diff
+++ b/test/tests/compiler/opt/each_filter_dependent.diff
@@ -1,0 +1,110 @@
+ {
+   lets: [
+     
+   ],
+   operators: [
+     GenericIr {
+       op: {
+         path: [
+           `export` @ 109..115
+         ],
+         ref: std::export/op
+       },
+       desc: "export",
+       args: [
+         
+       ],
+       filter: [
+         
+       ],
+       order: "ordered",
+       named_args: [
+         
+       ]
+     },
+     GenericIr {
+       op: {
+         path: [
+           `each` @ 116..120
+         ],
+         ref: std::each/op
+       },
+       desc: "each",
+       args: [
+         
+       ],
+       filter: [
+         
+       ],
+       order: "ordered",
+       named_args: [
+         
+       ],
+       pipeline: {
+         pipeline: {
+           lets: [
+             
+           ],
+           operators: [
+             from_ir {
+               events: [
+                 record {
+                   begin: 130..131,
+                   items: [
+                     field {
+                       name: `x` @ 131..132,
+                       expr: field_access {
+                         left: dollar_var `$this` -> 1 @ 134..139,
+                         dot: 139..140,
+                         has_question_mark: false,
+                         name: `n` @ 140..141
+                       }
+                     }
+                   ],
+                   end: 141..142
+                 }
+               ],
+               self: 125..129
+             },
+             where_ir {
+-              self: 145..150,
++              self: 0..0,
+               predicate: binary_expr {
+                 left: field_access {
+                   left: dollar_var `$this` -> 1 @ 151..156,
+                   dot: 156..157,
+                   has_question_mark: false,
+                   name: `n` @ 157..158
+                 },
+                 op: "gt" @ 159..160,
+                 right: constant int64 1 @ 161..162
+               }
+             },
+             GenericIr {
+               op: {
+                 path: [
+                   `discard` @ 165..172
+                 ],
+                 ref: std::discard/op
+               },
+               desc: "discard",
+               args: [
+                 
+               ],
+               filter: [
+                 
+               ],
+               order: "ordered",
+               named_args: [
+                 
+               ]
+             }
+           ]
+         } @ 121..174,
+         let_ids: {
+           "0": 1
+         }
+       }
+     }
+   ]
+ }

--- a/test/tests/compiler/opt/each_filter_dependent.tql
+++ b/test/tests/compiler/opt/each_filter_dependent.tql
@@ -1,0 +1,8 @@
+// A filter inside the subpipeline referencing $this stays in the subpipeline
+// and is not pushed upstream.
+export
+each {
+  from {x: $this.n}
+  where $this.n > 1
+  discard
+}

--- a/test/tests/compiler/opt/each_filter_independent.diff
+++ b/test/tests/compiler/opt/each_filter_independent.diff
@@ -1,0 +1,104 @@
+ {
+   lets: [
+     
+   ],
+   operators: [
+     GenericIr {
+       op: {
+         path: [
+           `export` @ 110..116
+         ],
+         ref: std::export/op
+       },
+       desc: "export",
+       args: [
+         
+       ],
+       filter: [
+         
+       ],
+       order: "ordered",
+       named_args: [
+         
+       ]
+     },
+     GenericIr {
+       op: {
+         path: [
+           `each` @ 117..121
+         ],
+         ref: std::each/op
+       },
+       desc: "each",
+       args: [
+         
+       ],
+       filter: [
+         
+       ],
+       order: "ordered",
+       named_args: [
+         
+       ],
+       pipeline: {
+         pipeline: {
+           lets: [
+             
+           ],
+           operators: [
+             from_ir {
+               events: [
+                 dollar_var `$this` -> 1 @ 131..136
+               ],
+               self: 126..130
++            },
++            where_ir {
++              self: 0..0,
++              predicate: binary_expr {
++                left: root_field {
++                  id: `x` @ 145..146,
++                  has_question_mark: false
++                },
++                op: "gt" @ 147..148,
++                right: constant int64 1 @ 149..150
++              }
+             }
+           ]
+         } @ 122..138,
+         let_ids: {
+           "0": 1
+         }
+-      }
+-    },
+-    where_ir {
+-      self: 139..144,
+-      predicate: binary_expr {
+-        left: root_field {
+-          id: `x` @ 145..146,
+-          has_question_mark: false
+-        },
+-        op: "gt" @ 147..148,
+-        right: constant int64 1 @ 149..150
+       }
+     },
+     GenericIr {
+       op: {
+         path: [
+           `discard` @ 151..158
+         ],
+         ref: std::discard/op
+       },
+       desc: "discard",
+       args: [
+         
+       ],
+       filter: [
+         
+       ],
+       order: "ordered",
+       named_args: [
+         
+       ]
+     }
+   ]
+ }

--- a/test/tests/compiler/opt/each_filter_independent.tql
+++ b/test/tests/compiler/opt/each_filter_independent.tql
@@ -1,0 +1,8 @@
+// A filter after each that does not reference $this gets pushed into the
+// subpipeline via from_downstream.
+export
+each {
+  from $this
+}
+where x > 1
+discard

--- a/test/tests/compiler/opt/load_balance_filter_kept.diff
+++ b/test/tests/compiler/opt/load_balance_filter_kept.diff
@@ -1,0 +1,90 @@
+ {
+   lets: [
+     
+   ],
+   operators: [
+     GenericIr {
+       op: {
+         path: [
+           `export` @ 113..119
+         ],
+         ref: std::export/op
+       },
+       desc: "export",
+       args: [
+         
+       ],
+       filter: [
+         
+       ],
+-      order: "ordered",
++      order: "unordered",
+       named_args: [
+         
+       ]
+     },
+     GenericIr {
+       op: {
+         path: [
+           `load_balance` @ 120..132
+         ],
+         ref: std::load_balance/op
+       },
+       desc: "load_balance",
+       args: [
+         located [
+           string "a",
+           string "b"
+         ] @ 133..138
+       ],
+       filter: [
+         
+       ],
+-      order: "ordered",
++      order: "unordered",
+       named_args: [
+         
+       ],
+       pipeline: {
+         pipeline: {
+           lets: [
+             
+           ],
+           operators: [
+             where_ir {
+-              self: 143..148,
++              self: 0..0,
+               predicate: binary_expr {
+                 left: dollar_var `$over` -> 2 @ 149..154,
+                 op: "eq" @ 155..157,
+                 right: constant string "a" @ 158..161
+               }
+             },
+             GenericIr {
+               op: {
+                 path: [
+                   `discard` @ 164..171
+                 ],
+                 ref: std::discard/op
+               },
+               desc: "discard",
+               args: [
+                 
+               ],
+               filter: [
+                 
+               ],
+               order: "ordered",
+               named_args: [
+                 
+               ]
+             }
+           ]
+         } @ 139..173,
+         let_ids: {
+           "0": 2
+         }
+       }
+     }
+   ]
+ }

--- a/test/tests/compiler/opt/load_balance_filter_kept.tql
+++ b/test/tests/compiler/opt/load_balance_filter_kept.tql
@@ -1,0 +1,8 @@
+// A filter inside the subpipeline that references $over must stay in the
+// subpipeline.
+let $over = ["a", "b"]
+export
+load_balance $over {
+  where $over == "a"
+  discard
+}

--- a/test/tests/compiler/opt/load_balance_filter_let_kept.diff
+++ b/test/tests/compiler/opt/load_balance_filter_let_kept.diff
@@ -1,0 +1,99 @@
+ {
+   lets: [
+     
+   ],
+   operators: [
+     GenericIr {
+       op: {
+         path: [
+           `export` @ 282..288
+         ],
+         ref: std::export/op
+       },
+       desc: "export",
+       args: [
+         
+       ],
+       filter: [
+         
+       ],
+-      order: "ordered",
++      order: "unordered",
+       named_args: [
+         
+       ]
+     },
+     GenericIr {
+       op: {
+         path: [
+           `load_balance` @ 289..301
+         ],
+         ref: std::load_balance/op
+       },
+       desc: "load_balance",
+       args: [
+         located [
+           string "a",
+           string "b"
+         ] @ 302..307
+       ],
+       filter: [
+         
+       ],
+-      order: "ordered",
++      order: "unordered",
+       named_args: [
+         
+       ],
+       pipeline: {
+         pipeline: {
+           lets: [
+             {
+               ident: `$x` @ 316..318,
+               expr: field_access {
+                 left: this_ 321..325,
+                 dot: 325..326,
+                 has_question_mark: false,
+                 name: `n` @ 326..327
+               },
+               id: 3
+             }
+           ],
+           operators: [
+             where_ir {
+-              self: 330..335,
++              self: 0..0,
+               predicate: binary_expr {
+                 left: dollar_var `$x` -> 3 @ 336..338,
+                 op: "gt" @ 339..340,
+                 right: constant int64 1 @ 341..342
+               }
+             },
+             GenericIr {
+               op: {
+                 path: [
+                   `discard` @ 345..352
+                 ],
+                 ref: std::discard/op
+               },
+               desc: "discard",
+               args: [
+                 
+               ],
+               filter: [
+                 
+               ],
+               order: "ordered",
+               named_args: [
+                 
+               ]
+             }
+           ]
+         } @ 308..354,
+         let_ids: {
+           "0": 2
+         }
+       }
+     }
+   ]
+ }

--- a/test/tests/compiler/opt/load_balance_filter_let_kept.tql
+++ b/test/tests/compiler/opt/load_balance_filter_let_kept.tql
@@ -1,0 +1,11 @@
+// A filter inside the subpipeline referencing a let binding declared in that
+// subpipeline must not be pushed upstream of `load_balance`. The let binding
+// `$x` is scoped to the subpipeline, so moving the filter outside would leave
+// an unbound variable.
+let $over = ["a", "b"]
+export
+load_balance $over {
+  let $x = this.n
+  where $x > 1
+  discard
+}

--- a/test/tests/compiler/opt/load_balance_filter_pushed.diff
+++ b/test/tests/compiler/opt/load_balance_filter_pushed.diff
@@ -1,0 +1,100 @@
+ {
+   lets: [
+     
+   ],
+   operators: [
+     GenericIr {
+       op: {
+         path: [
+           `export` @ 118..124
+         ],
+         ref: std::export/op
+       },
+       desc: "export",
+       args: [
+         
+       ],
+       filter: [
+-        
++        binary_expr {
++          left: root_field {
++            id: `x` @ 154..155,
++            has_question_mark: false
++          },
++          op: "gt" @ 156..157,
++          right: constant int64 1 @ 158..159
++        }
+       ],
+-      order: "ordered",
++      order: "unordered",
+       named_args: [
+         
+       ]
+     },
+     GenericIr {
+       op: {
+         path: [
+           `load_balance` @ 125..137
+         ],
+         ref: std::load_balance/op
+       },
+       desc: "load_balance",
+       args: [
+         located [
+           string "a",
+           string "b"
+         ] @ 138..143
+       ],
+       filter: [
+         
+       ],
+-      order: "ordered",
++      order: "unordered",
+       named_args: [
+         
+       ],
+       pipeline: {
+         pipeline: {
+           lets: [
+             
+           ],
+           operators: [
+-            where_ir {
+-              self: 148..153,
+-              predicate: binary_expr {
+-                left: root_field {
+-                  id: `x` @ 154..155,
+-                  has_question_mark: false
+-                },
+-                op: "gt" @ 156..157,
+-                right: constant int64 1 @ 158..159
+-              }
+-            },
+             GenericIr {
+               op: {
+                 path: [
+                   `discard` @ 162..169
+                 ],
+                 ref: std::discard/op
+               },
+               desc: "discard",
+               args: [
+                 
+               ],
+               filter: [
+                 
+               ],
+               order: "ordered",
+               named_args: [
+                 
+               ]
+             }
+           ]
+         } @ 144..171,
+         let_ids: {
+           "0": 2
+         }
+       }
+     }
+   ]
+ }

--- a/test/tests/compiler/opt/load_balance_filter_pushed.tql
+++ b/test/tests/compiler/opt/load_balance_filter_pushed.tql
@@ -1,0 +1,8 @@
+// A filter inside the subpipeline that does not reference $over should be
+// pushed upstream.
+let $over = ["a", "b"]
+export
+load_balance $over {
+  where x > 1
+  discard
+}

--- a/test/tests/compiler/opt/to_file_filter_let_kept.diff
+++ b/test/tests/compiler/opt/to_file_filter_let_kept.diff
@@ -1,0 +1,99 @@
+ {
+   lets: [
+     
+   ],
+   operators: [
+     GenericIr {
+       op: {
+         path: [
+           `export` @ 254..260
+         ],
+         ref: std::export/op
+       },
+       desc: "export",
+       args: [
+         
+       ],
+       filter: [
+         
+       ],
+       order: "ordered",
+       named_args: [
+         
+       ]
+     },
+     GenericIr {
+       op: {
+         path: [
+           `to_file` @ 261..268
+         ],
+         ref: std::to_file/op
+       },
+       desc: "tql2.to_file",
+       args: [
+         located {
+           buffer: {
+             chunk: chunk(size=56),
+             table-offset: 12
+           }
+         } @ 269..280
+       ],
+       filter: [
+         
+       ],
+       order: "ordered",
+       named_args: [
+         
+       ],
+       pipeline: {
+         pipeline: {
+           lets: [
+             {
+               ident: `$x` @ 289..291,
+               expr: field_access {
+                 left: this_ 294..298,
+                 dot: 298..299,
+                 has_question_mark: false,
+                 name: `n` @ 299..300
+               },
+               id: 1
+             }
+           ],
+           operators: [
+             where_ir {
+-              self: 303..308,
++              self: 0..0,
+               predicate: binary_expr {
+                 left: dollar_var `$x` -> 1 @ 309..311,
+                 op: "gt" @ 312..313,
+                 right: constant int64 1 @ 314..315
+               }
+             },
+             GenericIr {
+               op: {
+                 path: [
+                   `write_json` @ 318..328
+                 ],
+                 ref: std::write_json/op
+               },
+               desc: "tql2.write_json",
+               args: [
+                 
+               ],
+               filter: [
+                 
+               ],
+               order: "ordered",
+               named_args: [
+                 
+               ]
+             }
+           ]
+         } @ 281..330,
+         let_ids: {
+           
+         }
+       }
+     }
+   ]
+ }

--- a/test/tests/compiler/opt/to_file_filter_let_kept.tql
+++ b/test/tests/compiler/opt/to_file_filter_let_kept.tql
@@ -1,0 +1,10 @@
+// A filter inside the subpipeline referencing a let binding declared in that
+// subpipeline must not be pushed upstream of `to_file`. The let binding `$x`
+// is scoped to the subpipeline, so moving the filter outside would leave an
+// unbound variable.
+export
+to_file "/dev/null" {
+  let $x = this.n
+  where $x > 1
+  write_json
+}


### PR DESCRIPTION
Followup for #6184
Related to #6203

Some operators (load_balance and each) spawn subpipelines that contain
additional let variables. Filters that use such variables shouldn't be
pushed into parent's upstream.

Before this PR, load_balance and each never pushed filters upstream.

This PR makes upstream push conditional on presence of such variables.

To accomplish this, this PR:
- generalizes field_path_extractor to collect both kinds of references,
- makes split_filter_by_dependents to work with both kinds of refs.

