### PR TITLE
Fix synopsis lookup for `not in`

### DIFF
--- a/libtenzir/include/tenzir/min_max_synopsis.hpp
+++ b/libtenzir/include/tenzir/min_max_synopsis.hpp
@@ -72,14 +72,44 @@ public:
     switch (op) {
       case relational_operator::in:
         return membership();
-      case relational_operator::not_in:
-        if (auto result = membership()) {
-          // Invert the result if we are sure.
-          return not *result;
-        } else {
-          // May or may not contain the elements.
-          return result;
+      case relational_operator::not_in: {
+        // `min` and `max` are values we are sure exist in the partition.
+        // The predicate definitely holds whenever one of them is provably
+        // missing from the list; it can only be ruled out when every
+        // stored value is in the list, which from min/max alone is
+        // provable just in the degenerate `min == max` case.
+        auto xs = try_as<view<list>>(&rhs);
+        if (not xs) {
+          return {};
         }
+        auto min_found = false;
+        auto max_found = false;
+        auto uncomparable = false;
+        for (auto x : **xs) {
+          auto v = try_as<view<T>>(&x);
+          if (not v) {
+            // A type-mismatched element could still match an endpoint
+            // after coercion; treat it as preventing a definitive answer.
+            uncomparable = true;
+            continue;
+          }
+          if (*v == min_) {
+            min_found = true;
+          }
+          if (*v == max_) {
+            max_found = true;
+          }
+        }
+        // We can only conclude an endpoint is *not* in the list when we
+        // walked the entire list without any uncomparable entries.
+        if ((not min_found or not max_found) and not uncomparable) {
+          return true;
+        }
+        if (min_found and max_found and min_ == max_) {
+          return false;
+        }
+        return std::nullopt;
+      }
       case relational_operator::equal:
       case relational_operator::not_equal:
       case relational_operator::less:

--- a/libtenzir/test/synopsis.cpp
+++ b/libtenzir/test/synopsis.cpp
@@ -66,15 +66,46 @@ TEST("min - max synopsis") {
   MESSAGE("[4,7] op [0, 4]");
   auto zero_four = data{list{zero, four}};
   auto zero_four_view = make_view(zero_four);
-  verify(zero_four_view, {T, F, N, N, N, N, N, N, N, N});
+  // `in` matches because `4 == min`; `not_in` matches because `7` is a stored
+  // value not in the list.
+  verify(zero_four_view, {T, T, N, N, N, N, N, N, N, N});
   MESSAGE("[4,7] op [7, 9]");
   auto seven_nine = data{list{seven, nine}};
   auto seven_nine_view = make_view(seven_nine);
-  verify(seven_nine_view, {T, F, N, N, N, N, N, N, N, N});
+  // Symmetric to the previous case: `in` matches via `max`, `not_in` via `min`.
+  verify(seven_nine_view, {T, T, N, N, N, N, N, N, N, N});
   MESSAGE("[4,7] op [0, 9]");
   auto zero_nine = data{list{zero, nine}};
   auto zero_nine_view = make_view(zero_nine);
   verify(zero_nine_view, {F, T, N, N, N, N, N, N, N, N});
+  MESSAGE("[4,7] op [5, 6]");
+  time five = epoch + 5s;
+  auto five_six = data{list{five, six}};
+  auto five_six_view = make_view(five_six);
+  // Both elements lie strictly inside `(min, max)`. `in` is unknown
+  // (regression for the catalog bug); `not_in` is true because neither
+  // `4` nor `7` is in the list.
+  verify(five_six_view, {N, T, N, N, N, N, N, N, N, N});
+  MESSAGE("[4,7] op [4, 7]");
+  auto four_seven = data{list{four, seven}};
+  auto four_seven_view = make_view(four_seven);
+  // Both endpoints in the list, but interior values are unknown — `not_in`
+  // cannot be ruled out.
+  verify(four_seven_view, {T, N, N, N, N, N, N, N, N, N});
+  // Lists with `null` are treated conservatively. `null` cannot be compared
+  // against a stored value, so it neither confirms membership nor rules it
+  // out. `[4, null]` keeps `in` true via the `4 == min` match but forces
+  // `not_in` to stay unknown.
+  MESSAGE("[4,7] op [4, null]");
+  auto four_null = data{list{four, data{caf::none}}};
+  auto four_null_view = make_view(four_null);
+  verify(four_null_view, {T, N, N, N, N, N, N, N, N, N});
+  // An all-null list has no comparable elements at all, so both `in` and
+  // `not_in` must be unknown — pruning either direction would be unsafe.
+  MESSAGE("[4,7] op [null]");
+  auto just_null = data{list{data{caf::none}}};
+  auto just_null_view = make_view(just_null);
+  verify(just_null_view, {N, N, N, N, N, N, N, N, N, N});
   // Check that we don't do any implicit conversions.
   MESSAGE("[4,7] op count{{5}}");
   uint64_t c = 5;
@@ -82,5 +113,7 @@ TEST("min - max synopsis") {
   MESSAGE("[4,7] op [count{{5}}, 7]");
   auto heterogeneous = data{list{c, seven}};
   auto heterogeneous_view = make_view(heterogeneous);
-  verify(heterogeneous_view, {T, F, N, N, N, N, N, N, N, N});
+  // The type-mismatched element makes `min`'s membership uncertain, so
+  // `not_in` must stay nullopt rather than incorrectly inverting `in`.
+  verify(heterogeneous_view, {T, N, N, N, N, N, N, N, N, N});
 }


### PR DESCRIPTION
The min/max synopsis previously answered `not in` by inverting the `in`
result. That is unsound: `in` returning `nullopt` (unknown) was flipped
to `nullopt` again, but worse, `in` returning `false` was flipped to
`true` even though we only know that `min` and `max` are not in the
list — interior values could still match.

`not_in` is now evaluated directly: it is `true` only when a stored
endpoint is provably missing from the list, and `false` only in the
degenerate `min == max` case where the single stored value is in the
list. Type-mismatched or `null` elements force a `nullopt` result.