### PR TITLE
Custom metrics in the new executor

### DIFF
--- a/libtenzir/builtins/operators/accept_tcp.cpp
+++ b/libtenzir/builtins/operators/accept_tcp.cpp
@@ -8,13 +8,16 @@
 
 #include <tenzir/arc.hpp>
 #include <tenzir/async/dns.hpp>
+#include <tenzir/async/metrics.hpp>
 #include <tenzir/async/semaphore.hpp>
 #include <tenzir/async/tcp.hpp>
 #include <tenzir/async/tls.hpp>
+#include <tenzir/atomic.hpp>
 #include <tenzir/co_match.hpp>
 #include <tenzir/compile_ctx.hpp>
 #include <tenzir/concept/parseable/tenzir/endpoint.hpp>
 #include <tenzir/concept/parseable/to.hpp>
+#include <tenzir/defaults.hpp>
 #include <tenzir/detail/narrow.hpp>
 #include <tenzir/detail/scope_guard.hpp>
 #include <tenzir/endpoint.hpp>
@@ -90,6 +93,45 @@ struct PeerInfo {
   int64_t port;
 };
 
+struct TcpConnectionMetrics {
+  TcpConnectionMetrics(folly::coro::Transport const& transport,
+                       metric_handler handler)
+    : handle{transport.getPeerAddress().describe()},
+      handler{std::move(handler)} {
+    TENZIR_ASSERT(transport.getPeerAddress().isFamilyInet());
+  }
+
+  std::string handle;
+  metric_handler handler;
+  Atomic<uint64_t> reads = {};
+  Atomic<uint64_t> bytes_read = {};
+  Atomic<bool> closed = false;
+
+  auto record_read(size_t bytes) -> void {
+    reads.fetch_add(1, std::memory_order_relaxed);
+    bytes_read.fetch_add(bytes, std::memory_order_relaxed);
+  }
+
+  auto emit() -> void {
+    handler.emit({
+      {"handle", handle},
+      {"reads", reads.exchange(0, std::memory_order_relaxed)},
+      {"writes", uint64_t{0}},
+      {"bytes_read", bytes_read.exchange(0, std::memory_order_relaxed)},
+      {"bytes_written", uint64_t{0}},
+    });
+  }
+
+  auto close() -> void {
+    closed.store(true, std::memory_order_relaxed);
+    emit();
+  }
+
+  auto is_closed() const -> bool {
+    return closed.load(std::memory_order_relaxed);
+  }
+};
+
 auto make_peer_info(folly::SocketAddress const& address) -> PeerInfo {
   auto storage = sockaddr_storage{};
   auto length = address.getAddress(&storage);
@@ -111,6 +153,29 @@ auto make_peer_info(folly::SocketAddress const& address) -> PeerInfo {
     .address = result,
     .port = int64_t{address.getPort()},
   };
+}
+
+auto tcp_metrics_type() -> type {
+  return {
+    "tenzir.metrics.tcp",
+    record_type{
+      {"handle", string_type{}},
+      {"reads", uint64_type{}},
+      {"writes", uint64_type{}},
+      {"bytes_read", uint64_type{}},
+      {"bytes_written", uint64_type{}},
+    },
+  };
+}
+
+auto emit_tcp_metrics(Arc<TcpConnectionMetrics> metrics) -> Task<void> {
+  while (true) {
+    co_await sleep_for(defaults::metrics_interval);
+    if (metrics->is_closed()) {
+      co_return;
+    }
+    metrics->emit();
+  }
 }
 
 class AcceptTcpListener final : public Operator<void, table_slice> {
@@ -222,6 +287,7 @@ public:
       = ctx.make_counter(MetricsLabel{"operator", "accept_tcp"},
                          MetricsDirection::read, MetricsVisibility::external_,
                          MetricsUnit::events);
+    tcp_metrics_ = make_metric_handler(ctx, tcp_metrics_type());
     ctx.spawn_task([this, &ctx]() -> Task<void> {
       auto notify_finished = detail::scope_guard{[this, &ctx]() noexcept {
         ctx.spawn_task([this]() -> Task<void> {
@@ -305,6 +371,11 @@ public:
         co_await ctx.spawn_sub<chunk_ptr>(std::move(key),
                                           std::move(pipeline_copy),
                                           DiagnosticBehavior::ErrorToWarning);
+        auto tcp_metrics = Arc<TcpConnectionMetrics>{
+          std::in_place,
+          *transport,
+          tcp_metrics_,
+        };
         auto [_, inserted]
           = connections_.emplace(conn_id, std::move(transport));
         TENZIR_ASSERT(inserted);
@@ -312,11 +383,12 @@ public:
         if (it == connections_.end()) {
           co_return;
         }
+        ctx.spawn_task(emit_tcp_metrics(tcp_metrics));
         auto message_queue = message_queue_;
         ctx.spawn_task(folly::coro::co_withExecutor(
           transport_evb,
           read_loop(conn_id, it->second, std::move(message_queue),
-                    std::move(bytes_read))));
+                    std::move(bytes_read), std::move(tcp_metrics))));
       },
       [&](Payload payload) -> Task<void> {
         auto key = sub_key_for(payload.conn_id);
@@ -735,9 +807,10 @@ private:
     }
   }
 
-  static auto read_loop(uint64_t conn_id, Connection connection,
-                        Arc<MessageQueue> message_queue,
-                        MetricsCounter bytes_counter) -> Task<void> {
+  static auto
+  read_loop(uint64_t conn_id, Connection connection,
+            Arc<MessageQueue> message_queue, MetricsCounter bytes_counter,
+            Arc<TcpConnectionMetrics> tcp_metrics) -> Task<void> {
     auto read_error = Option<std::string>{};
     while (true) {
       try {
@@ -747,6 +820,7 @@ private:
           break;
         }
         bytes_counter.add((*read_result)->size());
+        tcp_metrics->record_read((*read_result)->size());
         co_await message_queue->enqueue(
           Payload{conn_id, std::move(*read_result)});
       } catch (folly::AsyncSocketException const& e) {
@@ -754,6 +828,7 @@ private:
         break;
       }
     }
+    tcp_metrics->close();
     co_await message_queue->enqueue(
       ConnectionClosed{conn_id, std::move(read_error)});
   }
@@ -774,6 +849,7 @@ private:
   Semaphore connection_slots_;
   std::unordered_map<uint64_t, Connection> connections_;
   MetricsCounter events_read_counter_;
+  metric_handler tcp_metrics_;
   Box<folly::CancellationSource> accept_cancel_{std::in_place};
   bool accept_loop_finished_ = true;
   bool peer_resolution_warning_emitted_ = false;

--- a/libtenzir/builtins/operators/export.cpp
+++ b/libtenzir/builtins/operators/export.cpp
@@ -9,6 +9,7 @@
 #include "tenzir/async.hpp"
 #include "tenzir/async/fetch_node.hpp"
 #include "tenzir/async/mail.hpp"
+#include "tenzir/async/metrics.hpp"
 #include "tenzir/connect_to_node.hpp"
 
 #include <tenzir/actors.hpp>
@@ -142,6 +143,23 @@ public:
       },
       MetricsDirection::read, MetricsVisibility::internal_,
       MetricsUnit::events);
