### PR TITLE
Improve `FromArrowFs` operators

### DIFF
--- a/libtenzir/include/tenzir/arrow_fs.hpp
+++ b/libtenzir/include/tenzir/arrow_fs.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "tenzir/async.hpp"
+#include "tenzir/async/bounded_queue.hpp"
 #include "tenzir/async/future_util.hpp"
 #include "tenzir/async/mutex.hpp"
 #include "tenzir/chunk.hpp"
@@ -27,7 +28,6 @@
 #include <arrow/result.h>
 #include <arrow/util/future.h>
 #include <arrow/util/uri.h>
-#include <folly/coro/BoundedQueue.h>
 #include <folly/coro/FutureUtil.h>
 #include <folly/coro/Task.h>
 #include <folly/coro/UnboundedQueue.h>
@@ -306,7 +306,7 @@ private:
   std::array<Option<TrackedFile>, max_jobs> processing_{};
   uint64_t next_job_id_ = 0;
   std::vector<std::string> cleanup_pending_;
-  mutable Box<folly::coro::BoundedQueue<AwaitResult>> results_{
+  mutable Box<BoundedQueue<AwaitResult>> results_{
     std::in_place,
     max_jobs + 1,
   };

--- a/libtenzir/include/tenzir/async/bounded_queue.hpp
+++ b/libtenzir/include/tenzir/async/bounded_queue.hpp
@@ -1,0 +1,134 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "tenzir/option.hpp"
+
+#include <folly/coro/Task.h>
+#include <folly/coro/UnboundedQueue.h>
+#include <folly/fibers/Semaphore.h>
+
+#include <cstdint>
+#include <utility>
+
+namespace tenzir {
+
+/// A bounded MPMC queue with an escape hatch for forced enqueues.
+///
+/// `enqueue` waits on a semaphore until a regular slot is free. `force_enqueue`
+/// always succeeds immediately, even if the queue already holds `capacity`
+/// (or more) items. A forced item, when later dequeued, does not free a
+/// slot for waiting regular enqueuers: the capacity gate accounts only for
+/// regular items, so `size()` may transiently exceed `capacity` until the
+/// forced items drain.
+///
+/// FIFO ordering is preserved across the mix of regular and forced items
+/// (by the time they hit the backing queue, as is standard for MPMC).
+///
+/// The `SingleProducer` and `SingleConsumer` template flags forward to the
+/// backing `folly::coro::UnboundedQueue`. Crucially, they constrain *all*
+/// producer- and consumer-side calls respectively: setting `SingleProducer`
+/// means no two of `enqueue` / `try_enqueue` / `force_enqueue` may be in
+/// flight concurrently, since `force_enqueue` is itself a producer against
+/// the inner queue.
+template <class T, bool SingleProducer = false, bool SingleConsumer = false>
+class BoundedQueue {
+public:
+  explicit BoundedQueue(uint32_t capacity) : sem_{capacity} {
+  }
+
+  ~BoundedQueue() = default;
+  BoundedQueue(const BoundedQueue&) = delete;
+  auto operator=(const BoundedQueue&) -> BoundedQueue& = delete;
+  BoundedQueue(BoundedQueue&&) = delete;
+  auto operator=(BoundedQueue&&) -> BoundedQueue& = delete;
+
+  /// Enqueue an item, waiting for a free slot if the queue is at capacity.
+  template <class U = T>
+  auto enqueue(U&& item) -> folly::coro::Task<void> {
+    co_await folly::coro::co_nothrow(sem_.co_wait());
+    queue_.enqueue(Slot{T(std::forward<U>(item)), /*forced=*/false});
+  }
+
+  /// Enqueue without blocking. Returns true on success, false if at capacity.
+  template <class U = T>
+  auto try_enqueue(U&& item) -> bool {
+    if (not sem_.try_wait()) {
+      return false;
+    }
+    queue_.enqueue(Slot{T(std::forward<U>(item)), /*forced=*/false});
+    return true;
+  }
+
+  /// Enqueue an item immediately, exceeding capacity if necessary.
+  ///
+  /// The capacity gate is not consumed on enqueue and not released on the
+  /// matching dequeue. Use for sentinels, shutdown markers, or other control
+  /// values that must reach the consumer even when the queue is full.
+  template <class U = T>
+  auto force_enqueue(U&& item) -> void {
+    queue_.enqueue(Slot{T(std::forward<U>(item)), /*forced=*/true});
+  }
+
+  /// Dequeue an item, waiting if the queue is empty.
+  auto dequeue() -> folly::coro::Task<T> {
+    auto slot = co_await queue_.dequeue();
+    if (not slot.forced) {
+      sem_.signal();
+    }
+    co_return std::move(slot.value);
+  }
+
+  /// Dequeue with a timeout. On timeout, the returned task completes with
+  /// `folly::OperationCancelled`, matching the inner queue's semantics.
+  template <class Duration>
+  auto try_dequeue_for(Duration timeout) -> folly::coro::Task<T> {
+    auto slot = co_await queue_.co_try_dequeue_for(timeout);
+    if (not slot.forced) {
+      sem_.signal();
+    }
+    co_return std::move(slot.value);
+  }
+
+  /// Dequeue without blocking. Returns `None` if the queue is empty.
+  auto try_dequeue() -> Option<T> {
+    auto slot = queue_.try_dequeue();
+    if (not slot) {
+      return None{};
+    }
+    if (not slot->forced) {
+      sem_.signal();
+    }
+    return Option<T>{std::move(slot->value)};
+  }
+
+  auto empty() const -> bool {
+    return queue_.empty();
+  }
+
+  auto size() const -> size_t {
+    return queue_.size();
+  }
+
+private:
+  // Items are tagged with whether they were forced so that the dequeue side
+  // knows whether to release a capacity slot. We cannot derive this from
+  // counters alone because FIFO ordering means a dequeued item could be
+  // either a regular or a forced one — without the tag, signaling on every
+  // dequeue would push the token count above `capacity` and break the gate.
+  struct Slot {
+    T value;
+    bool forced;
+  };
+
+  folly::coro::UnboundedQueue<Slot, SingleProducer, SingleConsumer> queue_;
+  folly::fibers::Semaphore sem_;
+};
+
+} // namespace tenzir

--- a/libtenzir/include/tenzir/folly_init.hpp
+++ b/libtenzir/include/tenzir/folly_init.hpp
@@ -1,0 +1,37 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <memory>
+
+namespace tenzir {
+
+/// RAII wrapper around `folly::Init` that hides folly headers and symbols
+/// behind libtenzir. Consumers (plugin test binaries, the main `tenzir`
+/// executable) can initialise folly without having to link folly directly,
+/// which matters when folly is bundled as a static archive inside
+/// libtenzir.so with no exported link interface.
+class folly_init_guard {
+public:
+  /// Initialise folly singletons with the same options as the main
+  /// `tenzir` binary: gflags disabled and `argv` left untouched.
+  explicit folly_init_guard(char** argv);
+  ~folly_init_guard();
+  folly_init_guard(folly_init_guard const&) = delete;
+  folly_init_guard& operator=(folly_init_guard const&) = delete;
+  folly_init_guard(folly_init_guard&&) = delete;
+  folly_init_guard& operator=(folly_init_guard&&) = delete;
+
+private:
+  // Held as a unique_ptr so the header doesn't need <folly/init/Init.h>.
+  struct impl;
+  std::unique_ptr<impl> impl_;
+};
+
+} // namespace tenzir

--- a/libtenzir/include/tenzir/fs_url_template.hpp
+++ b/libtenzir/include/tenzir/fs_url_template.hpp
@@ -52,14 +52,11 @@ public:
 
   /// Store the path extracted from `make_filesystem`'s result, undoing the
   /// sanitization. Finalises `has_uuid()` against the actual path and emits
-  /// any placeholder-related diagnostics. Call exactly once, after
-  /// `make_filesystem` returns.
-  ///
-  /// When `append` is set, the partition-without-`{uuid}` overwrite warning
-  /// is suppressed because in append mode each partition's stable file is
-  /// extended rather than overwritten.
+  /// a diagnostic if a `{uuid}` from the original URL was lost to the
+  /// authority/query portion. Call exactly once, after `make_filesystem`
+  /// returns.
   void set_path(std::string path_with_tokens, location url_loc,
-                Option<location> append, diagnostic_handler& dh);
+                diagnostic_handler& dh);
 
   /// Expand the stored path template with concrete partition values and a
   /// fresh UUIDv7.  `key` is the composite partition key (a `list` when

