### PR TITLE
Stop pinning CCACHE_DIR to /tmp in the nix dev shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -145,19 +145,16 @@ pkgs.mkShell (
     env.CCACHE_R2_ALLOWED_PREFIXES = "ccache/";
     env.CCACHE_R2_TEMP_CREDENTIAL_PERMISSION = "object-read-write";
     env.CCACHE_R2_TEMP_CREDENTIAL_TTL_SECONDS = "3600";
-    env.CCACHE_NOREMOTE_ONLY = "true";
     env.CCACHE_RESHARE = "true";
     env.CCACHE_NAMESPACE = "tenzir";
     env.CCACHE_COMPRESS = "true";
-    env.CCACHE_DIR = "/tmp/tenzir-ccache/cache";
     env.CCACHE_SLOPPINESS = "pch_defines,time_macros,include_file_mtime,include_file_ctime,random_seed";
 
     shellHook = ''
       ccache_s3_dir="/tmp/tenzir-ccache"
       ccache_s3_sock="$ccache_s3_dir/s3.sock"
-      mkdir -p "$ccache_s3_dir/cache"
+      mkdir -p "$ccache_s3_dir"
       chmod 1777 "$ccache_s3_dir" 2>/dev/null || true
-      chmod 0777 "$ccache_s3_dir/cache" 2>/dev/null || true
       export CCACHE_REMOTE_STORAGE="crsh:$ccache_s3_sock data-timeout=10s request-timeout=60s @max-pool-connections=64 @object-list-min-interval=300 @upload-queue-size=4096 @upload-queue-bytes=536870912 @upload-workers=8 @upload-drain-timeout=60"
       if [ -S "$ccache_s3_sock" ] && socat -u OPEN:/dev/null "UNIX-CONNECT:$ccache_s3_sock" >/dev/null 2>&1; then
         echo "ccache R2 helper: already running at $ccache_s3_sock."


### PR DESCRIPTION
## 🔍 Problem

- The dev shell set `CCACHE_DIR` to `/tmp/tenzir-ccache/cache`, copied from the sandboxed `nix build`.
- The sandbox uses `/tmp` only because its `$HOME` isn't writable/persistent. `nix develop` is **not** sandboxed, so the pin needlessly forced the local cache onto an ephemeral tmpfs — warm artifacts were lost between sessions.

## 🛠️ Solution

- Remove the `CCACHE_DIR` override and let ccache use its normal persistent default (`$XDG_CACHE_HOME/ccache`, else `~/.cache/ccache`, or a legacy `~/.ccache`). Where the local cache lives is ccache's concern — and the user's, via `XDG_CACHE_HOME`/`CCACHE_DIR` — not the dev shell's.
- Drop the now-unused `/tmp/tenzir-ccache/cache` directory setup. `/tmp/tenzir-ccache` is still created — it holds the R2 helper's unix socket.
- The R2 remote and all other ccache settings (namespace, compression, sloppiness, reshare) are unchanged.
- Sandboxed `nix build` and CI are untouched.

## 💬 Review

- Behavior change is dev-shell only; no user-facing impact, hence no changelog entry.
- Defers to ccache's well-defined default resolution for every setup: respects an explicit `CCACHE_DIR` or `XDG_CACHE_HOME`, and reuses an existing legacy `~/.ccache` if present.
