### PR TITLE
Cache resolved secrets

### DIFF
--- a/libtenzir/include/tenzir/async/shared_mutex.hpp
+++ b/libtenzir/include/tenzir/async/shared_mutex.hpp
@@ -1,0 +1,321 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "tenzir/async/semaphore.hpp"
+#include "tenzir/async/task.hpp"
+#include "tenzir/atomic.hpp"
+#include "tenzir/detail/assert.hpp"
+#include "tenzir/option.hpp"
+
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+namespace tenzir {
+
+class RawSharedMutex;
+
+template <class T>
+class SharedMutex;
+
+namespace detail {
+
+enum class SharedMutexMode {
+  unique,
+  shared,
+};
+
+template <SharedMutexMode Mode>
+class [[nodiscard]] RawSharedMutexGuard {
+public:
+  ~RawSharedMutexGuard() noexcept {
+    maybe_unlock();
+  }
+
+  RawSharedMutexGuard(RawSharedMutexGuard&& other) noexcept
+    : locked_{std::exchange(other.locked_, nullptr)},
+      turnstile_{std::move(other.turnstile_)},
+      room_empty_{std::move(other.room_empty_)} {
+  }
+
+  auto operator=(RawSharedMutexGuard&& other) noexcept -> RawSharedMutexGuard& {
+    if (this == &other) {
+      return *this;
+    }
+    maybe_unlock();
+    locked_ = std::exchange(other.locked_, nullptr);
+    turnstile_ = std::move(other.turnstile_);
+    room_empty_ = std::move(other.room_empty_);
+    return *this;
+  }
+  RawSharedMutexGuard(RawSharedMutexGuard const&) = delete;
+  auto operator=(RawSharedMutexGuard const&) -> RawSharedMutexGuard& = delete;
+
+  auto unlock() -> void;
+
+private:
+  auto maybe_unlock() -> void {
+    if (locked_) {
+      unlock();
+    }
+  }
+
+  friend class tenzir::RawSharedMutex;
+
+  explicit RawSharedMutexGuard(RawSharedMutex& mutex)
+    : locked_{std::addressof(mutex)} {
+  }
+
+  RawSharedMutexGuard(RawSharedMutex& mutex, SemaphorePermit turnstile,
+                      SemaphorePermit room_empty)
+    : locked_{std::addressof(mutex)},
+      turnstile_{std::move(turnstile)},
+      room_empty_{std::move(room_empty)} {
+  }
+
+  RawSharedMutex* locked_ = nullptr;
+  Option<SemaphorePermit> turnstile_ = None{};
+  Option<SemaphorePermit> room_empty_ = None{};
+};
+
+template <class T, SharedMutexMode Mode>
+class [[nodiscard]] SharedMutexGuard {
+private:
+  static constexpr auto is_unique = Mode == SharedMutexMode::unique;
+  using RawGuard = RawSharedMutexGuard<Mode>;
+  using Value = std::conditional_t<is_unique, T, T const>;
+
+public:
+  ~SharedMutexGuard() noexcept {
+    maybe_unlock();
+  }
+
+  SharedMutexGuard(SharedMutexGuard&& other) noexcept
+    : locked_{std::exchange(other.locked_, nullptr)},
+      guard_{std::move(other.guard_)} {
+  }
+  auto operator=(SharedMutexGuard&& other) noexcept -> SharedMutexGuard& {
+    if (this == &other) {
+      return *this;
+    }
+    maybe_unlock();
+    locked_ = std::exchange(other.locked_, nullptr);
+    guard_ = std::move(other.guard_);
+    return *this;
+  }
+  SharedMutexGuard(SharedMutexGuard const&) = delete;
+  auto operator=(SharedMutexGuard const&) -> SharedMutexGuard& = delete;
+
+  auto operator*() -> Value& {
+    TENZIR_ASSERT(locked_);
+    return locked_->value_;
+  }
+
+  auto operator->() -> Value* {
+    TENZIR_ASSERT(locked_);
+    return &locked_->value_;
+  }
+
+  auto unlock() -> void {
+    TENZIR_ASSERT(locked_);
+    guard_.unlock();
+    locked_ = nullptr;
+  }
+
+private:
+  auto maybe_unlock() -> void {
+    if (locked_) {
+      unlock();
+    }
+  }
+
+  friend class tenzir::SharedMutex<T>;
+
+  explicit SharedMutexGuard(SharedMutex<T>& mutex, RawGuard guard)
+    : locked_{std::addressof(mutex)}, guard_{std::move(guard)} {
+  }
+
+  SharedMutex<T>* locked_ = nullptr;
+  RawGuard guard_;
+};
+
+} // namespace detail
+
+using RawSharedMutexUniqueGuard
+  = detail::RawSharedMutexGuard<detail::SharedMutexMode::unique>;
+using RawSharedMutexSharedGuard
+  = detail::RawSharedMutexGuard<detail::SharedMutexMode::shared>;
+
+template <class T>
+using SharedMutexUniqueGuard
+  = detail::SharedMutexGuard<T, detail::SharedMutexMode::unique>;
+
+template <class T>
+using SharedMutexSharedGuard
+  = detail::SharedMutexGuard<T, detail::SharedMutexMode::shared>;
+
+/// A cancellable async shared mutex with writer preference once admitted.
+///
+/// Unique locks pass through a turnstile before waiting for the room to empty.
+/// A unique lock that holds the turnstile prevents later shared locks from
+/// entering while current shared locks drain. Writers and readers compete
+/// fairly for the turnstile itself, so a writer is not strictly prioritized
+/// over readers that are already queued behind it.
+class RawSharedMutex {
+public:
+  RawSharedMutex() = default;
+  RawSharedMutex(RawSharedMutex const&) = delete;
+  auto operator=(RawSharedMutex const&) -> RawSharedMutex& = delete;
+
+  RawSharedMutex(RawSharedMutex&& other) noexcept
+    : turnstile_{(other.assert_idle(), std::move(other.turnstile_))},
+      room_empty_{std::move(other.room_empty_)},
+      active_readers_{std::move(other.active_readers_)} {
+  }
+
+  auto operator=(RawSharedMutex&& other) noexcept -> RawSharedMutex& {
+    if (this != &other) {
+      assert_idle();       // target must be idle before we clobber it
+      other.assert_idle(); // source must be idle to move safely
+      turnstile_ = std::move(other.turnstile_);
+      room_empty_ = std::move(other.room_empty_);
+      active_readers_ = std::move(other.active_readers_);
+    }
+    return *this;
+  }
+
+  ~RawSharedMutex() = default;
+
+  auto unique_lock() -> Task<RawSharedMutexUniqueGuard>;
+
+  auto shared_lock() -> Task<RawSharedMutexSharedGuard>;
+
+private:
+  // A move is only safe (and the underlying semaphores only move losslessly)
+  // when the mutex is fully idle: no lock is held, which — because Folly's
+  // semaphore tokens never go negative — also guarantees nobody is waiting.
+  // Both semaphores have a fixed capacity of 1.
+  auto assert_idle() const -> void {
+    TENZIR_ASSERT(turnstile_.available_permits() == 1,
+                  "cannot move a held or contended RawSharedMutex");
+    TENZIR_ASSERT(room_empty_.available_permits() == 1,
+                  "cannot move a held or contended RawSharedMutex");
+    TENZIR_ASSERT(active_readers_.load(std::memory_order_acquire) == 0,
+                  "cannot move a RawSharedMutex with active readers");
+  }
+
+  auto unlock_shared() -> void;
+
+  template <detail::SharedMutexMode>
+  friend class detail::RawSharedMutexGuard;
+
+  Semaphore turnstile_{1};
+  Semaphore room_empty_{1};
+  Atomic<size_t> active_readers_ = 0;
+};
+
+template <class T>
+class SharedMutex {
+public:
+  SharedMutex() = default;
+
+  template <class... Args>
+    requires std::constructible_from<T, Args...>
+  SharedMutex(std::in_place_t, Args&&... args)
+    : value_{std::forward<Args>(args)...} {
+  }
+
+  explicit SharedMutex(T x) : value_{std::move(x)} {
+  }
+
+  auto unique_lock() -> Task<SharedMutexUniqueGuard<T>>;
+
+  auto shared_lock() -> Task<SharedMutexSharedGuard<T>>;
+
+private:
+  template <class, detail::SharedMutexMode>
+  friend class detail::SharedMutexGuard;
+
+  RawSharedMutex mutex_;
+  T value_ = {};
+};
+
+template <detail::SharedMutexMode Mode>
+auto detail::RawSharedMutexGuard<Mode>::unlock() -> void {
+  TENZIR_ASSERT(locked_);
+  if constexpr (Mode == detail::SharedMutexMode::unique) {
+    room_empty_ = None{};
+    turnstile_ = None{};
+  } else {
+    locked_->unlock_shared();
+  }
+  locked_ = nullptr;
+}
+
+inline auto RawSharedMutex::unique_lock() -> Task<RawSharedMutexUniqueGuard> {
+  auto turnstile = co_await turnstile_.acquire();
+  auto room_empty = co_await room_empty_.acquire();
+  co_return RawSharedMutexUniqueGuard{
+    *this,
+    std::move(turnstile),
+    std::move(room_empty),
+  };
+}
+
+inline auto RawSharedMutex::shared_lock() -> Task<RawSharedMutexSharedGuard> {
+  auto turnstile = co_await turnstile_.acquire();
+  auto const previous_readers
+    = active_readers_.fetch_add(1, std::memory_order_acq_rel);
+  if (previous_readers == 0) {
+    try {
+      // A cancelled `co_wait()` in Folly never atomically claims the permit, so
+      // the catch block below fully restores state on cancellation.
+      co_await room_empty_.consume();
+    } catch (...) {
+      auto const readers
+        = active_readers_.fetch_sub(1, std::memory_order_acq_rel);
+      TENZIR_ASSERT(readers > 0);
+      throw;
+    }
+    // At this point `room_empty_` is consumed and `active_readers_` is
+    // non-zero. The coroutine is committed to returning a guard. There is no
+    // `co_await` between here and `co_return`, so Folly cannot cancel in this
+    // window. If that assumption ever breaks, the rollback must be:
+    //   active_readers_.fetch_sub(1, acq_rel) + room_empty_.add_permit().
+  }
+  // Release the turnstile before returning so the next reader or writer can
+  // enter immediately rather than waiting for the guard's lifetime to end.
+  // This is intentionally explicit rather than relying on the SemaphorePermit
+  // RAII destructor, which would run only when the coroutine frame is torn down.
+  turnstile.release();
+  co_return RawSharedMutexSharedGuard{*this};
+}
+
+inline auto RawSharedMutex::unlock_shared() -> void {
+  auto const readers = active_readers_.fetch_sub(1, std::memory_order_acq_rel);
+  TENZIR_ASSERT(readers > 0);
+  if (readers == 1) {
+    room_empty_.add_permit();
+  }
+}
+
+template <class T>
+auto SharedMutex<T>::unique_lock() -> Task<SharedMutexUniqueGuard<T>> {
+  auto guard = co_await mutex_.unique_lock();
+  co_return SharedMutexUniqueGuard<T>{*this, std::move(guard)};
+}
+
+template <class T>
+auto SharedMutex<T>::shared_lock() -> Task<SharedMutexSharedGuard<T>> {
+  auto guard = co_await mutex_.shared_lock();
+  co_return SharedMutexSharedGuard<T>{*this, std::move(guard)};
+}
+
+} // namespace tenzir