+    if (not args_.internal) {
+      // We will always report `queued_events` as 0. In the old executor, these
+      // metrics were emitted by the export bridge itself, which is how it can
+      // report these metrics. In the new executor, we would need to mail the
+      // metrics receiver to the node on spawn, which potentially mails the
+      // actor across a process boundary, introducing shutdown issues.
+      export_metrics_
+        = make_metric_handler(ctx, type{
+                                     "tenzir.metrics.export",
+                                     record_type{
+                                       {"schema", string_type{}},
+                                       {"schema_id", string_type{}},
+                                       {"events", uint64_type{}},
+                                       {"queued_events", uint64_type{}},
+                                     },
+                                   });
+    }
     if (uses_prometheus_shape_) {
       prometheus_shapers_ = make_prometheus_shapers();
     }
@@ -258,23 +276,50 @@ public:
         }
         if (output.rows() > 0) {
           auto const rows = output.rows();
+          auto const schema = output.schema();
           co_await push(std::move(output));
           read_events_counter_.add(rows);
+          if (not args_.internal) {
+            export_metrics_.emit({
+              {"schema", std::string{schema.name()}},
+              {"schema_id", schema.make_fingerprint()},
+              {"events", uint64_t{rows}},
+              {"queued_events", uint64_t{0}},
+            });
+          }
         }
       }
       co_return;
     }
     if (not remainder_) {
       auto const rows = expected->rows();
+      auto const schema = expected->schema();
       co_await push(std::move(*expected));
       read_events_counter_.add(rows);
+      if (not args_.internal) {
+        export_metrics_.emit({
+          {"schema", std::string{schema.name()}},
+          {"schema_id", schema.make_fingerprint()},
+          {"events", uint64_t{rows}},
+          {"queued_events", uint64_t{0}},
+        });
+      }
       co_return;
     }
     auto output = filter2(*expected, *remainder_, ctx, false);
     if (output.rows() > 0) {
       auto const rows = output.rows();
+      auto const schema = output.schema();
       co_await push(std::move(output));
       read_events_counter_.add(rows);
+      if (not args_.internal) {
+        export_metrics_.emit({
+          {"schema", std::string{schema.name()}},
+          {"schema_id", schema.make_fingerprint()},
+          {"events", uint64_t{rows}},
+          {"queued_events", uint64_t{0}},
+        });
+      }
     }
   }
 