--- a/libtenzir/src/arrow_fs.cpp
+++ b/libtenzir/src/arrow_fs.cpp
@@ -632,21 +632,20 @@ auto ToArrowFsOperator::start(OpCtx& ctx) -> Task<void> {
   // `set_path` finalises `has_uuid()` based on the actual path portion and
   // emits any `{uuid}`-placement diagnostics.
   // TODO: Consider using separate types here to differentiate.
-  template_.set_path(std::move(fs->path), base_args_.url.source, append(),
-                     ctx.dh());
+  template_.set_path(std::move(fs->path), base_args_.url.source, ctx.dh());
   if (not template_.has_uuid()) {
     if (base_args_.max_size) {
       diagnostic::warning("`max_size` has no effect without a `{{uuid}}` "
                           "placeholder in the URL")
         .primary(base_args_.max_size->source)
-        .note("rotation requires `{{uuid}}` to produce unique filenames")
+        .note("rotation requires `{uuid}` to produce unique filenames")
         .emit(ctx.dh());
     }
     if (base_args_.timeout) {
       diagnostic::warning("`timeout` has no effect without a `{{uuid}}` "
                           "placeholder in the URL")
         .primary(base_args_.timeout->source)
-        .note("rotation requires `{{uuid}}` to produce unique filenames")
+        .note("rotation requires `{uuid}` to produce unique filenames")
         .emit(ctx.dh());
     }
   }

--- a/libtenzir/src/arrow_fs.cpp
+++ b/libtenzir/src/arrow_fs.cpp
@@ -266,7 +266,8 @@ auto FromArrowFsOperator::process_sub(SubKeyView key, table_slice slice,
 
 auto FromArrowFsOperator::finish_sub(SubKeyView key, Push<table_slice>&, OpCtx&)
   -> Task<void> {
-  co_await results_->enqueue(SubFinished{as<uint64_t>(key)});
+  results_->force_enqueue(SubFinished{as<uint64_t>(key)});
+  co_return;
 }
 
 auto FromArrowFsOperator::finalize(Push<table_slice>&, OpCtx& ctx)

--- a/libtenzir/src/folly_init.cpp
+++ b/libtenzir/src/folly_init.cpp
@@ -1,0 +1,33 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "tenzir/folly_init.hpp"
+
+#include <folly/init/Init.h>
+
+namespace tenzir {
+
+struct folly_init_guard::impl {
+  int argc = 1;
+  char** argv;
+  folly::Init init;
+
+  explicit impl(char** outer_argv)
+    : argv{outer_argv},
+      init{&argc, &argv,
+           folly::InitOptions{}.useGFlags(false).removeFlags(false)} {
+  }
+};
+
+folly_init_guard::folly_init_guard(char** argv)
+  : impl_{std::make_unique<impl>(argv)} {
+}
+
+folly_init_guard::~folly_init_guard() = default;
+
+} // namespace tenzir

--- a/libtenzir/src/fs_url_template.cpp
+++ b/libtenzir/src/fs_url_template.cpp
@@ -186,7 +186,7 @@ auto FsUrlTemplate::has_uuid() const -> bool {
 }
 
 void FsUrlTemplate::set_path(std::string path, location url_loc,
-                             Option<location> append, diagnostic_handler& dh) {
+                             diagnostic_handler& dh) {
   for (auto const& r : replacements_) {
     replace_all(path, r.token, r.original);
   }
@@ -199,17 +199,8 @@ void FsUrlTemplate::set_path(std::string path, location url_loc,
     diagnostic::warning("`{{uuid}}` placeholder does not appear in the "
                         "object path and will not be expanded")
       .primary(url_loc)
-      .note("`{{uuid}}` must be in the URL's path portion for rotation "
+      .note("`{uuid}` must be in the URL's path portion for rotation "
             "to produce unique files")
-      .emit(dh);
-  }
-  // In append mode each partition's stable file is extended on every push,
-  // so the overwrite warning is misleading.
-  if (not partition_fields_.empty() and not has_uuid_ and not append) {
-    diagnostic::warning("URL has no `{{uuid}}` placeholder in its path; "
-                        "files for the same partition key will overwrite "
-                        "each other on rotation")
-      .primary(url_loc)
       .emit(dh);
   }
 }

--- a/libtenzir/test/async/bounded_queue.cpp
+++ b/libtenzir/test/async/bounded_queue.cpp
@@ -1,0 +1,198 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "tenzir/async/bounded_queue.hpp"
+
+#include "tenzir/async/task.hpp"
+
+#include <folly/coro/BlockingWait.h>
+#include <folly/coro/Collect.h>
+
+#ifdef CHECK
+#  undef CHECK
+#endif
+#include "tenzir/test/test.hpp"
+
+#include <atomic>
+#include <chrono>
+
+namespace tenzir {
+
+namespace {
+
+// A move-only, non-default-constructible value type to ensure the queue does
+// not depend on `T` being default-constructible or copyable.
+struct MoveOnly {
+  explicit MoveOnly(int x) : value{x} {
+  }
+
+  ~MoveOnly() = default;
+  MoveOnly(const MoveOnly&) = delete;
+  auto operator=(const MoveOnly&) -> MoveOnly& = delete;
+  MoveOnly(MoveOnly&&) noexcept = default;
+  auto operator=(MoveOnly&&) noexcept -> MoveOnly& = default;
+
+  int value;
+};
+
+} // namespace
+
+TEST("bounded_queue dequeues regular enqueues in FIFO order") {
+  folly::coro::blockingWait([&]() -> Task<void> {
+    auto queue = BoundedQueue<int>{4};
+    co_await queue.enqueue(1);
+    co_await queue.enqueue(2);
+    co_await queue.enqueue(3);
+    check_eq(queue.size(), size_t{3});
+    check_eq(co_await queue.dequeue(), 1);
+    check_eq(co_await queue.dequeue(), 2);
+    check_eq(co_await queue.dequeue(), 3);
+    check(queue.empty());
+  }());
+}
+
+TEST("bounded_queue force_enqueue exceeds capacity without blocking") {
+  folly::coro::blockingWait([&]() -> Task<void> {
+    auto queue = BoundedQueue<int>{1};
+    co_await queue.enqueue(1);
+    // Fills the queue beyond `capacity` synchronously — must not suspend.
+    queue.force_enqueue(2);
+    queue.force_enqueue(3);
+    check_eq(queue.size(), size_t{3});
+    // FIFO is preserved: regular item enqueued first comes out first.
+    check_eq(co_await queue.dequeue(), 1);
+    check_eq(co_await queue.dequeue(), 2);
+    check_eq(co_await queue.dequeue(), 3);
+    check(queue.empty());
+  }());
+}
+
+TEST("bounded_queue forced dequeue does not release a capacity slot") {
+  folly::coro::blockingWait([&]() -> Task<void> {
+    auto queue = BoundedQueue<int>{1};
+    // `force_enqueue` first, while a slot is still available — the slot is
+    // NOT consumed by a forced item.
+    queue.force_enqueue(10);
+    // A regular enqueue still takes the only slot.
+    co_await queue.enqueue(20);
+    check_eq(queue.size(), size_t{2});
+    // No slot free, since the regular item is in flight.
+    check_eq(queue.try_enqueue(30), false);
+    // Dequeue the forced item first (FIFO). Capacity stays consumed.
+    check_eq(co_await queue.dequeue(), 10);
+    check_eq(queue.try_enqueue(30), false);
+    // Dequeue the regular item — now the slot is released.
+    check_eq(co_await queue.dequeue(), 20);
+    check_eq(queue.try_enqueue(30), true);
+    check_eq(co_await queue.dequeue(), 30);
+  }());
+}
+
+TEST("bounded_queue try_enqueue fails at capacity but force_enqueue still "
+     "succeeds") {
+  folly::coro::blockingWait([&]() -> Task<void> {
+    auto queue = BoundedQueue<int>{2};
+    check_eq(queue.try_enqueue(1), true);
+    check_eq(queue.try_enqueue(2), true);
+    check_eq(queue.try_enqueue(3), false);
+    queue.force_enqueue(99);
+    check_eq(queue.size(), size_t{3});
+    check_eq(co_await queue.dequeue(), 1);
+    check_eq(co_await queue.dequeue(), 2);
+    check_eq(co_await queue.dequeue(), 99);
+  }());
+}
+
+TEST("bounded_queue try_dequeue returns None on empty") {
+  auto queue = BoundedQueue<int>{1};
+  auto first = queue.try_dequeue();
+  check(first.is_none());
+  check(queue.try_enqueue(7));
+  auto second = queue.try_dequeue();
+  check(second.is_some());
+  check_eq(*second, 7);
+  auto third = queue.try_dequeue();
+  check(third.is_none());
+}
+
+TEST("bounded_queue enqueue blocks at capacity and resumes on dequeue") {
+  folly::coro::blockingWait([&]() -> Task<void> {
+    auto queue = BoundedQueue<int>{1};
+    co_await queue.enqueue(1);
+    auto producer_finished = std::atomic<bool>{false};
+    co_await folly::coro::collectAll(
+      [&]() -> Task<void> {
+        co_await queue.enqueue(2);
+        producer_finished.store(true, std::memory_order_release);
+      }(),
+      [&]() -> Task<void> {
+        // Yield a few times to give the producer a chance to start.
+        for (auto i = 0; i < 8; ++i) {
+          co_await folly::coro::co_reschedule_on_current_executor;
+        }
+        check_eq(producer_finished.load(std::memory_order_acquire), false);
+        check_eq(co_await queue.dequeue(), 1);
+      }());
+    check(producer_finished.load(std::memory_order_acquire));
+    check_eq(co_await queue.dequeue(), 2);
+  }());
+}
+
+TEST("bounded_queue forced dequeue does not unblock a waiting enqueue") {
+  folly::coro::blockingWait([&]() -> Task<void> {
+    auto queue = BoundedQueue<int>{1};
+    co_await queue.enqueue(1); // Consumes the only slot.
+    queue.force_enqueue(2);    // Bypasses the gate.
+    auto producer_finished = std::atomic<bool>{false};
+    co_await folly::coro::collectAll(
+      [&]() -> Task<void> {
+        co_await queue.enqueue(3); // Must suspend; slot held by `1`.
+        producer_finished.store(true, std::memory_order_release);
+      }(),
+      [&]() -> Task<void> {
+        for (auto i = 0; i < 8; ++i) {
+          co_await folly::coro::co_reschedule_on_current_executor;
+        }
+        // Drain the forced item first. The waiter must remain suspended
+        // because forced dequeues never release the gate.
+        check_eq(co_await queue.dequeue(), 1);
+        // After the regular item drains, the slot frees up and the waiter
+        // resumes — but only after we yield enough times for it to run.
+        for (auto i = 0; i < 8; ++i) {
+          co_await folly::coro::co_reschedule_on_current_executor;
+        }
+        check(producer_finished.load(std::memory_order_acquire));
+      }());
+    // Order seen by the consumer: 1 (regular), 2 (forced), 3 (regular).
+    check_eq(co_await queue.dequeue(), 2);
+    check_eq(co_await queue.dequeue(), 3);
+  }());
+}
+
+TEST("bounded_queue try_dequeue_for times out on empty queue") {
+  folly::coro::blockingWait([&]() -> Task<void> {
+    auto queue = BoundedQueue<int>{1};
+    auto result = co_await folly::coro::co_awaitTry(
+      queue.try_dequeue_for(std::chrono::milliseconds{10}));
+    check(result.hasException());
+  }());
+}
+
+TEST("bounded_queue works with move-only non-default-constructible types") {
+  folly::coro::blockingWait([&]() -> Task<void> {
+    auto queue = BoundedQueue<MoveOnly>{2};
+    co_await queue.enqueue(MoveOnly{1});
+    queue.force_enqueue(MoveOnly{2});
+    auto a = co_await queue.dequeue();
+    auto b = co_await queue.dequeue();
+    check_eq(a.value, 1);
+    check_eq(b.value, 2);
+  }());
+}
+
+} // namespace tenzir

--- a/libtenzir_test/src/main.cpp
+++ b/libtenzir_test/src/main.cpp
@@ -9,6 +9,7 @@
 #include "tenzir/configuration.hpp"
 #include "tenzir/detail/env.hpp"
 #include "tenzir/detail/scope_guard.hpp"
+#include "tenzir/folly_init.hpp"
 #include "tenzir/logger.hpp"
 #include "tenzir/plugin.hpp"
 #include "tenzir/test/test.hpp"
@@ -47,6 +48,10 @@ std::vector<std::string> get_test_args(int argc, const char* const* argv) {
 } // namespace
 
 int main(int argc, char** argv) {
+  // Initialize folly singletons (logger, Timekeeper, etc.) so tests can use
+  // folly facilities like coroutine timeouts. Wrapped in libtenzir so the
+  // folly headers and link dependency don't leak into consuming plugins.
+  auto folly_init = tenzir::folly_init_guard{argv};
   TENZIR_ASSERT(tenzir::detail::setenv("TENZIR_ABORT_ON_PANIC", "1")
                 == caf::none);
   TENZIR_ASSERT(tenzir::detail::setenv("TENZIR_BARE_MODE", "true")

--- a/plugins/azure-blob-storage/builtins/from_azure_blob_storage.cpp
+++ b/plugins/azure-blob-storage/builtins/from_azure_blob_storage.cpp
@@ -200,44 +200,50 @@ protected:
         .emit(dh);
       co_return failure::promise();
     }
-    co_return MakeFilesystemResult{fs_result.MoveValueUnsafe(),
-                                   std::move(path)};
+    auto service_client_result = opts.MakeBlobServiceClient();
+    if (not service_client_result.ok()) {
+      diagnostic::error("failed to create Azure Blob Storage service client")
+        .primary(args_.url)
+        .note(service_client_result.status().ToStringWithoutContextLines())
+        .emit(dh);
+      co_return failure::promise();
+    }
+    service_client_ = std::move(*service_client_result);
+    co_return MakeFilesystemResult{
+      fs_result.MoveValueUnsafe(),
+      std::move(path),
+    };
   }
 
   auto remove_file(std::string const& path, diagnostic_handler& dh) const
     -> Task<void> override {
-    auto* abs_fs
-      = dynamic_cast<arrow::fs::AzureFileSystem*>(filesystem().get());
-    TENZIR_ASSERT(abs_fs);
-    co_await spawn_blocking([&] {
-      auto service_client_result = abs_fs->options().MakeBlobServiceClient();
-      if (not service_client_result.ok()) {
-        diagnostic::warning("failed to delete `{}`", path)
-          .primary(args_.url)
-          .note("{}",
-                service_client_result.status().ToStringWithoutContextLines())
-          .emit(dh);
-        return;
-      }
-      try {
-        auto service_client = std::move(*service_client_result);
-        auto [container, blob_path] = split_at_first_slash(path);
-        auto container_client
-          = service_client->GetBlobContainerClient(container);
-        auto blob_client = container_client.GetBlobClient(blob_path);
-        blob_client.Delete();
-      } catch (const Azure::Core::RequestFailedException& e) {
-        diagnostic::warning("failed to delete `{}`", path)
-          .primary(args_.url)
-          .note("{}", e.what())
-          .emit(dh);
-      }
-    });
+    TENZIR_ASSERT(service_client_);
+    auto [container, blob_path] = split_at_first_slash(path);
+    auto error_message
+      = co_await spawn_blocking([service_client = *service_client_, container,
+                                 blob_path] -> Option<std::string> {
+          try {
+            auto container_client
+              = service_client.GetBlobContainerClient(container);
+            auto blob_client = container_client.GetBlobClient(blob_path);
+            blob_client.Delete();
+            return std::nullopt;
+          } catch (const Azure::Core::RequestFailedException& e) {
+            return e.what();
+          }
+        });
+    if (error_message) {
+      diagnostic::warning("failed to delete `{}`", path)
+        .primary(args_.url)
+        .note("{}", *error_message)
+        .emit(dh);
+    }
   }
 
 private:
   FromAzureBlobStorageArgs args_;
   std::string resolved_account_key_;
+  std::unique_ptr<Azure::Storage::Blobs::BlobServiceClient> service_client_;
 };
 
 class from_abs final : public operator_plugin2<from_abs_operator>,

--- a/plugins/gcs/builtins/from_google_cloud_storage.cpp
+++ b/plugins/gcs/builtins/from_google_cloud_storage.cpp
@@ -174,49 +174,51 @@ protected:
         .emit(dh);
       co_return failure::promise();
     }
-    co_return MakeFilesystemResult{fs_result.MoveValueUnsafe(),
-                                   std::move(path)};
+    auto gc_opts = google::cloud::Options{};
+    if (not opts.endpoint_override.empty()) {
+      gc_opts.set<google::cloud::storage::RestEndpointOption>(
+        opts.scheme + "://" + opts.endpoint_override);
+    }
+    if (opts.credentials.anonymous()) {
+      gc_opts.set<google::cloud::UnifiedCredentialsOption>(
+        google::cloud::MakeInsecureCredentials());
+    } else if (not opts.credentials.json_credentials().empty()) {
+      gc_opts.set<google::cloud::UnifiedCredentialsOption>(
+        google::cloud::MakeServiceAccountCredentials(
+          opts.credentials.json_credentials()));
+    } else if (not opts.credentials.access_token().empty()) {
+      gc_opts.set<google::cloud::UnifiedCredentialsOption>(
+        google::cloud::MakeAccessTokenCredentials(
+          opts.credentials.access_token(),
+          time_point_cast<std::chrono::system_clock::duration>(
+            opts.credentials.expiration())));
+    }
+    client_.emplace(std::move(gc_opts));
+    co_return MakeFilesystemResult{
+      fs_result.MoveValueUnsafe(),
+      std::move(path),
+    };
   }
 
   auto remove_file(std::string const& path, diagnostic_handler& dh) const
     -> Task<void> override {
-    auto* gcs_fs = dynamic_cast<arrow::fs::GcsFileSystem*>(filesystem().get());
-    TENZIR_ASSERT(gcs_fs);
-    co_await spawn_blocking([&] {
-      auto const& opts = gcs_fs->options();
-      auto gc_opts = google::cloud::Options{};
-      if (not opts.endpoint_override.empty()) {
-        gc_opts.set<google::cloud::storage::RestEndpointOption>(
-          opts.scheme + "://" + opts.endpoint_override);
-      }
-      if (opts.credentials.anonymous()) {
-        gc_opts.set<google::cloud::UnifiedCredentialsOption>(
-          google::cloud::MakeInsecureCredentials());
-      } else if (not opts.credentials.json_credentials().empty()) {
-        gc_opts.set<google::cloud::UnifiedCredentialsOption>(
-          google::cloud::MakeServiceAccountCredentials(
-            opts.credentials.json_credentials()));
-      } else if (not opts.credentials.access_token().empty()) {
-        gc_opts.set<google::cloud::UnifiedCredentialsOption>(
-          google::cloud::MakeAccessTokenCredentials(
-            opts.credentials.access_token(),
-            time_point_cast<std::chrono::system_clock::duration>(
-              opts.credentials.expiration())));
-      }
-      auto client = google::cloud::storage::Client{std::move(gc_opts)};
-      auto [bucket, key] = split_at_first_slash(path);
-      auto gc_status = client.DeleteObject(bucket, key);
-      if (not gc_status.ok()) {
-        diagnostic::warning("failed to delete `{}`", path)
-          .primary(args_.url)
-          .note("{}", gc_status.message())
-          .emit(dh);
-      }
-    });
+    TENZIR_ASSERT(client_);
+    auto [bucket, key] = split_at_first_slash(path);
+    auto gc_status
+      = co_await spawn_blocking([client = *client_, bucket, key] mutable {
+          return client.DeleteObject(bucket, key);
+        });
+    if (not gc_status.ok()) {
+      diagnostic::warning("failed to delete `{}`", path)
+        .primary(args_.url)
+        .note("{}", gc_status.message())
+        .emit(dh);
+    }
   }
 
 private:
   FromGoogleCloudStorageArgs args_;