--- a/libtenzir/include/tenzir/async_secret_resolution.hpp
+++ b/libtenzir/include/tenzir/async_secret_resolution.hpp
@@ -1,0 +1,45 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2025 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "tenzir/async/shared_mutex.hpp"
+#include "tenzir/detail/heterogeneous_string_hash.hpp"
+#include "tenzir/ecc.hpp"
+#include "tenzir/option.hpp"
+
+#include <folly/CancellationToken.h>
+
+namespace tenzir {
+
+class SecretCache {
+public:
+  constexpr static auto ttl = std::chrono::minutes{15};
+
+  auto lookup(std::string_view key) const -> Option<ecc::cleansing_blob>;
+  auto insert(std::string key, ecc::cleansing_blob value) -> void;
+  auto cleanup() -> duration;
+
+  static auto instance() -> SharedMutex<SecretCache>&;
+
+  static folly::CancellationSource cancel_source;
+
+private:
+  static auto start_cleanup() -> void;
+
+  struct cache_entry {
+    ecc::cleansing_blob value;
+    mutable Atomic<time> last_used;
+  };
+
+  std::unordered_map<std::string, cache_entry, detail::heterogeneous_string_hash,
+                     detail::heterogeneous_string_equal>
+    data_;
+};
+
+} // namespace tenzir

