### PR TITLE
Drain in-flight data on graceful shutdown

### DIFF
--- a/.agents/references/executor.md
+++ b/.agents/references/executor.md
@@ -48,6 +48,22 @@ Only override `state()` if the operator can terminate early (e.g., `head` stops
 after N rows). Operators that process until end-of-stream do not need to
 override `state()`.
 
+### Graceful shutdown contract
+
+Treat `stop()` and `finalize()` as different phases:
+
+- `stop()` means: stop producing new external work, but keep draining work and
+  input that was already accepted.
+- `finalize()` means: the input stream is exhausted.
+
+For operators with `Input != void`, graceful shutdown must not be treated as
+end-of-input. The executor should call `stop()` when shutdown begins, keep
+processing already accepted input, and call `finalize()` only after upstream has
+signaled end-of-data.
+
+For sources (`Input == void`), there is no upstream end-of-data signal, so a
+`stop()` should probably lead to operator terminating.
+
 ### Avoid Destructors
 
 Avoid defining destructors for operators. Work that needs to be done during a

--- a/.github/workflows/tenzir.yaml
+++ b/.github/workflows/tenzir.yaml
@@ -148,7 +148,7 @@ jobs:
       run-update-homebrew-tap: ${{ steps.select-jobs.outputs.run-update-homebrew-tap }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2
       - name: Fetch to merge-base
@@ -588,13 +588,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
       - name: Detect contrib/tenzir-plugins changes
         id: changes
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
-        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
           filters: |
             plugins:
@@ -703,9 +703,9 @@ jobs:
       TENZIR_BENCH_RUNNER_CLASS: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Authenticate to GHCR
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -757,7 +757,7 @@ jobs:
       DOCKER_BUILDKIT: 1
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to GitHub Container Registry
@@ -840,9 +840,9 @@ jobs:
       TENZIR_BENCH_RUNNER_CLASS: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Download static benchmark artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: tenzir-static-x86_64-linux
           path: ${{ runner.temp }}/static-artifact
@@ -906,7 +906,7 @@ jobs:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Tailscale
         if: false && runner.os == 'Linux'
         uses: tailscale/github-action@v3
@@ -1083,22 +1083,22 @@ jobs:
       TENZIR_VERSION_SUFFIX: ${{ needs.configure.outputs.tenzir-version-suffix }}
       TENZIR_VERSION_BUILD_METADATA: ${{ needs.configure.outputs.tenzir-version-build-metadata }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0.0
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
-        uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d  # v7.1.0
+        uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d # v7.1.0
         with:
           version: "0.9.2"
           python-version: ${{ matrix.python-version }}
       - name: Install Nix (for static binaries)
-        uses: cachix/install-nix-action@7ab6e7fd29da88e74b1e314a4ae9ac6b5cda3801  # v31.8.0
+        uses: cachix/install-nix-action@7ab6e7fd29da88e74b1e314a4ae9ac6b5cda3801 # v31.8.0
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - name: Setup Cachix
-        uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad  # v16
+        uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
         with:
           name: tenzir
           authToken: "${{ secrets.CACHIX_TENZIR_API_TOKEN }}"
@@ -1150,29 +1150,29 @@ jobs:
       TENZIR_VERSION_SUFFIX: ${{ needs.configure.outputs.tenzir-version-suffix }}
       TENZIR_VERSION_BUILD_METADATA: ${{ needs.configure.outputs.tenzir-version-build-metadata }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0.0
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
-        uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d  # v7.1.0
+        uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d # v7.1.0
         with:
           version: "0.9.2"
           python-version: ${{ matrix.python-version }}
       - name: Install Nix (for static binaries)
-        uses: cachix/install-nix-action@7ab6e7fd29da88e74b1e314a4ae9ac6b5cda3801  # v31.8.0
+        uses: cachix/install-nix-action@7ab6e7fd29da88e74b1e314a4ae9ac6b5cda3801 # v31.8.0
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - name: Setup Cachix
-        uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad  # v16
+        uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
         with:
           name: tenzir
           authToken: "${{ secrets.CACHIX_TENZIR_API_TOKEN }}"
           pushFilter: "(tenzir-ee|tenzir-plugins-source)"
       - name: Download signed tarball (macOS)
         if: runner.os == 'macOS'
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: tenzir-signed-tarball-arm64-darwin
           path: ${{ runner.temp }}/signed-tarball
@@ -1227,15 +1227,15 @@ jobs:
     name: Update Homebrew Tap
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Download signed package
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: tenzir-signed-pkg-arm64-darwin
           path: ${{ runner.temp }}/signed-pkg
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         with:
           app-id: ${{ vars.TENZIR_GITHUB_APP_ID }}
           private-key: ${{ secrets.TENZIR_GITHUB_APP_PRIVATE_KEY }}
@@ -1305,7 +1305,8 @@ jobs:
       - update-homebrew-tap
       # TODO: Re-enable this after v4.26 was released.
       # - regression-tests
-      - tenzir
+      # TODO: Re-enable when github.com/Homebrew/homebrew-core/issues/287708 is merged
+      # - tenzir
       - tenzir-static-arm64-darwin
       - tenzir-static-aarch64-linux
       - tenzir-static-x86_64-linux

--- a/changelog/releases/v6.2.0/entries/graceful-pipeline-shutdown-with-data-draining.md
+++ b/changelog/releases/v6.2.0/entries/graceful-pipeline-shutdown-with-data-draining.md
@@ -1,0 +1,16 @@
+---
+title: Graceful pipeline shutdown with data draining
+type: feature
+authors:
+  - aljazerzen
+created: 2026-05-21T19:28:37.839505Z
+---
+
+Stopping a pipeline or shutting down the node now drains in-flight data
+before terminating, instead of discarding it. Source operators receive a
+graceful stop signal and can finish outstanding work before the pipeline
+shuts down.
+
+A configurable grace period (`tenzir.shutdown-grace-period`, default
+30 seconds) bounds how long the system waits. After the grace period
+expires, remaining pipelines are force-killed.

--- a/libtenzir/builtins/operators/every.cpp
+++ b/libtenzir/builtins/operators/every.cpp
@@ -80,7 +80,16 @@ struct EveryImpl {
     return FinalizeBehavior::done;
   }
 
+  auto stop_impl() -> void
+    requires(std::same_as<Input, void>)
+  {
+    stop_spawning_ = true;
+  }
+
   auto state_impl() -> OperatorState {
+    if (stop_spawning_ and sub_finished_) {
+      return OperatorState::done;
+    }
     // We want to wait for subpipeline completion when we closed the subpipeline
     // ourselves before processing further input. Note that the case where the
     // subpipeline closed itself does not block input here, because as described
@@ -175,6 +184,12 @@ public:
     co_return finalize_impl();
   }
 
+  auto stop(OpCtx& ctx) -> Task<void> override {
+    TENZIR_UNUSED(ctx);
+    stop_impl();
+    co_return;
+  }
+
   auto state() -> OperatorState override {
     return state_impl();
   }
@@ -260,6 +275,12 @@ public:
   auto finalize(OpCtx& ctx) -> Task<FinalizeBehavior> override {
     TENZIR_UNUSED(ctx);
     co_return finalize_impl();
+  }
+
+  auto stop(OpCtx& ctx) -> Task<void> override {
+    TENZIR_UNUSED(ctx);
+    stop_impl();
+    co_return;
   }
 
   auto state() -> OperatorState override {

--- a/libtenzir/builtins/operators/repeat.cpp
+++ b/libtenzir/builtins/operators/repeat.cpp
@@ -173,6 +173,17 @@ public:
     return OperatorState::normal;
   }
 
+  auto stop(OpCtx& ctx) -> Task<void> override {
+    TENZIR_UNUSED(ctx);
+    // Without an explicit count, `repeat` replays its input forever. A
+    // graceful stop must end this otherwise infinite replay. With a finite
+    // count, we instead keep draining the remaining repetitions.
+    if (count_ == std::numeric_limits<uint64_t>::max()) {
+      phase_ = Phase::finished;
+    }
+    co_return;
+  }
+
   auto snapshot(Serde& serde) -> void override {
     serde("buffer", buffer_);
     serde("phase", phase_);

--- a/libtenzir/builtins/operators/repeat.cpp
+++ b/libtenzir/builtins/operators/repeat.cpp
@@ -173,14 +173,6 @@ public:
     return OperatorState::normal;
   }
 
-  auto stop(OpCtx& ctx) -> Task<void> override {
-    TENZIR_UNUSED(ctx);
-    phase_ = Phase::finished;
-    remaining_repetitions_ = 0;
-    next_index_ = 0;
-    co_return;
-  }
-
   auto snapshot(Serde& serde) -> void override {
     serde("buffer", buffer_);
     serde("phase", phase_);

--- a/libtenzir/builtins/operators/serve_http.cpp
+++ b/libtenzir/builtins/operators/serve_http.cpp
@@ -457,12 +457,6 @@ public:
                                             : FinalizeBehavior::continue_;
   }
 
-  auto stop(OpCtx& ctx) -> Task<void> override {
-    TENZIR_UNUSED(ctx);
-    co_await force_stop();
-    co_return;
-  }
-
   auto state() -> OperatorState override {
     cleanup_closed_clients();
     maybe_finish_draining();

--- a/libtenzir/builtins/operators/to_ftp.cpp
+++ b/libtenzir/builtins/operators/to_ftp.cpp
@@ -219,19 +219,6 @@ public:
     co_await finish_upload_task();
   }
 
-  auto stop(OpCtx& ctx) -> Task<void> override {
-    if (lifecycle_ == Lifecycle::done) {
-      co_return;
-    }
-    lifecycle_ = Lifecycle::done;
-    co_await request_upload_abort(true);
-    if (auto sub = ctx.get_sub(caf::none)) {
-      auto& printer = as<SubHandle<table_slice>>(*sub);
-      co_await printer.close();
-    }
-    co_return;
-  }
-
   auto state() -> OperatorState override {
     return lifecycle_ == Lifecycle::done ? OperatorState::done
                                          : OperatorState::normal;

--- a/libtenzir/include/tenzir/actors.hpp
+++ b/libtenzir/include/tenzir/actors.hpp
@@ -421,7 +421,11 @@ using pipeline_executor_actor = typed_actor_fwd<
   // called before the pipeline was started.
   auto(atom::pause)->caf::result<void>,
   // Resume the pipeline execution. No-op if it was not paused.
-  auto(atom::resume)->caf::result<void>>::unwrap;
+  auto(atom::resume)->caf::result<void>,
+  // Request a graceful stop: source operators finish in-flight work and the
+  // pipeline drains and terminates naturally. Idempotent. To force-kill the
+  // pipeline, send an exit message instead.
+  auto(atom::stop)->caf::result<void>>::unwrap;
 
 /// The interface of a PACKAGE LISTENER actor.
 /// Listeners are notified by the package manager in the following order:

--- a/libtenzir/include/tenzir/async.hpp
+++ b/libtenzir/include/tenzir/async.hpp
@@ -27,9 +27,11 @@
 /// - `process_task(result, push, ctx)` - Called when `await_task()` completes.
 /// - `prepare_snapshot(push, ctx)` - Called when checkpointing to let
 ///   operators push buffered output before state serialization.
-/// - `finalize(push, ctx)` - Called exactly once when upstream signals
-///   end-of-data. Use for buffering operators (tail, sort, aggregations) that
-///   must see all input before producing output.
+/// - `stop(ctx)` - Called on graceful shutdown to stop producing new external
+///   work while still draining all input that was already accepted.
+///   This must not be treated as end-of-input.
+/// - `finalize(push, ctx)` - Called exactly once after the input stream is
+///   exhausted.
 /// - `state()` - Polled after processing; return `done` for early completion.
 ///
 /// ## Key Invariants
@@ -285,7 +287,7 @@ public:
     co_return;
   }
 
-  /// Called once at end-of-stream. See file-level docs.
+  /// Called once after the input stream is exhausted. See file-level docs.
   virtual auto finalize(Push<Output>& push, OpCtx& ctx)
     -> Task<FinalizeBehavior> {
     TENZIR_UNUSED(push, ctx);
@@ -440,7 +442,14 @@ public:
     return OperatorState::normal;
   }
 
-  /// Called to signal that a source should gracefully shut down.
+  /// Called to request a graceful shutdown.
+  ///
+  /// `stop()` means "stop producing new work, but finish draining work that is
+  /// already in flight". For `Input != void`, operators should keep processing
+  /// accepted input until they later receive end-of-data and the executor calls
+  /// `finalize()`. For sources (`Input == void`), `stop()` typically quiesces
+  /// timers, listeners, or other work producers so that `finalize()` can run
+  /// afterwards.
   virtual auto stop(OpCtx& ctx) -> Task<void> {
     TENZIR_UNUSED(ctx);
     co_return;

--- a/libtenzir/include/tenzir/async/executor.hpp
+++ b/libtenzir/include/tenzir/async/executor.hpp
@@ -14,6 +14,7 @@
 #include "tenzir/async.hpp"
 #include "tenzir/async/channel.hpp"
 #include "tenzir/async/generator.hpp"
+#include "tenzir/async/notify.hpp"
 #include "tenzir/async/signal.hpp"
 #include "tenzir/result.hpp"
 
@@ -102,6 +103,14 @@ private:
 
 struct PostCommit {};
 
+/// Request a graceful shutdown of the operator.
+///
+/// For source operators (Input == void), calls `stop()` so the source can
+/// finish in-flight work and then proceed to `finalize()` naturally.
+/// Non-source operators ignore this signal — they drain via end-of-data
+/// propagation from upstream.
+struct GracefulStop {};
+
 /// Cancel everything that the inner operator implementation is doing.
 ///
 /// This does not stop the runner itself as we need to continue to forward
@@ -110,7 +119,7 @@ struct PostCommit {};
 /// to this signal immediately, but we'll leave that for later.
 struct HardStop {};
 
-using FromControl = variant<PostCommit, HardStop>;
+using FromControl = variant<PostCommit, GracefulStop, HardStop>;
 
 TENZIR_ENUM(
   /// A message sent from an operator to the controller.
@@ -282,7 +291,8 @@ public:
 
 /// Run a closed pipeline without external control.
 auto run_pipeline(OperatorChain<void, void> pipeline, ExecCtx& exec_ctx,
-                  caf::actor_system& sys, DiagHandler& dh) -> Task<void>;
+                  caf::actor_system& sys, DiagHandler& dh,
+                  Notify* graceful_stop = nullptr) -> Task<void>;
 
 /// Run a right-open pipeline without external control.
 template <class Output>

--- a/libtenzir/include/tenzir/detail/signal_guard.hpp
+++ b/libtenzir/include/tenzir/detail/signal_guard.hpp
@@ -1,0 +1,126 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2025 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "tenzir/async/notify.hpp"
+#include "tenzir/logger.hpp"
+#include "tenzir/ref.hpp"
+
+#include <fmt/format.h>
+#include <folly/CancellationToken.h>
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <csignal>
+#include <fcntl.h>
+#include <poll.h>
+#include <thread>
+#include <unistd.h>
+
+namespace tenzir::detail {
+
+/// Intercepts SIGINT/SIGTERM for graceful two-phase shutdown.
+///
+/// Uses the self-pipe trick: signal handlers write to a pipe, and a
+/// dedicated thread polls it. On first signal the `graceful_stop` Notify
+/// is fired so the pipeline can drain. On a second signal (or after the
+/// grace period) the `cancel_source` is triggered to force-cancel.
+///
+/// The destructor joins the thread and restores the original handlers.
+class SignalGuard {
+public:
+  SignalGuard(Notify& graceful_stop, folly::CancellationSource& cancel_source,
+              std::chrono::milliseconds grace)
+    : graceful_stop_{graceful_stop}, cancel_source_{cancel_source} {
+    (void)::pipe(signal_pipe_.data());
+    (void)::fcntl(signal_pipe_[1], F_SETFL, O_NONBLOCK);
+    (void)::pipe(wake_pipe_.data());
+    signal_write_fd_.store(signal_pipe_[1], std::memory_order_relaxed);
+    struct sigaction sa = {};
+    sa.sa_handler = [](int signum) { // NOLINT
+      auto fd = signal_write_fd_.load(std::memory_order_relaxed);
+      if (fd >= 0) {
+        auto byte = static_cast<char>(signum);
+        (void)::write(fd, &byte, 1);
+      }
+    };
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = SA_RESTART;
+    sigaction(SIGINT, &sa, &old_sigint_);
+    sigaction(SIGTERM, &sa, &old_sigterm_);
+    thread_
+      = std::thread(&SignalGuard::run, this, static_cast<int>(grace.count()));
+  }
+
+  ~SignalGuard() {
+    (void)::write(wake_pipe_[1], "x", 1);
+    thread_.join();
+    signal_write_fd_.store(-1, std::memory_order_relaxed);
+    sigaction(SIGINT, &old_sigint_, nullptr);
+    sigaction(SIGTERM, &old_sigterm_, nullptr);
+    for (auto fd :
+         {signal_pipe_[0], signal_pipe_[1], wake_pipe_[0], wake_pipe_[1]}) {
+      ::close(fd);
+    }
+  }
+
+  SignalGuard(const SignalGuard&) = delete;
+  auto operator=(const SignalGuard&) -> SignalGuard& = delete;
+  SignalGuard(SignalGuard&&) = delete;
+  auto operator=(SignalGuard&&) -> SignalGuard& = delete;
+
+private:
+  /// Waits for signals on the signal pipe, or for normal exit on the wake
+  /// pipe. Called on the dedicated thread.
+  auto run(int grace_ms) -> void {
+    auto pfds = std::array<pollfd, 2>{{
+      {signal_pipe_[0], POLLIN, 0},
+      {wake_pipe_[0], POLLIN, 0},
+    }};
+    auto rc = ::poll(pfds.data(), pfds.size(), -1);
+    if (rc <= 0 or (pfds[1].revents & POLLIN)) {
+      return;
+    }
+    // First signal: drain the byte and request graceful stop.
+    auto byte = char{};
+    (void)::read(signal_pipe_[0], &byte, 1);
+    TENZIR_DEBUG("received signal {}, initiating graceful shutdown",
+                 static_cast<int>(byte));
+    fmt::print(stderr, "\rinitiating graceful shutdown... "
+                       "(repeat to terminate immediately)\n");
+    graceful_stop_->notify_one();
+    // Wait for second signal, grace-period timeout, or normal completion.
+    pfds[0].revents = 0;
+    pfds[1].revents = 0;
+    rc = ::poll(pfds.data(), pfds.size(), grace_ms);
+    if (rc > 0 and (pfds[1].revents & POLLIN)) {
+      return; // Pipeline finished on its own.
+    }
+    if (rc > 0 and (pfds[0].revents & POLLIN)) {
+      TENZIR_DEBUG("received second signal, force-cancelling pipeline");
+    } else {
+      TENZIR_DEBUG("grace period expired, force-cancelling pipeline");
+    }
+    cancel_source_->requestCancellation();
+  }
+
+  // NOLINTBEGIN
+  static inline std::atomic<int> signal_write_fd_{-1};
+  // NOLINTEND
+  Ref<Notify> graceful_stop_;
+  Ref<folly::CancellationSource> cancel_source_;
+  std::array<int, 2> signal_pipe_{-1, -1};
+  std::array<int, 2> wake_pipe_{-1, -1};
+  struct sigaction old_sigint_ = {};
+  struct sigaction old_sigterm_ = {};
+  std::thread thread_;
+};
+
+} // namespace tenzir::detail

--- a/libtenzir/include/tenzir/tql2/exec.hpp
+++ b/libtenzir/include/tenzir/tql2/exec.hpp
@@ -84,11 +84,12 @@ auto parse_and_compile(std::string_view source, session ctx)
 /// Run a closed pipeline from a list of operators.
 auto run_plan(OperatorChain<void, void> chain, caf::actor_system& sys,
               DiagHandler& dh, Profiler profiler, bool has_terminal,
-              bool is_hidden) -> Task<failure_or<void>>;
+              bool is_hidden, Notify* graceful_stop = nullptr)
+  -> Task<failure_or<void>>;
 
 auto run_plan(OperatorChain<void, void> chain, caf::actor_system& sys,
-              DiagHandler& dh, Profiler profiler, bool is_hidden)
-  -> Task<failure_or<void>>;
+              DiagHandler& dh, Profiler profiler, bool is_hidden,
+              Notify* graceful_stop = nullptr) -> Task<failure_or<void>>;
 
 /// Feeds input into a transform pipeline.
 using TransformFeeder

--- a/libtenzir/src/async/executor.cpp
+++ b/libtenzir/src/async/executor.cpp
@@ -863,6 +863,12 @@ private:
     }
     add_from_sub_recv(it);
     add_to_control_recv(it);
+    // If we already received a graceful stop signal, forward it to the new
+    // subpipeline immediately so that nested sources also learn about the
+    // shutdown and don't keep producing new work indefinitely.
+    if (stop_requested_ and it->second.from_control_sender) {
+      co_await it->second.from_control_sender->send(GracefulStop{});
+    }
     // TODO: Where do we put this?
     TENZIR_ASSERT(operator_scope_);
     operator_scope_->spawn([this, key = std::move(sub_key),
@@ -1367,6 +1373,27 @@ private:
         LOGV("got post commit in {}", op_name());
         co_await base_op().post_commit(*this);
       },
+      [&](GracefulStop) -> Task<void> {
+        if (phase_ != Phase::running or stop_requested_) {
+          co_return;
+        }
+        stop_requested_ = true;
+        LOGE("got graceful stop in {}", op_name());
+        // Tell the operator to stop() producing new work and finish any
+        // in-flight work. It should eventually reach finalize() naturally,
+        // either by returning OperatorState::done from state() or by exhausting
+        // their await_task() loop.
+        co_await base_op().stop(*this);
+
+        // Propagate into all subpipelines so that nested sources (e.g.,
+        // `subscribe` inside `every 10s { ... }`) also learn about the
+        // graceful shutdown.
+        for (auto& [_, sub] : subpipelines_) {
+          if (sub.from_control_sender) {
+            co_await sub.from_control_sender->send(GracefulStop{});
+          }
+        }
+      },
       [&](HardStop) -> Task<void> {
         if (phase_ == Phase::stopping_forced or phase_ == Phase::stopped) {
           co_return;
@@ -1597,6 +1624,9 @@ private:
   bool got_end_of_data_{false};
   /// Tracks the shutdown sequencing of the operator.
   Phase phase_{Phase::running};
+  /// Whether we have received a `GracefulStop` signal. We remember this so we
+  /// can forward it to subpipelines spawned after the signal arrived.
+  bool stop_requested_{false};
   // TODO: Expose this as an atomic for metrics?
   size_t ticks_{0};
 };
@@ -1751,6 +1781,13 @@ private:
               for (auto& ctrl : op_controls_) {
                 if (ctrl.sender) {
                   co_await ctrl.sender->send(PostCommit{});
+                }
+              }
+            },
+            [&](GracefulStop) -> Task<void> {
+              for (auto& ctrl : op_controls_) {
+                if (ctrl.sender) {
+                  co_await ctrl.sender->send(GracefulStop{});
                 }
               }
             },
@@ -1970,19 +2007,25 @@ auto new_pipe_id() -> PipeId {
 
 } // namespace
 
+struct GracefulStopRequested {};
+
 auto run_pipeline(OperatorChain<void, void> pipeline, ExecCtx& exec_ctx,
-                  caf::actor_system& sys, DiagHandler& dh) -> Task<void> {
+                  caf::actor_system& sys, DiagHandler& dh,
+                  Notify* graceful_stop) -> Task<void> {
   auto id = new_pipe_id();
   auto [push_input, pull_input]
     = exec_ctx.make_channel<void>(ChannelId::first(id.op(0)));
   auto [push_output, pull_output]
     = exec_ctx.make_channel<void>(ChannelId::last(id.op(pipeline.size() - 1)));
   auto result = co_await async_try([&]() -> Task<void> {
-    auto [from_control_sender, from_control_receiver]
+    auto [from_control_sender_raw, from_control_receiver]
       = channel<FromControl>(16);
+    auto from_control_sender
+      = Option<Sender<FromControl>>{std::move(from_control_sender_raw)};
     auto [to_control_sender, to_control_receiver] = channel<ToControl>(16);
-    auto driver = JoinSet<
-      variant<Terminated, Option<ToControl>, Option<OperatorMsg<void>>>>{};
+    auto driver
+      = JoinSet<variant<Terminated, GracefulStopRequested, Option<ToControl>,
+                        Option<OperatorMsg<void>>>>{};
     LOGV("creating pipeline queue scope");
     co_await driver.activate([&] -> Task<void> {
       driver.add([&] -> Task<Terminated> {
@@ -1994,6 +2037,12 @@ auto run_pipeline(OperatorChain<void, void> pipeline, ExecCtx& exec_ctx,
       });
       driver.add(pull_output());
       driver.add(to_control_receiver.recv());
+      if (graceful_stop) {
+        driver.add([graceful_stop] -> Task<GracefulStopRequested> {
+          co_await graceful_stop->wait();
+          co_return GracefulStopRequested{};
+        });
+      }
 #if 0
       // TODO: We just have this right now to simulate checkpointing.
       queue.scope().spawn([&] -> Task<std::monostate> {
@@ -2009,9 +2058,20 @@ auto run_pipeline(OperatorChain<void, void> pipeline, ExecCtx& exec_ctx,
         co_await co_match(
           std::move(*next),
           [&](Terminated) -> Task<void> {
-            // TODO: The pipeline terminated?
             LOGI("run_pipeline got info that chain terminated");
+            from_control_sender = None{};
+            // If the pipeline terminated without graceful stop,
+            // the Notify would block the driver forever, never completing.
+            if (graceful_stop) {
+              graceful_stop->notify_one();
+            }
             co_return;
+          },
+          [&](GracefulStopRequested) -> Task<void> {
+            LOGI("run_pipeline got graceful stop request");
+            if (from_control_sender) {
+              co_await from_control_sender->send(GracefulStop{});
+            }
           },
           [&](Option<ToControl> to_control) -> Task<void> {
             if (not to_control) {
@@ -2026,7 +2086,7 @@ auto run_pipeline(OperatorChain<void, void> pipeline, ExecCtx& exec_ctx,
                 {
                   // FIXME: We should not leave this dangling.
                   auto _input = std::move(push_input);
-                  auto _control = std::move(from_control_sender);
+                  from_control_sender = None{};
                 }
                 break;
               case ToControl::checkpoint_begin:

--- a/libtenzir/src/async/executor.cpp
+++ b/libtenzir/src/async/executor.cpp
@@ -2054,11 +2054,13 @@ auto run_pipeline(OperatorChain<void, void> pipeline, ExecCtx& exec_ctx,
         }
       });
 #endif
+      auto terminated = false;
       while (auto next = co_await driver.next()) {
         co_await co_match(
           std::move(*next),
           [&](Terminated) -> Task<void> {
             LOGI("run_pipeline got info that chain terminated");
+            terminated = true;
             from_control_sender = None{};
             // If the pipeline terminated without graceful stop,
             // the Notify would block the driver forever, never completing.
@@ -2068,6 +2070,12 @@ auto run_pipeline(OperatorChain<void, void> pipeline, ExecCtx& exec_ctx,
             co_return;
           },
           [&](GracefulStopRequested) -> Task<void> {
+            if (terminated) {
+              // This is not a real stop request: the Terminated handler
+              // notifies `graceful_stop` solely to unblock the watcher task
+              // so that the JoinSet can complete.
+              co_return;
+            }
             LOGI("run_pipeline got graceful stop request");
             if (from_control_sender) {
               co_await from_control_sender->send(GracefulStop{});

--- a/libtenzir/src/async/executor.cpp
+++ b/libtenzir/src/async/executor.cpp
@@ -1374,7 +1374,8 @@ private:
         co_await base_op().post_commit(*this);
       },
       [&](GracefulStop) -> Task<void> {
-        if (phase_ != Phase::running or stop_requested_) {
+        if (phase_ == Phase::stopping_forced or phase_ == Phase::stopped
+            or stop_requested_) {
           co_return;
         }
         stop_requested_ = true;

--- a/libtenzir/src/node.cpp
+++ b/libtenzir/src/node.cpp
@@ -734,39 +734,52 @@ auto node(node_actor::stateful_pointer<node_state> self,
       }
       ps.clear();
       auto& registry = self->state().registry;
-      // Core components are terminated in a second stage, we remove them from
-      // the registry upfront and deal with them later.
+      // Core components are terminated in a second stage, but they must remain
+      // registered while the pipeline manager drains managed pipelines. Those
+      // pipelines may still need to resolve components like `importer` during
+      // graceful shutdown.
       std::vector<caf::actor> core_shutdown_handles;
+      auto core_shutdown_labels = std::vector<std::string_view>{};
+      auto add_core_handle = [&](std::string_view label) {
+        if (std::ranges::find(core_shutdown_labels, label)
+            != core_shutdown_labels.end()) {
+          return;
+        }
+        if (auto actor = registry.find_by_label(label)) {
+          core_shutdown_labels.push_back(label);
+          core_shutdown_handles.push_back(std::move(actor));
+        }
+      };
       // Always shut down the pipeline manager first. This is a must, as
       // otherwise the shutdown of other components can cause dependent
       // pipelines to either complete, stop, or fail, and if the pipeline
       // manager hasn't yet noticed that it's supposed to shutdown it may still
       // want to persist its state afterwards, causing the pipelines to be in
       // the wrong state after restarting.
-      if (auto pm = registry.remove("pipeline-manager")) {
-        core_shutdown_handles.push_back(std::move(pm->actor));
-      }
+      add_core_handle("pipeline-manager");
       for (const auto& name :
            self->state().ordered_components | std::ranges::views::reverse) {
-        if (auto comp = registry.remove(name)) {
-          core_shutdown_handles.push_back(comp->actor);
-        }
+        add_core_handle(name);
       }
       for (const char* name : ordered_core_components) {
-        if (auto comp = registry.remove(name)) {
-          core_shutdown_handles.push_back(comp->actor);
-        }
+        add_core_handle(name);
       }
+      auto is_deferred_component = [&](std::string_view label) {
+        return label == "pipeline-manager" or is_core_component(label)
+               or std::ranges::find(self->state().ordered_components, label)
+                    != self->state().ordered_components.end();
+      };
       std::vector<caf::actor> aux_components;
-      for (const auto& [_, comp] : registry.components()) {
+      for (const auto& [label, comp] : registry.components()) {
         // Ignore remote actors.
         if (comp.actor->node() != self->node()) {
           continue;
         }
+        if (is_deferred_component(label)) {
+          continue;
+        }
         aux_components.push_back(comp.actor);
       }
-      // Drop everything.
-      registry.clear();
       auto core_shutdown_sequence
         = [=, core_shutdown_handles
               = std::move(core_shutdown_handles)]() mutable {

--- a/libtenzir/src/pipeline_executor.cpp
+++ b/libtenzir/src/pipeline_executor.cpp
@@ -409,6 +409,22 @@ auto pipeline_executor(
     [self](atom::resume) -> caf::result<void> {
       return self->state().resume();
     },
+    [self](atom::stop) -> caf::result<void> {
+      // The legacy executor has no graceful drain phase; a stop request is
+      // equivalent to an exit with reason `user_shutdown`.
+      auto reason = caf::error{caf::exit_reason::user_shutdown};
+      if (self->state().start_rp.pending()) {
+        self->state().start_rp.deliver(reason);
+      }
+      if (self->state().is_started) {
+        for (const auto& exec_node : self->state().exec_nodes) {
+          TENZIR_ASSERT(exec_node);
+          self->send_exit(exec_node, reason);
+        }
+      }
+      self->quit(std::move(reason));
+      return {};
+    },
     [self](caf::exit_msg msg) {
       if (self->state().start_rp.pending()) {
         self->state().start_rp.deliver(msg.reason);

--- a/libtenzir/src/tql2/exec.cpp
+++ b/libtenzir/src/tql2/exec.cpp
@@ -18,6 +18,7 @@
 #include "tenzir/configuration.hpp"
 #include "tenzir/defaults.hpp"
 #include "tenzir/detail/assert.hpp"
+#include "tenzir/detail/signal_guard.hpp"
 #include "tenzir/diagnostics.hpp"
 #include "tenzir/element_type.hpp"
 #include "tenzir/exec_pipeline.hpp"
@@ -2040,14 +2041,14 @@ auto run_profiler(Profiler const& profiler, TestExecCtx& exec_ctx,
 
 auto run_plan(OperatorChain<void, void> chain, caf::actor_system& sys,
               DiagHandler& dh, Profiler profiler, bool has_terminal,
-              bool is_hidden) -> Task<failure_or<void>> {
+              bool is_hidden, Notify* graceful_stop) -> Task<failure_or<void>> {
   auto num_ops = chain.size();
   LOGW("spawning plan with {} operators", num_ops);
   auto exec_ctx = TestExecCtx{profiler, has_terminal, is_hidden};
   co_await async_scope([&](AsyncScope& scope) -> Task<void> {
     scope.spawn(run_profiler(profiler, exec_ctx, num_ops));
     LOGW("blocking on pipeline");
-    co_await run_pipeline(std::move(chain), exec_ctx, sys, dh);
+    co_await run_pipeline(std::move(chain), exec_ctx, sys, dh, graceful_stop);
     LOGW("blocking on pipeline done");
     scope.cancel();
   });
@@ -2055,10 +2056,10 @@ auto run_plan(OperatorChain<void, void> chain, caf::actor_system& sys,
 }
 
 auto run_plan(OperatorChain<void, void> chain, caf::actor_system& sys,
-              DiagHandler& dh, Profiler profiler, bool is_hidden)
-  -> Task<failure_or<void>> {
+              DiagHandler& dh, Profiler profiler, bool is_hidden,
+              Notify* graceful_stop) -> Task<failure_or<void>> {
   co_return co_await run_plan(std::move(chain), sys, dh, std::move(profiler),
-                              false, is_hidden);
+                              false, is_hidden, graceful_stop);
 }
 
 auto run_transform(OperatorChain<table_slice, table_slice> chain,
@@ -2219,11 +2220,14 @@ auto run_plan_blocking(OperatorChain<void, void> chain, caf::actor_system& sys,
   auto cancel_source = folly::CancellationSource{};
   auto diag_handler = ExecDiagHandler{dh, cancel_source};
   auto has_terminal = ::isatty(STDIN_FILENO) == 1;
+  auto graceful_stop = Notify{};
+  auto signal_guard = detail::SignalGuard{graceful_stop, cancel_source,
+                                          std::chrono::seconds{3}};
   auto task = folly::coro::co_invoke([&] -> Task<Option<failure_or<void>>> {
     co_return co_await catch_cancellation(folly::coro::co_withCancellation(
       cancel_source.getToken(),
       run_plan(std::move(chain), sys, diag_handler, std::move(profiler),
-               has_terminal, false)));
+               has_terminal, false, &graceful_stop)));
   });
 #if 0
   TENZIR_DEBUG("running pipeline on a single thread");
@@ -2237,7 +2241,8 @@ auto run_plan_blocking(OperatorChain<void, void> chain, caf::actor_system& sys,
   LOGI("end blocking");
   TRY(diag_handler.failure());
   if (not result) {
-    panic("pipeline got cancelled without error");
+    // The pipeline was cancelled, e.g., by a signal-triggered force-cancel.
+    return {};
   }
   if (result->is_error()) {
     panic("got failure from run_plan but not in diagnostic handler");

--- a/libtenzir/src/tql2/exec.cpp
+++ b/libtenzir/src/tql2/exec.cpp
@@ -2241,8 +2241,13 @@ auto run_plan_blocking(OperatorChain<void, void> chain, caf::actor_system& sys,
   LOGI("end blocking");
   TRY(diag_handler.failure());
   if (not result) {
-    // The pipeline was cancelled, e.g., by a signal-triggered force-cancel.
-    return {};
+    // The pipeline was force-cancelled, either by a second signal or because
+    // the grace period after a graceful stop request expired. In-flight data
+    // may have been lost, so we report failure.
+    diagnostic::error("pipeline was aborted before completion")
+      .note("in-flight data may have been lost")
+      .emit(dh);
+    return failure::promise();
   }
   if (result->is_error()) {
     panic("got failure from run_plan but not in diagnostic handler");

--- a/test/tests/node/shutdown.py
+++ b/test/tests/node/shutdown.py
@@ -13,6 +13,9 @@ Phase 5: source `every` with slow subpipeline -> SIGTERM -> restart
          -> verify shutdown does not spawn an extra subpipeline.
 Phase 6: streaming input into `every` with slow subpipeline -> SIGTERM
          -> restart -> verify shutdown still spawns follow-up subpipelines.
+Phase 7: subscriber whose topic never had publishers -> SIGTERM
+         -> verify shutdown drains promptly instead of hitting the
+         grace-period force-kill.
 
 Adapted from the pubsub/drain test pattern.  Uses managed pipelines
 (created via the REST API) so that all work runs inside the node and
@@ -444,6 +447,28 @@ try:
     data = export_summary(tenzir, "shutdown-phase6", "seq")
     assert data == {"count": 100, "lo": 0, "hi": 99}, f"phase6: {data}"
     print("phase6-every-transform-drains: ok")
+
+    # --- Phase 7: subscriber without publishers drains promptly ----------
+    # A subscribe pipeline whose topic never had a publisher must complete
+    # its drain immediately on shutdown instead of waiting for publishers
+    # that do not exist until the grace-period watchdog force-kills it.
+
+    web_proc, api = start_web_server(node.env)
+    tenzir = Executor.from_env(node.env)
+
+    create_pipeline(
+        api,
+        'subscribe "shutdown-no-publishers"\n@name = "shutdown-phase7"\nimport',
+        name="phase7-subscriber",
+    )
+    time.sleep(1)  # Let subscriber attach.
+    start = time.monotonic()
+    tenzir = stop_and_restart()
+    elapsed = time.monotonic() - start
+    # A hung drain runs into the 20 s SIGKILL fallback in _terminate (the
+    # grace period itself is 30 s), so anything close to that is a bug.
+    assert elapsed < 15, f"phase7: shutdown took {elapsed:.1f}s"
+    print("phase7-subscriber-without-publishers-drains-promptly: ok")
 
 finally:
     if web_proc:

--- a/test/tests/node/shutdown.py
+++ b/test/tests/node/shutdown.py
@@ -9,6 +9,10 @@ Phase 3: two sequential publishers + subscriber -> SIGTERM -> restart
          -> verify events from both publishers survived.
 Phase 4: publisher batches via sort, then publishes -> SIGTERM -> restart
          -> verify all events in correct order survived.
+Phase 5: source `every` with slow subpipeline -> SIGTERM -> restart
+         -> verify shutdown does not spawn an extra subpipeline.
+Phase 6: streaming input into `every` with slow subpipeline -> SIGTERM
+         -> restart -> verify shutdown still spawns follow-up subpipelines.
 
 Adapted from the pubsub/drain test pattern.  Uses managed pipelines
 (created via the REST API) so that all work runs inside the node and
@@ -206,6 +210,7 @@ class NodeController:
             f"--cache-directory={self.cache_dir}",
             "--endpoint=localhost:0",
             "--print-endpoint",
+            "--no-autostart",  # When restarting, don't resume pipelines
         ]
         if package_dirs := env.get("TENZIR_PACKAGE_DIRS"):
             cmd.append(f"--package-dirs={package_dirs}")
@@ -385,6 +390,60 @@ try:
     )
     assert rows == [{"x": 1}] * 3 + [{"x": 2}] * 3 + [{"x": 3}] * 3, f"phase4: {rows}"
     print("phase4-batched-publish-survives-sigterm: ok")
+
+    # --- Phase 5: source every stops respawning during shutdown ----------
+    # The first subpipeline takes longer than the interval. During graceful
+    # shutdown, `every` must drain the in-flight subpipeline, but must not
+    # start another one after stop was requested.
+
+    web_proc, api = start_web_server(node.env)
+    tenzir = Executor.from_env(node.env)
+
+    create_pipeline(
+        api,
+        "every 200ms {\n"
+        "  from {x: 1, _ts: 1970-01-01T00:00:02}\n"
+        "  delay _ts, start=1970-01-01T00:00:00, speed=1.0\n"
+        "  drop _ts\n"
+        '  @name = "shutdown-phase5"\n'
+        "  import\n"
+        "}",
+        name="phase5-every-source",
+    )
+    time.sleep(0.5)  # Let the timer elapse while the first subpipeline runs.
+    tenzir = stop_and_restart()
+    data = export_summary(tenzir, "shutdown-phase5", "x")
+    assert data == {"count": 1, "lo": 1, "hi": 1}, f"phase5: {data}"
+    print("phase5-every-source-stops: ok")
+
+    # --- Phase 6: sink every keeps respawning during shutdown ------------
+    # Unlike the source case above, `every` with table-slice input must keep
+    # spawning follow-up subpipelines while draining buffered input.
+
+    web_proc, api = start_web_server(node.env)
+    tenzir = Executor.from_env(node.env)
+
+    create_pipeline(
+        api,
+        """
+        from {}
+        repeat 100
+        enumerate seq
+        d = 1970-01-01T00:00 + 23ms * seq
+        delay d
+        drop d
+        every 50ms {
+          @name = "shutdown-phase6"
+          import
+        }
+        """,
+        name="phase6-every-transform",
+    )
+    time.sleep(1)  # Let it run (but not fully)
+    tenzir = stop_and_restart()
+    data = export_summary(tenzir, "shutdown-phase6", "seq")
+    assert data == {"count": 100, "lo": 0, "hi": 99}, f"phase6: {data}"
+    print("phase6-every-transform-drains: ok")
 
 finally:
     if web_proc:

--- a/test/tests/node/shutdown.py
+++ b/test/tests/node/shutdown.py
@@ -1,0 +1,392 @@
+# runner: python
+# timeout: 120
+
+"""Verify no data is lost when a node receives SIGTERM.
+
+Phase 1: managed import pipeline -> SIGTERM -> restart -> verify export.
+Phase 2: managed pub/sub+import -> SIGTERM -> restart -> verify export.
+Phase 3: two sequential publishers + subscriber -> SIGTERM -> restart
+         -> verify events from both publishers survived.
+Phase 4: publisher batches via sort, then publishes -> SIGTERM -> restart
+         -> verify all events in correct order survived.
+
+Adapted from the pubsub/drain test pattern.  Uses managed pipelines
+(created via the REST API) so that all work runs inside the node and
+the SIGTERM shutdown path drains them properly.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import socket
+import subprocess
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# REST API helpers (the only part not covered by the node fixture)
+# ---------------------------------------------------------------------------
+
+API = "/api/v0"
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _terminate(proc: subprocess.Popen[str], timeout: int = 20) -> None:
+    if proc.poll() is not None:
+        return
+    proc.terminate()
+    try:
+        proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+def _post(url: str, path: str, body: dict | None = None) -> tuple[int, dict]:
+    data = json.dumps(body or {}).encode()
+    req = urllib.request.Request(
+        f"{url}{API}{path}",
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as r:
+            return r.status, json.loads(r.read().decode() or "{}")
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read().decode() or "{}")
+
+
+def _wait_for_api(url: str, timeout: int = 20) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            status, _ = _post(url, "/ping")
+            if status == 200:
+                return
+        except (urllib.error.URLError, ConnectionError, OSError):
+            pass
+        time.sleep(0.2)
+    raise RuntimeError("REST API did not come up")
+
+
+# ---------------------------------------------------------------------------
+# Web server + managed pipeline helpers
+# ---------------------------------------------------------------------------
+
+
+def start_web_server(env: dict[str, str]) -> tuple[subprocess.Popen[str], str]:
+    """Start tenzir-ctl web server and return (process, api_base_url)."""
+    binary = shlex.split(env["TENZIR_NODE_CLIENT_BINARY"])
+    tenzir_ctl = str(Path(binary[0]).with_name("tenzir-ctl"))
+    endpoint = env["TENZIR_NODE_CLIENT_ENDPOINT"]
+    port = _free_port()
+    proc = subprocess.Popen(
+        [
+            tenzir_ctl,
+            "--bare-mode",
+            "--console-verbosity=warning",
+            f"--endpoint={endpoint}",
+            "web",
+            "server",
+            "--mode=dev",
+            "--bind=127.0.0.1",
+            f"--port={port}",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    api_url = f"http://127.0.0.1:{port}"
+    _wait_for_api(api_url)
+    return proc, api_url
+
+
+def create_pipeline(
+    api_url: str,
+    definition: str,
+    *,
+    name: str | None = None,
+    autostart: bool = True,
+) -> str:
+    """Create a managed pipeline via /pipeline/create.  Returns the id."""
+    body: dict = {
+        "definition": f"//neo\n{definition}",
+        "autostart": {"created": autostart},
+    }
+    if name is not None:
+        body["name"] = name
+    status, resp = _post(api_url, "/pipeline/create", body)
+    assert status == 200, f"/pipeline/create failed ({status}): {resp}"
+    pid = resp.get("id", "")
+    assert pid, f"no pipeline id in response: {resp}"
+    return pid
+
+
+# ---------------------------------------------------------------------------
+# Query helpers
+# ---------------------------------------------------------------------------
+
+
+def export_ndjson(tenzir: Executor, pipeline: str) -> list[dict]:
+    r = tenzir.run(pipeline)
+    assert r.returncode == 0, f"export failed: {r.stderr.decode()}"
+    stdout = r.stdout.decode().strip()
+    return [json.loads(line) for line in stdout.splitlines() if line.strip()]
+
+
+def export_summary(tenzir: Executor, schema: str, field: str) -> dict:
+    r = tenzir.run(
+        f"export\n"
+        f'where @name == "{schema}"\n'
+        f"summarize count=count(), lo=min({field}), hi=max({field})\n"
+        f"write_ndjson\n"
+    )
+    assert r.returncode == 0, f"export failed: {r.stderr.decode()}"
+    return json.loads(r.stdout.decode().strip())
+
+
+def wait_for_count(
+    tenzir: Executor, schema: str, expected: int, timeout: int = 30
+) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        r = tenzir.run(
+            f"export\n"
+            f'where @name == "{schema}"\n'
+            f"summarize count=count()\n"
+            f"write_ndjson\n"
+        )
+        if r.returncode == 0:
+            try:
+                if json.loads(r.stdout.decode().strip()).get("count") == expected:
+                    return
+            except (json.JSONDecodeError, ValueError):
+                pass
+        time.sleep(0.5)
+    raise AssertionError(f"timed out waiting for {expected} events in {schema}")
+
+
+# ---------------------------------------------------------------------------
+# Node lifecycle helpers
+# ---------------------------------------------------------------------------
+
+
+class NodeController:
+    def __init__(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory(prefix="shutdown-node-")
+        self.root = Path(self.temp_dir.name)
+        self.state_dir = self.root / "state"
+        self.cache_dir = self.root / "cache"
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        self.proc: subprocess.Popen[str] | None = None
+        self.env: dict[str, str] = {}
+
+    def start(self) -> dict[str, str]:
+        pid_lock = self.state_dir / "pid.lock"
+        pid_lock.unlink(missing_ok=True)
+        node_binary = shlex.split(os.environ["TENZIR_NODE_BINARY"])
+        env = os.environ.copy()
+        cmd = [
+            *node_binary,
+            "--bare-mode",
+            "--console-verbosity=warning",
+            f"--state-directory={self.state_dir}",
+            f"--cache-directory={self.cache_dir}",
+            "--endpoint=localhost:0",
+            "--print-endpoint",
+        ]
+        if package_dirs := env.get("TENZIR_PACKAGE_DIRS"):
+            cmd.append(f"--package-dirs={package_dirs}")
+        self.proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+            env=env,
+            cwd=Path(__file__).parent,
+            start_new_session=True,
+        )
+        assert self.proc.stdout is not None
+        endpoint = self.proc.stdout.readline().strip()
+        if not endpoint:
+            returncode = self.proc.poll()
+            stderr = ""
+            if self.proc.stderr is not None:
+                stderr = self.proc.stderr.read()
+            detail = []
+            if returncode is not None:
+                detail.append(f"exit code {returncode}")
+            if stderr:
+                detail.append(f"stderr:\n{stderr}")
+            raise RuntimeError(
+                "failed to obtain endpoint from tenzir-node "
+                f"({'; '.join(detail) if detail else 'no additional diagnostics available'})"
+            )
+        self.env = {
+            "TENZIR_NODE_CLIENT_ENDPOINT": endpoint,
+            "TENZIR_NODE_CLIENT_BINARY": os.environ["TENZIR_BINARY"],
+            "TENZIR_NODE_CLIENT_TIMEOUT": os.environ.get("TENZIR_TIMEOUT", "120"),
+            "TENZIR_NODE_STATE_DIRECTORY": str(self.state_dir),
+            "TENZIR_NODE_CACHE_DIRECTORY": str(self.cache_dir),
+        }
+        return self.env
+
+    def stop(self) -> None:
+        if self.proc is not None:
+            _terminate(self.proc)
+            if self.proc.stdout is not None:
+                self.proc.stdout.close()
+            if self.proc.stderr is not None:
+                self.proc.stderr.close()
+            self.proc = None
+        self.env = {}
+
+    def cleanup(self) -> None:
+        self.stop()
+        self.temp_dir.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+node = NodeController()
+web_proc = None
+
+
+def stop_and_restart() -> Executor:
+    global web_proc
+    if web_proc:
+        _terminate(web_proc)
+        web_proc = None
+    node.stop()
+    node.start()
+    return Executor.from_env(node.env)
+
+
+try:
+    # --- Phase 1: managed import survives SIGTERM -------------------------
+
+    node.start()
+    web_proc, api = start_web_server(node.env)
+    tenzir = Executor.from_env(node.env)
+
+    create_pipeline(
+        api,
+        'from {}\nrepeat 100\nenumerate index\n@name = "shutdown-phase1"\nimport',
+        name="phase1-import",
+    )
+    wait_for_count(tenzir, "shutdown-phase1", 100)
+    tenzir = stop_and_restart()
+    data = export_summary(tenzir, "shutdown-phase1", "index")
+    assert data == {"count": 100, "lo": 0, "hi": 99}, f"phase1: {data}"
+    print("phase1-import-survives-sigterm: ok")
+
+    # --- Phase 2: managed pubsub drain survives SIGTERM -------------------
+
+    web_proc, api = start_web_server(node.env)
+    tenzir = Executor.from_env(node.env)
+
+    create_pipeline(
+        api,
+        'subscribe "shutdown-drain"\n@name = "shutdown-phase2"\nimport',
+        name="phase2-subscriber",
+    )
+    time.sleep(1)  # Let subscriber attach (same pattern as pubsub/drain).
+    create_pipeline(
+        api,
+        'from {}\nrepeat 100\nenumerate x\npublish "shutdown-drain"',
+        name="phase2-publisher",
+    )
+    wait_for_count(tenzir, "shutdown-phase2", 100)
+    tenzir = stop_and_restart()
+    data = export_summary(tenzir, "shutdown-phase2", "x")
+    assert data == {"count": 100, "lo": 0, "hi": 99}, f"phase2: {data}"
+    print("phase2-pubsub-drain-survives-sigterm: ok")
+
+    # --- Phase 3: sequential publishers survive SIGTERM -------------------
+    # Adapted from pubsub/sequential: two publishers publish to the same
+    # topic one after another; the subscriber must see events from both.
+
+    web_proc, api = start_web_server(node.env)
+    tenzir = Executor.from_env(node.env)
+
+    create_pipeline(
+        api,
+        'subscribe "shutdown-sequential"\n@name = "shutdown-phase3"\nimport',
+        name="phase3-subscriber",
+    )
+    time.sleep(1)  # Let subscriber attach.
+    create_pipeline(
+        api,
+        'every 10ms {\n  from {id: "pub-a"}\n}\nhead 5\npublish "shutdown-sequential"',
+        name="phase3-publisher-a",
+    )
+    time.sleep(1)  # Sequential: publisher B starts after A.
+    create_pipeline(
+        api,
+        'from {id: "pub-b"}\npublish "shutdown-sequential"',
+        name="phase3-publisher-b",
+    )
+    wait_for_count(tenzir, "shutdown-phase3", 6)
+    tenzir = stop_and_restart()
+    rows = export_ndjson(
+        tenzir,
+        "export\n"
+        'where @name == "shutdown-phase3"\n'
+        "sort id\n"
+        "deduplicate id\n"
+        "write_ndjson\n",
+    )
+    assert rows == [{"id": "pub-a"}, {"id": "pub-b"}], f"phase3: {rows}"
+    print("phase3-sequential-publishers-survive-sigterm: ok")
+
+    # --- Phase 4: batched publish after sort survives SIGTERM -------------
+    # Adapted from pubsub/finalize_drain: the publisher accumulates events
+    # through a blocking operator (sort), then publishes the sorted batch.
+
+    web_proc, api = start_web_server(node.env)
+    tenzir = Executor.from_env(node.env)
+
+    create_pipeline(
+        api,
+        'subscribe "shutdown-finalize"\n@name = "shutdown-phase4"\nimport',
+        name="phase4-subscriber",
+    )
+    time.sleep(1)  # Let subscriber attach.
+    create_pipeline(
+        api,
+        "every 50ms {\n"
+        "  from {x: 3}, {x: 1}, {x: 2}\n"
+        "}\n"
+        "head 9\n"
+        "sort x\n"
+        'publish "shutdown-finalize"',
+        name="phase4-publisher",
+    )
+    wait_for_count(tenzir, "shutdown-phase4", 9)
+    tenzir = stop_and_restart()
+    rows = export_ndjson(
+        tenzir,
+        'export\nwhere @name == "shutdown-phase4"\nsort x\nwrite_ndjson\n',
+    )
+    assert rows == [{"x": 1}] * 3 + [{"x": 2}] * 3 + [{"x": 3}] * 3, f"phase4: {rows}"
+    print("phase4-batched-publish-survives-sigterm: ok")
+
+finally:
+    if web_proc:
+        _terminate(web_proc)
+    node.cleanup()

--- a/test/tests/node/shutdown.txt
+++ b/test/tests/node/shutdown.txt
@@ -2,3 +2,5 @@ phase1-import-survives-sigterm: ok
 phase2-pubsub-drain-survives-sigterm: ok
 phase3-sequential-publishers-survive-sigterm: ok
 phase4-batched-publish-survives-sigterm: ok
+phase5-every-source-stops: ok
+phase6-every-transform-drains: ok

--- a/test/tests/node/shutdown.txt
+++ b/test/tests/node/shutdown.txt
@@ -4,3 +4,4 @@ phase3-sequential-publishers-survive-sigterm: ok
 phase4-batched-publish-survives-sigterm: ok
 phase5-every-source-stops: ok
 phase6-every-transform-drains: ok
+phase7-subscriber-without-publishers-drains-promptly: ok

--- a/test/tests/node/shutdown.txt
+++ b/test/tests/node/shutdown.txt
@@ -1,0 +1,4 @@
+phase1-import-survives-sigterm: ok
+phase2-pubsub-drain-survives-sigterm: ok
+phase3-sequential-publishers-survive-sigterm: ok
+phase4-batched-publish-survives-sigterm: ok


### PR DESCRIPTION
## 🔍 Problem

Restarting the node or stopping a pipeline discards all in-flight data. This is a serious issue for long-running pipelines with publish/subscribe coordination, where data loss is invisible to users.

## 🛠️ Solution

- Add a `GracefulStop` signal to the executor framework that calls `stop()` on source operators and propagates into subpipelines.
- `pipeline_executor2` uses two-phase exit handling: first exit triggers graceful drain, second exit force-cancels.
- Pipeline manager coordinates node-wide shutdown with a configurable grace period (`tenzir.shutdown-grace-period`, default 30s). Single-pipeline stop uses the same mechanism with a per-pipeline watchdog.
- Router tracks publisher refcounts per topic so subscribers terminate naturally when all publishers finish.

## 💬 Review

- The multi-publisher drain scenario has a known race: publisher registration is lazy (on first flush), so if publisher A finishes before B starts, the subscriber may terminate early. Eager registration in `Publish::start()` would fix this.
- The `GracefulStop` signal propagates through operator chains and into subpipelines, so nested sources (e.g., `subscribe` inside `every`) also receive the signal.

<sub>
📦 Plugins PR: tenzir/tenzir-plugins#551<br>
✅ Closes TNZ-538
</sub>