+  Option<google::cloud::storage::Client> client_;
 };
 
 class from_gcs final : public operator_plugin2<from_gcs_operator> {

--- a/plugins/s3/builtins/from_s3.cpp
+++ b/plugins/s3/builtins/from_s3.cpp
@@ -312,43 +312,44 @@ protected:
         .emit(dh);
       co_return failure::promise();
     }
-    co_return MakeFilesystemResult{fs_result.MoveValueUnsafe(),
-                                   std::move(path)};
+    auto config = Aws::S3::S3ClientConfiguration{};
+    config.region = opts.region;
+    if (not opts.endpoint_override.empty()) {
+      config.endpointOverride = opts.endpoint_override;
+      config.useVirtualAddressing = opts.force_virtual_addressing;
+    }
+    config.scheme = opts.scheme == "http" ? Aws::Http::Scheme::HTTP
+                                          : Aws::Http::Scheme::HTTPS;
+    client_.emplace(opts.credentials_provider, nullptr, config);
+    co_return MakeFilesystemResult{
+      fs_result.MoveValueUnsafe(),
+      std::move(path),
+    };
   }
 
   auto remove_file(std::string const& path, diagnostic_handler& dh) const
     -> Task<void> override {
-    auto* s3_fs = dynamic_cast<arrow::fs::S3FileSystem*>(filesystem().get());
-    TENZIR_ASSERT(s3_fs);
-    co_await spawn_blocking([&] {
-      auto const& options = s3_fs->options();
-      auto config = Aws::S3::S3ClientConfiguration{};
-      config.region = options.region;
-      if (not options.endpoint_override.empty()) {
-        config.endpointOverride = options.endpoint_override;
-        config.useVirtualAddressing = options.force_virtual_addressing;
-      }
-      config.scheme = options.scheme == "http" ? Aws::Http::Scheme::HTTP
-                                               : Aws::Http::Scheme::HTTPS;
-      auto [bucket, key] = split_at_first_slash(path);
-      auto client
-        = Aws::S3::S3Client{options.credentials_provider, nullptr, config};
-      auto request = Aws::S3::Model::DeleteObjectRequest{};
-      request.SetBucket(bucket);
-      request.SetKey(key);
-      auto outcome = client.DeleteObject(request);
-      if (not outcome.IsSuccess()) {
-        diagnostic::warning("failed to delete `{}`", path)
-          .primary(args_.url)
-          .note("{}", outcome.GetError().GetMessage())
-          .emit(dh);
-      }
-    });
+    TENZIR_ASSERT(client_);
+    auto [bucket, key] = split_at_first_slash(path);
+    auto request = Aws::S3::Model::DeleteObjectRequest{};
+    request.SetBucket(bucket);
+    request.SetKey(key);
+    auto outcome = co_await spawn_blocking(
+      [client = *client_, request = std::move(request)] mutable {
+        return client.DeleteObject(request);
+      });
+    if (not outcome.IsSuccess()) {
+      diagnostic::warning("failed to delete `{}`", path)
+        .primary(args_.url)
+        .note("{}", outcome.GetError().GetMessage())
+        .emit(dh);
+    }
   }
 
 private:
   FromS3Args args_;
   std::optional<ResolvedAwsIamAuth> resolved_;