--- a/libtenzir/include/tenzir/secret_resolution.hpp
+++ b/libtenzir/include/tenzir/secret_resolution.hpp
@@ -11,6 +11,7 @@
 #include "tenzir/diagnostics.hpp"
 #include "tenzir/ecc.hpp"
 #include "tenzir/location.hpp"
+#include "tenzir/option.hpp"
 #include "tenzir/secret.hpp"
 
 #include <arrow/type_fwd.h>
@@ -189,7 +190,7 @@ auto make_secret_request(located<data>& value, diagnostic_handler& dh)
 
 struct located_resolved_secret {
   location loc;
-  ecc::cleansing_blob value;
+  Option<ecc::cleansing_blob> value;
 
   located_resolved_secret(location loc) : loc{loc} {
   }

--- a/libtenzir/src/async/executor.cpp
+++ b/libtenzir/src/async/executor.cpp
@@ -14,6 +14,7 @@
 #include "tenzir/async/log.hpp"
 #include "tenzir/async/mail.hpp"
 #include "tenzir/async/select_set.hpp"
+#include "tenzir/async_secret_resolution.hpp"
 #include "tenzir/co_match.hpp"
 #include "tenzir/ir.hpp"
 #include "tenzir/option.hpp"
@@ -21,7 +22,11 @@
 #include "tenzir/substitute_ctx.hpp"
 
 #include <folly/Demangle.h>
+#include <folly/OperationCancelled.h>
 #include <folly/coro/BoundedQueue.h>
+
+#include <chrono>
+#include <mutex>
 
 // TODO: Why does this not report line numbers correctly?
 #undef TENZIR_UNREACHABLE
@@ -650,61 +655,86 @@ private:
       }
       co_return {};
     }