@@ -301,6 +346,7 @@ private:
   prometheus_shaper_map prometheus_shapers_ = {};
   detail::heterogeneous_string_hashset warned_unsupported_prometheus_schemas_;
   MetricsCounter read_events_counter_;
+  metric_handler export_metrics_ = {};
   bool done_ = false;
 };
 

--- a/libtenzir/builtins/operators/import.cpp
+++ b/libtenzir/builtins/operators/import.cpp
@@ -10,6 +10,7 @@
 #include <tenzir/async.hpp>
 #include <tenzir/async/fetch_node.hpp>
 #include <tenzir/async/mail.hpp>
+#include <tenzir/async/metrics.hpp>
 #include <tenzir/atoms.hpp>
 #include <tenzir/concept/parseable/string/char_class.hpp>
 #include <tenzir/concept/parseable/tenzir/pipeline.hpp>
@@ -53,6 +54,14 @@ public:
       },
       MetricsDirection::write, MetricsVisibility::internal_,
       MetricsUnit::events);
+    import_metrics_ = make_metric_handler(ctx, {
+                                                 "tenzir.metrics.import",
+                                                 record_type{
+                                                   {"schema", string_type{}},
+                                                   {"schema_id", string_type{}},
+                                                   {"events", uint64_type{}},
+                                                 },
+                                               });
     auto node = co_await fetch_node(ctx.actor_system(), ctx.dh());
     if (not node) {
       co_return;
@@ -102,6 +111,13 @@ public:
     }
     write_bytes_counter_.add(input.approx_bytes());
     write_events_counter_.add(input.rows());
