### PR TITLE
Materialize all GeoIP fields

### DIFF
--- a/changelog/unreleased/complete-geoip-record-enrichment.md
+++ b/changelog/unreleased/complete-geoip-record-enrichment.md
@@ -1,0 +1,12 @@
+---
+title: Complete GeoIP record enrichment
+type: bugfix
+authors:
+  - mavam
+  - codex
+prs:
+  - 6239
+created: 2026-05-29T10:35:15.531152Z
+---
+
+GeoIP enrichment now includes all fields from MaxMind records. Previously, records containing `uint128` values could stop materializing subsequent fields, which could omit later enrichment data from affected databases.

--- a/libtenzir/builtins/contexts/geoip.cpp
+++ b/libtenzir/builtins/contexts/geoip.cpp
@@ -313,6 +313,7 @@ public:
       case MMDB_DATA_TYPE_UINT128:
         r[key] = cast_128_bit_unsigned_to_64_bit(
           entry_data_list->entry_data.uint128);
+        entry_data_list = entry_data_list->next;
         break;
       case MMDB_DATA_TYPE_INT32:
         r[key] = int64_t{entry_data_list->entry_data.int32};


### PR DESCRIPTION
## 🔍 Problem

- GeoIP enrichment could fail to advance past `uint128` values while materializing MaxMind records.
- The integration coverage only used an ASN database, so it did not prove City fields such as latitude and longitude.

## 🛠️ Solution

- Advance the MaxMind entry cursor after converting `uint128` record values.
- Bump the plugins submodule to include a City database regression test for `geo.location.latitude` and `geo.location.longitude`.

## 💬 Review

- The code fix is intentionally narrow; the rest of the MMDB scalar and container types already advance the cursor.
- The companion plugins PR carries the binary fixture and TQL regression test.

<sub>
📎 Related: tenzir/tenzir-plugins#560
</sub>
