### PR TITLE
Resolve secrets in from_http bodies

### DIFF
--- a/libtenzir/builtins/operators/from_http.cpp
+++ b/libtenzir/builtins/operators/from_http.cpp
@@ -26,6 +26,7 @@
 #include <tenzir/plugin/register.hpp>
 #include <tenzir/result.hpp>
 #include <tenzir/secret_resolution.hpp>
+#include <tenzir/secret_resolution_utilities.hpp>
 #include <tenzir/series_builder.hpp>
 #include <tenzir/substitute_ctx.hpp>
 #include <tenzir/tls_options.hpp>
@@ -204,7 +205,8 @@ auto add_default_content_type(std::vector<http::Header>& headers,
 // Resolves method, serializes the body (records become JSON, blobs are sent
 // verbatim), and assembles request headers.
 auto make_request_config(FromHttpArgs const& args,
-                         std::vector<http::Header> headers) -> RequestConfig {
+                         std::vector<http::Header> headers,
+                         Option<data> const& resolved_body) -> RequestConfig {
   // Resolve HTTP method (validated at describe time).
   // Default to POST when a body is present, GET otherwise.
   auto method_str = args.method ? args.method->inner
@@ -215,8 +217,8 @@ auto make_request_config(FromHttpArgs const& args,
   // Serialize the optional body. Records become JSON; blobs and strings are
   // sent verbatim.
   auto body = std::vector<std::byte>{};
-  if (args.body) {
-    auto serialized = serialize_body(args.body->inner, args.encode);
+  if (resolved_body) {
+    auto serialized = serialize_body(*resolved_body, args.encode);
     TENZIR_ASSERT(serialized);
     body = std::move(serialized->body);
     add_default_content_type(headers, std::move(serialized->content_type));
@@ -247,7 +249,8 @@ auto make_paginated_request_config(std::vector<http::Header> headers)
 
 auto resolve_http_secrets(OpCtx& ctx, FromHttpArgs const& args,
                           std::string& resolved_url,
-                          std::vector<http::Header>& resolved_headers)
+                          std::vector<http::Header>& resolved_headers,
+                          Option<data>& resolved_body)
   -> Task<failure_or<bool>> {
   resolved_url.clear();
   auto requests = std::vector<secret_request>{};
@@ -258,6 +261,14 @@ auto resolve_http_secrets(OpCtx& ctx, FromHttpArgs const& args,
   requests.insert(requests.end(),
                   std::make_move_iterator(header_requests.begin()),
                   std::make_move_iterator(header_requests.end()));
+  if (args.body) {
+    resolved_body = args.body->inner;
+    auto body_requests
+      = make_secret_request(*resolved_body, args.body->source, ctx.dh());
+    requests.insert(requests.end(),
+                    std::make_move_iterator(body_requests.begin()),
+                    std::make_move_iterator(body_requests.end()));
+  }
   if (auto result = co_await ctx.resolve_secrets(std::move(requests));
       result.is_error()) {
     co_return failure::promise();
@@ -873,8 +884,9 @@ public:
     pagination_.spec = std::move(*paginate);
     // resolve secrets
     std::string resolved_url;
+    auto resolved_body = Option<data>{};
     auto secret_resolution = co_await resolve_http_secrets(
-      ctx, args_, resolved_url, resolved_headers_);
+      ctx, args_, resolved_url, resolved_headers_, resolved_body);
     if (secret_resolution.is_error()) {
       lifecycle_ = Lifecycle::done;
       co_return;
@@ -884,7 +896,8 @@ public:
     fetch_config_ = make_fetch_config(args_);
     // ensure system CA paths are registered
     http::ensure_default_ca_paths();
-    pagination_.current_request = make_request_config(args_, resolved_headers_);
+    pagination_.current_request
+      = make_request_config(args_, resolved_headers_, resolved_body);
     co_await start_fetch(ctx, pagination_.current_request);
   }
 

--- a/libtenzir/include/tenzir/secret_resolution.hpp
+++ b/libtenzir/include/tenzir/secret_resolution.hpp
@@ -177,6 +177,16 @@ auto make_secret_request(std::string name, const located<secret>& s,
                          std::string& out, diagnostic_handler& dh)
   -> secret_request;
 
+/// Creates secret requests for every secret nested inside `value` and writes
+/// resolved UTF-8 string values back into the nested data tree in place.
+auto make_secret_request(data& value, location loc, diagnostic_handler& dh)
+  -> std::vector<secret_request>;
+
+/// Creates secret requests for every secret nested inside `value` and writes
+/// resolved UTF-8 string values back into the nested data tree in place.
+auto make_secret_request(located<data>& value, diagnostic_handler& dh)
+  -> std::vector<secret_request>;
+
 struct located_resolved_secret {
   location loc;
   ecc::cleansing_blob value;

--- a/libtenzir/include/tenzir/secret_resolution_utilities.hpp
+++ b/libtenzir/include/tenzir/secret_resolution_utilities.hpp
@@ -8,7 +8,6 @@
 
 #pragma once
 #include "tenzir/aliases.hpp"
-#include "tenzir/concepts.hpp"
 #include "tenzir/operator_control_plane.hpp"
 
 #include <arrow/util/uri.h>
@@ -19,8 +18,6 @@
 /// the resolution utility for records
 
 namespace tenzir {
-
-class data;
 
 /// The callback will be invoked with the initial `key`, the resolved `value`
 /// and an additional out-parameter to signal failure, if so desired.

--- a/libtenzir/include/tenzir/secret_resolution_utilities.hpp
+++ b/libtenzir/include/tenzir/secret_resolution_utilities.hpp
@@ -49,16 +49,6 @@ auto make_secret_request(const located<record>& r,
                          record_secret_request_callback callback)
   -> secret_request_combined;
 
-/// Creates secret requests for every secret nested inside `value` and writes
-/// resolved UTF-8 string values back into the nested data tree in place.
-auto make_secret_request(data& value, location loc, diagnostic_handler& dh)
-  -> std::vector<secret_request>;
-
-/// Creates secret requests for every secret nested inside `value` and writes
-/// resolved UTF-8 string values back into the nested data tree in place.
-auto make_secret_request(located<data>& value, diagnostic_handler& dh)
-  -> std::vector<secret_request>;
-
 /// Creates a secret request that will set `uri`. The secret URI is validated
 /// as utf8 and potentially prepended with `prefix`.
 /// @relates operator_control_plane::resolve_secrets_must_yield

--- a/libtenzir/include/tenzir/secret_resolution_utilities.hpp
+++ b/libtenzir/include/tenzir/secret_resolution_utilities.hpp
@@ -20,6 +20,8 @@
 
 namespace tenzir {
 
+class data;
+
 /// The callback will be invoked with the initial `key`, the resolved `value`
 /// and an additional out-parameter to signal failure, if so desired.
 using record_secret_request_callback = std::function<failure_or<void>(
@@ -46,6 +48,16 @@ auto make_secret_request(record r, location loc,
 auto make_secret_request(const located<record>& r,
                          record_secret_request_callback callback)
   -> secret_request_combined;
+
+/// Creates secret requests for every secret nested inside `value` and writes
+/// resolved UTF-8 string values back into the nested data tree in place.
+auto make_secret_request(data& value, location loc, diagnostic_handler& dh)
+  -> std::vector<secret_request>;
+
+/// Creates secret requests for every secret nested inside `value` and writes
+/// resolved UTF-8 string values back into the nested data tree in place.
+auto make_secret_request(located<data>& value, diagnostic_handler& dh)
+  -> std::vector<secret_request>;
 
 /// Creates a secret request that will set `uri`. The secret URI is validated
 /// as utf8 and potentially prepended with `prefix`.

--- a/libtenzir/src/secret_resolution.cpp
+++ b/libtenzir/src/secret_resolution.cpp
@@ -180,6 +180,50 @@ auto make_secret_request(std::string name, const located<secret>& s,
 
 namespace {
 
+auto visit_secret_values(data& value,
+                         std::function<void(data&)> const& on_secret) -> void {
+  if (auto* s = try_as<secret>(value)) {
+    TENZIR_UNUSED(s);
+    on_secret(value);
+    return;
+  }
+  if (auto* r = try_as<record>(value)) {
+    for (auto& [k, v] : *r) {
+      visit_secret_values(v, on_secret);
+    }
+    return;
+  }
+  if (auto* l = try_as<list>(value)) {
+    for (size_t i = 0; i < l->size(); ++i) {
+      visit_secret_values(l->operator[](i), on_secret);
+    }
+  }
+}
+
+} // namespace
+
+auto make_secret_request(data& value, location loc, diagnostic_handler& dh)
+  -> std::vector<secret_request> {
+  auto requests = std::vector<secret_request>{};
+  visit_secret_values(value, [&](data& target) {
+    requests.emplace_back(as<secret>(target), loc,
+                          [&target, loc,
+                           &dh](resolved_secret_value v) -> failure_or<void> {
+                            TRY(auto str, v.utf8_view("value", loc, dh));
+                            target = std::string{str};
+                            return {};
+                          });
+  });
+  return requests;
+}
+
+auto make_secret_request(located<data>& value, diagnostic_handler& dh)
+  -> std::vector<secret_request> {
+  return make_secret_request(value.inner, value.source, dh);
+}
+
+namespace {
+
 auto apply_transformation(ecc::cleansing_blob blob,
                           fbs::data::SecretTransformations operation,
                           diagnostic_handler& dh, location loc)

--- a/libtenzir/src/secret_resolution_utilities.cpp
+++ b/libtenzir/src/secret_resolution_utilities.cpp
@@ -50,64 +50,11 @@ auto arrow_uri_callback(std::string prefix, arrow::util::Uri& uri,
 
 } // namespace
 
-auto make_uri_request(secret s, location loc, std::string prefix,
-                      arrow::util::Uri& uri, diagnostic_handler& dh)
-  -> secret_request {
-  return secret_request{s, loc,
-                        arrow_uri_callback(std::move(prefix), uri, dh, loc)};
-}
-
 auto make_uri_request(const located<secret>& s, std::string prefix,
                       arrow::util::Uri& uri, diagnostic_handler& dh)
   -> secret_request {
   return secret_request{s, arrow_uri_callback(std::move(prefix), uri, dh,
                                               s.source)};
-}
-
-namespace {
-
-auto visit_secret_values(
-  std::string key, data& value,
-  std::function<void(std::string, data&)> const& on_secret) -> void {
-  if (auto* s = try_as<secret>(value)) {
-    TENZIR_UNUSED(s);
-    on_secret(std::move(key), value);
-    return;
-  }
-  if (auto* r = try_as<record>(value)) {
-    for (auto& [k, v] : *r) {
-      visit_secret_values(key + "." + k, v, on_secret);
-    }
-    return;
-  }
-  if (auto* l = try_as<list>(value)) {
-    for (size_t i = 0; i < l->size(); ++i) {
-      visit_secret_values(key + "[" + std::to_string(i) + "]", l->operator[](i),
-                          on_secret);
-    }
-  }
-}
-
-} // namespace
-
-auto make_secret_request(data& value, location loc, diagnostic_handler& dh)
-  -> std::vector<secret_request> {
-  auto requests = std::vector<secret_request>{};
-  visit_secret_values("", value, [&](std::string, data& target) {
-    requests.emplace_back(as<secret>(target), loc,
-                          [&target, loc,
-                           &dh](resolved_secret_value v) -> failure_or<void> {
-                            TRY(auto str, v.utf8_view("value", loc, dh));
-                            target = std::string{str};
-                            return {};
-                          });
-  });
-  return requests;
-}
-
-auto make_secret_request(located<data>& value, diagnostic_handler& dh)
-  -> std::vector<secret_request> {
-  return make_secret_request(value.inner, value.source, dh);
 }
 
 auto resolve_secrets_must_yield(
@@ -122,15 +69,30 @@ auto resolve_secrets_must_yield(
       continue;
     }
     auto& record_request = as<secret_request_record>(req);
-    for (auto& [k, v] : record_request.value) {
-      visit_secret_values(k, v, [&](std::string key, data& target) {
+    const auto handle_value
+      = [&record_request, &translated_requests](
+          this const auto& self, std::string key, tenzir::data& value) -> void {
+      if (auto* s = try_as<secret>(value)) {
         translated_requests.emplace_back(
-          std::move(as<secret>(target)), record_request.location,
+          std::move(*s), record_request.location,
           [cb = record_request.callback,
-           key = std::move(key)](resolved_secret_value v) -> failure_or<void> {
+           key](resolved_secret_value v) -> failure_or<void> {
             return cb(key, std::move(v));
           });
-      });
+      }
+      if (auto* r = try_as<record>(value)) {
+        for (auto& [k, v] : *r) {
+          self(key + "." + k, v);
+        }
+      }
+      if (auto* l = try_as<list>(value)) {
+        for (size_t i = 0; i < l->size(); ++i) {
+          self(key + "[" + std::to_string(i) + "]", l->operator[](i));
+        }
+      }
+    };
+    for (auto& [k, v] : record_request.value) {
+      handle_value(k, v);
     }
   }
   return ctrl.resolve_secrets_must_yield(std::move(translated_requests),

--- a/libtenzir/src/secret_resolution_utilities.cpp
+++ b/libtenzir/src/secret_resolution_utilities.cpp
@@ -64,6 +64,52 @@ auto make_uri_request(const located<secret>& s, std::string prefix,
                                               s.source)};
 }
 
+namespace {
+
+auto visit_secret_values(
+  std::string key, data& value,
+  std::function<void(std::string, data&)> const& on_secret) -> void {
+  if (auto* s = try_as<secret>(value)) {
+    TENZIR_UNUSED(s);
+    on_secret(std::move(key), value);
+    return;
+  }
+  if (auto* r = try_as<record>(value)) {
+    for (auto& [k, v] : *r) {
+      visit_secret_values(key + "." + k, v, on_secret);
+    }
+    return;
+  }
+  if (auto* l = try_as<list>(value)) {
+    for (size_t i = 0; i < l->size(); ++i) {
+      visit_secret_values(key + "[" + std::to_string(i) + "]", l->operator[](i),
+                          on_secret);
+    }
+  }
+}
+
+} // namespace
+
+auto make_secret_request(data& value, location loc, diagnostic_handler& dh)
+  -> std::vector<secret_request> {
+  auto requests = std::vector<secret_request>{};
+  visit_secret_values("", value, [&](std::string, data& target) {
+    requests.emplace_back(as<secret>(target), loc,
+                          [&target, loc,
+                           &dh](resolved_secret_value v) -> failure_or<void> {
+                            TRY(auto str, v.utf8_view("value", loc, dh));
+                            target = std::string{str};
+                            return {};
+                          });
+  });
+  return requests;
+}
+
+auto make_secret_request(located<data>& value, diagnostic_handler& dh)
+  -> std::vector<secret_request> {
+  return make_secret_request(value.inner, value.source, dh);
+}
+
 auto resolve_secrets_must_yield(
   operator_control_plane& ctrl, std::vector<secret_request_combined> requests,
   operator_control_plane::final_callback_t final_callback)
@@ -76,30 +122,15 @@ auto resolve_secrets_must_yield(
       continue;
     }
     auto& record_request = as<secret_request_record>(req);
-    const auto handle_value
-      = [&record_request, &translated_requests](
-          this const auto& self, std::string key, tenzir::data& value) -> void {
-      if (auto* s = try_as<secret>(value)) {
+    for (auto& [k, v] : record_request.value) {
+      visit_secret_values(k, v, [&](std::string key, data& target) {
         translated_requests.emplace_back(
-          std::move(*s), record_request.location,
+          std::move(as<secret>(target)), record_request.location,
           [cb = record_request.callback,
-           key](resolved_secret_value v) -> failure_or<void> {
+           key = std::move(key)](resolved_secret_value v) -> failure_or<void> {
             return cb(key, std::move(v));
           });
-      }
-      if (auto* r = try_as<record>(value)) {
-        for (auto& [k, v] : *r) {
-          self(key + "." + k, v);
-        }
-      }
-      if (auto* l = try_as<list>(value)) {
-        for (size_t i = 0; i < l->size(); ++i) {
-          self(key + "[" + std::to_string(i) + "]", l->operator[](i));
-        }
-      }
-    };
-    for (auto& [k, v] : record_request.value) {
-      handle_value(k, v);
+      });
     }
   }
   return ctrl.resolve_secrets_must_yield(std::move(translated_requests),

--- a/test/tests/operators/from_http/secrets_body_form_literal.tql
+++ b/test/tests/operators/from_http/secrets_body_form_literal.tql
@@ -1,0 +1,16 @@
+---
+fixtures:
+- http_server:
+    expected:
+    - header_name: Content-Type
+      header_value: application/x-www-form-urlencoded
+timeout: 60
+---
+
+from_http env("HTTP_FIXTURE_BODY_URL"),
+          method="post",
+          body={client_id: "hello", nested: {client_secret: secret("alpha", _literal=true)}},
+          encode="form",
+          tls=false {
+  read_json
+}

--- a/test/tests/operators/from_http/secrets_body_form_literal.txt
+++ b/test/tests/operators/from_http/secrets_body_form_literal.txt
@@ -1,0 +1,3 @@
+{
+  body: "client_id=hello&nested.client_secret=alpha",
+}


### PR DESCRIPTION
## 🔍 Problem

- `from_http` resolved secrets in the URL and headers, but not in request bodies.
- Form-encoded token requests therefore sent censored placeholders like `*****` instead of the resolved secret value.

## 🛠️ Solution

- Resolve secrets recursively inside nested `data` values and write the resolved UTF-8 strings back into the body in place.
- Reuse that helper from `from_http` before serializing the request body.
- Add an integration test for a form-encoded body with `client_secret`.

## 💬 Review

- Focus on the new nested `data` secret-resolution helper in `secret_resolution_utilities.cpp`.
- The behavioral change in `from_http` is intentionally small and covered by the new integration test.

<sub>
📚 Docs PR: tenzir/docs#354<br>
✅ Closes TNZ-645
</sub>
