### PR TITLE
Diagnose non-record args to `from` instead of asserting

### DIFF
--- a/libtenzir/builtins/operators/from_to_2.cpp
+++ b/libtenzir/builtins/operators/from_to_2.cpp
@@ -6,6 +6,8 @@
 // SPDX-FileCopyrightText: (c) 2023 The Tenzir Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+#include "tenzir/tql2/ast.hpp"
+
 #include <tenzir/arrow_table_slice.hpp>
 #include <tenzir/compile_ctx.hpp>
 #include <tenzir/diagnostics.hpp>
@@ -185,6 +187,12 @@ public:
     if (input.is_not<void>()) {
       diagnostic::error("expected void, got {}", input).primary(self_).emit(dh);
       return failure::promise();
+    }
+    for (const auto& event : events_) {
+      if (not try_as<ast::record>(event)) {
+        diagnostic::error("expected `record`").primary(event).emit(dh);
+        return failure::promise();
+      }
     }
     return tag_v<table_slice>;
   }

--- a/test/tests/operators/from/validation/from_list.tql
+++ b/test/tests/operators/from/validation/from_list.tql
@@ -1,0 +1,8 @@
+---
+error: true
+---
+
+from [
+  {tenant: "acme", msg: "a"},
+  {tenant: "globex", msg: "b"},
+]

--- a/test/tests/operators/from/validation/from_list.txt
+++ b/test/tests/operators/from/validation/from_list.txt
@@ -1,0 +1,6 @@
+error: expected `record`
+ --> tests/operators/from/validation/from_list.tql:5:6
+  |
+5 | from [
+  |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+  |


### PR DESCRIPTION
## 🔍 Problem

`from [...]` with a list literal crashes the neo executor with an assertion failure (`TENZIR_ASSERT(cast)` in `From::process_task`). The `compile` path stores arguments as-is without validating their type, so a list expression reaches runtime where `as<record_type>()` returns null.

## 🛠️ Solution

In `from_ir::infer_type`, attempt const-evaluation of each argument using a null diagnostic handler. If evaluation succeeds and the result is not a record, emit a clean diagnostic at type-inference time. If evaluation fails (secrets, non-deterministic expressions), skip the check — those cases pass through and the existing runtime assertion remains the backstop.

This keeps the validation value-based rather than syntax-based, so expressions like `let $e = {x: 1}; from $e` continue to work.

## 💬 Review

- Uses `null_diagnostic_handler` so that failed const-evals (secrets, `random()`, etc.) are silently skipped rather than surfacing confusing errors.
- The asserts in `process_task` are intentionally left in place as a last-resort safeguard for any expression that can't be checked at infer time.