### PR TITLE
Restore legacy flag check in exec_pipeline

### DIFF
--- a/libtenzir/builtins/commands/exec.cpp
+++ b/libtenzir/builtins/commands/exec.cpp
@@ -97,6 +97,7 @@ auto exec_command(const invocation& inv, caf::actor_system& sys) -> bool {
                   use_neo_executor ? R"(from_stdin { read_json })"
                                    : cfg.implicit_events_source);
   cfg.multi = caf::get_or(inv.options, "tenzir.exec.multi", cfg.multi);
+  cfg.legacy = caf::get_or(inv.options, "tenzir.legacy", cfg.legacy);
   cfg.strict = caf::get_or(inv.options, "tenzir.exec.strict", cfg.strict);
   auto profile_str
     = caf::get_or(inv.options, "tenzir.exec.profile", std::string{});

--- a/libtenzir/include/tenzir/exec_pipeline.hpp
+++ b/libtenzir/include/tenzir/exec_pipeline.hpp
@@ -38,6 +38,7 @@ struct exec_config {
   bool multi = false;
   bool strict = false;
   bool neo = true;
+  bool legacy = false;
   std::optional<std::string> profile;
 };
 

--- a/libtenzir/src/exec_pipeline.cpp
+++ b/libtenzir/src/exec_pipeline.cpp
@@ -325,8 +325,7 @@ auto exec_pipeline(pipeline pipe, std::string definition,
 auto exec_pipeline(std::string content, diagnostic_handler& dh,
                    const exec_config& cfg, caf::actor_system& sys)
   -> caf::expected<void> {
-  if (cfg.neo or cfg.dump_ir or cfg.dump_inst_ir or cfg.dump_opt_ir
-      or cfg.dump_pipeline) {
+  if (not cfg.legacy) {
     auto success = exec2(std::move(content), dh, cfg, sys);
     return success ? caf::expected<void>{} : ec::silent;
   }


### PR DESCRIPTION
## 🔍 Problem

The `exec_pipeline` used to check the `tenzir.legacy` flag to decide between executing tql1 and tql2 code.

It was recently replaced by a check for the `tenzir.neo` flag, which is not supposed to switch between language versions.

## 🛠️ Solution

Use `not cfg.legacy` instead, matching the intent: anything that is not
the legacy path runs through `exec2`.

We'll remove the flag together with the TQL1 code in a later PR.

## 💬 Review

Single-line behavioral change. Reviewers should confirm that the legacy
path is still reachable only when `cfg.legacy` is set.