+  Option<Aws::S3::S3Client> client_;
 };
 
 class from_s3 final : public operator_plugin2<from_s3_operator>,

--- a/tenzir/tenzir.cpp
+++ b/tenzir/tenzir.cpp
@@ -14,6 +14,7 @@
 #include "tenzir/detail/settings.hpp"
 #include "tenzir/detail/signal_handlers.hpp"
 #include "tenzir/diagnostics.hpp"
+#include "tenzir/folly_init.hpp"
 #include "tenzir/legacy_type.hpp" // IWYU pragma: keep
 #include "tenzir/logger.hpp"
 #include "tenzir/module.hpp"
@@ -39,7 +40,6 @@
 #include <caf/telemetry/metric_family_impl.hpp>
 #include <caf/telemetry/metric_registry.hpp>
 #include <caf/thread_owner.hpp>
-#include <folly/init/Init.h>
 #include <sys/resource.h>
 
 #include <csignal>
@@ -124,10 +124,7 @@ auto main(int argc, char** argv) -> int try {
 #endif
   // Some Folly builds use strict mode, even though that is not the default. In
   // that case, we need to call `folly::Init` before using its singletons.
-  auto argc2 = 1;
-  auto argv2 = argv;
-  auto folly_init = folly::Init{
-    &argc2, &argv2, folly::InitOptions{}.useGFlags(false).removeFlags(false)};
+  auto folly_init = tenzir::folly_init_guard{argv};
   // Tweak CAF parameters in case we're running a client command.
   const auto is_server = is_server_from_app_path(argv[0]);
   // Mask SIGINT and SIGTERM so we can handle those in a dedicated thread.

--- a/test/tests/operators/to_file/stress/01_write.txt
+++ b/test/tests/operators/to_file/stress/01_write.txt
@@ -1,6 +1,0 @@
-warning: URL has no `{uuid}` placeholder in its path; files for the same partition key will overwrite each other on rotation
- --> tests/operators/to_file/stress/01_write.tql:6:9
-  |
-6 | to_file env("FILE_ROOT") + "/out/stress/**/file.json", partition_by=[x] {
-  |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
-  |


### PR DESCRIPTION
- Replace the `folly::coro::BoundedQueue` used for completion results in `FromArrowFsOperator` with a custom `BoundedQueue` that supports forced enqueues. `finish_sub` previously awaited a free slot while holding the path that would free one, deadlocking the operator.
- Cache the per-operator `S3Client`, `BlobServiceClient`, and `StorageClient` so that each file deletion no longer rebuilds the SDK request client.