+    if (not input.schema().attribute("internal").has_value()) {
+      import_metrics_.emit({
+        {"schema", std::string{input.schema().name()}},
+        {"schema_id", input.schema().make_fingerprint()},
+        {"events", input.rows()},
+      });
+    }
     auto* diagnostics = &ctx.dh();
     inflight_.push_back(
       ctx.spawn_task([importer = importer_, slice = std::move(input),
@@ -142,6 +158,7 @@ private:
   importer_actor importer_;
   MetricsCounter write_bytes_counter_ = {};
   MetricsCounter write_events_counter_ = {};
+  metric_handler import_metrics_ = {};
   std::deque<AsyncHandle<void>> inflight_ = {};
 };
 

--- a/libtenzir/builtins/operators/serve_tcp.cpp
+++ b/libtenzir/builtins/operators/serve_tcp.cpp
@@ -6,12 +6,16 @@
 // SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+#include <tenzir/arc.hpp>
+#include <tenzir/async/metrics.hpp>
 #include <tenzir/async/semaphore.hpp>
 #include <tenzir/async/tls.hpp>
+#include <tenzir/atomic.hpp>
 #include <tenzir/co_match.hpp>
 #include <tenzir/compile_ctx.hpp>
 #include <tenzir/concept/parseable/tenzir/endpoint.hpp>
 #include <tenzir/concept/parseable/to.hpp>
+#include <tenzir/defaults.hpp>
 #include <tenzir/detail/narrow.hpp>
 #include <tenzir/detail/scope_guard.hpp>
 #include <tenzir/endpoint.hpp>
@@ -57,6 +61,68 @@ struct ServeTcpArgs {
   located<ir::pipeline> printer;
 };
 
+struct TcpConnectionMetrics {
+  TcpConnectionMetrics(folly::coro::Transport const& transport,
+                       metric_handler handler)
+    : handle{transport.getPeerAddress().describe()},
+      handler{std::move(handler)} {
+    TENZIR_ASSERT(transport.getPeerAddress().isFamilyInet());
+  }
+
+  auto record_write(size_t bytes) -> void {
+    writes.fetch_add(1, std::memory_order_relaxed);
+    bytes_written.fetch_add(bytes, std::memory_order_relaxed);
+  }
+
+  auto emit() -> void {
+    handler.emit({
+      {"handle", handle},
+      {"reads", uint64_t{0}},
+      {"writes", writes.exchange(0, std::memory_order_relaxed)},
+      {"bytes_read", uint64_t{0}},
+      {"bytes_written", bytes_written.exchange(0, std::memory_order_relaxed)},
+    });
+  }
+
+  auto close() -> void {
+    closed.store(true, std::memory_order_relaxed);
+    emit();
+  }
+
+  auto is_closed() const -> bool {
+    return closed.load(std::memory_order_relaxed);
+  }
+
+  std::string handle;
+  metric_handler handler;
+  Atomic<uint64_t> writes = {};
+  Atomic<uint64_t> bytes_written = {};
+  Atomic<bool> closed = false;
+};
+
+auto tcp_metrics_type() -> type {
+  return {
+    "tenzir.metrics.tcp",
+    record_type{
+      {"handle", string_type{}},
+      {"reads", uint64_type{}},
+      {"writes", uint64_type{}},
+      {"bytes_read", uint64_type{}},
+      {"bytes_written", uint64_type{}},
+    },
+  };
+}
+
+auto emit_tcp_metrics(Arc<TcpConnectionMetrics> metrics) -> Task<void> {
+  while (true) {
+    co_await sleep_for(defaults::metrics_interval);
+    if (metrics->is_closed()) {
+      co_return;
+    }
+    metrics->emit();
+  }
+}
+
 class ServeTcp final : public Operator<table_slice, void> {
 public:
   struct Accepted {
@@ -71,6 +137,11 @@ public:
 
   using Message = variant<Accepted, Payload, AcceptLoopFinished>;
   using MessageQueue = folly::coro::BoundedQueue<Message>;
+
+  struct Client {
+    Box<folly::coro::Transport> transport;
+    Arc<TcpConnectionMetrics> metrics;
+  };
 
   enum class Lifecycle {
     running,
@@ -118,6 +189,7 @@ public:
     server_ = std::make_unique<folly::coro::ServerSocket>(
       std::move(socket), address_, listen_backlog);
     accept_loop_finished_ = false;
+    tcp_metrics_ = make_metric_handler(ctx, tcp_metrics_type());
     ctx.spawn_task([this, &ctx]() -> Task<void> {
       auto notify_finished = detail::scope_guard{[this, &ctx]() noexcept {
         ctx.spawn_task([this]() -> Task<void> {
@@ -160,7 +232,16 @@ public:
         }
         TENZIR_DEBUG("accepted client {}",
                      accepted.client->getPeerAddress().describe());
-        clients_.push_back(std::move(accepted.client));
+        auto metrics = Arc<TcpConnectionMetrics>{
+          std::in_place,
+          *accepted.client,
+          tcp_metrics_,
+        };
+        ctx.spawn_task(emit_tcp_metrics(metrics));
+        clients_.push_back({
+          .transport = std::move(accepted.client),
+          .metrics = std::move(metrics),
+        });
         co_return;
       },
       [&](Payload payload) -> Task<void> {
@@ -238,6 +319,11 @@ private:
     });
   }
 
+  static auto close_client(Client client) -> void {
+    client.metrics->close();
+    close_client(std::move(client.transport));
+  }
+
   auto stop_accepting() -> void {
     accept_cancel_->requestCancellation();
     if (server_ and evb_) {
@@ -291,12 +377,13 @@ private:
     clients_.clear();
   }
 
-  auto write_to_client(folly::coro::Transport& client, folly::ByteRange data)
-    -> Task<bool> {
-    auto* client_evb = client.getEventBase();
+  auto write_to_client(Client& client, folly::ByteRange data) -> Task<bool> {
+    auto* client_evb = client.transport->getEventBase();
     TENZIR_ASSERT(client_evb);
     try {
-      co_await folly::coro::co_withExecutor(client_evb, client.write(data));
+      co_await folly::coro::co_withExecutor(client_evb,
+                                            client.transport->write(data));
+      client.metrics->record_write(data.size());
       co_return true;
     } catch (folly::AsyncSocketException const&) {
       // TODO: Surface peer disconnects and other routine TCP write failures
@@ -314,7 +401,7 @@ private:
       chunk->size(),
     };
     for (size_t i = 0; i < clients_.size();) {
-      auto ok = co_await write_to_client(*clients_[i], data);
+      auto ok = co_await write_to_client(clients_[i], data);
       if (ok) {
         ++i;
         continue;
@@ -403,7 +490,8 @@ private:
                                            message_queue_capacity};
   Semaphore connection_slots_;
   Box<folly::CancellationSource> accept_cancel_{std::in_place};
-  std::vector<Box<folly::coro::Transport>> clients_;
+  std::vector<Client> clients_;
+  metric_handler tcp_metrics_ = {};
   bool accept_loop_finished_ = true;
   Lifecycle lifecycle_ = Lifecycle::running;
 };

--- a/libtenzir/builtins/operators/throttle.cpp
+++ b/libtenzir/builtins/operators/throttle.cpp
@@ -9,6 +9,7 @@
 #include "tenzir/detail/weak_run_delayed.hpp"
 
 #include <tenzir/async.hpp>
+#include <tenzir/async/metrics.hpp>
 #include <tenzir/async/task.hpp>
 #include <tenzir/checked_math.hpp>
 #include <tenzir/diagnostics.hpp>
@@ -238,9 +239,31 @@ public:
   explicit Throttle(ThrottleArgs args) : args_{std::move(args)} {
   }
 
+  auto start(OpCtx& ctx) -> Task<void> override {
+    if (args_.drop) {
+      throttle_metrics_
+        = make_metric_handler(ctx, type{
+                                     "tenzir.metrics.throttle",
+                                     record_type{
+                                       {"dropped_events", int64_type{}},
+                                     },
+                                   });
+      last_emit_ = std::chrono::steady_clock::now();
+    }
+    co_return;
+  }
+
   auto process(table_slice input, Push<table_slice>& push, OpCtx& ctx)
     -> Task<void> override {
     auto now = std::chrono::steady_clock::now();
+    if (args_.drop and last_emit_
+        and now - *last_emit_ >= std::chrono::seconds{1}) {
+      last_emit_ = now;
+      if (dropped_events_ > 0) {
+        throttle_metrics_.emit({{"dropped_events", int64_t(dropped_events_)}});
+        dropped_events_ = 0;
+      }
+    }
     if (not start_) {
       start_ = now;
     }
@@ -251,6 +274,7 @@ public:
     // Preemptive check: the previous slice already exhausted the window budget.
     if (total_ >= args_.rate.inner) {
       if (args_.drop) {
+        dropped_events_ += input.rows();
         diagnostic::warning("dropping input due to rate limit")
           .primary(*args_.drop)
           .emit(ctx.dh());
@@ -268,6 +292,7 @@ public:
         break;
       }
       if (first_cutoff != input.rows()) {
+        dropped_events_ += input.rows() - first_cutoff;
         diagnostic::warning("dropping input due to rate limit")
           .primary(*args_.drop)
           .emit(ctx.dh());
@@ -354,9 +379,21 @@ private:
     }
   }
 
+  auto finalize(Push<table_slice>& push, OpCtx& ctx)
+    -> Task<FinalizeBehavior> override {
+    TENZIR_UNUSED(push, ctx);
+    if (args_.drop and dropped_events_ > 0) {
+      throttle_metrics_.emit({{"dropped_events", int64_t(dropped_events_)}});
+    }
+    co_return FinalizeBehavior::done;
+  }
+
   ThrottleArgs args_;
   Option<std::chrono::steady_clock::time_point> start_;
   uint64_t total_ = 0;
+  metric_handler throttle_metrics_ = {};
+  uint64_t dropped_events_ = 0;
+  Option<std::chrono::steady_clock::time_point> last_emit_ = {};
 };
 
 class plugin final : public virtual operator_plugin2<throttle_operator>,

--- a/libtenzir/include/tenzir/async/metrics.hpp
+++ b/libtenzir/include/tenzir/async/metrics.hpp
@@ -1,0 +1,29 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "tenzir/async.hpp"
+#include "tenzir/metric_handler.hpp"
+#include "tenzir/type.hpp"
+
+namespace tenzir {
+
+inline auto make_metric_handler(OpCtx& ctx, const type& metric_type)
+  -> metric_handler {
+  auto receiver = ctx.metrics_receiver();
+  if (not receiver) {
+    return {};
+  }
+  /// We just always use operator index 0 here, as the integral operator index
+  /// does not translate to the new executor; It didnt even work correctly in
+  /// the old executor.
+  return metric_handler{std::move(receiver), uint64_t{0}, metric_type};
+}
+
+} // namespace tenzir


### PR DESCRIPTION
The `import`, `export`, and `throttle` operators — as well as `context::enrich` and `context::lookup` (via the companion plugins PR) — had no custom metrics on the new (neo) executor path. 

This PR adds back those metrics as well as adding them to `accept_tcp` and `serve_tcp`.

<sub>
✅ Closes TNZ-663<br>
📎 Companion: tenzir/tenzir-plugins#556
</sub>