### PR TITLE
Fix folly's non-static aarch64 build and enable SIMD memcpy/memset

### DIFF
--- a/nix/facebook-network-stack.nix
+++ b/nix/facebook-network-stack.nix
@@ -3,8 +3,8 @@
   folly = {
     owner = "tenzir";
     repo = "folly";
-    rev = "d9b6ea7fb7b332df05141d2de789f281eb6315dd";
-    hash = "sha256-Ec7hENYj9XQRPz5tbAV2NatKpLwfiUuLzX4kR0Jrivk=";
+    rev = "d001905091451d3f66e59e231cfdc01d85a8df3d";
+    hash = "sha256-L8kBkNnO1MjTtHKHBigkTedX+q58L+xQmTt/OPhoR5s=";
   };
   fizz = {
     owner = "facebookincubator";

--- a/nix/overrides/folly.nix
+++ b/nix/overrides/folly.nix
@@ -3,7 +3,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch2,
   glog,
   xz,
 }:
@@ -26,22 +25,28 @@ folly.overrideAttrs (orig: {
   patches =
     (builtins.filter (
       x:
-      # replaced below
+      # The aarch64 memcpy/memset wiring is carried in the tenzir/folly fork.
       ((builtins.match ".*-memset-memcpy-aarch64\.patch" "${x}") == null)
       # no longer applicable
       && ((builtins.match ".*-folly-fix-glog-0\.7\.patch$" "${x}") == null)
       && ((builtins.match ".*-char_traits\.patch" "${x}") == null)
       && ((builtins.match ".*-fix-__type_pack_element\.patch" "${x}") == null)
     ) orig.patches)
-    ++ [
-      (fetchpatch2 {
-        name = "folly-fix-aarch64-duplicate-symbol-errors.patch";
-        url = "https://github.com/facebook/folly/commit/f51f51246756aaaa6242cf2c5efc6cd0d5f5ec75.patch";
-        hash = "sha256-+S/q457jGIWYA4bUagw9A9NV9msFGou+AFfNceEgi1I=";
-      })
-    ]
     ++ lib.optional stdenv.hostPlatform.isMusl ./folly-musl-compat.patch
     ++ lib.optional stdenv.hostPlatform.isStatic ./folly-static-compat.patch;
+
+  # Replaces nixpkgs' postPatch: keep the libfolly.pc.in fixup but drop its
+  # aarch64 aor EXCLUDE_FROM_MONOLITH substitution. The fork removes the -use
+  # aor variants, so that --replace-fail has nothing to match.
+  postPatch = ''
+    substituteInPlace CMake/libfolly.pc.in \
+      --replace-fail \
+        ${lib.escapeShellArg "\${exec_prefix}/@LIB_INSTALL_DIR@"} \
+        '@CMAKE_INSTALL_FULL_LIBDIR@' \
+      --replace-fail \
+        ${lib.escapeShellArg "\${prefix}/@CMAKE_INSTALL_INCLUDEDIR@"} \
+        '@CMAKE_INSTALL_FULL_INCLUDEDIR@'
+  '';
 
   preConfigure = lib.optionalString stdenv.hostPlatform.isx86_64 ''
     cmakeFlagsArray+=("-DCMAKE_CXX_FLAGS=-msse -msse2 -msse3 -mssse3 -msse4.1 -msse4.2 -mavx -mavx2")


### PR DESCRIPTION
## Summary

`main` CI is green because every build job is static, and this only affects dynamic (shared) folly builds, which CI never runs. The non-static aarch64-linux build (e.g. the `nix develop` dev shell) currently fails to build folly.

The duplicate-symbol fetchpatch in `folly.nix` marks the `folly/external/aor` `-use` memcpy/memset targets `EXCLUDE_FROM_MONOLITH`. In a shared build that makes each one a standalone shared library, but nothing links them, so they stay orphaned and the build fails to produce and install `libfolly_external_aor_mem*_aarch64-use.so`. In a static build they are just orphaned `.a` files that build fine, which is why static CI passes. On top of that, the ARM memcpy/memset code was never wired into `libfolly` at all, so folly fell back to libc on aarch64 regardless.

This bumps folly to a `tenzir/folly` rev (`d9b6ea7` to `d0019050`) that wires the non-`-use` aor targets into the monolithic `libfolly` via the `mem*_select_aarch64.cpp` selectors and `DEPS` (matching `folly/BUCK`), and drops the unused `-use` override variants. The selectors use ifunc, which musl does not support, so the wiring is gated on a glibc aarch64 target (`FOLLY_AARCH64_SIMD`); on musl folly keeps the plain libc memcpy/memset. `folly.nix` no longer needs the duplicate-symbol fetchpatch, so it instead overrides `postPatch` to keep nixpkgs' `libfolly.pc.in` fixup while dropping the aarch64 aor `substituteInPlace` that no longer matches.

## Test plan

- [x] Dynamic (glibc) aarch64-linux build compiles folly and tenzir (fails on `main`).
- [x] Static aarch64-linux (musl) and arm64-darwin CI jobs pass.