-    auto node = co_await fetch_node(sys_, *dh_);
-    if (not node or not *node) {
-      co_return failure::promise();
-    }
-    // All futures for requests we send to the node
-    auto tasks = std::vector<Task<caf::expected<secret_resolution_result>>>{};
-    // Key pairs used for the request encryption per request
-    auto keys = std::vector<ecc::string_keypair>{};
-    for (auto& [name, out] : requested_secrets) {
-      auto key_pair = ecc::generate_keypair();
-      TENZIR_ASSERT(key_pair);
-      auto public_key = key_pair->public_key;
-      tasks.push_back(
-        async_mail(atom::resolve_v, name, public_key).request(*node));
-      keys.push_back(std::move(*key_pair));
-    }
-    const auto results
-      = co_await folly::coro::collectAllRange(std::move(tasks));
-    // We use a bool here to be able to validate all secrets instead of early
-    // exiting.
-    auto success = true;
-    for (auto&& [expected, key, secret] :
-         std::views::zip(results, std::as_const(keys), requested_secrets)) {
-      auto& [name, out] = secret;
-      if (not expected) {
-        diagnostic::error(expected.error())
-          .primary(out.loc, "secret `{}` failed", name)
-          .emit(dh_);
-        success = false;
-        continue;
+    auto all_cached = true;
+    {
+      auto cache = co_await SecretCache::instance().shared_lock();
+      for (auto& [k, v] : requested_secrets) {
+        if (auto s = cache->lookup(k)) {
+          v.value = s;
+          continue;
+        }
+        all_cached = false;
       }
-      match(
-        *expected,
-        [&](const encrypted_secret_value& v) {
-          auto decrypted = ecc::decrypt(v.value, key);
-          if (not decrypted) {
-            diagnostic::error("failed to decrypt secret: {}", decrypted.error())
-              .primary(out.loc, "secret `{}` failed", name)
-              .emit(dh_);
-            success = false;
-            return;
-          }
-          out.value = std::move(*decrypted);
-        },
-        [&](const secret_resolution_error& e) {
-          diagnostic::error("could not get secret value: {}", e.message)
+    }
+    if (not all_cached) {
+      auto node = co_await fetch_node(sys_, *dh_);
+      if (not node or not *node) {
+        co_return failure::promise();
+      }
+      // All futures for requests we send to the node
+      auto tasks = std::vector<Task<caf::expected<secret_resolution_result>>>{};
+      // Key pairs used for the request encryption per request
+      struct name_and_key {
+        std::string name;
+        ecc::string_keypair keys;
+      };
+      auto names_and_keys = std::vector<name_and_key>{};
+      for (auto& [name, out] : requested_secrets) {
+        if (out.value) {
+          continue;
+        }
+        auto key_pair = ecc::generate_keypair();
+        TENZIR_ASSERT(key_pair);
+        auto public_key = key_pair->public_key;
+        tasks.push_back(
+          async_mail(atom::resolve_v, name, public_key).request(*node));
+        names_and_keys.emplace_back(name, std::move(*key_pair));
+      }
+      const auto results
+        = co_await folly::coro::collectAllRange(std::move(tasks));
+      // We use a bool here to be able to validate all secrets instead of early
+      // exiting.
+      auto success = true;
+      auto cache = co_await SecretCache::instance().unique_lock();
+      for (auto&& [expected, name_and_key] :
+           std::views::zip(results, names_and_keys)) {
+        auto& [name, key] = name_and_key;
+        auto& out = requested_secrets.at(name);
+        if (not expected) {
+          diagnostic::error(expected.error())
             .primary(out.loc, "secret `{}` failed", name)
             .emit(dh_);
           success = false;
-        });
-    }
-    if (not success) {
-      co_return failure::promise();
+          continue;
+        }
+        match(
+          *expected,
+          [&](const encrypted_secret_value& v) {
+            auto decrypted = ecc::decrypt(v.value, key);
+            if (not decrypted) {
+              diagnostic::error("failed to decrypt secret: {}",
+                                decrypted.error())
+                .primary(out.loc, "secret `{}` failed", name)
+                .emit(dh_);
+              success = false;
+              return;
+            }
+            cache->insert(name, *decrypted);
+            out.value = std::move(*decrypted);
+          },
+          [&](const secret_resolution_error& e) {
+            diagnostic::error("could not get secret value: {}", e.message)
+              .primary(out.loc, "secret `{}` failed", name)
+              .emit(dh_);
+            success = false;
+          });
+      }
+      if (not success) {
+        co_return failure::promise();
+      }
     }
     /// Finish all secrets via the respective finisher.
+    auto success = true;
     for (const auto& f : finishers) {
       success &= static_cast<bool>(f.finish(requested_secrets, censor_, *dh_));
     }

--- a/libtenzir/src/async_secret_resolution.cpp
+++ b/libtenzir/src/async_secret_resolution.cpp
@@ -1,0 +1,114 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2025 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "tenzir/async_secret_resolution.hpp"
+
+#include "tenzir/async/task.hpp"
+
+#include <folly/coro/Sleep.h>
+#include <folly/executors/GlobalExecutor.h>
+#include <folly/futures/ThreadWheelTimekeeper.h>
+
+#include <chrono>
+#include <mutex>
+
+namespace tenzir {
+
+namespace {
+
+auto run_secret_cache_cleanup() -> Task<void> {
+  auto timekeeper = folly::ThreadWheelTimekeeper{};
+  while (true) {
+    co_await folly::coro::co_safe_point;
+    auto wait = duration{};
+    {
+      auto cache = co_await SecretCache::instance().unique_lock();
+      wait = cache->cleanup();
+    }
+    co_await folly::coro::sleep(
+      std::chrono::duration_cast<folly::HighResDuration>(wait), &timekeeper);
+  }
+}
+
+} // namespace
+
+folly::CancellationSource SecretCache::cancel_source{};
+
+auto SecretCache::lookup(std::string_view key) const
+  -> Option<ecc::cleansing_blob> {
+  auto it = data_.find(key);
+  if (it == data_.end()) {
+    return None{};
+  }
+  auto& [value, last_used] = it->second;
+  auto const now = time::clock::now();
+  if (now - last_used.load(std::memory_order_relaxed) < SecretCache::ttl) {
+    last_used = time::clock::now();
+    return value;
+  }
+  return None{};
+}
+
+auto SecretCache::insert(std::string key, ecc::cleansing_blob value) -> void {
+  auto const now = time::clock::now();
+  const auto [it, inserted]
+    = data_.try_emplace(std::move(key), std::move(value), now);
+  start_cleanup();
+  if (inserted) {
+    return;
+  }
+  auto& entry = it->second;
+  entry.value = std::move(value);
+  entry.last_used = now;
+}
+
+auto SecretCache::cleanup() -> duration {
+  auto const now = time::clock::now();
+  auto const cutoff = now - ttl;
+  auto wait = duration{ttl};
+  for (auto it = data_.begin(); it != data_.end();) {
+    const auto& [_, entry] = *it;
+    auto last_used = entry.last_used.load(std::memory_order_relaxed);
+    if (last_used < cutoff) {
+      it = data_.erase(it);
+      continue;
+    }
+    auto const age = (now - last_used);
+    auto const entry_wait = ttl - age;
+    if (entry_wait < wait) {
+      wait = entry_wait;
+    }
+    ++it;
+  }
+  return wait;
+}
+
+auto SecretCache::instance() -> SharedMutex<SecretCache>& {
+  static auto instance = SharedMutex<SecretCache>{};
+  return instance;
+}
+
+auto SecretCache::start_cleanup() -> void {
+  static auto once = std::once_flag{};
+  std::call_once(once, [] {
+    folly::coro::co_withCancellation(
+      cancel_source.getToken(),
+      folly::coro::co_withExecutor(folly::getGlobalCPUExecutor(),
+                                   run_secret_cache_cleanup()))
+      .start([](auto&& result) {
+        if (result.template hasException<folly::OperationCancelled>()) {
+          return;
+        }
+        if (result.hasException()) {
+          result.exception().throw_exception();
+        }
+      });
+  });
+}
+
+} // namespace tenzir

--- a/libtenzir/src/secret_resolution.cpp
+++ b/libtenzir/src/secret_resolution.cpp
@@ -291,8 +291,8 @@ struct secret_resolver {
   auto operator()(const fbs::data::SecretName& l) -> ret_t {
     const auto it = requested.find(detail::secrets::deref(l.value()).str());
     TENZIR_ASSERT(it != requested.end());
-    censor.add(it->second.value);
-    return resolved_secret_value{it->second.value, false};
+    censor.add(*it->second.value);
+    return resolved_secret_value{*it->second.value, false};
   }
 
   auto operator()(const fbs::data::SecretConcatenation& concat) -> ret_t {

--- a/libtenzir/test/async/shared_mutex.cpp
+++ b/libtenzir/test/async/shared_mutex.cpp
@@ -1,0 +1,99 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "tenzir/async/shared_mutex.hpp"
+
+#include "tenzir/async/task.hpp"
+
+#include <folly/coro/BlockingWait.h>
+
+#ifdef CHECK
+#  undef CHECK
+#endif
+#include "tenzir/test/test.hpp"
+
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace tenzir {
+
+namespace {
+
+// Confirms that both lock flavors still work on a mutex after `mutex` has been
+// moved into its final location.
+auto exercise(RawSharedMutex& mutex) -> Task<void> {
+  {
+    auto guard = co_await mutex.unique_lock();
+  }
+  {
+    auto guard = co_await mutex.shared_lock();
+  }
+  // Multiple concurrent shared locks should coexist.
+  {
+    auto a = co_await mutex.shared_lock();
+    auto b = co_await mutex.shared_lock();
+  }
+  // And a unique lock must be obtainable again once the readers drain.
+  {
+    auto guard = co_await mutex.unique_lock();
+  }
+  co_return;
+}
+
+} // namespace
+
+TEST("RawSharedMutex move construction preserves a working mutex") {
+  folly::coro::blockingWait([]() -> Task<void> {
+    auto original = RawSharedMutex{};
+    auto moved = std::move(original);
+    co_await exercise(moved);
+  }());
+}
+
+TEST("RawSharedMutex move assignment preserves a working mutex") {
+  folly::coro::blockingWait([]() -> Task<void> {
+    auto source = RawSharedMutex{};
+    auto target = RawSharedMutex{};
+    target = std::move(source);
+    co_await exercise(target);
+  }());
+}
+
+TEST("RawSharedMutex can be moved into place while idle") {
+  folly::coro::blockingWait([]() -> Task<void> {
+    auto storage = std::vector<RawSharedMutex>{};
+    storage.emplace_back();
+    // Force a reallocation so the elements are relocated via move.
+    storage.reserve(storage.capacity() + 1);
+    storage.emplace_back();
+    co_await exercise(storage.front());
+    co_await exercise(storage.back());
+    auto opt = std::optional<RawSharedMutex>{};
+    opt.emplace();
+    co_await exercise(*opt);
+  }());
+}
+
+TEST("SharedMutex is movable and keeps its value") {
+  folly::coro::blockingWait([&]() -> Task<void> {
+    auto original = SharedMutex<int>{42};
+    auto moved = std::move(original);
+    {
+      auto guard = co_await moved.unique_lock();
+      check_eq(*guard, 42);
+      *guard = 7;
+    }
+    {
+      auto guard = co_await moved.shared_lock();
+      check_eq(*guard, 7);
+    }
+  }());
+}
+
+} // namespace tenzir

--- a/tenzir/tenzir.cpp
+++ b/tenzir/tenzir.cpp
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "tenzir/application.hpp"
+#include "tenzir/async_secret_resolution.hpp"
 #include "tenzir/concept/convertible/to.hpp"
 #include "tenzir/default_configuration.hpp"
 #include "tenzir/detail/posix.hpp"
@@ -124,6 +125,10 @@ auto main(int argc, char** argv) -> int try {
   // Some Folly builds use strict mode, even though that is not the default. In
   // that case, we need to call `folly::Init` before using its singletons.
   auto folly_init = tenzir::folly_init_guard{argv};
+  // Setup a guard that cancels the process local secret cache cleanup task.
+  auto secret_cache_guard = detail::scope_guard([]() noexcept {
+    SecretCache::cancel_source.requestCancellation();
+  });
   // Tweak CAF parameters in case we're running a client command.
   const auto is_server = is_server_from_app_path(argv[0]);
   // Mask SIGINT and SIGTERM so we can handle those in a dedicated thread.


### PR DESCRIPTION
Previously secrets would be resolved independently by every operator on
every start. This is highly undesirable for setups involving `every` or
`each`.

With this, a new process local cache is added to the neo execution model,
together with a TTL mechanism to clear secrets out of the cache.

Resolves https://linear.app/tenzir/issue/TNZ-647
