### PR TITLE
Warn about unused options in `ToArrowFs` operators

### DIFF
--- a/libtenzir/include/tenzir/arrow_fs.hpp
+++ b/libtenzir/include/tenzir/arrow_fs.hpp
@@ -316,9 +316,12 @@ private:
 
 /// Common arguments for Arrow filesystem-based sink operators.
 struct ToArrowFsArgs {
+  static constexpr uint64_t default_max_size = uint64_t{100} * 1024 * 1024;
+  static constexpr duration default_timeout = std::chrono::minutes{5};
+
   located<secret> url;
-  uint64_t max_size = uint64_t{100} * 1024 * 1024;
-  duration timeout = std::chrono::minutes{5};
+  Option<located<uint64_t>> max_size;
+  Option<located<duration>> timeout;
   located<ir::pipeline> pipe;
   Option<ast::expression> partition_by;
 
@@ -329,26 +332,26 @@ struct ToArrowFsArgs {
              and std::invocable<F, DescribeCtx&>
   static auto describe_to(Describer<Args, Impls...>& d, F extra = {}) -> void {
     d.template positional<located<secret>>("url", &ToArrowFsArgs::url);
-    auto max_size_arg = d.template named_optional<uint64_t>(
+    auto max_size_arg = d.template named<located<uint64_t>>(
       "max_size", &ToArrowFsArgs::max_size);
     auto timeout_arg
-      = d.template named_optional<duration>("timeout", &ToArrowFsArgs::timeout);
+      = d.template named<located<duration>>("timeout", &ToArrowFsArgs::timeout);
     auto partition_arg = d.template named<ast::expression>(
       "partition_by", &ToArrowFsArgs::partition_by, "list<field>");
     auto pipe_arg
       = d.pipeline(&ToArrowFsArgs::pipe, SubOptimize::from_downstream);
     d.validate([=](DescribeCtx& ctx) -> Empty {
       if (auto max_size = ctx.get(max_size_arg)) {
-        if (*max_size == 0) {
+        if (max_size->inner == 0) {
           diagnostic::error("`max_size` must be a positive number")
-            .primary(*ctx.get_location(max_size_arg))
+            .primary(max_size->source)
             .emit(ctx);
         }
       }
       if (auto timeout = ctx.get(timeout_arg)) {
-        if (*timeout <= duration::zero()) {
+        if (timeout->inner <= duration::zero()) {
           diagnostic::error("`timeout` must be a positive duration")
-            .primary(*ctx.get_location(timeout_arg))
+            .primary(timeout->source)
             .emit(ctx);
         }
       }

--- a/libtenzir/src/arrow_fs.cpp
+++ b/libtenzir/src/arrow_fs.cpp
@@ -633,6 +633,22 @@ auto ToArrowFsOperator::start(OpCtx& ctx) -> Task<void> {
   // TODO: Consider using separate types here to differentiate.
   template_.set_path(std::move(fs->path), base_args_.url.source, append(),
                      ctx.dh());
+  if (not template_.has_uuid()) {
+    if (base_args_.max_size) {
+      diagnostic::warning("`max_size` has no effect without a `{{uuid}}` "
+                          "placeholder in the URL")
+        .primary(base_args_.max_size->source)
+        .note("rotation requires `{{uuid}}` to produce unique filenames")
+        .emit(ctx.dh());
+    }
+    if (base_args_.timeout) {
+      diagnostic::warning("`timeout` has no effect without a `{{uuid}}` "
+                          "placeholder in the URL")
+        .primary(base_args_.timeout->source)
+        .note("rotation requires `{{uuid}}` to produce unique filenames")
+        .emit(ctx.dh());
+    }
+  }
   bytes_written_counter_
     = ctx.make_counter(MetricsLabel{"operator", "to_arrow_fs"},
                        MetricsDirection::write, MetricsVisibility::external_,
@@ -715,7 +731,9 @@ auto ToArrowFsOperator::process(table_slice input, OpCtx& ctx) -> Task<void> {
                 co_await folly::coro::co_current_cancellation_token,
                 cancel_token);
               co_await folly::coro::co_withCancellation(
-                token, sleep_for(base_args_.timeout));
+                token,
+                sleep_for(base_args_.timeout ? base_args_.timeout->inner
+                                             : ToArrowFsArgs::default_timeout));
               co_await rotate(sk);
             });
         }
@@ -788,7 +806,9 @@ auto ToArrowFsOperator::process_sub(SubKeyView key, chunk_ptr chunk, OpCtx& ctx)
   bytes_written_counter_.add(chunk->size());
   part->stream_bytes += chunk->size();
   const auto can_rotate = template_.has_uuid() and not part->is_rotating;
-  const auto over_max_size = part->stream_bytes >= base_args_.max_size;
+  const auto max_size = base_args_.max_size ? base_args_.max_size->inner
+                                            : ToArrowFsArgs::default_max_size;
+  const auto over_max_size = part->stream_bytes >= max_size;
   if (can_rotate and over_max_size) {
     co_await rotate(sk);
   }


### PR DESCRIPTION
Emit warnings when `max_size` or `timeout` are set on `to_s3`/`to_abs`/`to_google_cloud_storage`/`to_file` but the URL lacks a `{uuid}` placeholder — the options were silently ignored before.