### PR TITLE
Raise to_s3 request timeout

### DIFF
--- a/plugins/s3/builtins/to_s3.cpp
+++ b/plugins/s3/builtins/to_s3.cpp
@@ -19,6 +19,8 @@
 namespace tenzir::plugins::s3 {
 namespace {
 
+constexpr auto default_request_timeout = 30.0;
+
 struct ToS3Args : ToArrowFsArgs {
   bool anonymous = false;
   Option<located<record>> aws_iam;
@@ -72,6 +74,9 @@ protected:
       co_return failure::promise();
     }
     auto opts = opts_result.MoveValueUnsafe();
+    if (opts.request_timeout < 0) {
+      opts.request_timeout = default_request_timeout;
+    }
     if (args_.anonymous) {
       opts.ConfigureAnonymousCredentials();
     } else {


### PR DESCRIPTION
## 🔍 Problem

- Arrow/AWS SDK can abort `CreateMultipartUpload` when a slow S3 response trips the Curl low-speed request timeout.
- This can fail `to_s3` before any event data is uploaded, even though the pipeline itself is not producing data continuously.

## 🛠️ Solution

- Default the TQL2 `to_s3` request timeout to 30 seconds when Arrow leaves it unset.
- Keep eager output stream opens, so open-time S3 errors still fail the pipeline directly.

## 💬 Review

- `from_s3` and the legacy S3 operators are intentionally unchanged.
- Explicit Arrow URL options still win if `FromUri` sets `request_timeout`.
- No changelog entry, per request.
