### PR TITLE
Fix changelog code span

### DIFF
--- a/changelog/unreleased/compaction-resolves-package-udos-at-startup.md
+++ b/changelog/unreleased/compaction-resolves-package-udos-at-startup.md
@@ -7,7 +7,7 @@ created: 2026-05-20T17:40:00.000000Z
 ---
 
 The `compaction` plugin no longer fails to start with
-`module \`<package>\` not found` when a rule's `pipeline` references an
+`module <package> not found` when a rule's `pipeline` references an
 operator defined by an installed package. Previously, depending on the
 order in which the node's components were initialized, the compactor's
 eager rule-pipeline parse could run before the package manager had


### PR DESCRIPTION
## 🔍 Problem

- The compaction changelog entry nests Markdown code spans inside the startup error message.
- This prevents the package placeholder from rendering as part of the same code span.

## 🛠️ Solution

- Render the complete error message as one Markdown code span while keeping the original wording.

## 💬 Review

- Changelog-only Markdown fix.

<sub>
📎 Related: tenzir/tenzir#6210
</sub>