### PR TITLE
Load partition transform inputs in transformer

### DIFF
--- a/changelog/unreleased/rebuild-memory-limits.md
+++ b/changelog/unreleased/rebuild-memory-limits.md
@@ -1,0 +1,18 @@
+---
+title: Rebuild memory limits
+type: bugfix
+authors:
+  - tobim
+  - codex
+prs:
+  - 6216
+created: 2026-06-02T11:17:41.584713Z
+---
+
+Rebuilds now limit how much partition data they load into memory at once.
+This reduces the risk that automatic rebuilds or `tenzir-ctl rebuild start`
+cause the node to run out of memory when many partitions are selected.
+
+When memory is scarce, rebuilds load fewer partitions in one batch and retry the
+remaining partitions later instead of materializing the full selected input set
+up front.

--- a/libtenzir/builtins/commands/rebuild.cpp
+++ b/libtenzir/builtins/commands/rebuild.cpp
@@ -529,6 +529,7 @@ struct rebuilder_state {
                 return lhs.max_import_time < rhs.max_import_time;
               });
     auto selected_partitions = current_run_partitions;
+    auto retry_partitions = current_run_partitions;
     const auto num_partitions = current_run_partitions.size();
     self
       ->mail(atom::apply_v, std::move(*rebatch),
@@ -600,8 +601,12 @@ struct rebuilder_state {
           rp.delegate(static_cast<rebuilder_actor>(self), atom::internal_v,
                       atom::rebuild_v);
         },
-        [this, num_partitions, rp](caf::error& error) mutable {
+        [this, retry_partitions = std::move(retry_partitions), num_partitions,
+         rp](caf::error& error) mutable {
           TENZIR_WARN("{} failed to rebuild partitions: {}", *self, error);
+          run->remaining_partitions.insert(run->remaining_partitions.begin(),
+                                           retry_partitions.begin(),
+                                           retry_partitions.end());
           run->statistics.num_rebuilding -= num_partitions;
           rp.deliver(std::move(error));
         });

--- a/libtenzir/builtins/commands/rebuild.cpp
+++ b/libtenzir/builtins/commands/rebuild.cpp
@@ -132,12 +132,18 @@ auto read_cgroup_memory_available(const std::filesystem::path& dir,
     current = read_memory_value(dir / "memory.usage_in_bytes");
     max = read_memory_value(dir / "memory.limit_in_bytes");
   }
-  if (not current or not max or *current >= *max) {
+  if (not current or not max) {
     return std::nullopt;
   }
   static constexpr auto unlimited_cgroup_limit = uint64_t{1} << 60;
   if (*max >= unlimited_cgroup_limit) {
     return std::nullopt;
+  }
+  if (*current >= *max) {
+    return memory_available{
+      .bytes = 0,
+      .source = std::move(source),
+    };
   }
   return memory_available{
     .bytes = *max - *current,
@@ -226,7 +232,7 @@ auto rebuild_byte_budget() -> memory_budget {
     // the new Feather store, and the store writer builds additional Arrow
     // structures during persist. Admit substantially less than the apparent
     // free memory to leave room for those copies and unrelated node activity.
-    .bytes = std::max(available.bytes / 4, uint64_t{1}),
+    .bytes = available.bytes / 4,
     .available = std::move(available),
   };
 }
@@ -565,6 +571,13 @@ struct rebuilder_state {
     auto current_run_bytes = uint64_t{0};
     auto current_run_is_full = false;
     auto current_run_budget = rebuild_byte_budget();
+    if (current_run_budget.bytes == 0) {
+      TENZIR_VERBOSE("{} skips rebuild work because no memory budget is "
+                     "available (available: {} from {})",
+                     *self, format_bytes(current_run_budget.available.bytes),
+                     current_run_budget.available.source);
+      return {};
+    }
     // Take the first partition and collect as many of the same
     // type as possible to create new paritions. The approach used may
     // collects too many partitions if there is no exact match, but that is
@@ -642,6 +655,7 @@ struct rebuilder_state {
               [](const partition_info& lhs, const partition_info& rhs) {
                 return lhs.max_import_time < rhs.max_import_time;
               });
+    auto selected_partitions = current_run_partitions;
     const auto num_partitions = current_run_partitions.size();
     self
       ->mail(atom::apply_v, std::move(*rebatch),
@@ -649,9 +663,10 @@ struct rebuilder_state {
              std::string{"rebuild"})
       .request(index, caf::infinite)
       .then(
-        [this, rp, current_run_events,
-         num_partitions](std::vector<partition_info>& result) mutable {
-          if (result.empty()) {
+        [this, rp, selected_partitions = std::move(selected_partitions),
+         num_partitions](partition_transform_apply_result& result) mutable {
+          if (result.input_partitions.empty()
+              and result.output_partitions.empty()) {
             TENZIR_DEBUG("{} skipped {} partitions as they are already being "
                          "transformed by another actor",
                          *self, num_partitions);
@@ -662,32 +677,51 @@ struct rebuilder_state {
                         atom::rebuild_v);
             return;
           }
+          auto unconsumed_partitions = selected_partitions;
+          std::erase_if(unconsumed_partitions, [&](const auto& partition) {
+            return std::find(result.input_partitions.begin(),
+                             result.input_partitions.end(), partition)
+                   != result.input_partitions.end();
+          });
+          if (not result.input_complete or not unconsumed_partitions.empty()) {
+            TENZIR_DEBUG("{} requeues {} partition(s) that were selected but "
+                         "not loaded by the transformer",
+                         *self, unconsumed_partitions.size());
+            run->remaining_partitions.insert(run->remaining_partitions.begin(),
+                                             unconsumed_partitions.begin(),
+                                             unconsumed_partitions.end());
+          }
           TENZIR_DEBUG("{} rebuilt {} into {} partitions", *self,
-                       num_partitions, result.size());
-          for (const auto& partition : result) {
+                       result.input_partitions.size(),
+                       result.output_partitions.size());
+          for (const auto& partition : result.output_partitions) {
             learn_size_estimate(partition);
           }
           // If the number of events in the resulting partitions does not
           // match the number of events in the partitions that went in we ran
           // into a conflict with other partition transformations on an
           // overlapping set.
-          const auto result_events
-            = std::transform_reduce(result.begin(), result.end(), size_t{},
-                                    std::plus<>{},
-                                    [](const partition_info& partition) {
-                                      return partition.events;
-                                    });
-          if (current_run_events != result_events) {
+          const auto input_events = std::transform_reduce(
+            result.input_partitions.begin(), result.input_partitions.end(),
+            size_t{}, std::plus<>{}, [](const partition_info& partition) {
+              return partition.events;
+            });
+          const auto result_events = std::transform_reduce(
+            result.output_partitions.begin(), result.output_partitions.end(),
+            size_t{}, std::plus<>{}, [](const partition_info& partition) {
+              return partition.events;
+            });
+          if (input_events != result_events) {
             TENZIR_WARN("{} detected a mismatch: rebuilt {} events from {} "
                         "partitions into {} events in {} partitions",
-                        *self, current_run_events, num_partitions,
-                        result_events, result.size());
+                        *self, input_events, result.input_partitions.size(),
+                        result_events, result.output_partitions.size());
           }
           // Adjust the counters, update the indicator, and move back
           // undersized transformed partitions to the list of remainig
           // partitions as desired.
-          run->statistics.num_completed += num_partitions;
-          run->statistics.num_results += result.size();
+          run->statistics.num_completed += result.input_partitions.size();
+          run->statistics.num_results += result.output_partitions.size();
           run->statistics.num_rebuilding -= num_partitions;
           // Pick up new work until we run out of remainig partitions.
           rp.delegate(static_cast<rebuilder_actor>(self), atom::internal_v,

--- a/libtenzir/builtins/commands/rebuild.cpp
+++ b/libtenzir/builtins/commands/rebuild.cpp
@@ -640,7 +640,6 @@ struct rebuilder_state {
                 return lhs.max_import_time < rhs.max_import_time;
               });
     auto selected_partitions = current_run_partitions;
-    auto retry_partitions = selected_partitions;
     const auto num_partitions = current_run_partitions.size();
     self
       ->mail(atom::apply_v, std::move(*rebatch),
@@ -712,16 +711,10 @@ struct rebuilder_state {
           rp.delegate(static_cast<rebuilder_actor>(self), atom::internal_v,
                       atom::rebuild_v);
         },
-        [this, num_partitions, retry_partitions = std::move(retry_partitions),
-         rp](caf::error& error) mutable {
+        [this, num_partitions, rp](caf::error& error) mutable {
           TENZIR_WARN("{} failed to rebuild partitions: {}", *self, error);
           run->statistics.num_rebuilding -= num_partitions;
-          run->remaining_partitions.insert(run->remaining_partitions.begin(),
-                                           retry_partitions.begin(),
-                                           retry_partitions.end());
-          // Pick up new work until we run out of remainig partitions.
-          rp.delegate(static_cast<rebuilder_actor>(self), atom::internal_v,
-                      atom::rebuild_v);
+          rp.deliver(std::move(error));
         });
     return rp;
   }

--- a/libtenzir/builtins/commands/rebuild.cpp
+++ b/libtenzir/builtins/commands/rebuild.cpp
@@ -218,8 +218,16 @@ struct rebuilder_state {
     if (partition.events == 0 or partition.approx_bytes == 0) {
       return;
     }
-    approx_bytes_per_event[partition.schema]
+    const auto bytes_per_event
       = std::max<uint64_t>(partition.approx_bytes / partition.events, 1);
+    auto& estimate = approx_bytes_per_event[partition.schema];
+    if (estimate == 0) {
+      estimate = bytes_per_event;
+    } else if (estimate < bytes_per_event) {
+      estimate += (bytes_per_event - estimate) / 2;
+    } else {
+      estimate = bytes_per_event + (estimate - bytes_per_event) / 2;
+    }
   }
 
   auto has_size_estimate(const partition_info& partition) const -> bool {

--- a/libtenzir/builtins/commands/rebuild.cpp
+++ b/libtenzir/builtins/commands/rebuild.cpp
@@ -604,13 +604,6 @@ struct rebuilder_state {
       });
     run->remaining_partitions.erase(first_removed,
                                     run->remaining_partitions.end());
-    TENZIR_INFO("{} selected {} partition(s) for rebuild of schema {} with {} "
-                "estimated decoded bytes (budget: {}, available: {} from {})",
-                *self, current_run_partitions.size(), schema,
-                format_bytes(current_run_bytes),
-                format_bytes(current_run_budget.bytes),
-                format_bytes(current_run_budget.available.bytes),
-                current_run_budget.available.source);
     run->statistics.num_rebuilding += current_run_partitions.size();
     // If we have just a single partition then we shouldn't rebuild if our
     // intent was to merge undersized partitions, unless the partition is

--- a/libtenzir/builtins/commands/rebuild.cpp
+++ b/libtenzir/builtins/commands/rebuild.cpp
@@ -16,6 +16,7 @@
 #include <tenzir/defaults.hpp>
 #include <tenzir/detail/inspection_common.hpp>
 #include <tenzir/detail/narrow.hpp>
+#include <tenzir/detail/saturating_arithmetic.hpp>
 #include <tenzir/detail/weak_run_delayed.hpp>
 #include <tenzir/fwd.hpp>
 #include <tenzir/index.hpp>
@@ -244,23 +245,6 @@ auto format_bytes(uint64_t bytes) -> std::string {
   return fmt::format("{} bytes", bytes);
 }
 
-auto saturating_multiply(uint64_t lhs, uint64_t rhs) -> uint64_t {
-  if (lhs == 0 or rhs == 0) {
-    return 0;
-  }
-  if (lhs > std::numeric_limits<uint64_t>::max() / rhs) {
-    return std::numeric_limits<uint64_t>::max();
-  }
-  return lhs * rhs;
-}
-
-auto saturating_add(uint64_t lhs, uint64_t rhs) -> uint64_t {
-  if (lhs > std::numeric_limits<uint64_t>::max() - rhs) {
-    return std::numeric_limits<uint64_t>::max();
-  }
-  return lhs + rhs;
-}
-
 /// Statistics for an ongoing rebuild. Numbers are partitions.
 struct statistics {
   size_t num_total = {};
@@ -363,7 +347,7 @@ struct rebuilder_state {
     }
     if (auto it = approx_bytes_per_event.find(partition.schema);
         it != approx_bytes_per_event.end()) {
-      return saturating_multiply(
+      return detail::saturating_mul(
         it->second, detail::narrow_cast<uint64_t>(partition.events));
     }
     return unknown_partition_bytes;
@@ -595,13 +579,13 @@ struct rebuilder_state {
           const auto partition_bytes
             = estimate_approx_bytes(partition, current_run_budget.bytes);
           if (not current_run_partitions.empty()
-              and saturating_add(current_run_bytes, partition_bytes)
+              and detail::saturating_add(current_run_bytes, partition_bytes)
                     > current_run_budget.bytes) {
             current_run_is_full = true;
             return false;
           }
           current_run_bytes
-            = saturating_add(current_run_bytes, partition_bytes);
+            = detail::saturating_add(current_run_bytes, partition_bytes);
           current_run_events += partition.events;
           current_run_partitions.push_back(partition);
           TENZIR_TRACE("{} selects partition {} (v{}, {}) with "

--- a/libtenzir/builtins/commands/rebuild.cpp
+++ b/libtenzir/builtins/commands/rebuild.cpp
@@ -220,6 +220,11 @@ struct rebuilder_state {
       = std::max<uint64_t>(partition.approx_bytes / partition.events, 1);
   }
 
+  auto has_size_estimate(const partition_info& partition) const -> bool {
+    return partition.events == 0 or partition.approx_bytes > 0
+           or approx_bytes_per_event.contains(partition.schema);
+  }
+
   auto estimate_approx_bytes(const partition_info& partition,
                              uint64_t unknown_partition_bytes) const
     -> uint64_t {
@@ -490,7 +495,8 @@ struct rebuilder_state {
       = run->options.undersized and current_run_partitions.size() == 1
         and current_run_partitions[0].version
               == version::current_partition_version
-        and current_run_partitions[0].events <= max_partition_size;
+        and current_run_partitions[0].events <= max_partition_size
+        and has_size_estimate(current_run_partitions[0]);
     if (skip_rebuild) {
       run->statistics.num_rebuilding -= 1;
       run->statistics.num_total -= 1;

--- a/libtenzir/builtins/commands/rebuild.cpp
+++ b/libtenzir/builtins/commands/rebuild.cpp
@@ -42,6 +42,11 @@
 #include <caf/typed_event_based_actor.hpp>
 #include <fmt/format.h>
 
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <unordered_map>
+
 namespace tenzir::plugins::rebuild {
 
 namespace {
@@ -90,6 +95,64 @@ namespace {
 /// The threshold at which to consider a partition undersized, relative to the
 /// configured 'tenzir.max-partition-size'.
 inline constexpr auto undersized_threshold = 0.8;
+
+auto read_memory_value(const std::filesystem::path& path)
+  -> std::optional<uint64_t> {
+  auto file = std::ifstream{path};
+  auto value = std::string{};
+  file >> value;
+  if (value.empty() or value == "max") {
+    return std::nullopt;
+  }
+  try {
+    return std::stoull(value);
+  } catch (const std::exception&) {
+    return std::nullopt;
+  }
+}
+
+auto available_memory() -> std::optional<uint64_t> {
+  auto current = read_memory_value("/sys/fs/cgroup/memory.current");
+  auto max = read_memory_value("/sys/fs/cgroup/memory.max");
+  if (current and max and *current < *max) {
+    return *max - *current;
+  }
+  auto meminfo = std::ifstream{"/proc/meminfo"};
+  auto key = std::string{};
+  auto value = uint64_t{};
+  auto unit = std::string{};
+  while (meminfo >> key >> value >> unit) {
+    if (key == "MemAvailable:") {
+      return value * uint64_t{1024};
+    }
+  }
+  return std::nullopt;
+}
+
+auto rebuild_byte_budget() -> uint64_t {
+  auto available = available_memory();
+  if (not available) {
+    return std::numeric_limits<uint64_t>::max();
+  }
+  return std::max(*available / 2, uint64_t{1});
+}
+
+auto saturating_multiply(uint64_t lhs, uint64_t rhs) -> uint64_t {
+  if (lhs == 0 or rhs == 0) {
+    return 0;
+  }
+  if (lhs > std::numeric_limits<uint64_t>::max() / rhs) {
+    return std::numeric_limits<uint64_t>::max();
+  }
+  return lhs * rhs;
+}
+
+auto saturating_add(uint64_t lhs, uint64_t rhs) -> uint64_t {
+  if (lhs > std::numeric_limits<uint64_t>::max() - rhs) {
+    return std::numeric_limits<uint64_t>::max();
+  }
+  return lhs + rhs;
+}
 
 /// Statistics for an ongoing rebuild. Numbers are partitions.
 struct statistics {
@@ -145,6 +208,10 @@ struct rebuilder_state {
   std::optional<struct run> run = {};
   bool stopping = false;
 
+  /// Runtime byte estimates for legacy partitions that do not have persisted
+  /// `approx_bytes` metadata yet.
+  std::unordered_map<type, uint64_t> approx_bytes_per_event = {};
+
   /// Shows the status of a currently ongoing rebuild.
   auto status(status_verbosity) -> record {
     if (not run) {
@@ -171,6 +238,28 @@ struct rebuilder_state {
          {"automatic", run->options.automatic},
        }},
     };
+  }
+
+  void learn_size_estimate(const partition_info& partition) {
+    if (partition.events == 0 or partition.approx_bytes == 0) {
+      return;
+    }
+    approx_bytes_per_event[partition.schema]
+      = std::max<uint64_t>(partition.approx_bytes / partition.events, 1);
+  }
+
+  auto estimate_approx_bytes(const partition_info& partition,
+                             uint64_t unknown_partition_bytes) const
+    -> uint64_t {
+    if (partition.approx_bytes > 0 or partition.events == 0) {
+      return partition.approx_bytes;
+    }
+    if (auto it = approx_bytes_per_event.find(partition.schema);
+        it != approx_bytes_per_event.end()) {
+      return saturating_multiply(
+        it->second, detail::narrow_cast<uint64_t>(partition.events));
+    }
+    return unknown_partition_bytes;
   }
 
   /// Start a new rebuild.
@@ -255,6 +344,10 @@ struct rebuilder_state {
         [this, finish](catalog_lookup_result& lookup_result) mutable {
           TENZIR_ASSERT(run->statistics.num_total == 0);
           for (auto& [type, result] : lookup_result.candidate_infos) {
+            std::erase_if(result.partition_infos,
+                          [](const partition_info& partition) {
+                            return partition.events == 0;
+                          });
             if (not run->options.all) {
               std::erase_if(
                 result.partition_infos, [&](const partition_info& partition) {
@@ -269,6 +362,9 @@ struct rebuilder_state {
                   }
                   return true;
                 });
+            }
+            for (const auto& partition : result.partition_infos) {
+              learn_size_estimate(partition);
             }
             if (run->options.max_partitions < result.partition_infos.size()) {
               std::stable_sort(result.partition_infos.begin(),
@@ -365,6 +461,9 @@ struct rebuilder_state {
     }
     auto current_run_partitions = std::vector<partition_info>{};
     auto current_run_events = size_t{0};
+    auto current_run_bytes = uint64_t{0};
+    auto current_run_is_full = false;
+    auto current_run_budget = rebuild_byte_budget();
     // Take the first partition and collect as many of the same
     // type as possible to create new paritions. The approach used may
     // collects too many partitions if there is no exact match, but that is
@@ -377,13 +476,27 @@ struct rebuilder_state {
       run->remaining_partitions.begin(), run->remaining_partitions.end(),
       [&](const partition_info& partition) {
         if (schema == partition.schema
-            and current_run_events < max_partition_size) {
+            and current_run_events < max_partition_size
+            and not current_run_is_full) {
+          const auto partition_bytes
+            = estimate_approx_bytes(partition, current_run_budget);
+          if (not current_run_partitions.empty()
+              and saturating_add(current_run_bytes, partition_bytes)
+                    > current_run_budget) {
+            current_run_is_full = true;
+            return false;
+          }
+          current_run_bytes
+            = saturating_add(current_run_bytes, partition_bytes);
           current_run_events += partition.events;
           current_run_partitions.push_back(partition);
           TENZIR_TRACE("{} selects partition {} (v{}, {}) with "
-                       "{} events (total: {})",
+                       "{} events and {} estimated bytes (total: {} events, "
+                       "{} estimated bytes, budget: {})",
                        *self, partition.uuid, partition.version,
-                       partition.schema, partition.events, current_run_events);
+                       partition.schema, partition.events, partition_bytes,
+                       current_run_events, current_run_bytes,
+                       current_run_budget);
           return true;
         }
         return false;
@@ -447,6 +560,9 @@ struct rebuilder_state {
           }
           TENZIR_DEBUG("{} rebuilt {} into {} partitions", *self,
                        num_partitions, result.size());
+          for (const auto& partition : result) {
+            learn_size_estimate(partition);
+          }
           // If the number of events in the resulting partitions does not
           // match the number of events in the partitions that went in we ran
           // into a conflict with other partition transformations on an

--- a/libtenzir/builtins/commands/rebuild.cpp
+++ b/libtenzir/builtins/commands/rebuild.cpp
@@ -103,18 +103,20 @@ struct memory_budget {
   detail::available_memory_info available = {};
 };
 
-auto rebuild_byte_budget() -> memory_budget {
+auto rebuild_byte_budget(size_t parallelism) -> memory_budget {
   auto available
     = detail::available_memory().value_or(detail::available_memory_info{
       .bytes = uint64_t{512} * 1024 * 1024,
       .source = "fallback",
     });
+  const auto divisor
+    = std::max<uint64_t>(detail::narrow_cast<uint64_t>(parallelism), 1);
   return {
     // The transformer currently holds decoded output slices before persisting
     // the new Feather store, and the store writer builds additional Arrow
     // structures during persist. Admit substantially less than the apparent
     // free memory to leave room for those copies and unrelated node activity.
-    .bytes = available.bytes / 4,
+    .bytes = available.bytes / 4 / divisor,
     .available = std::move(available),
   };
 }
@@ -440,7 +442,7 @@ struct rebuilder_state {
     auto current_run_events = size_t{0};
     auto current_run_bytes = uint64_t{0};
     auto current_run_is_full = false;
-    auto current_run_budget = rebuild_byte_budget();
+    auto current_run_budget = rebuild_byte_budget(run->options.parallel);
     if (current_run_budget.bytes == 0) {
       return caf::make_error(ec::out_of_memory,
                              "rebuild has no memory budget available "

--- a/libtenzir/builtins/commands/rebuild.cpp
+++ b/libtenzir/builtins/commands/rebuild.cpp
@@ -14,6 +14,7 @@
 #include <tenzir/connect_to_node.hpp>
 #include <tenzir/data.hpp>
 #include <tenzir/defaults.hpp>
+#include <tenzir/detail/available_memory.hpp>
 #include <tenzir/detail/inspection_common.hpp>
 #include <tenzir/detail/narrow.hpp>
 #include <tenzir/detail/saturating_arithmetic.hpp>
@@ -43,8 +44,6 @@
 #include <caf/typed_event_based_actor.hpp>
 #include <fmt/format.h>
 
-#include <filesystem>
-#include <fstream>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -99,135 +98,17 @@ namespace {
 /// configured 'tenzir.max-partition-size'.
 inline constexpr auto undersized_threshold = 0.8;
 
-struct memory_available {
-  uint64_t bytes = 0;
-  std::string source = {};
-};
-
 struct memory_budget {
   uint64_t bytes = 0;
-  memory_available available = {};
+  detail::available_memory_info available = {};
 };
 
-auto read_memory_value(const std::filesystem::path& path)
-  -> std::optional<uint64_t> {
-  auto file = std::ifstream{path};
-  auto value = std::string{};
-  file >> value;
-  if (value.empty() or value == "max") {
-    return std::nullopt;
-  }
-  try {
-    return std::stoull(value);
-  } catch (const std::exception&) {
-    return std::nullopt;
-  }
-}
-
-auto read_cgroup_memory_available(const std::filesystem::path& dir,
-                                  std::string source)
-  -> std::optional<memory_available> {
-  auto current = read_memory_value(dir / "memory.current");
-  auto max = read_memory_value(dir / "memory.max");
-  if (not current or not max) {
-    current = read_memory_value(dir / "memory.usage_in_bytes");
-    max = read_memory_value(dir / "memory.limit_in_bytes");
-  }
-  if (not current or not max) {
-    return std::nullopt;
-  }
-  static constexpr auto unlimited_cgroup_limit = uint64_t{1} << 60;
-  if (*max >= unlimited_cgroup_limit) {
-    return std::nullopt;
-  }
-  if (*current >= *max) {
-    return memory_available{
-      .bytes = 0,
-      .source = std::move(source),
-    };
-  }
-  return memory_available{
-    .bytes = *max - *current,
-    .source = std::move(source),
-  };
-}
-
-auto relative_cgroup_path(std::string_view raw) -> std::filesystem::path {
-  while (raw.starts_with('/')) {
-    raw.remove_prefix(1);
-  }
-  return std::filesystem::path{std::string{raw}};
-}
-
-auto cgroup_memory_available() -> std::optional<memory_available> {
-  auto cgroups = std::ifstream{"/proc/self/cgroup"};
-  auto line = std::string{};
-  while (std::getline(cgroups, line)) {
-    const auto first = line.find(':');
-    if (first == std::string::npos) {
-      continue;
-    }
-    const auto second = line.find(':', first + 1);
-    if (second == std::string::npos) {
-      continue;
-    }
-    const auto controllers
-      = std::string_view{line}.substr(first + 1, second - first - 1);
-    const auto path
-      = relative_cgroup_path(std::string_view{line}.substr(second + 1));
-    if (controllers.empty()) {
-      if (auto result = read_cgroup_memory_available(
-            std::filesystem::path{"/sys/fs/cgroup"} / path, "cgroup-v2")) {
-        return result;
-      }
-    } else if (controllers.find("memory") != std::string_view::npos) {
-      if (auto result = read_cgroup_memory_available(
-            std::filesystem::path{"/sys/fs/cgroup/memory"} / path,
-            "cgroup-v1")) {
-        return result;
-      }
-      if (auto result = read_cgroup_memory_available(
-            std::filesystem::path{"/sys/fs/cgroup"} / path, "cgroup-v1")) {
-        return result;
-      }
-    }
-  }
-  return read_cgroup_memory_available("/sys/fs/cgroup", "cgroup");
-}
-
-auto system_memory_available() -> std::optional<memory_available> {
-  auto meminfo = std::ifstream{"/proc/meminfo"};
-  auto key = std::string{};
-  auto value = uint64_t{};
-  auto unit = std::string{};
-  while (meminfo >> key >> value >> unit) {
-    if (key == "MemAvailable:") {
-      return memory_available{
-        .bytes = value * uint64_t{1024},
-        .source = "/proc/meminfo",
-      };
-    }
-  }
-  return std::nullopt;
-}
-
-auto available_memory() -> std::optional<memory_available> {
-  auto cgroup = cgroup_memory_available();
-  auto system = system_memory_available();
-  if (cgroup and system and system->bytes < cgroup->bytes) {
-    return system;
-  }
-  if (cgroup) {
-    return cgroup;
-  }
-  return system;
-}
-
 auto rebuild_byte_budget() -> memory_budget {
-  auto available = available_memory().value_or(memory_available{
-    .bytes = uint64_t{512} * 1024 * 1024,
-    .source = "fallback",
-  });
+  auto available
+    = detail::available_memory().value_or(detail::available_memory_info{
+      .bytes = uint64_t{512} * 1024 * 1024,
+      .source = "fallback",
+    });
   return {
     // The transformer currently holds decoded output slices before persisting
     // the new Feather store, and the store writer builds additional Arrow

--- a/libtenzir/builtins/commands/rebuild.cpp
+++ b/libtenzir/builtins/commands/rebuild.cpp
@@ -556,11 +556,11 @@ struct rebuilder_state {
     auto current_run_is_full = false;
     auto current_run_budget = rebuild_byte_budget();
     if (current_run_budget.bytes == 0) {
-      TENZIR_VERBOSE("{} skips rebuild work because no memory budget is "
-                     "available (available: {} from {})",
-                     *self, format_bytes(current_run_budget.available.bytes),
-                     current_run_budget.available.source);
-      return {};
+      return caf::make_error(ec::out_of_memory,
+                             "rebuild has no memory budget available "
+                             "({} available from {})",
+                             format_bytes(current_run_budget.available.bytes),
+                             current_run_budget.available.source);
     }
     // Take the first partition and collect as many of the same
     // type as possible to create new paritions. The approach used may

--- a/libtenzir/builtins/commands/rebuild.cpp
+++ b/libtenzir/builtins/commands/rebuild.cpp
@@ -97,7 +97,6 @@ namespace {
 /// The threshold at which to consider a partition undersized, relative to the
 /// configured 'tenzir.max-partition-size'.
 inline constexpr auto undersized_threshold = 0.8;
-inline constexpr auto max_partitions_per_rebuild_batch = size_t{16};
 
 struct memory_available {
   uint64_t bytes = 0;
@@ -579,7 +578,6 @@ struct rebuilder_state {
       [&](const partition_info& partition) {
         if (schema == partition.schema
             and current_run_events < max_partition_size
-            and current_run_partitions.size() < max_partitions_per_rebuild_batch
             and not current_run_is_full) {
           const auto partition_bytes
             = estimate_approx_bytes(partition, current_run_budget.bytes);

--- a/libtenzir/builtins/commands/rebuild.cpp
+++ b/libtenzir/builtins/commands/rebuild.cpp
@@ -45,7 +45,9 @@
 #include <filesystem>
 #include <fstream>
 #include <optional>
+#include <string>
 #include <unordered_map>
+#include <vector>
 
 namespace tenzir::plugins::rebuild {
 
@@ -95,6 +97,17 @@ namespace {
 /// The threshold at which to consider a partition undersized, relative to the
 /// configured 'tenzir.max-partition-size'.
 inline constexpr auto undersized_threshold = 0.8;
+inline constexpr auto max_partitions_per_rebuild_batch = size_t{16};
+
+struct memory_available {
+  uint64_t bytes = 0;
+  std::string source = {};
+};
+
+struct memory_budget {
+  uint64_t bytes = 0;
+  memory_available available = {};
+};
 
 auto read_memory_value(const std::filesystem::path& path)
   -> std::optional<uint64_t> {
@@ -111,30 +124,119 @@ auto read_memory_value(const std::filesystem::path& path)
   }
 }
 
-auto available_memory() -> std::optional<uint64_t> {
-  auto current = read_memory_value("/sys/fs/cgroup/memory.current");
-  auto max = read_memory_value("/sys/fs/cgroup/memory.max");
-  if (current and max and *current < *max) {
-    return *max - *current;
+auto read_cgroup_memory_available(const std::filesystem::path& dir,
+                                  std::string source)
+  -> std::optional<memory_available> {
+  auto current = read_memory_value(dir / "memory.current");
+  auto max = read_memory_value(dir / "memory.max");
+  if (not current or not max) {
+    current = read_memory_value(dir / "memory.usage_in_bytes");
+    max = read_memory_value(dir / "memory.limit_in_bytes");
   }
+  if (not current or not max or *current >= *max) {
+    return std::nullopt;
+  }
+  static constexpr auto unlimited_cgroup_limit = uint64_t{1} << 60;
+  if (*max >= unlimited_cgroup_limit) {
+    return std::nullopt;
+  }
+  return memory_available{
+    .bytes = *max - *current,
+    .source = std::move(source),
+  };
+}
+
+auto relative_cgroup_path(std::string_view raw) -> std::filesystem::path {
+  while (raw.starts_with('/')) {
+    raw.remove_prefix(1);
+  }
+  return std::filesystem::path{std::string{raw}};
+}
+
+auto cgroup_memory_available() -> std::optional<memory_available> {
+  auto cgroups = std::ifstream{"/proc/self/cgroup"};
+  auto line = std::string{};
+  while (std::getline(cgroups, line)) {
+    const auto first = line.find(':');
+    if (first == std::string::npos) {
+      continue;
+    }
+    const auto second = line.find(':', first + 1);
+    if (second == std::string::npos) {
+      continue;
+    }
+    const auto controllers
+      = std::string_view{line}.substr(first + 1, second - first - 1);
+    const auto path
+      = relative_cgroup_path(std::string_view{line}.substr(second + 1));
+    if (controllers.empty()) {
+      if (auto result = read_cgroup_memory_available(
+            std::filesystem::path{"/sys/fs/cgroup"} / path, "cgroup-v2")) {
+        return result;
+      }
+    } else if (controllers.find("memory") != std::string_view::npos) {
+      if (auto result = read_cgroup_memory_available(
+            std::filesystem::path{"/sys/fs/cgroup/memory"} / path,
+            "cgroup-v1")) {
+        return result;
+      }
+      if (auto result = read_cgroup_memory_available(
+            std::filesystem::path{"/sys/fs/cgroup"} / path, "cgroup-v1")) {
+        return result;
+      }
+    }
+  }
+  return read_cgroup_memory_available("/sys/fs/cgroup", "cgroup");
+}
+
+auto system_memory_available() -> std::optional<memory_available> {
   auto meminfo = std::ifstream{"/proc/meminfo"};
   auto key = std::string{};
   auto value = uint64_t{};
   auto unit = std::string{};
   while (meminfo >> key >> value >> unit) {
     if (key == "MemAvailable:") {
-      return value * uint64_t{1024};
+      return memory_available{
+        .bytes = value * uint64_t{1024},
+        .source = "/proc/meminfo",
+      };
     }
   }
   return std::nullopt;
 }
 
-auto rebuild_byte_budget() -> uint64_t {
-  auto available = available_memory();
-  if (not available) {
-    return std::numeric_limits<uint64_t>::max();
+auto available_memory() -> std::optional<memory_available> {
+  auto cgroup = cgroup_memory_available();
+  auto system = system_memory_available();
+  if (cgroup and system and system->bytes < cgroup->bytes) {
+    return system;
   }
-  return std::max(*available / 2, uint64_t{1});
+  if (cgroup) {
+    return cgroup;
+  }
+  return system;
+}
+
+auto rebuild_byte_budget() -> memory_budget {
+  auto available = available_memory().value_or(memory_available{
+    .bytes = uint64_t{512} * 1024 * 1024,
+    .source = "fallback",
+  });
+  return {
+    // The transformer currently holds decoded output slices before persisting
+    // the new Feather store, and the store writer builds additional Arrow
+    // structures during persist. Admit substantially less than the apparent
+    // free memory to leave room for those copies and unrelated node activity.
+    .bytes = std::max(available.bytes / 4, uint64_t{1}),
+    .available = std::move(available),
+  };
+}
+
+auto format_bytes(uint64_t bytes) -> std::string {
+  if (bytes == std::numeric_limits<uint64_t>::max()) {
+    return "unlimited";
+  }
+  return fmt::format("{} bytes", bytes);
 }
 
 auto saturating_multiply(uint64_t lhs, uint64_t rhs) -> uint64_t {
@@ -477,12 +579,13 @@ struct rebuilder_state {
       [&](const partition_info& partition) {
         if (schema == partition.schema
             and current_run_events < max_partition_size
+            and current_run_partitions.size() < max_partitions_per_rebuild_batch
             and not current_run_is_full) {
           const auto partition_bytes
-            = estimate_approx_bytes(partition, current_run_budget);
+            = estimate_approx_bytes(partition, current_run_budget.bytes);
           if (not current_run_partitions.empty()
               and saturating_add(current_run_bytes, partition_bytes)
-                    > current_run_budget) {
+                    > current_run_budget.bytes) {
             current_run_is_full = true;
             return false;
           }
@@ -496,13 +599,20 @@ struct rebuilder_state {
                        *self, partition.uuid, partition.version,
                        partition.schema, partition.events, partition_bytes,
                        current_run_events, current_run_bytes,
-                       current_run_budget);
+                       current_run_budget.bytes);
           return true;
         }
         return false;
       });
     run->remaining_partitions.erase(first_removed,
                                     run->remaining_partitions.end());
+    TENZIR_INFO("{} selected {} partition(s) for rebuild of schema {} with {} "
+                "estimated decoded bytes (budget: {}, available: {} from {})",
+                *self, current_run_partitions.size(), schema,
+                format_bytes(current_run_bytes),
+                format_bytes(current_run_budget.bytes),
+                format_bytes(current_run_budget.available.bytes),
+                current_run_budget.available.source);
     run->statistics.num_rebuilding += current_run_partitions.size();
     // If we have just a single partition then we shouldn't rebuild if our
     // intent was to merge undersized partitions, unless the partition is

--- a/libtenzir/builtins/commands/rebuild.cpp
+++ b/libtenzir/builtins/commands/rebuild.cpp
@@ -648,7 +648,7 @@ struct rebuilder_state {
       .request(index, caf::infinite)
       .then(
         [this, rp, selected_partitions = std::move(selected_partitions),
-         num_partitions](partition_transform_apply_result& result) mutable {
+         num_partitions](partition_apply_result& result) mutable {
           if (result.input_partitions.empty()
               and result.output_partitions.empty()) {
             TENZIR_DEBUG("{} skipped {} partitions as they are already being "

--- a/libtenzir/builtins/commands/rebuild.cpp
+++ b/libtenzir/builtins/commands/rebuild.cpp
@@ -640,6 +640,7 @@ struct rebuilder_state {
                 return lhs.max_import_time < rhs.max_import_time;
               });
     auto selected_partitions = current_run_partitions;
+    auto retry_partitions = selected_partitions;
     const auto num_partitions = current_run_partitions.size();
     self
       ->mail(atom::apply_v, std::move(*rebatch),
@@ -711,10 +712,13 @@ struct rebuilder_state {
           rp.delegate(static_cast<rebuilder_actor>(self), atom::internal_v,
                       atom::rebuild_v);
         },
-        [this, num_partitions = current_run_partitions.size(),
+        [this, num_partitions, retry_partitions = std::move(retry_partitions),
          rp](caf::error& error) mutable {
-          TENZIR_WARN("{} failed to rebuild partititons: {}", *self, error);
+          TENZIR_WARN("{} failed to rebuild partitions: {}", *self, error);
           run->statistics.num_rebuilding -= num_partitions;
+          run->remaining_partitions.insert(run->remaining_partitions.begin(),
+                                           retry_partitions.begin(),
+                                           retry_partitions.end());
           // Pick up new work until we run out of remainig partitions.
           rp.delegate(static_cast<rebuilder_actor>(self), atom::internal_v,
                       atom::rebuild_v);

--- a/libtenzir/builtins/commands/rebuild.cpp
+++ b/libtenzir/builtins/commands/rebuild.cpp
@@ -614,16 +614,19 @@ struct rebuilder_state {
               == version::current_partition_version
         and current_run_partitions[0].events <= max_partition_size;
     if (skip_rebuild) {
-      TENZIR_DEBUG("{} skips rebuilding of undersized partition {} because no "
-                   "other partition of schema {} exists",
-                   *self, current_run_partitions[0].uuid,
-                   current_run_partitions[0].schema);
       run->statistics.num_rebuilding -= 1;
       run->statistics.num_total -= 1;
       // Pick up new work until we run out of remainig partitions.
       return self->mail(atom::internal_v, atom::rebuild_v)
         .delegate(static_cast<rebuilder_actor>(self));
     }
+    TENZIR_VERBOSE(
+      "{} selected {} partition(s) for rebuild of schema {} with {} "
+      "estimated decoded bytes (budget: {}, available: {} from {})",
+      *self, current_run_partitions.size(), schema,
+      format_bytes(current_run_bytes), format_bytes(current_run_budget.bytes),
+      format_bytes(current_run_budget.available.bytes),
+      current_run_budget.available.source);
     // Ask the index to rebuild the partitions we selected.
     auto rp = self->make_response_promise<void>();
     auto dh = null_diagnostic_handler{};

--- a/libtenzir/fbs/partition_synopsis.fbs
+++ b/libtenzir/fbs/partition_synopsis.fbs
@@ -23,6 +23,9 @@ table LegacyPartitionSynopsis {
   /// The schema of this partition. Note that this field was not present for
   /// partition synopses with a version number of 0.
   schema: [ubyte] (nested_flatbuffer: "tenzir.fbs.Type");
+
+  /// Best-effort estimate of the decoded in-memory size of the partition data.
+  approx_bytes: ulong;
 }
 
 union PartitionSynopsis {

--- a/libtenzir/include/tenzir/actors.hpp
+++ b/libtenzir/include/tenzir/actors.hpp
@@ -217,7 +217,7 @@ using index_actor = typed_actor_fwd<
   // ids, and makes new partitions preserving them.
   auto(atom::apply, ast::pipeline, std::vector<tenzir::partition_info>,
        keep_original_partition, std::string)
-    ->caf::result<partition_transform_apply_result>,
+    ->caf::result<partition_apply_result>,
   // Decomissions all active partitions, effectively flushing them to disk.
   auto(atom::flush)->caf::result<void>,
   // Returns all events from active and unpersisted partitions.
@@ -266,7 +266,7 @@ using filesystem_actor = typed_actor_fwd<
 using partition_transformer_actor = typed_actor_fwd<
   // Persist the transformed partitions and return the generated
   // partition synopses.
-  auto(atom::persist)->caf::result<partition_transform_result>,
+  auto(atom::persist)->caf::result<partition_transformer_result>,
   // INTERNAL: Continuation handler for `atom::done`.
   auto(atom::internal, atom::resume, atom::done)->caf::result<void>>
   // extract_query_context API
@@ -496,7 +496,7 @@ CAF_END_TYPE_ID_BLOCK(tenzir_actors)
 CAF_ALLOW_UNSAFE_MESSAGE_TYPE(std::shared_ptr<tenzir_uuid_synopsis_map>)
 CAF_ALLOW_UNSAFE_MESSAGE_TYPE(tenzir::partition_synopsis_ptr)
 CAF_ALLOW_UNSAFE_MESSAGE_TYPE(tenzir::partition_synopsis_pair)
-CAF_ALLOW_UNSAFE_MESSAGE_TYPE(tenzir::partition_transform_result)
+CAF_ALLOW_UNSAFE_MESSAGE_TYPE(tenzir::partition_transformer_result)
 #undef tenzir_uuid_synopsis_map
 
 #undef TENZIR_ADD_TYPE_ID

--- a/libtenzir/include/tenzir/actors.hpp
+++ b/libtenzir/include/tenzir/actors.hpp
@@ -266,7 +266,7 @@ using filesystem_actor = typed_actor_fwd<
 using partition_transformer_actor = typed_actor_fwd<
   // Persist the transformed partitions and return the generated
   // partition synopses.
-  auto(atom::persist)->caf::result<std::vector<partition_synopsis_pair>>,
+  auto(atom::persist)->caf::result<partition_transform_result>,
   // INTERNAL: Continuation handler for `atom::done`.
   auto(atom::internal, atom::resume, atom::done)->caf::result<void>>
   // extract_query_context API
@@ -496,6 +496,7 @@ CAF_END_TYPE_ID_BLOCK(tenzir_actors)
 CAF_ALLOW_UNSAFE_MESSAGE_TYPE(std::shared_ptr<tenzir_uuid_synopsis_map>)
 CAF_ALLOW_UNSAFE_MESSAGE_TYPE(tenzir::partition_synopsis_ptr)
 CAF_ALLOW_UNSAFE_MESSAGE_TYPE(tenzir::partition_synopsis_pair)
+CAF_ALLOW_UNSAFE_MESSAGE_TYPE(tenzir::partition_transform_result)
 #undef tenzir_uuid_synopsis_map
 
 #undef TENZIR_ADD_TYPE_ID

--- a/libtenzir/include/tenzir/actors.hpp
+++ b/libtenzir/include/tenzir/actors.hpp
@@ -217,7 +217,7 @@ using index_actor = typed_actor_fwd<
   // ids, and makes new partitions preserving them.
   auto(atom::apply, ast::pipeline, std::vector<tenzir::partition_info>,
        keep_original_partition, std::string)
-    ->caf::result<std::vector<partition_info>>,
+    ->caf::result<partition_transform_apply_result>,
   // Decomissions all active partitions, effectively flushing them to disk.
   auto(atom::flush)->caf::result<void>,
   // Returns all events from active and unpersisted partitions.

--- a/libtenzir/include/tenzir/detail/available_memory.hpp
+++ b/libtenzir/include/tenzir/detail/available_memory.hpp
@@ -1,0 +1,24 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+namespace tenzir::detail {
+
+struct available_memory_info {
+  uint64_t bytes = 0;
+  std::string source = {};
+};
+
+auto available_memory() -> std::optional<available_memory_info>;
+
+} // namespace tenzir::detail

--- a/libtenzir/include/tenzir/detail/saturating_arithmetic.hpp
+++ b/libtenzir/include/tenzir/detail/saturating_arithmetic.hpp
@@ -10,6 +10,9 @@
 
 #include "tenzir/concepts.hpp"
 
+#include <limits>
+#include <type_traits>
+
 namespace tenzir::detail {
 
 // TODO: Generalize this to accept different input types and
@@ -17,22 +20,40 @@ namespace tenzir::detail {
 template <std::integral T, std::integral Result = T>
 Result saturating_add(T lhs, T rhs) {
   Result result;
-  __builtin_add_overflow(lhs, rhs, &result);
-  return result;
+  if (not __builtin_add_overflow(lhs, rhs, &result)) {
+    return result;
+  }
+  if constexpr (std::is_signed_v<T>) {
+    return rhs < 0 ? std::numeric_limits<Result>::min()
+                   : std::numeric_limits<Result>::max();
+  }
+  return std::numeric_limits<Result>::max();
 }
 
 template <std::integral T, std::integral Result = T>
 Result saturating_sub(T lhs, T rhs) {
   Result result;
-  __builtin_sub_overflow(lhs, rhs, &result);
-  return result;
+  if (not __builtin_sub_overflow(lhs, rhs, &result)) {
+    return result;
+  }
+  if constexpr (std::is_signed_v<T>) {
+    return rhs < 0 ? std::numeric_limits<Result>::max()
+                   : std::numeric_limits<Result>::min();
+  }
+  return std::numeric_limits<Result>::min();
 }
 
 template <std::integral T, std::integral Result = T>
 Result saturating_mul(T lhs, T rhs) {
   Result result;
-  __builtin_mul_overflow(lhs, rhs, &result);
-  return result;
+  if (not __builtin_mul_overflow(lhs, rhs, &result)) {
+    return result;
+  }
+  if constexpr (std::is_signed_v<T>) {
+    return (lhs < 0) == (rhs < 0) ? std::numeric_limits<Result>::max()
+                                  : std::numeric_limits<Result>::min();
+  }
+  return std::numeric_limits<Result>::max();
 }
 
 } // namespace tenzir::detail

--- a/libtenzir/include/tenzir/fwd.hpp
+++ b/libtenzir/include/tenzir/fwd.hpp
@@ -252,6 +252,7 @@ struct package_pipelines_map;
 struct package_contexts_map;
 struct partition_info;
 struct partition_synopsis_pair;
+struct partition_transform_result;
 struct partition_synopsis;
 struct passive_partition_state;
 struct predicate;
@@ -477,6 +478,7 @@ CAF_BEGIN_TYPE_ID_BLOCK(tenzir_types, first_tenzir_type_id)
   TENZIR_ADD_TYPE_ID((tenzir::partition_info))
   TENZIR_ADD_TYPE_ID((tenzir::partition_synopsis_pair))
   TENZIR_ADD_TYPE_ID((tenzir::partition_synopsis_ptr))
+  TENZIR_ADD_TYPE_ID((tenzir::partition_transform_result))
   TENZIR_ADD_TYPE_ID((tenzir::pattern))
   TENZIR_ADD_TYPE_ID((tenzir::pipeline))
   TENZIR_ADD_TYPE_ID((tenzir::ast::pipeline))

--- a/libtenzir/include/tenzir/fwd.hpp
+++ b/libtenzir/include/tenzir/fwd.hpp
@@ -251,6 +251,7 @@ struct package;
 struct package_pipelines_map;
 struct package_contexts_map;
 struct partition_info;
+struct partition_transform_apply_result;
 struct partition_synopsis_pair;
 struct partition_transform_result;
 struct partition_synopsis;
@@ -476,6 +477,7 @@ CAF_BEGIN_TYPE_ID_BLOCK(tenzir_types, first_tenzir_type_id)
   TENZIR_ADD_TYPE_ID((tenzir::operator_type))
   TENZIR_ADD_TYPE_ID((tenzir::package))
   TENZIR_ADD_TYPE_ID((tenzir::partition_info))
+  TENZIR_ADD_TYPE_ID((tenzir::partition_transform_apply_result))
   TENZIR_ADD_TYPE_ID((tenzir::partition_synopsis_pair))
   TENZIR_ADD_TYPE_ID((tenzir::partition_synopsis_ptr))
   TENZIR_ADD_TYPE_ID((tenzir::partition_transform_result))

--- a/libtenzir/include/tenzir/fwd.hpp
+++ b/libtenzir/include/tenzir/fwd.hpp
@@ -250,11 +250,11 @@ struct operator_metric;
 struct package;
 struct package_pipelines_map;
 struct package_contexts_map;
+struct partition_apply_result;
 struct partition_info;
-struct partition_transform_apply_result;
 struct partition_synopsis_pair;
-struct partition_transform_result;
 struct partition_synopsis;
+struct partition_transformer_result;
 struct passive_partition_state;
 struct predicate;
 struct qualified_record_field;
@@ -476,11 +476,11 @@ CAF_BEGIN_TYPE_ID_BLOCK(tenzir_types, first_tenzir_type_id)
   TENZIR_ADD_TYPE_ID((tenzir::operator_metric))
   TENZIR_ADD_TYPE_ID((tenzir::operator_type))
   TENZIR_ADD_TYPE_ID((tenzir::package))
+  TENZIR_ADD_TYPE_ID((tenzir::partition_apply_result))
   TENZIR_ADD_TYPE_ID((tenzir::partition_info))
-  TENZIR_ADD_TYPE_ID((tenzir::partition_transform_apply_result))
   TENZIR_ADD_TYPE_ID((tenzir::partition_synopsis_pair))
   TENZIR_ADD_TYPE_ID((tenzir::partition_synopsis_ptr))
-  TENZIR_ADD_TYPE_ID((tenzir::partition_transform_result))
+  TENZIR_ADD_TYPE_ID((tenzir::partition_transformer_result))
   TENZIR_ADD_TYPE_ID((tenzir::pattern))
   TENZIR_ADD_TYPE_ID((tenzir::pipeline))
   TENZIR_ADD_TYPE_ID((tenzir::ast::pipeline))

--- a/libtenzir/include/tenzir/index.hpp
+++ b/libtenzir/include/tenzir/index.hpp
@@ -145,6 +145,10 @@ struct index_state {
   /// Maps partitions to their expected location on the file system.
   [[nodiscard]] std::filesystem::path partition_path(const uuid& id) const;
 
+  /// Returns a format string that can be formatted with a partition id to get
+  /// the input location of that partition for the partition transformer.
+  [[nodiscard]] std::string partition_path_template() const;
+
   /// The path to which a partition transformer should write a partition with
   /// the UUID `id`.
   [[nodiscard]] std::filesystem::path

--- a/libtenzir/include/tenzir/index.hpp
+++ b/libtenzir/include/tenzir/index.hpp
@@ -145,6 +145,9 @@ struct index_state {
   /// Maps partitions to their expected location on the file system.
   [[nodiscard]] std::filesystem::path partition_path(const uuid& id) const;
 
+  /// The directory that contains passive partition stores.
+  [[nodiscard]] std::filesystem::path archive_dir() const;
+
   /// Returns a format string that can be formatted with a partition id to get
   /// the input location of that partition for the partition transformer.
   [[nodiscard]] std::string partition_path_template() const;

--- a/libtenzir/include/tenzir/partition_synopsis.hpp
+++ b/libtenzir/include/tenzir/partition_synopsis.hpp
@@ -196,30 +196,30 @@ struct partition_synopsis_pair {
   }
 };
 
-struct partition_transform_result {
+struct partition_transformer_result {
   std::vector<partition_info> input_partitions;
   std::vector<partition_synopsis_pair> output_partitions;
   bool input_complete = true;
 
   template <class Inspector>
-  friend auto inspect(Inspector& f, partition_transform_result& x) {
+  friend auto inspect(Inspector& f, partition_transformer_result& x) {
     return f.object(x)
-      .pretty_name("tenzir.partition-transform-result")
+      .pretty_name("tenzir.partition-transformer-result")
       .fields(f.field("input-partitions", x.input_partitions),
               f.field("output-partitions", x.output_partitions),
               f.field("input-complete", x.input_complete));
   }
 };
 
-struct partition_transform_apply_result {
+struct partition_apply_result {
   std::vector<partition_info> input_partitions;
   std::vector<partition_info> output_partitions;
   bool input_complete = true;
 
   template <class Inspector>
-  friend auto inspect(Inspector& f, partition_transform_apply_result& x) {
+  friend auto inspect(Inspector& f, partition_apply_result& x) {
     return f.object(x)
-      .pretty_name("tenzir.partition-transform-apply-result")
+      .pretty_name("tenzir.partition-apply-result")
       .fields(f.field("input-partitions", x.input_partitions),
               f.field("output-partitions", x.output_partitions),
               f.field("input-complete", x.input_complete));

--- a/libtenzir/include/tenzir/partition_synopsis.hpp
+++ b/libtenzir/include/tenzir/partition_synopsis.hpp
@@ -196,4 +196,17 @@ struct partition_synopsis_pair {
   }
 };
 
+struct partition_transform_result {
+  std::vector<partition_info> input_partitions;
+  std::vector<partition_synopsis_pair> output_partitions;
+
+  template <class Inspector>
+  friend auto inspect(Inspector& f, partition_transform_result& x) {
+    return f.object(x)
+      .pretty_name("tenzir.partition-transform-result")
+      .fields(f.field("input-partitions", x.input_partitions),
+              f.field("output-partitions", x.output_partitions));
+  }
+};
+
 } // namespace tenzir

--- a/libtenzir/include/tenzir/partition_synopsis.hpp
+++ b/libtenzir/include/tenzir/partition_synopsis.hpp
@@ -199,13 +199,30 @@ struct partition_synopsis_pair {
 struct partition_transform_result {
   std::vector<partition_info> input_partitions;
   std::vector<partition_synopsis_pair> output_partitions;
+  bool input_complete = true;
 
   template <class Inspector>
   friend auto inspect(Inspector& f, partition_transform_result& x) {
     return f.object(x)
       .pretty_name("tenzir.partition-transform-result")
       .fields(f.field("input-partitions", x.input_partitions),
-              f.field("output-partitions", x.output_partitions));
+              f.field("output-partitions", x.output_partitions),
+              f.field("input-complete", x.input_complete));
+  }
+};
+
+struct partition_transform_apply_result {
+  std::vector<partition_info> input_partitions;
+  std::vector<partition_info> output_partitions;
+  bool input_complete = true;
+
+  template <class Inspector>
+  friend auto inspect(Inspector& f, partition_transform_apply_result& x) {
+    return f.object(x)
+      .pretty_name("tenzir.partition-transform-apply-result")
+      .fields(f.field("input-partitions", x.input_partitions),
+              f.field("output-partitions", x.output_partitions),
+              f.field("input-complete", x.input_complete));
   }
 };
 

--- a/libtenzir/include/tenzir/partition_synopsis.hpp
+++ b/libtenzir/include/tenzir/partition_synopsis.hpp
@@ -73,6 +73,9 @@ struct partition_synopsis final : public caf::ref_counted {
   /// The version number of this partition.
   uint64_t version = version::current_partition_version;
 
+  /// Best-effort estimate of the decoded in-memory size of the partition data.
+  uint64_t approx_bytes = 0;
+
   /// The schema of this partition. This is only set for partition synopses with
   /// a version >= 1, because they are guaranteed to be homogenous.
   type schema = {};
@@ -109,18 +112,24 @@ struct partition_info {
   partition_info() noexcept = default;
 
   partition_info(class uuid uuid, size_t events, time max_import_time,
-                 type schema, uint64_t version) noexcept
+                 type schema, uint64_t version,
+                 uint64_t approx_bytes = 0) noexcept
     : uuid{uuid},
       events{events},
       max_import_time{max_import_time},
       schema{std::move(schema)},
-      version{version} {
+      version{version},
+      approx_bytes{approx_bytes} {
     // nop
   }
 
   partition_info(class uuid uuid, const partition_synopsis& synopsis)
-    : partition_info{uuid, synopsis.events, synopsis.max_import_time,
-                     synopsis.schema, synopsis.version} {
+    : partition_info{uuid,
+                     synopsis.events,
+                     synopsis.max_import_time,
+                     synopsis.schema,
+                     synopsis.version,
+                     synopsis.approx_bytes} {
     // nop
   }
 
@@ -139,6 +148,9 @@ struct partition_info {
 
   /// The internal version of the partition.
   uint64_t version = {};
+
+  /// Best-effort estimate of the decoded in-memory size of the partition data.
+  uint64_t approx_bytes = 0;
 
   friend std::strong_ordering
   operator<=>(const partition_info& lhs, const partition_info& rhs) noexcept {
@@ -166,7 +178,8 @@ struct partition_info {
       .pretty_name("tenzir.partition-info")
       .fields(f.field("uuid", x.uuid), f.field("events", x.events),
               f.field("max-import-time", x.max_import_time),
-              f.field("schema", x.schema), f.field("version", x.version));
+              f.field("schema", x.schema), f.field("version", x.version),
+              f.field("approx-bytes", x.approx_bytes));
   }
 };
 

--- a/libtenzir/include/tenzir/partition_transformer.hpp
+++ b/libtenzir/include/tenzir/partition_transformer.hpp
@@ -68,14 +68,14 @@ struct partition_transformer_state {
   /// The TQL2 AST of the transform to apply to the data.
   ast::pipeline transform = {};
 
-  /// Collector for the received table slices.
-  std::vector<table_slice> input = {};
-
   /// Cached stream error, if the stream terminated abnormally.
   caf::error stream_error = {};
 
   /// Cached transform error, if the transform returns one.
   caf::error transform_error = {};
+
+  /// The partitions selected as input for the transform.
+  std::vector<partition_info> input_partitions = {};
 
   /// The maximum number of events per partition. (not really necessary, but
   /// required by the partition synopsis)
@@ -116,8 +116,9 @@ struct partition_transformer_state {
   /// Options for creating new value indices.
   caf::settings index_opts = {};
 
-  // Two format strings that can be formatted with a `tenzir::uuid`
-  // as the single parameter. They give the
+  // Format strings that can be formatted with a `tenzir::uuid` as the single
+  // parameter for input partitions and transformed output files.
+  std::string input_partition_path_template;
   std::string partition_path_template;
   std::string synopsis_path_template;
 
@@ -144,15 +145,16 @@ struct partition_transformer_state {
 
 /// Spawns a PARTITION TRANSFORMER actor with the given parameters.
 ///
-/// The actor collects table slices from a query stream, applies the given
-/// `table_slice -> table_slice` AST pipeline via the new coroutine executor,
-/// and writes the resulting slices into one or more new partitions.
+/// The actor loads the selected partitions, applies the given `table_slice ->
+/// table_slice` AST pipeline via the new coroutine executor, and writes the
+/// resulting slices into one or more new partitions.
 auto partition_transformer(
   partition_transformer_actor::stateful_pointer<partition_transformer_state>,
   std::string store_id, const index_config& synopsis_opts,
   const caf::settings& index_opts, catalog_actor catalog, filesystem_actor fs,
-  ast::pipeline transform, std::string partition_path_template,
-  std::string synopsis_path_template, std::string origin = "rebuild")
-  -> partition_transformer_actor::behavior_type;
+  std::vector<partition_info> input_partitions, ast::pipeline transform,
+  std::string input_partition_path_template,
+  std::string partition_path_template, std::string synopsis_path_template,
+  std::string origin = "rebuild") -> partition_transformer_actor::behavior_type;
 
 } // namespace tenzir

--- a/libtenzir/include/tenzir/partition_transformer.hpp
+++ b/libtenzir/include/tenzir/partition_transformer.hpp
@@ -81,6 +81,9 @@ struct partition_transformer_state {
   /// The input partitions that the transformer actually consumed.
   std::vector<partition_info> transformed_input_partitions = {};
 
+  /// Whether the transformer consumed every selected input partition.
+  bool input_complete = true;
+
   /// The maximum number of events per partition. (not really necessary, but
   /// required by the partition synopsis)
   size_t partition_capacity = 0ull;

--- a/libtenzir/include/tenzir/partition_transformer.hpp
+++ b/libtenzir/include/tenzir/partition_transformer.hpp
@@ -29,7 +29,7 @@ namespace tenzir {
 struct partition_transformer_state {
   static constexpr const char* name = "partition-transformer";
 
-  using result_type = partition_transform_result;
+  using result_type = partition_transformer_result;
   using promise_type = caf::typed_response_promise<result_type>;
   using partition_tuple = std::tuple<tenzir::uuid, tenzir::type, chunk_ptr>;
   using synopsis_tuple = std::tuple<tenzir::uuid, chunk_ptr>;

--- a/libtenzir/include/tenzir/partition_transformer.hpp
+++ b/libtenzir/include/tenzir/partition_transformer.hpp
@@ -16,6 +16,7 @@
 
 #include <caf/typed_event_based_actor.hpp>
 
+#include <filesystem>
 #include <unordered_map>
 #include <variant>
 #include <vector>
@@ -119,6 +120,7 @@ struct partition_transformer_state {
   // Format strings that can be formatted with a `tenzir::uuid` as the single
   // parameter for input partitions and transformed output files.
   std::string input_partition_path_template;
+  std::filesystem::path archive_dir;
   std::string partition_path_template;
   std::string synopsis_path_template;
 
@@ -153,7 +155,7 @@ auto partition_transformer(
   std::string store_id, const index_config& synopsis_opts,
   const caf::settings& index_opts, catalog_actor catalog, filesystem_actor fs,
   std::vector<partition_info> input_partitions, ast::pipeline transform,
-  std::string input_partition_path_template,
+  std::string input_partition_path_template, std::filesystem::path archive_dir,
   std::string partition_path_template, std::string synopsis_path_template,
   std::string origin = "rebuild") -> partition_transformer_actor::behavior_type;
 

--- a/libtenzir/include/tenzir/partition_transformer.hpp
+++ b/libtenzir/include/tenzir/partition_transformer.hpp
@@ -123,8 +123,9 @@ struct partition_transformer_state {
   /// Options for creating new value indices.
   caf::settings index_opts = {};
 
-  // Format strings that can be formatted with a `tenzir::uuid` as the single
-  // parameter for input partitions and transformed output files.
+  // Paths used to read existing partitions and write transformed output files.
+  // The template strings can be formatted with a `tenzir::uuid` as the single
+  // parameter.
   std::string input_partition_path_template;
   std::filesystem::path archive_dir;
   std::string partition_path_template;

--- a/libtenzir/include/tenzir/partition_transformer.hpp
+++ b/libtenzir/include/tenzir/partition_transformer.hpp
@@ -29,7 +29,7 @@ namespace tenzir {
 struct partition_transformer_state {
   static constexpr const char* name = "partition-transformer";
 
-  using result_type = std::vector<partition_synopsis_pair>;
+  using result_type = partition_transform_result;
   using promise_type = caf::typed_response_promise<result_type>;
   using partition_tuple = std::tuple<tenzir::uuid, tenzir::type, chunk_ptr>;
   using synopsis_tuple = std::tuple<tenzir::uuid, chunk_ptr>;
@@ -77,6 +77,9 @@ struct partition_transformer_state {
 
   /// The partitions selected as input for the transform.
   std::vector<partition_info> input_partitions = {};
+
+  /// The input partitions that the transformer actually consumed.
+  std::vector<partition_info> transformed_input_partitions = {};
 
   /// The maximum number of events per partition. (not really necessary, but
   /// required by the partition synopsis)

--- a/libtenzir/include/tenzir/tql2/exec.hpp
+++ b/libtenzir/include/tenzir/tql2/exec.hpp
@@ -17,6 +17,7 @@
 #include "tenzir/tql2/ast.hpp"
 #include "tenzir/variant.hpp"
 
+#include <functional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -88,6 +89,24 @@ auto run_plan(OperatorChain<void, void> chain, caf::actor_system& sys,
 auto run_plan(OperatorChain<void, void> chain, caf::actor_system& sys,
               DiagHandler& dh, Profiler profiler, bool is_hidden)
   -> Task<failure_or<void>>;
+
+/// Feeds input into a transform pipeline.
+using TransformFeeder
+  = std::function<Task<void>(Push<OperatorMsg<table_slice>>&)>;
+
+/// Drains output from a transform pipeline.
+using TransformDrainer
+  = std::function<Task<void>(Pull<OperatorMsg<table_slice>>&)>;
+
+/// Run a `table_slice -> table_slice` chain with caller-provided IO.
+///
+/// The feeder receives the pipeline input push endpoint. It should push all
+/// input slices and then an `EndOfData` signal. The drainer receives the output
+/// pull endpoint and can process transformed slices incrementally.
+auto run_transform(OperatorChain<table_slice, table_slice> chain,
+                   caf::actor_system& sys, DiagHandler& dh, Profiler profiler,
+                   bool is_hidden, TransformFeeder feed_input,
+                   TransformDrainer drain_output) -> Task<failure_or<void>>;
 
 /// Run a `table_slice -> table_slice` chain over a fixed input vector.
 ///

--- a/libtenzir/src/catalog.cpp
+++ b/libtenzir/src/catalog.cpp
@@ -252,6 +252,7 @@ auto build_partition_slices(const std::vector<partition_synopsis_pair>& synopses
             + synopsis.synopsis->indexes_file.size
             + synopsis.synopsis->sketches_file.size);
     event.field("events").data(synopsis.synopsis->events);
+    event.field("approx_bytes").data(synopsis.synopsis->approx_bytes);
     event.field("min_import_time").data(synopsis.synopsis->min_import_time);
     event.field("max_import_time").data(synopsis.synopsis->max_import_time);
     event.field("version").data(synopsis.synopsis->version);

--- a/libtenzir/src/detail/available_memory.cpp
+++ b/libtenzir/src/detail/available_memory.cpp
@@ -1,0 +1,167 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "tenzir/detail/available_memory.hpp"
+
+#if defined(__APPLE__) && __has_include(<mach/mach.h>)
+#  include <mach/mach.h>
+#  include <mach/mach_host.h>
+
+#  include <unistd.h>
+#endif
+
+#include <exception>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <string_view>
+
+namespace tenzir::detail {
+
+namespace {
+
+auto read_memory_value(const std::filesystem::path& path)
+  -> std::optional<uint64_t> {
+  auto file = std::ifstream{path};
+  auto value = std::string{};
+  file >> value;
+  if (value.empty() or value == "max") {
+    return std::nullopt;
+  }
+  try {
+    return std::stoull(value);
+  } catch (const std::exception&) {
+    return std::nullopt;
+  }
+}
+
+auto read_cgroup_memory_available(const std::filesystem::path& dir,
+                                  std::string source)
+  -> std::optional<available_memory_info> {
+  auto current = read_memory_value(dir / "memory.current");
+  auto max = read_memory_value(dir / "memory.max");
+  if (not current or not max) {
+    current = read_memory_value(dir / "memory.usage_in_bytes");
+    max = read_memory_value(dir / "memory.limit_in_bytes");
+  }
+  if (not current or not max) {
+    return std::nullopt;
+  }
+  static constexpr auto unlimited_cgroup_limit = uint64_t{1} << 60;
+  if (*max >= unlimited_cgroup_limit) {
+    return std::nullopt;
+  }
+  if (*current >= *max) {
+    return available_memory_info{
+      .bytes = 0,
+      .source = std::move(source),
+    };
+  }
+  return available_memory_info{
+    .bytes = *max - *current,
+    .source = std::move(source),
+  };
+}
+
+auto relative_cgroup_path(std::string_view raw) -> std::filesystem::path {
+  while (raw.starts_with('/')) {
+    raw.remove_prefix(1);
+  }
+  return std::filesystem::path{std::string{raw}};
+}
+
+auto cgroup_memory_available() -> std::optional<available_memory_info> {
+  auto cgroups = std::ifstream{"/proc/self/cgroup"};
+  auto line = std::string{};
+  while (std::getline(cgroups, line)) {
+    const auto first = line.find(':');
+    if (first == std::string::npos) {
+      continue;
+    }
+    const auto second = line.find(':', first + 1);
+    if (second == std::string::npos) {
+      continue;
+    }
+    const auto controllers
+      = std::string_view{line}.substr(first + 1, second - first - 1);
+    const auto path
+      = relative_cgroup_path(std::string_view{line}.substr(second + 1));
+    if (controllers.empty()) {
+      if (auto result = read_cgroup_memory_available(
+            std::filesystem::path{"/sys/fs/cgroup"} / path, "cgroup-v2")) {
+        return result;
+      }
+    } else if (controllers.find("memory") != std::string_view::npos) {
+      if (auto result = read_cgroup_memory_available(
+            std::filesystem::path{"/sys/fs/cgroup/memory"} / path,
+            "cgroup-v1")) {
+        return result;
+      }
+      if (auto result = read_cgroup_memory_available(
+            std::filesystem::path{"/sys/fs/cgroup"} / path, "cgroup-v1")) {
+        return result;
+      }
+    }
+  }
+  return read_cgroup_memory_available("/sys/fs/cgroup", "cgroup");
+}
+
+auto procfs_memory_available() -> std::optional<available_memory_info> {
+  auto meminfo = std::ifstream{"/proc/meminfo"};
+  auto key = std::string{};
+  auto value = uint64_t{};
+  auto unit = std::string{};
+  while (meminfo >> key >> value >> unit) {
+    if (key == "MemAvailable:") {
+      return available_memory_info{
+        .bytes = value * uint64_t{1024},
+        .source = "/proc/meminfo",
+      };
+    }
+  }
+  return std::nullopt;
+}
+
+auto mach_memory_available() -> std::optional<available_memory_info> {
+#if defined(__APPLE__) && __has_include(<mach/mach.h>)
+  static const auto page_size = static_cast<uint64_t>(getpagesize());
+  auto vm_count = mach_msg_type_number_t{HOST_VM_INFO64_COUNT};
+  auto vm = vm_statistics64_data_t{};
+  if (KERN_SUCCESS
+      != host_statistics64(mach_host_self(), HOST_VM_INFO64,
+                           reinterpret_cast<host_info64_t>(&vm), &vm_count)) {
+    return std::nullopt;
+  }
+  return available_memory_info{
+    .bytes
+    = static_cast<uint64_t>(vm.free_count + vm.inactive_count) * page_size,
+    .source = "mach",
+  };
+#else
+  return std::nullopt;
+#endif
+}
+
+} // namespace
+
+auto available_memory() -> std::optional<available_memory_info> {
+  auto cgroup = cgroup_memory_available();
+  auto system = procfs_memory_available();
+  if (not system) {
+    system = mach_memory_available();
+  }
+  if (cgroup and system and system->bytes < cgroup->bytes) {
+    return system;
+  }
+  if (cgroup) {
+    return cgroup;
+  }
+  return system;
+}
+
+} // namespace tenzir::detail

--- a/libtenzir/src/detail/available_memory.cpp
+++ b/libtenzir/src/detail/available_memory.cpp
@@ -18,6 +18,7 @@
 #include <exception>
 #include <filesystem>
 #include <fstream>
+#include <sstream>
 #include <string>
 #include <string_view>
 
@@ -68,11 +69,132 @@ auto read_cgroup_memory_available(const std::filesystem::path& dir,
   };
 }
 
+auto octal_digit(char ch) -> std::optional<char> {
+  if (ch < '0' or ch > '7') {
+    return std::nullopt;
+  }
+  return ch - '0';
+}
+
+auto unescape_mountinfo_field(std::string_view raw) -> std::string {
+  auto result = std::string{};
+  result.reserve(raw.size());
+  for (auto i = size_t{0}; i < raw.size(); ++i) {
+    if (raw[i] != '\\' or i + 3 >= raw.size()) {
+      result.push_back(raw[i]);
+      continue;
+    }
+    auto first = octal_digit(raw[i + 1]);
+    auto second = octal_digit(raw[i + 2]);
+    auto third = octal_digit(raw[i + 3]);
+    if (not first or not second or not third) {
+      result.push_back(raw[i]);
+      continue;
+    }
+    result.push_back(
+      static_cast<char>((*first << 6) + (*second << 3) + *third));
+    i += 3;
+  }
+  return result;
+}
+
 auto relative_cgroup_path(std::string_view raw) -> std::filesystem::path {
   while (raw.starts_with('/')) {
     raw.remove_prefix(1);
   }
   return std::filesystem::path{std::string{raw}};
+}
+
+struct cgroup2_mount {
+  std::filesystem::path root = {};
+  std::filesystem::path mount_point = {};
+};
+
+auto find_cgroup2_mount() -> std::optional<cgroup2_mount> {
+  auto mountinfo = std::ifstream{"/proc/self/mountinfo"};
+  auto line = std::string{};
+  while (std::getline(mountinfo, line)) {
+    const auto separator = line.find(" - ");
+    if (separator == std::string::npos) {
+      continue;
+    }
+    auto before_separator = std::istringstream{line.substr(0, separator)};
+    auto id = std::string{};
+    auto parent_id = std::string{};
+    auto major_minor = std::string{};
+    auto root = std::string{};
+    auto mount_point = std::string{};
+    if (not(before_separator >> id >> parent_id >> major_minor >> root
+            >> mount_point)) {
+      continue;
+    }
+    auto after_separator = std::istringstream{line.substr(separator + 3)};
+    auto filesystem_type = std::string{};
+    after_separator >> filesystem_type;
+    if (filesystem_type != "cgroup2") {
+      continue;
+    }
+    return cgroup2_mount{
+      .root = unescape_mountinfo_field(root),
+      .mount_point = unescape_mountinfo_field(mount_point),
+    };
+  }
+  return std::nullopt;
+}
+
+auto path_stays_below_root(const std::filesystem::path& path) -> bool {
+  for (const auto& element : path) {
+    if (element == "..") {
+      return false;
+    }
+  }
+  return true;
+}
+
+auto resolve_cgroup2_path(const cgroup2_mount& mount,
+                          const std::filesystem::path& path)
+  -> std::filesystem::path {
+  auto absolute_path = (std::filesystem::path{"/"} / path).lexically_normal();
+  auto root = mount.root.lexically_normal();
+  if (root.empty()) {
+    root = "/";
+  }
+  auto relative_path = std::filesystem::path{};
+  if (root == "/") {
+    relative_path = absolute_path.relative_path();
+  } else if (absolute_path == root) {
+    relative_path = std::filesystem::path{};
+  } else if (auto relative_to_root = absolute_path.lexically_relative(root);
+             not relative_to_root.empty()
+             and path_stays_below_root(relative_to_root)) {
+    relative_path = relative_to_root;
+  } else {
+    relative_path = path;
+  }
+  return (mount.mount_point / relative_path).lexically_normal();
+}
+
+auto cgroup2_memory_available(const std::filesystem::path& path)
+  -> std::optional<available_memory_info> {
+  auto mount = find_cgroup2_mount().value_or(cgroup2_mount{
+    .root = "/",
+    .mount_point = "/sys/fs/cgroup",
+  });
+  auto current = resolve_cgroup2_path(mount, path);
+  auto root = mount.mount_point.lexically_normal();
+  auto result = std::optional<available_memory_info>{};
+  while (true) {
+    if (auto available = read_cgroup_memory_available(current, "cgroup-v2")) {
+      if (not result or available->bytes < result->bytes) {
+        result = std::move(available);
+      }
+    }
+    if (current == root or current == current.parent_path()) {
+      break;
+    }
+    current = current.parent_path();
+  }
+  return result;
 }
 
 auto cgroup_memory_available() -> std::optional<available_memory_info> {
@@ -92,8 +214,7 @@ auto cgroup_memory_available() -> std::optional<available_memory_info> {
     const auto path
       = relative_cgroup_path(std::string_view{line}.substr(second + 1));
     if (controllers.empty()) {
-      if (auto result = read_cgroup_memory_available(
-            std::filesystem::path{"/sys/fs/cgroup"} / path, "cgroup-v2")) {
+      if (auto result = cgroup2_memory_available(path)) {
         return result;
       }
     } else if (controllers.find("memory") != std::string_view::npos) {

--- a/libtenzir/src/detail/available_memory.cpp
+++ b/libtenzir/src/detail/available_memory.cpp
@@ -8,6 +8,8 @@
 
 #include "tenzir/detail/available_memory.hpp"
 
+#include "tenzir/config.hpp"
+
 #if defined(__APPLE__) && __has_include(<mach/mach.h>)
 #  include <mach/mach.h>
 #  include <mach/mach_host.h>
@@ -15,10 +17,14 @@
 #  include <unistd.h>
 #endif
 
+#if TENZIR_LINUX
+#  include <pfs/procfs.hpp>
+#endif
+
+#include <algorithm>
 #include <exception>
 #include <filesystem>
 #include <fstream>
-#include <sstream>
 #include <string>
 #include <string_view>
 
@@ -69,35 +75,6 @@ auto read_cgroup_memory_available(const std::filesystem::path& dir,
   };
 }
 
-auto octal_digit(char ch) -> std::optional<char> {
-  if (ch < '0' or ch > '7') {
-    return std::nullopt;
-  }
-  return ch - '0';
-}
-
-auto unescape_mountinfo_field(std::string_view raw) -> std::string {
-  auto result = std::string{};
-  result.reserve(raw.size());
-  for (auto i = size_t{0}; i < raw.size(); ++i) {
-    if (raw[i] != '\\' or i + 3 >= raw.size()) {
-      result.push_back(raw[i]);
-      continue;
-    }
-    auto first = octal_digit(raw[i + 1]);
-    auto second = octal_digit(raw[i + 2]);
-    auto third = octal_digit(raw[i + 3]);
-    if (not first or not second or not third) {
-      result.push_back(raw[i]);
-      continue;
-    }
-    result.push_back(
-      static_cast<char>((*first << 6) + (*second << 3) + *third));
-    i += 3;
-  }
-  return result;
-}
-
 auto relative_cgroup_path(std::string_view raw) -> std::filesystem::path {
   while (raw.starts_with('/')) {
     raw.remove_prefix(1);
@@ -111,34 +88,20 @@ struct cgroup2_mount {
 };
 
 auto find_cgroup2_mount() -> std::optional<cgroup2_mount> {
-  auto mountinfo = std::ifstream{"/proc/self/mountinfo"};
-  auto line = std::string{};
-  while (std::getline(mountinfo, line)) {
-    const auto separator = line.find(" - ");
-    if (separator == std::string::npos) {
-      continue;
+#if TENZIR_LINUX
+  try {
+    for (const auto& mount : pfs::procfs{}.get_task().get_mountinfo()) {
+      if (mount.filesystem_type != "cgroup2") {
+        continue;
+      }
+      return cgroup2_mount{
+        .root = mount.root,
+        .mount_point = mount.point,
+      };
     }
-    auto before_separator = std::istringstream{line.substr(0, separator)};
-    auto id = std::string{};
-    auto parent_id = std::string{};
-    auto major_minor = std::string{};
-    auto root = std::string{};
-    auto mount_point = std::string{};
-    if (not(before_separator >> id >> parent_id >> major_minor >> root
-            >> mount_point)) {
-      continue;
-    }
-    auto after_separator = std::istringstream{line.substr(separator + 3)};
-    auto filesystem_type = std::string{};
-    after_separator >> filesystem_type;
-    if (filesystem_type != "cgroup2") {
-      continue;
-    }
-    return cgroup2_mount{
-      .root = unescape_mountinfo_field(root),
-      .mount_point = unescape_mountinfo_field(mount_point),
-    };
+  } catch (const std::exception&) {
   }
+#endif
   return std::nullopt;
 }
 
@@ -198,37 +161,31 @@ auto cgroup2_memory_available(const std::filesystem::path& path)
 }
 
 auto cgroup_memory_available() -> std::optional<available_memory_info> {
-  auto cgroups = std::ifstream{"/proc/self/cgroup"};
-  auto line = std::string{};
-  while (std::getline(cgroups, line)) {
-    const auto first = line.find(':');
-    if (first == std::string::npos) {
-      continue;
-    }
-    const auto second = line.find(':', first + 1);
-    if (second == std::string::npos) {
-      continue;
-    }
-    const auto controllers
-      = std::string_view{line}.substr(first + 1, second - first - 1);
-    const auto path
-      = relative_cgroup_path(std::string_view{line}.substr(second + 1));
-    if (controllers.empty()) {
-      if (auto result = cgroup2_memory_available(path)) {
-        return result;
-      }
-    } else if (controllers.find("memory") != std::string_view::npos) {
-      if (auto result = read_cgroup_memory_available(
-            std::filesystem::path{"/sys/fs/cgroup/memory"} / path,
-            "cgroup-v1")) {
-        return result;
-      }
-      if (auto result = read_cgroup_memory_available(
-            std::filesystem::path{"/sys/fs/cgroup"} / path, "cgroup-v1")) {
-        return result;
+#if TENZIR_LINUX
+  try {
+    for (const auto& cgroup : pfs::procfs{}.get_task().get_cgroups()) {
+      const auto path = relative_cgroup_path(cgroup.pathname);
+      if (cgroup.controllers.empty()) {
+        if (auto result = cgroup2_memory_available(path)) {
+          return result;
+        }
+      } else if (std::find(cgroup.controllers.begin(), cgroup.controllers.end(),
+                           "memory")
+                 != cgroup.controllers.end()) {
+        if (auto result = read_cgroup_memory_available(
+              std::filesystem::path{"/sys/fs/cgroup/memory"} / path,
+              "cgroup-v1")) {
+          return result;
+        }
+        if (auto result = read_cgroup_memory_available(
+              std::filesystem::path{"/sys/fs/cgroup"} / path, "cgroup-v1")) {
+          return result;
+        }
       }
     }
+  } catch (const std::exception&) {
   }
+#endif
   return read_cgroup_memory_available("/sys/fs/cgroup", "cgroup");
 }
 

--- a/libtenzir/src/index.cpp
+++ b/libtenzir/src/index.cpp
@@ -1523,8 +1523,8 @@ index(index_actor::stateful_pointer<index_state> self,
     },
     [self](atom::apply, ast::pipeline pipe,
            std::vector<partition_info> selected_partitions,
-           keep_original_partition keep,
-           std::string origin) -> caf::result<std::vector<partition_info>> {
+           keep_original_partition keep, std::string origin)
+      -> caf::result<partition_transform_apply_result> {
       if (selected_partitions.empty()) {
         return caf::make_error(ec::invalid_argument, "no partitions given");
       }
@@ -1562,7 +1562,7 @@ index(index_actor::stateful_pointer<index_state> self,
         }
       }
       if (corrected_partitions.empty()) {
-        return std::vector<partition_info>{};
+        return partition_transform_apply_result{};
       }
       auto store_id = std::string{self->state().store_actor_plugin->name()};
       auto input_partition_path_template
@@ -1596,10 +1596,10 @@ index(index_actor::stateful_pointer<index_state> self,
         std::move(partition_completion_disposable));
       TENZIR_ASSERT(inserted);
       auto marker_path = self->state().marker_path(uuid::random());
-      auto rp = self->make_response_promise<std::vector<partition_info>>();
+      auto rp = self->make_response_promise<partition_transform_apply_result>();
       auto deliver =
         [self, rp, corrected_partitions, marker_path](
-          caf::expected<std::vector<partition_info>>&& result) mutable {
+          caf::expected<partition_transform_apply_result>&& result) mutable {
           // Erase errors don't matter too much here, leftover in-progress
           // transforms will be cleaned up on next startup.
           self->mail(atom::erase_v, marker_path)
@@ -1663,6 +1663,9 @@ index(index_actor::stateful_pointer<index_state> self,
               };
               result.emplace_back(std::move(info));
             }
+            auto transformed_input_partitions
+              = std::move(transform_result.input_partitions);
+            auto input_complete = transform_result.input_complete;
             // Record in-progress marker.
             auto marker_chunk
               = create_marker(old_partition_ids, new_partition_ids, keep);
@@ -1698,7 +1701,8 @@ index(index_actor::stateful_pointer<index_state> self,
                             self->mail(atom::merge_v, apsv)
                               .request(self->state().catalog, caf::infinite)
                               .then(
-                                [self, deliver, result = std::move(result),
+                                [self, deliver, transformed_input_partitions,
+                                 result, input_complete,
                                  apsv](atom::ok) mutable {
                                   // Update index statistics and list of
                                   // persisted partitions.
@@ -1707,20 +1711,31 @@ index(index_actor::stateful_pointer<index_state> self,
                                       aps.uuid);
                                   }
                                   self->state().flush_to_disk();
-                                  deliver(std::move(result));
+                                  deliver(partition_transform_apply_result{
+                                    .input_partitions
+                                    = std::move(transformed_input_partitions),
+                                    .output_partitions = std::move(result),
+                                    .input_complete = input_complete,
+                                  });
                                 },
                                 [deliver](caf::error& e) mutable {
                                   deliver(std::move(e));
                                 });
                           } else {
-                            deliver(result);
+                            deliver(partition_transform_apply_result{
+                              .input_partitions
+                              = std::move(transformed_input_partitions),
+                              .output_partitions = std::move(result),
+                              .input_complete = input_complete,
+                            });
                           }
                         } else { // keep == keep_original_partition::no
                           self->mail(atom::replace_v, old_partition_ids, apsv)
                             .request(self->state().catalog, caf::infinite)
                             .then(
-                              [self, deliver, old_partition_ids, result,
-                               apsv](atom::ok) mutable {
+                              [self, deliver, old_partition_ids,
+                               transformed_input_partitions, result, apsv,
+                               input_complete](atom::ok) mutable {
                                 for (auto const& aps : apsv) {
                                   self->state().persisted_partitions.emplace(
                                     aps.uuid);
@@ -1731,7 +1746,12 @@ index(index_actor::stateful_pointer<index_state> self,
                                            caf::infinite)
                                   .then(
                                     [=](atom::done) mutable {
-                                      deliver(result);
+                                      deliver(partition_transform_apply_result{
+                                        .input_partitions = std::move(
+                                          transformed_input_partitions),
+                                        .output_partitions = std::move(result),
+                                        .input_complete = input_complete,
+                                      });
                                     },
                                     [=](const caf::error& e) mutable {
                                       deliver(e);

--- a/libtenzir/src/index.cpp
+++ b/libtenzir/src/index.cpp
@@ -1523,8 +1523,8 @@ index(index_actor::stateful_pointer<index_state> self,
     },
     [self](atom::apply, ast::pipeline pipe,
            std::vector<partition_info> selected_partitions,
-           keep_original_partition keep, std::string origin)
-      -> caf::result<partition_transform_apply_result> {
+           keep_original_partition keep,
+           std::string origin) -> caf::result<partition_apply_result> {
       if (selected_partitions.empty()) {
         return caf::make_error(ec::invalid_argument, "no partitions given");
       }
@@ -1562,7 +1562,7 @@ index(index_actor::stateful_pointer<index_state> self,
         }
       }
       if (corrected_partitions.empty()) {
-        return partition_transform_apply_result{};
+        return partition_apply_result{};
       }
       auto store_id = std::string{self->state().store_actor_plugin->name()};
       auto input_partition_path_template
@@ -1596,39 +1596,38 @@ index(index_actor::stateful_pointer<index_state> self,
         std::move(partition_completion_disposable));
       TENZIR_ASSERT(inserted);
       auto marker_path = self->state().marker_path(uuid::random());
-      auto rp = self->make_response_promise<partition_transform_apply_result>();
-      auto deliver =
-        [self, rp, corrected_partitions, marker_path](
-          caf::expected<partition_transform_apply_result>&& result) mutable {
-          // Erase errors don't matter too much here, leftover in-progress
-          // transforms will be cleaned up on next startup.
-          self->mail(atom::erase_v, marker_path)
-            .request(self->state().filesystem, caf::infinite)
-            .then(
-              [](atom::done) { /* nop */
-                               ;
-              },
-              [self, marker_path](const caf::error& e) {
-                TENZIR_DEBUG("{} failed to erase in-progress marker at {}: "
-                             "{}",
-                             *self, marker_path, e);
-              });
-          for (const auto& [_, candidate_info] :
-               corrected_partitions.candidate_infos) {
-            for (const auto& partition : candidate_info.partition_infos) {
-              self->state().partitions_in_transformation.erase(partition.uuid);
-            }
+      auto rp = self->make_response_promise<partition_apply_result>();
+      auto deliver = [self, rp, corrected_partitions, marker_path](
+                       caf::expected<partition_apply_result>&& result) mutable {
+        // Erase errors don't matter too much here, leftover in-progress
+        // transforms will be cleaned up on next startup.
+        self->mail(atom::erase_v, marker_path)
+          .request(self->state().filesystem, caf::infinite)
+          .then(
+            [](atom::done) { /* nop */
+                             ;
+            },
+            [self, marker_path](const caf::error& e) {
+              TENZIR_DEBUG("{} failed to erase in-progress marker at {}: "
+                           "{}",
+                           *self, marker_path, e);
+            });
+        for (const auto& [_, candidate_info] :
+             corrected_partitions.candidate_infos) {
+          for (const auto& partition : candidate_info.partition_infos) {
+            self->state().partitions_in_transformation.erase(partition.uuid);
           }
-          if (result) {
-            rp.deliver(std::move(*result));
-          } else {
-            rp.deliver(std::move(result.error()));
-          }
-          // We clear the in-memory partitions here because they are only used
-          // by the partition transformer which will take quite some time to
-          // start again.
-          self->state().inmem_partitions.clear();
-        };
+        }
+        if (result) {
+          rp.deliver(std::move(*result));
+        } else {
+          rp.deliver(std::move(result.error()));
+        }
+        // We clear the in-memory partitions here because they are only used
+        // by the partition transformer which will take quite some time to
+        // start again.
+        self->state().inmem_partitions.clear();
+      };
       // TODO: Implement some kind of monadic composition instead of these
       // nested requests.
       // TODO: With CAF 0.19 it will no longer be needed to keep
@@ -1639,7 +1638,7 @@ index(index_actor::stateful_pointer<index_state> self,
         .then(
           [self, deliver, corrected_partitions, keep, marker_path, rp,
            partition_transfomer](
-            partition_transform_result& transform_result) mutable {
+            partition_transformer_result& transform_result) mutable {
             std::vector<uuid> old_partition_ids;
             old_partition_ids.reserve(transform_result.input_partitions.size());
             for (const auto& partition : transform_result.input_partitions) {
@@ -1711,7 +1710,7 @@ index(index_actor::stateful_pointer<index_state> self,
                                       aps.uuid);
                                   }
                                   self->state().flush_to_disk();
-                                  deliver(partition_transform_apply_result{
+                                  deliver(partition_apply_result{
                                     .input_partitions
                                     = std::move(transformed_input_partitions),
                                     .output_partitions = std::move(result),
@@ -1722,7 +1721,7 @@ index(index_actor::stateful_pointer<index_state> self,
                                   deliver(std::move(e));
                                 });
                           } else {
-                            deliver(partition_transform_apply_result{
+                            deliver(partition_apply_result{
                               .input_partitions
                               = std::move(transformed_input_partitions),
                               .output_partitions = std::move(result),
@@ -1746,7 +1745,7 @@ index(index_actor::stateful_pointer<index_state> self,
                                            caf::infinite)
                                   .then(
                                     [=](atom::done) mutable {
-                                      deliver(partition_transform_apply_result{
+                                      deliver(partition_apply_result{
                                         .input_partitions = std::move(
                                           transformed_input_partitions),
                                         .output_partitions = std::move(result),

--- a/libtenzir/src/index.cpp
+++ b/libtenzir/src/index.cpp
@@ -343,6 +343,10 @@ std::filesystem::path index_state::partition_path(const uuid& id) const {
   return dir / fmt::format("{:l}", id);
 }
 
+std::filesystem::path index_state::archive_dir() const {
+  return dir / ".." / "archive";
+}
+
 std::string index_state::partition_path_template() const {
   return (dir / "{:l}").string();
 }
@@ -1563,6 +1567,7 @@ index(index_actor::stateful_pointer<index_state> self,
       auto store_id = std::string{self->state().store_actor_plugin->name()};
       auto input_partition_path_template
         = self->state().partition_path_template();
+      auto archive_dir = self->state().archive_dir();
       auto partition_path_template
         = self->state().transformer_partition_path_template();
       auto partition_synopsis_path_template
@@ -1572,7 +1577,7 @@ index(index_actor::stateful_pointer<index_state> self,
         partition_transformer, store_id, self->state().synopsis_opts,
         self->state().index_opts, self->state().catalog,
         self->state().filesystem, std::move(input_partitions), pipe,
-        std::move(input_partition_path_template),
+        std::move(input_partition_path_template), std::move(archive_dir),
         std::move(partition_path_template),
         std::move(partition_synopsis_path_template), std::move(origin));
       /// Monitor the actor to remove it from the collection of active

--- a/libtenzir/src/index.cpp
+++ b/libtenzir/src/index.cpp
@@ -1639,15 +1639,13 @@ index(index_actor::stateful_pointer<index_state> self,
         .then(
           [self, deliver, corrected_partitions, keep, marker_path, rp,
            partition_transfomer](
-            std::vector<partition_synopsis_pair>& apsv) mutable {
+            partition_transform_result& transform_result) mutable {
             std::vector<uuid> old_partition_ids;
-            old_partition_ids.reserve(corrected_partitions.size());
-            for (const auto& [_, candidate_info] :
-                 corrected_partitions.candidate_infos) {
-              for (const auto& partition : candidate_info.partition_infos) {
-                old_partition_ids.emplace_back(partition.uuid);
-              }
+            old_partition_ids.reserve(transform_result.input_partitions.size());
+            for (const auto& partition : transform_result.input_partitions) {
+              old_partition_ids.emplace_back(partition.uuid);
             }
+            auto apsv = std::move(transform_result.output_partitions);
             std::vector<uuid> new_partition_ids;
             new_partition_ids.reserve(apsv.size());
             for (auto const& [uuid, _] : apsv) {

--- a/libtenzir/src/index.cpp
+++ b/libtenzir/src/index.cpp
@@ -343,6 +343,10 @@ std::filesystem::path index_state::partition_path(const uuid& id) const {
   return dir / fmt::format("{:l}", id);
 }
 
+std::string index_state::partition_path_template() const {
+  return (dir / "{:l}").string();
+}
+
 std::filesystem::path
 index_state::transformer_partition_path(const uuid& id) const {
   return markersdir / fmt::format("{:l}", id);
@@ -1517,13 +1521,14 @@ index(index_actor::stateful_pointer<index_state> self,
            std::vector<partition_info> selected_partitions,
            keep_original_partition keep,
            std::string origin) -> caf::result<std::vector<partition_info>> {
-      const auto current_sender = self->current_sender();
       if (selected_partitions.empty()) {
         return caf::make_error(ec::invalid_argument, "no partitions given");
       }
       TENZIR_DEBUG("{} applies a pipeline to partitions {}", *self,
                    selected_partitions);
       TENZIR_ASSERT(self->state().store_actor_plugin);
+      auto input_partitions = std::vector<partition_info>{};
+      input_partitions.reserve(selected_partitions.size());
       std::erase_if(selected_partitions, [&](const auto& entry) {
         if (self->state().persisted_partitions.contains(entry.uuid)) {
           return false;
@@ -1539,6 +1544,7 @@ index(index_actor::stateful_pointer<index_state> self,
               .second) {
           corrected_partitions.candidate_infos[partition.schema]
             .partition_infos.emplace_back(partition);
+          input_partitions.emplace_back(partition);
         } else {
           // Getting overlapping partitions triggers a warning, and we
           // silently ignore the partition at the cost of the transformation
@@ -1555,6 +1561,8 @@ index(index_actor::stateful_pointer<index_state> self,
         return std::vector<partition_info>{};
       }
       auto store_id = std::string{self->state().store_actor_plugin->name()};
+      auto input_partition_path_template
+        = self->state().partition_path_template();
       auto partition_path_template
         = self->state().transformer_partition_path_template();
       auto partition_synopsis_path_template
@@ -1563,7 +1571,9 @@ index(index_actor::stateful_pointer<index_state> self,
       partition_transformer_actor partition_transfomer = self->spawn(
         partition_transformer, store_id, self->state().synopsis_opts,
         self->state().index_opts, self->state().catalog,
-        self->state().filesystem, pipe, std::move(partition_path_template),
+        self->state().filesystem, std::move(input_partitions), pipe,
+        std::move(input_partition_path_template),
+        std::move(partition_path_template),
         std::move(partition_synopsis_path_template), std::move(origin));
       /// Monitor the actor to remove it from the collection of active
       /// transformers.
@@ -1580,38 +1590,7 @@ index(index_actor::stateful_pointer<index_state> self,
         std::move(partition_transformer_addr),
         std::move(partition_completion_disposable));
       TENZIR_ASSERT(inserted);
-      // match_everything == '"" in #schema'
-      static const auto match_everything
-        = tenzir::predicate{meta_extractor{meta_extractor::schema},
-                            relational_operator::ni, data{""}};
-      auto query_context = query_context::make_extract(
-        fmt::format("{:?}", pipe), partition_transfomer, match_everything);
-      auto transform_id = self->state().pending_queries.create_query_id();
-      query_context.id = transform_id;
-      // We set the query priority for partition transforms to zero so they
-      // always get less priority than queries.
-      query_context.priority = 0;
-      TENZIR_TRACE("{} emplaces {} for pipeline {:?}", *self, query_context,
-                   pipe);
-      auto query_contexts = query_state::type_query_context_map{};
-      for (const auto& [type, _] : corrected_partitions.candidate_infos) {
-        query_contexts[type] = query_context;
-      }
-      auto input_size
-        = detail::narrow_cast<uint32_t>(corrected_partitions.size());
-      auto err = self->state().pending_queries.insert(
-        query_state{.query_contexts_per_type = query_contexts,
-                    .client = caf::actor_cast<receiver_actor<atom::done>>(
-                      partition_transfomer),
-                    .candidate_partitions = input_size,
-                    .requested_partitions = input_size},
-        catalog_lookup_result{corrected_partitions});
-      TENZIR_ASSERT(err == caf::none);
-      const auto num_scheduled = self->state().schedule_lookups();
-      TENZIR_DEBUG("{} scheduled {} partitions following a request to "
-                   "transform partitions",
-                   *self, num_scheduled);
-      auto marker_path = self->state().marker_path(transform_id);
+      auto marker_path = self->state().marker_path(uuid::random());
       auto rp = self->make_response_promise<std::vector<partition_info>>();
       auto deliver =
         [self, rp, corrected_partitions, marker_path](

--- a/libtenzir/src/partition_synopsis.cpp
+++ b/libtenzir/src/partition_synopsis.cpp
@@ -21,6 +21,7 @@ partition_synopsis::partition_synopsis(partition_synopsis&& that) noexcept {
   min_import_time = std::exchange(that.min_import_time, time::max());
   max_import_time = std::exchange(that.max_import_time, time::min());
   version = std::exchange(that.version, version::current_partition_version);
+  approx_bytes = std::exchange(that.approx_bytes, uint64_t{0});
   schema = std::exchange(that.schema, {});
   type_synopses_ = std::exchange(that.type_synopses_, {});
   field_synopses_ = std::exchange(that.field_synopses_, {});
@@ -34,6 +35,7 @@ partition_synopsis::operator=(partition_synopsis&& that) noexcept {
     min_import_time = std::exchange(that.min_import_time, time::max());
     max_import_time = std::exchange(that.max_import_time, time::min());
     version = std::exchange(that.version, version::current_partition_version);
+    approx_bytes = std::exchange(that.approx_bytes, uint64_t{0});
     schema = std::exchange(that.schema, {});
     type_synopses_ = std::exchange(that.type_synopses_, {});
     field_synopses_ = std::exchange(that.field_synopses_, {});
@@ -118,6 +120,7 @@ void partition_synopsis::add(const table_slice& slice,
     schema = slice.schema();
   }
   TENZIR_ASSERT_EXPENSIVE(schema == slice.schema());
+  approx_bytes += slice.approx_bytes();
   auto each = as<record_type>(schema).leaves();
   auto leaf_it = each.begin();
   caf::settings synopsis_opts;
@@ -199,6 +202,7 @@ partition_synopsis* partition_synopsis::copy() const {
   result->min_import_time = min_import_time;
   result->max_import_time = max_import_time;
   result->version = version;
+  result->approx_bytes = approx_bytes;
   result->schema = schema;
   result->memusage_ = memusage_.load();
   result->type_synopses_.reserve(type_synopses_.size());
@@ -254,6 +258,7 @@ pack(flatbuffers::FlatBufferBuilder& builder, const partition_synopsis& x) {
   ps_builder.add_import_time_range(&import_time_range);
   ps_builder.add_version(x.version);
   ps_builder.add_schema(schema_vector);
+  ps_builder.add_approx_bytes(x.approx_bytes);
   return ps_builder.Finish();
 }
 
@@ -309,6 +314,7 @@ caf::error unpack(const fbs::partition_synopsis::LegacyPartitionSynopsis& x,
     ps.max_import_time = time{};
   }
   ps.version = x.version();
+  ps.approx_bytes = x.approx_bytes();
   if (const auto* schema = x.schema()) {
     ps.schema = type{chunk::copy(as_bytes(*schema))};
   }

--- a/libtenzir/src/partition_transformer.cpp
+++ b/libtenzir/src/partition_transformer.cpp
@@ -394,8 +394,8 @@ private:
       = archive_dir_
         / fmt::format("{}.{}", store_uuid, partition_state.store_id);
     if (store_path.extension() == ".feather") {
-      TENZIR_INFO("{} loads feather store for partition {} from {}",
-                  "partition-transformer", partition.uuid, store_path);
+      TENZIR_DEBUG("{} loads feather store for partition {} from {}",
+                   "partition-transformer", partition.uuid, store_path);
     }
     auto store_chunk = chunk::mmap(store_path);
     if (not store_chunk) {

--- a/libtenzir/src/partition_transformer.cpp
+++ b/libtenzir/src/partition_transformer.cpp
@@ -36,11 +36,157 @@
 #include <folly/futures/Future.h>
 
 #include <filesystem>
+#include <fstream>
 #include <memory>
+#include <optional>
+#include <string>
 
 namespace tenzir {
 
 namespace {
+
+struct memory_available {
+  uint64_t bytes = 0;
+  std::string source = {};
+};
+
+struct memory_budget {
+  uint64_t initial_available = 0;
+  uint64_t bytes = 0;
+  std::string source = {};
+};
+
+auto read_memory_value(const std::filesystem::path& path)
+  -> std::optional<uint64_t> {
+  auto file = std::ifstream{path};
+  auto value = std::string{};
+  file >> value;
+  if (value.empty() or value == "max") {
+    return std::nullopt;
+  }
+  try {
+    return std::stoull(value);
+  } catch (const std::exception&) {
+    return std::nullopt;
+  }
+}
+
+auto read_cgroup_memory_available(const std::filesystem::path& dir,
+                                  std::string source)
+  -> std::optional<memory_available> {
+  auto current = read_memory_value(dir / "memory.current");
+  auto max = read_memory_value(dir / "memory.max");
+  if (not current or not max) {
+    current = read_memory_value(dir / "memory.usage_in_bytes");
+    max = read_memory_value(dir / "memory.limit_in_bytes");
+  }
+  if (not current or not max or *current >= *max) {
+    return std::nullopt;
+  }
+  static constexpr auto unlimited_cgroup_limit = uint64_t{1} << 60;
+  if (*max >= unlimited_cgroup_limit) {
+    return std::nullopt;
+  }
+  return memory_available{
+    .bytes = *max - *current,
+    .source = std::move(source),
+  };
+}
+
+auto relative_cgroup_path(std::string_view raw) -> std::filesystem::path {
+  while (raw.starts_with('/')) {
+    raw.remove_prefix(1);
+  }
+  return std::filesystem::path{std::string{raw}};
+}
+
+auto cgroup_memory_available() -> std::optional<memory_available> {
+  auto cgroups = std::ifstream{"/proc/self/cgroup"};
+  auto line = std::string{};
+  while (std::getline(cgroups, line)) {
+    const auto first = line.find(':');
+    if (first == std::string::npos) {
+      continue;
+    }
+    const auto second = line.find(':', first + 1);
+    if (second == std::string::npos) {
+      continue;
+    }
+    const auto controllers
+      = std::string_view{line}.substr(first + 1, second - first - 1);
+    const auto path
+      = relative_cgroup_path(std::string_view{line}.substr(second + 1));
+    if (controllers.empty()) {
+      if (auto result = read_cgroup_memory_available(
+            std::filesystem::path{"/sys/fs/cgroup"} / path, "cgroup-v2")) {
+        return result;
+      }
+    } else if (controllers.find("memory") != std::string_view::npos) {
+      if (auto result = read_cgroup_memory_available(
+            std::filesystem::path{"/sys/fs/cgroup/memory"} / path,
+            "cgroup-v1")) {
+        return result;
+      }
+      if (auto result = read_cgroup_memory_available(
+            std::filesystem::path{"/sys/fs/cgroup"} / path, "cgroup-v1")) {
+        return result;
+      }
+    }
+  }
+  return read_cgroup_memory_available("/sys/fs/cgroup", "cgroup");
+}
+
+auto system_memory_available() -> std::optional<memory_available> {
+  auto meminfo = std::ifstream{"/proc/meminfo"};
+  auto key = std::string{};
+  auto value = uint64_t{};
+  auto unit = std::string{};
+  while (meminfo >> key >> value >> unit) {
+    if (key == "MemAvailable:") {
+      return memory_available{
+        .bytes = value * uint64_t{1024},
+        .source = "/proc/meminfo",
+      };
+    }
+  }
+  return std::nullopt;
+}
+
+auto available_memory() -> std::optional<memory_available> {
+  auto cgroup = cgroup_memory_available();
+  auto system = system_memory_available();
+  if (cgroup and system and system->bytes < cgroup->bytes) {
+    return system;
+  }
+  if (cgroup) {
+    return cgroup;
+  }
+  return system;
+}
+
+auto make_memory_budget() -> std::optional<memory_budget> {
+  auto available = available_memory();
+  if (not available) {
+    return std::nullopt;
+  }
+  return memory_budget{
+    .initial_available = available->bytes,
+    .bytes = std::max(available->bytes / 4, uint64_t{1}),
+    .source = std::move(available->source),
+  };
+}
+
+auto live_budget_used(const memory_budget& budget)
+  -> std::optional<std::pair<uint64_t, uint64_t>> {
+  auto current = available_memory();
+  if (not current) {
+    return std::nullopt;
+  }
+  const auto used = budget.initial_available > current->bytes
+                      ? budget.initial_available - current->bytes
+                      : uint64_t{0};
+  return std::pair{used, current->bytes};
+}
 
 void store_or_fulfill(
   partition_transformer_actor::stateful_pointer<partition_transformer_state>
@@ -135,6 +281,7 @@ struct partition_source_state {
   caf::error error = {};
   tenzir::time min_import_time = tenzir::time::max();
   tenzir::time max_import_time = tenzir::time::min();
+  std::vector<partition_info> loaded_partitions = {};
 };
 
 class partition_loader {
@@ -146,12 +293,27 @@ public:
     : partitions_{std::move(partitions)},
       partition_path_template_{std::move(partition_path_template)},
       archive_dir_{std::move(archive_dir)},
+      memory_budget_{make_memory_budget()},
       state_{std::move(state)} {
     TENZIR_ASSERT(state_);
   }
 
   auto feed(Push<OperatorMsg<table_slice>>& push_input) const -> Task<void> {
     for (const auto& partition : partitions_) {
+      if (memory_budget_ and not state_->loaded_partitions.empty()) {
+        if (auto used = live_budget_used(*memory_budget_);
+            used and used->first >= memory_budget_->bytes) {
+          TENZIR_INFO("{} stops loading transform input before partition {} "
+                      "after {} partition(s); live memory budget is full "
+                      "({} bytes used, {} bytes budget, {} bytes available, "
+                      "source: {})",
+                      "partition-transformer", partition.uuid,
+                      state_->loaded_partitions.size(), used->first,
+                      memory_budget_->bytes, used->second,
+                      memory_budget_->source);
+          break;
+        }
+      }
       for (auto&& slice : load_partition(partition)) {
         const auto import_time = slice.import_time();
         state_->min_import_time
@@ -167,6 +329,7 @@ public:
         co_await push_input(OperatorMsg<table_slice>{Signal{EndOfData{}}});
         co_return;
       }
+      state_->loaded_partitions.push_back(partition);
     }
     co_await push_input(OperatorMsg<table_slice>{Signal{EndOfData{}}});
   }
@@ -256,6 +419,7 @@ private:
   std::vector<partition_info> partitions_;
   std::string partition_path_template_;
   std::filesystem::path archive_dir_;
+  std::optional<memory_budget> memory_budget_;
   std::shared_ptr<partition_source_state> state_;
 };
 
@@ -356,7 +520,10 @@ void partition_transformer_state::fulfill(
   // Return early if no error occured and no new data was created,
   // ie. the input was erased completely.
   if (self->state().events == 0) {
-    promise.deliver(std::vector<partition_synopsis_pair>{});
+    promise.deliver(partition_transform_result{
+      .input_partitions = self->state().transformed_input_partitions,
+      .output_partitions = {},
+    });
     self->quit();
     return;
   }
@@ -399,7 +566,11 @@ void partition_transformer_state::fulfill(
         quit_or_stall(self,
                       partition_transformer_state::transformer_is_finished{
                         .promise = std::move(promise),
-                        .result = std::move(result),
+                        .result = partition_transform_result{
+                          .input_partitions
+                          = self->state().transformed_input_partitions,
+                          .output_partitions = std::move(result),
+                        },
                       });
       },
       [self, promise](std::vector<partition_synopsis_pair>&&,
@@ -677,6 +848,8 @@ auto partition_transformer(
             }
             self->state().min_import_time = source_state->min_import_time;
             self->state().max_import_time = source_state->max_import_time;
+            self->state().transformed_input_partitions
+              = std::move(source_state->loaded_partitions);
             finish_transform();
           });
         });
@@ -779,10 +952,9 @@ auto partition_transformer(
       }();
       store_or_fulfill(self, std::move(stream_data));
     },
-    [self](atom::persist) -> caf::result<std::vector<partition_synopsis_pair>> {
+    [self](atom::persist) -> caf::result<partition_transform_result> {
       TENZIR_DEBUG("{} received request to persist", *self);
-      auto promise
-        = self->make_response_promise<std::vector<partition_synopsis_pair>>();
+      auto promise = self->make_response_promise<partition_transform_result>();
       auto path_data = partition_transformer_state::path_data{
         .promise = promise,
       };

--- a/libtenzir/src/partition_transformer.cpp
+++ b/libtenzir/src/partition_transformer.cpp
@@ -14,6 +14,7 @@
 #include "tenzir/atomic.hpp"
 #include "tenzir/co_match.hpp"
 #include "tenzir/compile_ctx.hpp"
+#include "tenzir/detail/available_memory.hpp"
 #include "tenzir/detail/fanout_counter.hpp"
 #include "tenzir/fbs/utils.hpp"
 #include "tenzir/ir.hpp"
@@ -40,7 +41,6 @@
 
 #include <atomic>
 #include <filesystem>
-#include <fstream>
 #include <memory>
 #include <optional>
 #include <string>
@@ -49,133 +49,14 @@ namespace tenzir {
 
 namespace {
 
-struct memory_available {
-  uint64_t bytes = 0;
-  std::string source = {};
-};
-
 struct memory_budget {
   uint64_t initial_available = 0;
   uint64_t bytes = 0;
   std::string source = {};
 };
 
-auto read_memory_value(const std::filesystem::path& path)
-  -> std::optional<uint64_t> {
-  auto file = std::ifstream{path};
-  auto value = std::string{};
-  file >> value;
-  if (value.empty() or value == "max") {
-    return std::nullopt;
-  }
-  try {
-    return std::stoull(value);
-  } catch (const std::exception&) {
-    return std::nullopt;
-  }
-}
-
-auto read_cgroup_memory_available(const std::filesystem::path& dir,
-                                  std::string source)
-  -> std::optional<memory_available> {
-  auto current = read_memory_value(dir / "memory.current");
-  auto max = read_memory_value(dir / "memory.max");
-  if (not current or not max) {
-    current = read_memory_value(dir / "memory.usage_in_bytes");
-    max = read_memory_value(dir / "memory.limit_in_bytes");
-  }
-  if (not current or not max) {
-    return std::nullopt;
-  }
-  static constexpr auto unlimited_cgroup_limit = uint64_t{1} << 60;
-  if (*max >= unlimited_cgroup_limit) {
-    return std::nullopt;
-  }
-  if (*current >= *max) {
-    return memory_available{
-      .bytes = 0,
-      .source = std::move(source),
-    };
-  }
-  return memory_available{
-    .bytes = *max - *current,
-    .source = std::move(source),
-  };
-}
-
-auto relative_cgroup_path(std::string_view raw) -> std::filesystem::path {
-  while (raw.starts_with('/')) {
-    raw.remove_prefix(1);
-  }
-  return std::filesystem::path{std::string{raw}};
-}
-
-auto cgroup_memory_available() -> std::optional<memory_available> {
-  auto cgroups = std::ifstream{"/proc/self/cgroup"};
-  auto line = std::string{};
-  while (std::getline(cgroups, line)) {
-    const auto first = line.find(':');
-    if (first == std::string::npos) {
-      continue;
-    }
-    const auto second = line.find(':', first + 1);
-    if (second == std::string::npos) {
-      continue;
-    }
-    const auto controllers
-      = std::string_view{line}.substr(first + 1, second - first - 1);
-    const auto path
-      = relative_cgroup_path(std::string_view{line}.substr(second + 1));
-    if (controllers.empty()) {
-      if (auto result = read_cgroup_memory_available(
-            std::filesystem::path{"/sys/fs/cgroup"} / path, "cgroup-v2")) {
-        return result;
-      }
-    } else if (controllers.find("memory") != std::string_view::npos) {
-      if (auto result = read_cgroup_memory_available(
-            std::filesystem::path{"/sys/fs/cgroup/memory"} / path,
-            "cgroup-v1")) {
-        return result;
-      }
-      if (auto result = read_cgroup_memory_available(
-            std::filesystem::path{"/sys/fs/cgroup"} / path, "cgroup-v1")) {
-        return result;
-      }
-    }
-  }
-  return read_cgroup_memory_available("/sys/fs/cgroup", "cgroup");
-}
-
-auto system_memory_available() -> std::optional<memory_available> {
-  auto meminfo = std::ifstream{"/proc/meminfo"};
-  auto key = std::string{};
-  auto value = uint64_t{};
-  auto unit = std::string{};
-  while (meminfo >> key >> value >> unit) {
-    if (key == "MemAvailable:") {
-      return memory_available{
-        .bytes = value * uint64_t{1024},
-        .source = "/proc/meminfo",
-      };
-    }
-  }
-  return std::nullopt;
-}
-
-auto available_memory() -> std::optional<memory_available> {
-  auto cgroup = cgroup_memory_available();
-  auto system = system_memory_available();
-  if (cgroup and system and system->bytes < cgroup->bytes) {
-    return system;
-  }
-  if (cgroup) {
-    return cgroup;
-  }
-  return system;
-}
-
 auto make_memory_budget() -> std::optional<memory_budget> {
-  auto available = available_memory();
+  auto available = detail::available_memory();
   if (not available) {
     return std::nullopt;
   }
@@ -188,7 +69,7 @@ auto make_memory_budget() -> std::optional<memory_budget> {
 
 auto live_budget_used(const memory_budget& budget)
   -> std::optional<std::pair<uint64_t, uint64_t>> {
-  auto current = available_memory();
+  auto current = detail::available_memory();
   if (not current) {
     return std::nullopt;
   }

--- a/libtenzir/src/partition_transformer.cpp
+++ b/libtenzir/src/partition_transformer.cpp
@@ -11,7 +11,6 @@
 #include "tenzir/async/executor.hpp"
 #include "tenzir/async/future_util.hpp"
 #include "tenzir/atomic.hpp"
-#include "tenzir/base_ctx.hpp"
 #include "tenzir/co_match.hpp"
 #include "tenzir/compile_ctx.hpp"
 #include "tenzir/detail/fanout_counter.hpp"
@@ -165,6 +164,7 @@ public:
         co_await push_input(OperatorMsg<table_slice>{std::move(slice)});
       }
       if (state_->error.valid()) {
+        co_await push_input(OperatorMsg<table_slice>{Signal{EndOfData{}}});
         co_return;
       }
     }
@@ -436,12 +436,13 @@ auto partition_transformer(
   std::string store_id, const index_config& synopsis_opts,
   const caf::settings& index_opts, catalog_actor catalog, filesystem_actor fs,
   std::vector<partition_info> input_partitions, ast::pipeline transform,
-  std::string input_partition_path_template,
+  std::string input_partition_path_template, std::filesystem::path archive_dir,
   std::string partition_path_template, std::string synopsis_path_template,
   std::string origin) -> partition_transformer_actor::behavior_type {
   self->state().synopsis_opts = synopsis_opts;
   self->state().input_partition_path_template
     = std::move(input_partition_path_template);
+  self->state().archive_dir = std::move(archive_dir);
   self->state().partition_path_template = std::move(partition_path_template);
   self->state().synopsis_path_template = std::move(synopsis_path_template);
   // For historic reasons, the `tenzir.max-partition-size` is stored as the
@@ -547,21 +548,12 @@ auto partition_transformer(
         self->mail(atom::internal_v, atom::resume_v, atom::done_v)
           .send(static_cast<partition_transformer_actor>(self));
       };
-      auto db_dir = std::filesystem::path{caf::get_or(
-        content(self->state().fs->home_system().config()),
-        "tenzir.state-directory", defaults::state_directory.data())};
-      std::error_code err{};
-      auto archive_dir = std::filesystem::absolute(db_dir, err) / "archive";
-      if (err) {
-        return caf::make_error(ec::filesystem_error,
-                               "failed to resolve state directory {}: {}",
-                               db_dir, err.message());
-      }
       // Move input metadata and AST out so the actor's state is empty when the
       // run begins; they live inside the coroutine until it finishes.
       auto input_partitions = std::exchange(self->state().input_partitions, {});
       auto input_partition_path_template
         = std::move(self->state().input_partition_path_template);
+      auto archive_dir = std::move(self->state().archive_dir);
       auto ast = std::move(self->state().transform);
       // We deliver `rp` immediately and signal real completion later via the
       // store-builder monitors set up in `finish_transform`.

--- a/libtenzir/src/partition_transformer.cpp
+++ b/libtenzir/src/partition_transformer.cpp
@@ -230,6 +230,10 @@ private:
     auto store_path
       = archive_dir_
         / fmt::format("{}.{}", store_uuid, partition_state.store_id);
+    if (store_path.extension() == ".feather") {
+      TENZIR_INFO("{} loads feather store for partition {} from {}",
+                  "partition-transformer", partition.uuid, store_path);
+    }
     auto store_chunk = chunk::mmap(store_path);
     if (not store_chunk) {
       fail(diagnostic::error(store_chunk.error())

--- a/libtenzir/src/partition_transformer.cpp
+++ b/libtenzir/src/partition_transformer.cpp
@@ -303,14 +303,14 @@ public:
       if (memory_budget_ and not state_->loaded_partitions.empty()) {
         if (auto used = live_budget_used(*memory_budget_);
             used and used->first >= memory_budget_->bytes) {
-          TENZIR_INFO("{} stops loading transform input before partition {} "
-                      "after {} partition(s); live memory budget is full "
-                      "({} bytes used, {} bytes budget, {} bytes available, "
-                      "source: {})",
-                      "partition-transformer", partition.uuid,
-                      state_->loaded_partitions.size(), used->first,
-                      memory_budget_->bytes, used->second,
-                      memory_budget_->source);
+          TENZIR_VERBOSE("{} stops loading transform input before partition {} "
+                         "after {} partition(s); live memory budget is full "
+                         "({} bytes used, {} bytes budget, {} bytes available, "
+                         "source: {})",
+                         "partition-transformer", partition.uuid,
+                         state_->loaded_partitions.size(), used->first,
+                         memory_budget_->bytes, used->second,
+                         memory_budget_->source);
           break;
         }
       }

--- a/libtenzir/src/partition_transformer.cpp
+++ b/libtenzir/src/partition_transformer.cpp
@@ -38,6 +38,7 @@
 #include <folly/executors/GlobalExecutor.h>
 #include <folly/futures/Future.h>
 
+#include <atomic>
 #include <filesystem>
 #include <fstream>
 #include <memory>
@@ -301,9 +302,28 @@ struct partition_source_state {
   caf::error error = {};
   tenzir::time min_import_time = tenzir::time::max();
   tenzir::time max_import_time = tenzir::time::min();
+  std::atomic<duration::rep> loaded_min_import_time
+    = time::max().time_since_epoch().count();
   std::vector<partition_info> selected_partitions = {};
   std::vector<partition_info> loaded_partitions = {};
   bool input_complete = true;
+
+  auto observe_import_time(time import_time) -> void {
+    min_import_time = std::min(min_import_time, import_time);
+    max_import_time = std::max(max_import_time, import_time);
+    auto import_time_count = import_time.time_since_epoch().count();
+    auto current = loaded_min_import_time.load(std::memory_order_relaxed);
+    while (import_time_count < current
+           and not loaded_min_import_time.compare_exchange_weak(
+             current, import_time_count, std::memory_order_relaxed)) {
+      // nop
+    }
+  }
+
+  auto min_loaded_import_time() const -> time {
+    return time{}
+           + duration{loaded_min_import_time.load(std::memory_order_relaxed)};
+  }
 };
 
 class partition_loader {
@@ -359,11 +379,7 @@ public:
         co_return;
       }
       for (auto&& slice : *maybe_slices) {
-        const auto import_time = slice.import_time();
-        state_->min_import_time
-          = std::min(state_->min_import_time, import_time);
-        state_->max_import_time
-          = std::max(state_->max_import_time, import_time);
+        state_->observe_import_time(slice.import_time());
         if (slice.rows() == 0) {
           continue;
         }
@@ -704,7 +720,8 @@ auto partition_transformer(
                              "externally pushed table slices");
     },
     [self](atom::done) -> caf::result<void> {
-      auto process_slice = [self](table_slice slice) {
+      auto process_slice = [self](table_slice slice,
+                                  time fallback_import_time) {
         auto& partition_data = self->state().create_or_get_partition(slice);
         if (not partition_data.synopsis) {
           partition_data.id = tenzir::uuid::random();
@@ -715,7 +732,10 @@ auto partition_transformer(
         }
         auto* unshared_synopsis = partition_data.synopsis.unshared_ptr();
         if (slice.import_time() == time{}) {
-          slice.import_time(self->state().min_import_time);
+          if (fallback_import_time == time::max()) {
+            fallback_import_time = time{};
+          }
+          slice.import_time(fallback_import_time);
         }
         unshared_synopsis->min_import_time
           = std::min(unshared_synopsis->min_import_time, slice.import_time());
@@ -832,7 +852,7 @@ auto partition_transformer(
               co_await loader.feed(push_input);
             };
             auto drain_output
-              = [self, weak, process_slice](
+              = [self, weak, process_slice, source_state](
                   Pull<OperatorMsg<table_slice>>& pull_output) mutable
               -> Task<void> {
               while (auto msg = co_await pull_output()) {
@@ -851,10 +871,13 @@ auto partition_transformer(
                     if (not strong) {
                       promise_ptr->setValue(folly::unit);
                     } else {
+                      auto fallback_import_time
+                        = source_state->min_loaded_import_time();
                       self->schedule_fn(
                         [process_slice, slice = std::move(slice),
+                         fallback_import_time,
                          promise = std::move(promise_ptr)]() mutable {
-                          process_slice(std::move(slice));
+                          process_slice(std::move(slice), fallback_import_time);
                           promise->setValue(folly::unit);
                         });
                     }

--- a/libtenzir/src/partition_transformer.cpp
+++ b/libtenzir/src/partition_transformer.cpp
@@ -599,7 +599,7 @@ void partition_transformer_state::fulfill(
   // Return early if no error occured and no new data was created,
   // ie. the input was erased completely.
   if (self->state().events == 0) {
-    promise.deliver(partition_transform_result{
+    promise.deliver(partition_transformer_result{
       .input_partitions = self->state().transformed_input_partitions,
       .output_partitions = {},
       .input_complete = self->state().input_complete,
@@ -646,7 +646,7 @@ void partition_transformer_state::fulfill(
         quit_or_stall(self,
                       partition_transformer_state::transformer_is_finished{
                         .promise = std::move(promise),
-                        .result = partition_transform_result{
+                        .result = partition_transformer_result{
                           .input_partitions
                           = self->state().transformed_input_partitions,
                           .output_partitions = std::move(result),
@@ -1047,9 +1047,10 @@ auto partition_transformer(
       }();
       store_or_fulfill(self, std::move(stream_data));
     },
-    [self](atom::persist) -> caf::result<partition_transform_result> {
+    [self](atom::persist) -> caf::result<partition_transformer_result> {
       TENZIR_DEBUG("{} received request to persist", *self);
-      auto promise = self->make_response_promise<partition_transform_result>();
+      auto promise
+        = self->make_response_promise<partition_transformer_result>();
       auto path_data = partition_transformer_state::path_data{
         .promise = promise,
       };

--- a/libtenzir/src/partition_transformer.cpp
+++ b/libtenzir/src/partition_transformer.cpp
@@ -10,6 +10,7 @@
 
 #include "tenzir/async/executor.hpp"
 #include "tenzir/async/future_util.hpp"
+#include "tenzir/async/mail.hpp"
 #include "tenzir/atomic.hpp"
 #include "tenzir/co_match.hpp"
 #include "tenzir/compile_ctx.hpp"
@@ -19,7 +20,9 @@
 #include "tenzir/logger.hpp"
 #include "tenzir/partition_synopsis.hpp"
 #include "tenzir/passive_partition.hpp"
+#include "tenzir/pipeline.hpp"
 #include "tenzir/plugin.hpp"
+#include "tenzir/query_context.hpp"
 #include "tenzir/session.hpp"
 #include "tenzir/store.hpp"
 #include "tenzir/substitute_ctx.hpp"
@@ -194,6 +197,17 @@ auto live_budget_used(const memory_budget& budget)
   return std::pair{used, current->bytes};
 }
 
+auto collect_table_slices(caf::event_based_actor*,
+                          std::shared_ptr<std::vector<table_slice>> slices)
+  -> caf::behavior {
+  return {
+    [slices = std::move(slices)](table_slice slice) -> caf::result<void> {
+      slices->push_back(std::move(slice));
+      return {};
+    },
+  };
+}
+
 void store_or_fulfill(
   partition_transformer_actor::stateful_pointer<partition_transformer_state>
     self,
@@ -287,6 +301,7 @@ struct partition_source_state {
   caf::error error = {};
   tenzir::time min_import_time = tenzir::time::max();
   tenzir::time max_import_time = tenzir::time::min();
+  std::vector<partition_info> selected_partitions = {};
   std::vector<partition_info> loaded_partitions = {};
   bool input_complete = true;
 };
@@ -296,13 +311,16 @@ public:
   partition_loader(std::vector<partition_info> partitions,
                    std::string partition_path_template,
                    std::filesystem::path archive_dir,
+                   filesystem_actor filesystem,
                    std::shared_ptr<partition_source_state> state)
     : partitions_{std::move(partitions)},
       partition_path_template_{std::move(partition_path_template)},
       archive_dir_{std::move(archive_dir)},
+      filesystem_{std::move(filesystem)},
       memory_budget_{make_memory_budget()},
       state_{std::move(state)} {
     TENZIR_ASSERT(state_);
+    state_->selected_partitions = partitions_;
   }
 
   auto feed(Push<OperatorMsg<table_slice>>& push_input) const -> Task<void> {
@@ -334,7 +352,13 @@ public:
           break;
         }
       }
-      for (auto&& slice : load_partition(partition)) {
+      auto maybe_slices = co_await load_partition(partition);
+      if (not maybe_slices) {
+        fail(std::move(maybe_slices.error()));
+        co_await push_input(OperatorMsg<table_slice>{Signal{EndOfData{}}});
+        co_return;
+      }
+      for (auto&& slice : *maybe_slices) {
         const auto import_time = slice.import_time();
         state_->min_import_time
           = std::min(state_->min_import_time, import_time);
@@ -360,85 +384,104 @@ private:
   }
 
   auto load_partition(const partition_info& partition) const
-    -> generator<table_slice> {
+    -> Task<caf::expected<std::vector<table_slice>>> {
     const auto filename = fmt::format(
       TENZIR_FMT_RUNTIME(partition_path_template_), partition.uuid);
     auto partition_path = std::filesystem::path{filename};
     auto partition_chunk = chunk::mmap(partition_path);
     if (not partition_chunk) {
-      fail(diagnostic::error(partition_chunk.error())
-             .note("failed to mmap partition {} at {}", partition.uuid,
-                   partition_path)
-             .to_error());
-      co_return;
+      co_return diagnostic::error(partition_chunk.error())
+        .note("failed to mmap partition {} at {}", partition.uuid,
+              partition_path)
+        .to_error();
     }
     auto partition_state = passive_partition_state{};
     if (auto err = partition_state.initialize_from_chunk(*partition_chunk);
         err.valid()) {
-      fail(diagnostic::error(std::move(err))
-             .note("failed to load partition {}", partition.uuid)
-             .to_error());
-      co_return;
+      co_return diagnostic::error(std::move(err))
+        .note("failed to load partition {}", partition.uuid)
+        .to_error();
     }
     if (partition_state.id != partition.uuid) {
-      fail(caf::make_error(ec::format_error,
-                           "unexpected ID for passive partition: "
-                           "expected {}, got {}",
-                           partition.uuid, partition_state.id));
-      co_return;
+      co_return caf::make_error(ec::format_error,
+                                "unexpected ID for passive partition: "
+                                "expected {}, got {}",
+                                partition.uuid, partition_state.id);
     }
-    auto const* plugin = plugins::find<store_plugin>(partition_state.store_id);
+    if (auto const* plugin
+        = plugins::find<store_plugin>(partition_state.store_id)) {
+      if (partition_state.store_header.size() != uuid::num_bytes) {
+        co_return caf::make_error(ec::format_error,
+                                  "unexpected store header size for "
+                                  "partition {}: expected {}, got {}",
+                                  partition.uuid, uuid::num_bytes,
+                                  partition_state.store_header.size());
+      }
+      auto store = plugin->make_passive_store();
+      if (not store) {
+        co_return std::move(store.error());
+      }
+      const auto store_uuid
+        = uuid{partition_state.store_header.subspan<0, uuid::num_bytes>()};
+      auto store_path
+        = archive_dir_
+          / fmt::format("{}.{}", store_uuid, partition_state.store_id);
+      if (store_path.extension() == ".feather") {
+        TENZIR_DEBUG("{} loads feather store for partition {} from {}",
+                     "partition-transformer", partition.uuid, store_path);
+      }
+      auto store_chunk = chunk::mmap(store_path);
+      if (not store_chunk) {
+        co_return diagnostic::error(store_chunk.error())
+          .note("failed to mmap store for partition {} at {}", partition.uuid,
+                store_path)
+          .to_error();
+      }
+      if (auto err = (*store)->load(std::move(*store_chunk)); err.valid()) {
+        co_return diagnostic::error(std::move(err))
+          .note("failed to load store for partition {}", partition.uuid)
+          .to_error();
+      }
+      auto result = std::vector<table_slice>{};
+      for (auto&& slice : (*store)->slices()) {
+        result.push_back(std::move(slice));
+      }
+      co_return result;
+    }
+    auto const* plugin
+      = plugins::find<store_actor_plugin>(partition_state.store_id);
     if (not plugin) {
-      fail(caf::make_error(ec::format_error,
-                           "encountered unhandled store backend "
-                           "'{}' for partition {}",
-                           partition_state.store_id, partition.uuid));
-      co_return;
+      co_return caf::make_error(ec::format_error,
+                                "encountered unhandled store backend "
+                                "'{}' for partition {}",
+                                partition_state.store_id, partition.uuid);
     }
-    if (partition_state.store_header.size() != uuid::num_bytes) {
-      fail(caf::make_error(ec::format_error,
-                           "unexpected store header size for "
-                           "partition {}: expected {}, got {}",
-                           partition.uuid, uuid::num_bytes,
-                           partition_state.store_header.size()));
-      co_return;
-    }
-    auto store = plugin->make_passive_store();
+    auto store = plugin->make_store(filesystem_, partition_state.store_header);
     if (not store) {
-      fail(std::move(store.error()));
-      co_return;
+      co_return std::move(store.error());
     }
-    const auto store_uuid
-      = uuid{partition_state.store_header.subspan<0, uuid::num_bytes>()};
-    auto store_path
-      = archive_dir_
-        / fmt::format("{}.{}", store_uuid, partition_state.store_id);
-    if (store_path.extension() == ".feather") {
-      TENZIR_DEBUG("{} loads feather store for partition {} from {}",
-                   "partition-transformer", partition.uuid, store_path);
+    auto result = std::make_shared<std::vector<table_slice>>();
+    auto collector
+      = filesystem_->home_system().spawn(collect_table_slices, result);
+    auto query = query_context::make_extract(
+      "partition-transformer",
+      caf::actor_cast<receiver_actor<table_slice>>(collector),
+      trivially_true_expression());
+    query.id = uuid::random();
+    auto num_hits
+      = co_await async_mail(atom::query_v, std::move(query)).request(*store);
+    caf::anon_send_exit(collector, caf::exit_reason::user_shutdown);
+    caf::anon_send_exit(*store, caf::exit_reason::user_shutdown);
+    if (not num_hits) {
+      co_return std::move(num_hits.error());
     }
-    auto store_chunk = chunk::mmap(store_path);
-    if (not store_chunk) {
-      fail(diagnostic::error(store_chunk.error())
-             .note("failed to mmap store for partition {} at {}",
-                   partition.uuid, store_path)
-             .to_error());
-      co_return;
-    }
-    if (auto err = (*store)->load(std::move(*store_chunk)); err.valid()) {
-      fail(diagnostic::error(std::move(err))
-             .note("failed to load store for partition {}", partition.uuid)
-             .to_error());
-      co_return;
-    }
-    for (auto&& slice : (*store)->slices()) {
-      co_yield std::move(slice);
-    }
+    co_return std::move(*result);
   }
 
   std::vector<partition_info> partitions_;
   std::string partition_path_template_;
   std::filesystem::path archive_dir_;
+  filesystem_actor filesystem_;
   std::optional<memory_budget> memory_budget_;
   std::shared_ptr<partition_source_state> state_;
 };
@@ -779,6 +822,7 @@ auto partition_transformer(
               std::move(input_partitions),
               std::move(input_partition_path_template),
               std::move(archive_dir),
+              self->state().fs,
               source_state,
             };
             auto feed_input
@@ -874,7 +918,9 @@ auto partition_transformer(
             self->state().min_import_time = source_state->min_import_time;
             self->state().max_import_time = source_state->max_import_time;
             self->state().transformed_input_partitions
-              = std::move(source_state->loaded_partitions);
+              = source_state->input_complete
+                  ? std::move(source_state->selected_partitions)
+                  : std::move(source_state->loaded_partitions);
             self->state().input_complete = source_state->input_complete;
             finish_transform();
           });

--- a/libtenzir/src/partition_transformer.cpp
+++ b/libtenzir/src/partition_transformer.cpp
@@ -695,6 +695,7 @@ auto partition_transformer(
       auto input_partition_path_template
         = std::move(self->state().input_partition_path_template);
       auto archive_dir = std::move(self->state().archive_dir);
+      auto fs = self->state().fs;
       auto ast = std::move(self->state().transform);
       // We deliver `rp` immediately and signal real completion later via the
       // store-builder monitors set up in `finish_transform`.
@@ -708,8 +709,8 @@ auto partition_transformer(
           [ast = std::move(ast), input_partitions = std::move(input_partitions),
            input_partition_path_template
            = std::move(input_partition_path_template),
-           archive_dir = std::move(archive_dir), &sys, weak, self,
-           process_slice,
+           archive_dir = std::move(archive_dir), fs = std::move(fs), &sys, weak,
+           self, process_slice,
            source_state]() mutable -> folly::coro::Task<failure_or<void>> {
             // Compaction and rebuild have no user-facing diagnostic sink, so
             // we log to the server log. The handler is owned by this
@@ -723,7 +724,7 @@ auto partition_transformer(
               std::move(input_partitions),
               std::move(input_partition_path_template),
               std::move(archive_dir),
-              self->state().fs,
+              std::move(fs),
               source_state,
             };
             auto feed_input

--- a/libtenzir/src/partition_transformer.cpp
+++ b/libtenzir/src/partition_transformer.cpp
@@ -9,8 +9,10 @@
 #include "tenzir/partition_transformer.hpp"
 
 #include "tenzir/async/executor.hpp"
+#include "tenzir/async/future_util.hpp"
 #include "tenzir/atomic.hpp"
 #include "tenzir/base_ctx.hpp"
+#include "tenzir/co_match.hpp"
 #include "tenzir/compile_ctx.hpp"
 #include "tenzir/detail/fanout_counter.hpp"
 #include "tenzir/fbs/utils.hpp"
@@ -27,8 +29,12 @@
 #include <caf/event_based_actor.hpp>
 #include <caf/make_copy_on_write.hpp>
 #include <flatbuffers/flatbuffers.h>
+#include <folly/Unit.h>
 #include <folly/coro/Invoke.h>
 #include <folly/executors/GlobalExecutor.h>
+#include <folly/futures/Future.h>
+
+#include <memory>
 
 namespace tenzir {
 
@@ -330,29 +336,29 @@ auto partition_transformer(
       self->state().input.push_back(std::move(slice));
     },
     [self](atom::done) -> caf::result<void> {
-      auto process_slices = [self](std::vector<table_slice> slices) {
-        for (auto& slice : slices) {
-          auto& partition_data = self->state().create_or_get_partition(slice);
-          if (not partition_data.synopsis) {
-            partition_data.id = tenzir::uuid::random();
-            partition_data.store_id = self->state().store_id;
-            partition_data.events = 0ull;
-            partition_data.synopsis
-              = caf::make_copy_on_write<partition_synopsis>();
-          }
-          auto* unshared_synopsis = partition_data.synopsis.unshared_ptr();
-          if (slice.import_time() == time{}) {
-            slice.import_time(self->state().min_import_time);
-          }
-          unshared_synopsis->min_import_time
-            = std::min(unshared_synopsis->min_import_time, slice.import_time());
-          unshared_synopsis->max_import_time
-            = std::max(unshared_synopsis->max_import_time, slice.import_time());
-          partition_data.events += slice.rows();
-          self->state().events += slice.rows();
-          self->state().partition_buildup[partition_data.id].slices.push_back(
-            std::move(slice));
+      auto process_slice = [self](table_slice slice) {
+        auto& partition_data = self->state().create_or_get_partition(slice);
+        if (not partition_data.synopsis) {
+          partition_data.id = tenzir::uuid::random();
+          partition_data.store_id = self->state().store_id;
+          partition_data.events = 0ull;
+          partition_data.synopsis
+            = caf::make_copy_on_write<partition_synopsis>();
         }
+        auto* unshared_synopsis = partition_data.synopsis.unshared_ptr();
+        if (slice.import_time() == time{}) {
+          slice.import_time(self->state().min_import_time);
+        }
+        unshared_synopsis->min_import_time
+          = std::min(unshared_synopsis->min_import_time, slice.import_time());
+        unshared_synopsis->max_import_time
+          = std::max(unshared_synopsis->max_import_time, slice.import_time());
+        partition_data.events += slice.rows();
+        self->state().events += slice.rows();
+        self->state().partition_buildup[partition_data.id].slices.push_back(
+          std::move(slice));
+      };
+      auto finish_transform = [self]() {
         auto stream_data = partition_transformer_state::stream_data{
           .partition_chunks
           = std::vector<std::tuple<tenzir::uuid, tenzir::type, chunk_ptr>>{},
@@ -419,66 +425,112 @@ auto partition_transformer(
       auto input = std::exchange(self->state().input, {});
       auto ast = std::move(self->state().transform);
       // We deliver `rp` immediately and signal real completion later via the
-      // store-builder monitors set up in `process_slices`.
+      // store-builder monitors set up in `finish_transform`.
       auto rp = self->make_response_promise<void>();
       auto weak = caf::weak_actor_ptr{self->ctrl(), caf::add_ref};
       auto& sys = self->system();
       folly::coro::co_withExecutor(
         folly::getGlobalCPUExecutor(),
-        folly::coro::co_invoke(
-          [ast = std::move(ast), input = std::move(input), &sys]() mutable
-            -> folly::coro::Task<failure_or<std::vector<table_slice>>> {
-            // Compaction and rebuild have no user-facing diagnostic sink, so
-            // we log to the server log. The handler is owned by this
-            // coroutine frame so its address is stable across awaits and it
-            // outlives every operator inside `run_transform` that references
-            // it.
-            auto dh = TransformerDiagHandler{};
-            CO_TRY(auto chain,
-                   compile_table_slice_transform(std::move(ast), dh));
-            CO_TRY(auto slices,
-                   co_await run_transform(std::move(input), std::move(chain),
-                                          sys, dh, NoProfiler{},
-                                          /*is_hidden=*/true));
-            co_return std::move(slices);
-          }))
-        .start(
-          [self, weak = std::move(weak),
-           process_slices = std::move(process_slices)](
-            folly::Try<failure_or<std::vector<table_slice>>>&& result) mutable {
-            auto strong = weak.lock();
-            if (not strong) {
-              return;
-            }
-            // We're on the folly executor thread here. All mutations of actor
-            // state must happen inside the `schedule_fn` body, which runs on
-            // the actor's thread.
-            auto error = caf::error{};
-            auto slices = std::vector<table_slice>{};
-            if (result.hasException()) {
-              error = caf::make_error(ec::logic_error,
-                                      fmt::format("partition transform: {}",
-                                                  result.exception().what()));
-            } else if (result.value().is_error()) {
-              error = caf::make_error(ec::logic_error,
-                                      "partition transform: pipeline failed; "
-                                      "see server log for diagnostics");
-            } else {
-              slices = std::move(result.value()).unwrap();
-            }
-            self->schedule_fn([self, process_slices = std::move(process_slices),
-                               slices = std::move(slices),
-                               error = std::move(error)]() mutable {
-              if (error) {
-                TENZIR_ERROR("{} pipeline executor failed: {}", *self, error);
-                self->state().transform_error = std::move(error);
-              } else {
-                TENZIR_DEBUG("{} pipeline executor completed successfully",
-                             *self);
+        folly::coro::co_invoke([ast = std::move(ast), input = std::move(input),
+                                &sys, weak, self, process_slice]() mutable
+                                 -> folly::coro::Task<failure_or<void>> {
+          // Compaction and rebuild have no user-facing diagnostic sink, so
+          // we log to the server log. The handler is owned by this
+          // coroutine frame so its address is stable across awaits and it
+          // outlives every operator inside `run_transform` that references
+          // it.
+          auto dh = TransformerDiagHandler{};
+          CO_TRY(auto chain, compile_table_slice_transform(std::move(ast), dh));
+          auto feed_input =
+            [input_slices = std::move(input)](
+              Push<OperatorMsg<table_slice>>& push_input) mutable -> Task<void> {
+            for (auto& slice : input_slices) {
+              if (slice.rows() == 0) {
+                continue;
               }
-              process_slices(std::move(slices));
-            });
+              co_await push_input(OperatorMsg<table_slice>{std::move(slice)});
+            }
+            co_await push_input(OperatorMsg<table_slice>{Signal{EndOfData{}}});
+          };
+          auto drain_output
+            = [self, weak, process_slice](
+                Pull<OperatorMsg<table_slice>>& pull_output) mutable
+            -> Task<void> {
+            while (auto msg = co_await pull_output()) {
+              co_await co_match(
+                std::move(*msg),
+                [&](table_slice slice) -> Task<void> {
+                  if (slice.rows() == 0) {
+                    co_return;
+                  }
+                  auto [promise, future]
+                    = folly::makePromiseContract<folly::Unit>();
+                  auto promise_ptr
+                    = std::make_shared<folly::Promise<folly::Unit>>(
+                      std::move(promise));
+                  auto strong = weak.lock();
+                  if (not strong) {
+                    promise_ptr->setValue(folly::unit);
+                  } else {
+                    self->schedule_fn(
+                      [process_slice, slice = std::move(slice),
+                       promise = std::move(promise_ptr)]() mutable {
+                        process_slice(std::move(slice));
+                        promise->setValue(folly::unit);
+                      });
+                  }
+                  co_await to_task_interrupt_on_cancel(std::move(future));
+                },
+                [&](Signal signal) -> Task<void> {
+                  co_await co_match(
+                    signal,
+                    [&](EndOfData) -> Task<void> {
+                      co_return;
+                    },
+                    [&](Checkpoint) -> Task<void> {
+                      co_return;
+                    });
+                });
+            }
+          };
+          CO_TRY(co_await run_transform(
+            std::move(chain), sys, dh, NoProfiler{}, /*is_hidden=*/true,
+            std::move(feed_input), std::move(drain_output)));
+          co_return {};
+        }))
+        .start([self, weak = std::move(weak),
+                finish_transform = std::move(finish_transform)](
+                 folly::Try<failure_or<void>>&& result) mutable {
+          auto strong = weak.lock();
+          if (not strong) {
+            return;
+          }
+          // We're on the folly executor thread here. All mutations of actor
+          // state must happen inside the `schedule_fn` body, which runs on
+          // the actor's thread.
+          auto error = caf::error{};
+          if (result.hasException()) {
+            error = caf::make_error(ec::logic_error,
+                                    fmt::format("partition transform: {}",
+                                                result.exception().what()));
+          } else if (result.value().is_error()) {
+            error = caf::make_error(ec::logic_error,
+                                    "partition transform: pipeline failed; "
+                                    "see server log for diagnostics");
+          }
+          self->schedule_fn([self,
+                             finish_transform = std::move(finish_transform),
+                             error = std::move(error)]() mutable {
+            if (error) {
+              TENZIR_ERROR("{} pipeline executor failed: {}", *self, error);
+              self->state().transform_error = std::move(error);
+            } else {
+              TENZIR_DEBUG("{} pipeline executor completed successfully",
+                           *self);
+            }
+            finish_transform();
           });
+        });
       rp.deliver();
       return rp;
     },

--- a/libtenzir/src/partition_transformer.cpp
+++ b/libtenzir/src/partition_transformer.cpp
@@ -80,12 +80,18 @@ auto read_cgroup_memory_available(const std::filesystem::path& dir,
     current = read_memory_value(dir / "memory.usage_in_bytes");
     max = read_memory_value(dir / "memory.limit_in_bytes");
   }
-  if (not current or not max or *current >= *max) {
+  if (not current or not max) {
     return std::nullopt;
   }
   static constexpr auto unlimited_cgroup_limit = uint64_t{1} << 60;
   if (*max >= unlimited_cgroup_limit) {
     return std::nullopt;
+  }
+  if (*current >= *max) {
+    return memory_available{
+      .bytes = 0,
+      .source = std::move(source),
+    };
   }
   return memory_available{
     .bytes = *max - *current,
@@ -171,7 +177,7 @@ auto make_memory_budget() -> std::optional<memory_budget> {
   }
   return memory_budget{
     .initial_available = available->bytes,
-    .bytes = std::max(available->bytes / 4, uint64_t{1}),
+    .bytes = available->bytes / 4,
     .source = std::move(available->source),
   };
 }
@@ -282,6 +288,7 @@ struct partition_source_state {
   tenzir::time min_import_time = tenzir::time::max();
   tenzir::time max_import_time = tenzir::time::min();
   std::vector<partition_info> loaded_partitions = {};
+  bool input_complete = true;
 };
 
 class partition_loader {
@@ -300,9 +307,21 @@ public:
 
   auto feed(Push<OperatorMsg<table_slice>>& push_input) const -> Task<void> {
     for (const auto& partition : partitions_) {
-      if (memory_budget_ and not state_->loaded_partitions.empty()) {
+      if (memory_budget_) {
         if (auto used = live_budget_used(*memory_budget_);
             used and used->first >= memory_budget_->bytes) {
+          if (state_->loaded_partitions.empty()) {
+            fail(caf::make_error(ec::out_of_memory,
+                                 "partition transform memory budget is "
+                                 "exhausted before loading partition {} "
+                                 "({} bytes used, {} bytes budget, {} bytes "
+                                 "available, source: {})",
+                                 partition.uuid, used->first,
+                                 memory_budget_->bytes, used->second,
+                                 memory_budget_->source));
+            co_await push_input(OperatorMsg<table_slice>{Signal{EndOfData{}}});
+            co_return;
+          }
           TENZIR_VERBOSE("{} stops loading transform input before partition {} "
                          "after {} partition(s); live memory budget is full "
                          "({} bytes used, {} bytes budget, {} bytes available, "
@@ -311,6 +330,7 @@ public:
                          state_->loaded_partitions.size(), used->first,
                          memory_budget_->bytes, used->second,
                          memory_budget_->source);
+          state_->input_complete = false;
           break;
         }
       }
@@ -523,6 +543,7 @@ void partition_transformer_state::fulfill(
     promise.deliver(partition_transform_result{
       .input_partitions = self->state().transformed_input_partitions,
       .output_partitions = {},
+      .input_complete = self->state().input_complete,
     });
     self->quit();
     return;
@@ -570,6 +591,7 @@ void partition_transformer_state::fulfill(
                           .input_partitions
                           = self->state().transformed_input_partitions,
                           .output_partitions = std::move(result),
+                          .input_complete = self->state().input_complete,
                         },
                       });
       },
@@ -837,6 +859,9 @@ auto partition_transformer(
             if (error) {
               TENZIR_ERROR("{} pipeline executor failed: {}", *self, error);
               self->state().transform_error = std::move(error);
+              store_or_fulfill(self,
+                               partition_transformer_state::stream_data{});
+              return;
             } else if (source_state->error.valid()) {
               self->state().stream_error = std::move(source_state->error);
               store_or_fulfill(self,
@@ -850,6 +875,7 @@ auto partition_transformer(
             self->state().max_import_time = source_state->max_import_time;
             self->state().transformed_input_partitions
               = std::move(source_state->loaded_partitions);
+            self->state().input_complete = source_state->input_complete;
             finish_transform();
           });
         });

--- a/libtenzir/src/partition_transformer.cpp
+++ b/libtenzir/src/partition_transformer.cpp
@@ -19,8 +19,10 @@
 #include "tenzir/ir.hpp"
 #include "tenzir/logger.hpp"
 #include "tenzir/partition_synopsis.hpp"
+#include "tenzir/passive_partition.hpp"
 #include "tenzir/plugin.hpp"
 #include "tenzir/session.hpp"
+#include "tenzir/store.hpp"
 #include "tenzir/substitute_ctx.hpp"
 #include "tenzir/tql2/exec.hpp"
 #include "tenzir/try.hpp"
@@ -34,6 +36,7 @@
 #include <folly/executors/GlobalExecutor.h>
 #include <folly/futures/Future.h>
 
+#include <filesystem>
 #include <memory>
 
 namespace tenzir {
@@ -127,6 +130,129 @@ public:
 
 private:
   Atomic<bool> failed_ = false;
+};
+
+struct partition_source_state {
+  caf::error error = {};
+  tenzir::time min_import_time = tenzir::time::max();
+  tenzir::time max_import_time = tenzir::time::min();
+};
+
+class partition_loader {
+public:
+  partition_loader(std::vector<partition_info> partitions,
+                   std::string partition_path_template,
+                   std::filesystem::path archive_dir,
+                   std::shared_ptr<partition_source_state> state)
+    : partitions_{std::move(partitions)},
+      partition_path_template_{std::move(partition_path_template)},
+      archive_dir_{std::move(archive_dir)},
+      state_{std::move(state)} {
+    TENZIR_ASSERT(state_);
+  }
+
+  auto feed(Push<OperatorMsg<table_slice>>& push_input) const -> Task<void> {
+    for (const auto& partition : partitions_) {
+      for (auto&& slice : load_partition(partition)) {
+        const auto import_time = slice.import_time();
+        state_->min_import_time
+          = std::min(state_->min_import_time, import_time);
+        state_->max_import_time
+          = std::max(state_->max_import_time, import_time);
+        if (slice.rows() == 0) {
+          continue;
+        }
+        co_await push_input(OperatorMsg<table_slice>{std::move(slice)});
+      }
+      if (state_->error.valid()) {
+        co_return;
+      }
+    }
+    co_await push_input(OperatorMsg<table_slice>{Signal{EndOfData{}}});
+  }
+
+private:
+  void fail(caf::error error) const {
+    state_->error = std::move(error);
+  }
+
+  auto load_partition(const partition_info& partition) const
+    -> generator<table_slice> {
+    const auto filename = fmt::format(
+      TENZIR_FMT_RUNTIME(partition_path_template_), partition.uuid);
+    auto partition_path = std::filesystem::path{filename};
+    auto partition_chunk = chunk::mmap(partition_path);
+    if (not partition_chunk) {
+      fail(diagnostic::error(partition_chunk.error())
+             .note("failed to mmap partition {} at {}", partition.uuid,
+                   partition_path)
+             .to_error());
+      co_return;
+    }
+    auto partition_state = passive_partition_state{};
+    if (auto err = partition_state.initialize_from_chunk(*partition_chunk);
+        err.valid()) {
+      fail(diagnostic::error(std::move(err))
+             .note("failed to load partition {}", partition.uuid)
+             .to_error());
+      co_return;
+    }
+    if (partition_state.id != partition.uuid) {
+      fail(caf::make_error(ec::format_error,
+                           "unexpected ID for passive partition: "
+                           "expected {}, got {}",
+                           partition.uuid, partition_state.id));
+      co_return;
+    }
+    auto const* plugin = plugins::find<store_plugin>(partition_state.store_id);
+    if (not plugin) {
+      fail(caf::make_error(ec::format_error,
+                           "encountered unhandled store backend "
+                           "'{}' for partition {}",
+                           partition_state.store_id, partition.uuid));
+      co_return;
+    }
+    if (partition_state.store_header.size() != uuid::num_bytes) {
+      fail(caf::make_error(ec::format_error,
+                           "unexpected store header size for "
+                           "partition {}: expected {}, got {}",
+                           partition.uuid, uuid::num_bytes,
+                           partition_state.store_header.size()));
+      co_return;
+    }
+    auto store = plugin->make_passive_store();
+    if (not store) {
+      fail(std::move(store.error()));
+      co_return;
+    }
+    const auto store_uuid
+      = uuid{partition_state.store_header.subspan<0, uuid::num_bytes>()};
+    auto store_path
+      = archive_dir_
+        / fmt::format("{}.{}", store_uuid, partition_state.store_id);
+    auto store_chunk = chunk::mmap(store_path);
+    if (not store_chunk) {
+      fail(diagnostic::error(store_chunk.error())
+             .note("failed to mmap store for partition {} at {}",
+                   partition.uuid, store_path)
+             .to_error());
+      co_return;
+    }
+    if (auto err = (*store)->load(std::move(*store_chunk)); err.valid()) {
+      fail(diagnostic::error(std::move(err))
+             .note("failed to load store for partition {}", partition.uuid)
+             .to_error());
+      co_return;
+    }
+    for (auto&& slice : (*store)->slices()) {
+      co_yield std::move(slice);
+    }
+  }
+
+  std::vector<partition_info> partitions_;
+  std::string partition_path_template_;
+  std::filesystem::path archive_dir_;
+  std::shared_ptr<partition_source_state> state_;
 };
 
 /// Compile an AST `table_slice -> table_slice` pipeline to a closed operator
@@ -309,10 +435,13 @@ auto partition_transformer(
     self,
   std::string store_id, const index_config& synopsis_opts,
   const caf::settings& index_opts, catalog_actor catalog, filesystem_actor fs,
-  ast::pipeline transform, std::string partition_path_template,
-  std::string synopsis_path_template, std::string origin)
-  -> partition_transformer_actor::behavior_type {
+  std::vector<partition_info> input_partitions, ast::pipeline transform,
+  std::string input_partition_path_template,
+  std::string partition_path_template, std::string synopsis_path_template,
+  std::string origin) -> partition_transformer_actor::behavior_type {
   self->state().synopsis_opts = synopsis_opts;
+  self->state().input_partition_path_template
+    = std::move(input_partition_path_template);
   self->state().partition_path_template = std::move(partition_path_template);
   self->state().synopsis_path_template = std::move(synopsis_path_template);
   // For historic reasons, the `tenzir.max-partition-size` is stored as the
@@ -322,18 +451,16 @@ auto partition_transformer(
   self->state().index_opts = index_opts;
   self->state().fs = std::move(fs);
   self->state().catalog = std::move(catalog);
+  self->state().input_partitions = std::move(input_partitions);
   self->state().transform = std::move(transform);
   self->state().store_id = std::move(store_id);
   self->state().origin = std::move(origin);
+  self->mail(atom::done_v).send(static_cast<partition_transformer_actor>(self));
   return {
-    [self](tenzir::table_slice& slice) {
-      // Adjust the import time range iff necessary.
-      const auto old_import_time = slice.import_time();
-      self->state().min_import_time
-        = std::min(self->state().min_import_time, old_import_time);
-      self->state().max_import_time
-        = std::max(self->state().max_import_time, old_import_time);
-      self->state().input.push_back(std::move(slice));
+    [](tenzir::table_slice&) -> caf::result<void> {
+      return caf::make_error(ec::logic_error,
+                             "partition transformer no longer accepts "
+                             "externally pushed table slices");
     },
     [self](atom::done) -> caf::result<void> {
       auto process_slice = [self](table_slice slice) {
@@ -420,85 +547,104 @@ auto partition_transformer(
         self->mail(atom::internal_v, atom::resume_v, atom::done_v)
           .send(static_cast<partition_transformer_actor>(self));
       };
-      // Move input and AST out so the actor's state is empty when the run
-      // begins; they live inside the coroutine until it finishes.
-      auto input = std::exchange(self->state().input, {});
+      auto db_dir = std::filesystem::path{caf::get_or(
+        content(self->state().fs->home_system().config()),
+        "tenzir.state-directory", defaults::state_directory.data())};
+      std::error_code err{};
+      auto archive_dir = std::filesystem::absolute(db_dir, err) / "archive";
+      if (err) {
+        return caf::make_error(ec::filesystem_error,
+                               "failed to resolve state directory {}: {}",
+                               db_dir, err.message());
+      }
+      // Move input metadata and AST out so the actor's state is empty when the
+      // run begins; they live inside the coroutine until it finishes.
+      auto input_partitions = std::exchange(self->state().input_partitions, {});
+      auto input_partition_path_template
+        = std::move(self->state().input_partition_path_template);
       auto ast = std::move(self->state().transform);
       // We deliver `rp` immediately and signal real completion later via the
       // store-builder monitors set up in `finish_transform`.
       auto rp = self->make_response_promise<void>();
       auto weak = caf::weak_actor_ptr{self->ctrl(), caf::add_ref};
       auto& sys = self->system();
+      auto source_state = std::make_shared<partition_source_state>();
       folly::coro::co_withExecutor(
         folly::getGlobalCPUExecutor(),
-        folly::coro::co_invoke([ast = std::move(ast), input = std::move(input),
-                                &sys, weak, self, process_slice]() mutable
-                                 -> folly::coro::Task<failure_or<void>> {
-          // Compaction and rebuild have no user-facing diagnostic sink, so
-          // we log to the server log. The handler is owned by this
-          // coroutine frame so its address is stable across awaits and it
-          // outlives every operator inside `run_transform` that references
-          // it.
-          auto dh = TransformerDiagHandler{};
-          CO_TRY(auto chain, compile_table_slice_transform(std::move(ast), dh));
-          auto feed_input =
-            [input_slices = std::move(input)](
-              Push<OperatorMsg<table_slice>>& push_input) mutable -> Task<void> {
-            for (auto& slice : input_slices) {
-              if (slice.rows() == 0) {
-                continue;
-              }
-              co_await push_input(OperatorMsg<table_slice>{std::move(slice)});
-            }
-            co_await push_input(OperatorMsg<table_slice>{Signal{EndOfData{}}});
-          };
-          auto drain_output
-            = [self, weak, process_slice](
-                Pull<OperatorMsg<table_slice>>& pull_output) mutable
-            -> Task<void> {
-            while (auto msg = co_await pull_output()) {
-              co_await co_match(
-                std::move(*msg),
-                [&](table_slice slice) -> Task<void> {
-                  if (slice.rows() == 0) {
-                    co_return;
-                  }
-                  auto [promise, future]
-                    = folly::makePromiseContract<folly::Unit>();
-                  auto promise_ptr
-                    = std::make_shared<folly::Promise<folly::Unit>>(
-                      std::move(promise));
-                  auto strong = weak.lock();
-                  if (not strong) {
-                    promise_ptr->setValue(folly::unit);
-                  } else {
-                    self->schedule_fn(
-                      [process_slice, slice = std::move(slice),
-                       promise = std::move(promise_ptr)]() mutable {
-                        process_slice(std::move(slice));
-                        promise->setValue(folly::unit);
+        folly::coro::co_invoke(
+          [ast = std::move(ast), input_partitions = std::move(input_partitions),
+           input_partition_path_template
+           = std::move(input_partition_path_template),
+           archive_dir = std::move(archive_dir), &sys, weak, self,
+           process_slice,
+           source_state]() mutable -> folly::coro::Task<failure_or<void>> {
+            // Compaction and rebuild have no user-facing diagnostic sink, so
+            // we log to the server log. The handler is owned by this
+            // coroutine frame so its address is stable across awaits and it
+            // outlives every operator inside `run_transform` that references
+            // it.
+            auto dh = TransformerDiagHandler{};
+            CO_TRY(auto chain,
+                   compile_table_slice_transform(std::move(ast), dh));
+            auto loader = partition_loader{
+              std::move(input_partitions),
+              std::move(input_partition_path_template),
+              std::move(archive_dir),
+              source_state,
+            };
+            auto feed_input
+              = [loader = std::move(loader)](
+                  Push<OperatorMsg<table_slice>>& push_input) mutable
+              -> Task<void> {
+              co_await loader.feed(push_input);
+            };
+            auto drain_output
+              = [self, weak, process_slice](
+                  Pull<OperatorMsg<table_slice>>& pull_output) mutable
+              -> Task<void> {
+              while (auto msg = co_await pull_output()) {
+                co_await co_match(
+                  std::move(*msg),
+                  [&](table_slice slice) -> Task<void> {
+                    if (slice.rows() == 0) {
+                      co_return;
+                    }
+                    auto [promise, future]
+                      = folly::makePromiseContract<folly::Unit>();
+                    auto promise_ptr
+                      = std::make_shared<folly::Promise<folly::Unit>>(
+                        std::move(promise));
+                    auto strong = weak.lock();
+                    if (not strong) {
+                      promise_ptr->setValue(folly::unit);
+                    } else {
+                      self->schedule_fn(
+                        [process_slice, slice = std::move(slice),
+                         promise = std::move(promise_ptr)]() mutable {
+                          process_slice(std::move(slice));
+                          promise->setValue(folly::unit);
+                        });
+                    }
+                    co_await to_task_interrupt_on_cancel(std::move(future));
+                  },
+                  [&](Signal signal) -> Task<void> {
+                    co_await co_match(
+                      signal,
+                      [&](EndOfData) -> Task<void> {
+                        co_return;
+                      },
+                      [&](Checkpoint) -> Task<void> {
+                        co_return;
                       });
-                  }
-                  co_await to_task_interrupt_on_cancel(std::move(future));
-                },
-                [&](Signal signal) -> Task<void> {
-                  co_await co_match(
-                    signal,
-                    [&](EndOfData) -> Task<void> {
-                      co_return;
-                    },
-                    [&](Checkpoint) -> Task<void> {
-                      co_return;
-                    });
-                });
-            }
-          };
-          CO_TRY(co_await run_transform(
-            std::move(chain), sys, dh, NoProfiler{}, /*is_hidden=*/true,
-            std::move(feed_input), std::move(drain_output)));
-          co_return {};
-        }))
-        .start([self, weak = std::move(weak),
+                  });
+              }
+            };
+            CO_TRY(co_await run_transform(
+              std::move(chain), sys, dh, NoProfiler{}, /*is_hidden=*/true,
+              std::move(feed_input), std::move(drain_output)));
+            co_return {};
+          }))
+        .start([self, weak = std::move(weak), source_state,
                 finish_transform = std::move(finish_transform)](
                  folly::Try<failure_or<void>>&& result) mutable {
           auto strong = weak.lock();
@@ -520,14 +666,21 @@ auto partition_transformer(
           }
           self->schedule_fn([self,
                              finish_transform = std::move(finish_transform),
-                             error = std::move(error)]() mutable {
+                             source_state, error = std::move(error)]() mutable {
             if (error) {
               TENZIR_ERROR("{} pipeline executor failed: {}", *self, error);
               self->state().transform_error = std::move(error);
+            } else if (source_state->error.valid()) {
+              self->state().stream_error = std::move(source_state->error);
+              store_or_fulfill(self,
+                               partition_transformer_state::stream_data{});
+              return;
             } else {
               TENZIR_DEBUG("{} pipeline executor completed successfully",
                            *self);
             }
+            self->state().min_import_time = source_state->min_import_time;
+            self->state().max_import_time = source_state->max_import_time;
             finish_transform();
           });
         });
@@ -542,6 +695,9 @@ auto partition_transformer(
         auto& buildup = self->state().partition_buildup.at(data.id);
         auto offset = id{0};
         for (auto& slice : buildup.slices) {
+          if (slice.import_time() == time{}) {
+            slice.import_time(self->state().min_import_time);
+          }
           slice.offset(offset);
           offset += slice.rows();
           self->mail(slice).send(data.builder);

--- a/libtenzir/src/tql2/exec.cpp
+++ b/libtenzir/src/tql2/exec.cpp
@@ -2075,11 +2075,10 @@ auto run_plan(OperatorChain<void, void> chain, caf::actor_system& sys,
                               false, is_hidden);
 }
 
-auto run_transform(std::vector<table_slice> input,
-                   OperatorChain<table_slice, table_slice> chain,
+auto run_transform(OperatorChain<table_slice, table_slice> chain,
                    caf::actor_system& sys, DiagHandler& dh, Profiler profiler,
-                   bool is_hidden)
-  -> Task<failure_or<std::vector<table_slice>>> {
+                   bool is_hidden, TransformFeeder feed_input,
+                   TransformDrainer drain_output) -> Task<failure_or<void>> {
   auto exec_ctx = TestExecCtx{profiler, /*has_terminal=*/false, is_hidden};
   auto num_ops = chain.size();
   TENZIR_ASSERT(num_ops > 0);
@@ -2095,7 +2094,6 @@ auto run_transform(std::vector<table_slice> input,
   // chain's `JoinSet` open forever.
   auto from_ctl_recv = std::get<1>(channel<FromControl>(16));
   auto [to_ctl_send, to_ctl_recv] = channel<ToControl>(16);
-  auto output_slices = std::vector<table_slice>{};
   // Feeder cancellation. The chain's receiver may be dropped before the feeder
   // pushes all input (for example, a `head N` operator inside the transform
   // emits `no_more_input` after seeing N events). Because dropping a receiver
@@ -2119,17 +2117,11 @@ auto run_transform(std::vector<table_slice> input,
     // Feeder. Drops `push_input` on exit, closing the input channel. Honors
     // `feed_cancel` so we exit promptly if the chain stops reading upstream.
     scope.spawn(folly::coro::co_invoke(
-      [input_slices = std::move(input), push_input = std::move(push_input),
+      [&feed_input, push_input = std::move(push_input),
        token = feed_cancel.getToken()]() mutable -> Task<void> {
         co_await folly::coro::co_withCancellation(
           token, folly::coro::co_invoke([&]() mutable -> Task<void> {
-            for (auto& slice : input_slices) {
-              if (slice.rows() == 0) {
-                continue;
-              }
-              co_await push_input(OperatorMsg<table_slice>{std::move(slice)});
-            }
-            co_await push_input(OperatorMsg<table_slice>{Signal{EndOfData{}}});
+            co_await feed_input(*push_input);
           }));
       }));
     // Drain control messages and react to `no_more_input` by cancelling the
@@ -2143,7 +2135,32 @@ auto run_transform(std::vector<table_slice> input,
         }
       }
     }));
-    // Output drainer.
+    co_await drain_output(*pull_output);
+    scope.cancel();
+  });
+  co_return dh.failure();
+}
+
+auto run_transform(std::vector<table_slice> input,
+                   OperatorChain<table_slice, table_slice> chain,
+                   caf::actor_system& sys, DiagHandler& dh, Profiler profiler,
+                   bool is_hidden)
+  -> Task<failure_or<std::vector<table_slice>>> {
+  auto output_slices = std::vector<table_slice>{};
+  auto feed_input
+    = [input_slices = std::move(input)](
+        Push<OperatorMsg<table_slice>>& push_input) mutable -> Task<void> {
+    for (auto& slice : input_slices) {
+      if (slice.rows() == 0) {
+        continue;
+      }
+      co_await push_input(OperatorMsg<table_slice>{std::move(slice)});
+    }
+    co_await push_input(OperatorMsg<table_slice>{Signal{EndOfData{}}});
+  };
+  auto drain_output
+    = [&output_slices](
+        Pull<OperatorMsg<table_slice>>& pull_output) mutable -> Task<void> {
     while (auto msg = co_await pull_output()) {
       co_await co_match(
         std::move(*msg),
@@ -2164,9 +2181,10 @@ auto run_transform(std::vector<table_slice> input,
             });
         });
     }
-    scope.cancel();
-  });
-  CO_TRY(dh.failure());
+  };
+  CO_TRY(co_await run_transform(std::move(chain), sys, dh, std::move(profiler),
+                                is_hidden, std::move(feed_input),
+                                std::move(drain_output)));
   co_return output_slices;
 }
 


### PR DESCRIPTION
## 🔍 Problem

Partition transforms still route input through the index query path before running the transform pipeline. That keeps the index involved in materializing rebuild and compaction input data and limits how much backpressure the transformer can apply.

## 🛠️ Solution

- Split `run_transform` so callers can feed input and drain output incrementally.
- Pass selected partition metadata to the partition transformer.
- Let the transformer load selected partitions itself and feed them into the transform runner one partition at a time.
- Keep transformed output draining incremental on the actor side.
- Report partially consumed transform inputs so rebuild can retry selected partitions that were not loaded under memory pressure.

## 💬 Review

Focus on the transformer/index handoff and the lifetime boundaries around loaded partition stores, the transform runner feeder/drainer callbacks, and actor-thread state mutation.

<sub>
📚 Docs PR: tenzir/docs#373<br>
📎 Related: tenzir/tenzir-plugins#554<br>
Resolves TNZ-628.<br>
Resolves TNZ-548.<br>
Resolves TNZ-419.
</sub>