### PR TITLE
Fix usage signature for new operator diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ CLAUDE.local.md
 CLAUDE-TODOS.md
 .docs/
 
+AGENTS.local.md
+
 # The VSCode codex extension really wants to create this empty file for reasons
 .codex
 .agents/agents.override.md

--- a/libtenzir/src/operator_plugin.cpp
+++ b/libtenzir/src/operator_plugin.cpp
@@ -17,7 +17,9 @@
 #include "tenzir/substitute_ctx.hpp"
 #include "tenzir/tql2/eval.hpp"
 
+#include <algorithm>
 #include <map>
+#include <ranges>
 
 namespace tenzir::_::operator_plugin {
 
@@ -81,8 +83,21 @@ private:
 
 namespace {
 
+auto is_hidden_argument(std::string_view name) -> bool {
+  return name.starts_with('_');
+}
+
+auto is_hidden_argument(const Named& named) -> bool {
+  return std::ranges::all_of(named.names, [](const auto& name) {
+    return is_hidden_argument(name);
+  });
+}
+
 auto display_names(const Named& named) -> std::string {
-  return fmt::format("{}", fmt::join(named.names, "|"));
+  auto names = named.names | std::views::filter([](const auto& name) {
+                 return not is_hidden_argument(name);
+               });
+  return fmt::format("{}", fmt::join(names, "|"));
 }
 
 auto primary_name(const Named& named) -> std::string_view {
@@ -95,6 +110,8 @@ auto setter_to_type_string(const AnySetter& setter) -> std::string {
     setter,
     []<class T>(const Setter<located<T>>&) -> std::string {
       if constexpr (std::same_as<T, std::string>) {
+        return "string";
+      } else if constexpr (std::same_as<T, secret>) {
         return "string";
       } else if constexpr (std::same_as<T, int64_t>
                            or std::same_as<T, uint64_t>) {
@@ -129,6 +146,9 @@ auto get_usage(const Description& desc) -> std::string {
   auto in_brackets = false;
   // Print positional arguments.
   for (auto [idx, positional] : detail::enumerate(desc.positional)) {
+    if (is_hidden_argument(positional.name)) {
+      continue;
+    }
     auto is_optional = desc.first_optional and idx >= *desc.first_optional;
     if (std::exchange(has_previous, true)) {
       result += ", ";
@@ -149,6 +169,9 @@ auto get_usage(const Description& desc) -> std::string {
     if (not named.required) {
       continue;
     }
+    if (is_hidden_argument(named)) {
+      continue;
+    }
     if (in_brackets) {
       result += ']';
       in_brackets = false;
@@ -166,6 +189,9 @@ auto get_usage(const Description& desc) -> std::string {
   // Print optional named arguments.
   for (const auto& named : desc.named) {
     if (named.required) {
+      continue;
+    }
+    if (is_hidden_argument(named)) {
       continue;
     }
     if (std::exchange(has_previous, true)) {

--- a/test/tests/operators/accept_http/error_missing_parser.txt
+++ b/test/tests/operators/accept_http/error_missing_parser.txt
@@ -4,5 +4,5 @@ error: required subpipeline was not provided
 5 | accept_http "127.0.0.1:8080"
   | ^^^^^^^^^^^ 
   |
-  = usage: accept_http endpoint:secret, [responses=record, max_request_size=int, max_connections=int, tls=record]
+  = usage: accept_http endpoint:string, [responses=record, max_request_size=int, max_connections=int, tls=record]
   = docs: https://docs.tenzir.com/reference/operators/accept_http

--- a/test/tests/operators/from_ftp/validation/error_missing_parser_pipeline.txt
+++ b/test/tests/operators/from_ftp/validation/error_missing_parser_pipeline.txt
@@ -4,5 +4,5 @@ error: required subpipeline was not provided
 5 | from_ftp "ftp://127.0.0.1:21/download.ndjson"
   | ^^^^^^^^ 
   |
-  = usage: from_ftp url:secret, [tls=record]
+  = usage: from_ftp url:string, [tls=record]
   = docs: https://docs.tenzir.com/reference/operators/from_ftp

--- a/test/tests/operators/from_http/error_metadata_fields_arg.txt
+++ b/test/tests/operators/from_http/error_metadata_fields_arg.txt
@@ -4,5 +4,5 @@ error: named argument `metadata_fields` does not exist
 5 | from_http "http://127.0.0.1:0/", metadata_fields=true {
   |                                  ^^^^^^^^^^^^^^^ 
   |
-  = usage: from_http url:secret, [method=string, body=any, headers=record, tls=record, timeout=duration, error_field=field, metadata_field=any, paginate=any, paginate_delay=duration, connection_timeout=duration, max_retry_count=int, retry_delay=duration, encode=string, server=bool]
+  = usage: from_http url:string, [method=string, body=any, headers=record, tls=record, timeout=duration, error_field=field, metadata_field=any, paginate=any, paginate_delay=duration, connection_timeout=duration, max_retry_count=int, retry_delay=duration, encode=string, server=bool]
   = docs: https://docs.tenzir.com/reference/operators/from_http

--- a/test/tests/operators/to_ftp/validation/error_missing_printer_pipeline.txt
+++ b/test/tests/operators/to_ftp/validation/error_missing_printer_pipeline.txt
@@ -4,5 +4,5 @@ error: required subpipeline was not provided
 5 | to_ftp "ftp://127.0.0.1:21/upload.ndjson"
   | ^^^^^^ 
   |
-  = usage: to_ftp url:secret, [tls=record]
+  = usage: to_ftp url:string, [tls=record]
   = docs: https://docs.tenzir.com/reference/operators/to_ftp


### PR DESCRIPTION
Previously, an incorrectly user operator may print

    usage: to_clickhouse table=string, [host=secret, port=int, user=secret, password=secret, mode=string, primary=field, _jobs=int, tls=record]

which mentions which arguments _can_ be secrets (but dont have to) as well as hidden arguments.

With this change, we get the intended

    usage: to_clickhouse table=string, [host=string, port=int, user=string, password=string, mode=string, primary=field, tls=record]

Resolves: https://linear.app/tenzir/issue/TNZ-642
