### PR TITLE
Improve diagnostics for lambda-valued let bindings

### DIFF
--- a/changelog/unreleased/diagnostics-for-lambda-valued-let-bindings.md
+++ b/changelog/unreleased/diagnostics-for-lambda-valued-let-bindings.md
@@ -1,0 +1,13 @@
+---
+title: Diagnostics for lambda-valued let bindings
+type: bugfix
+authors:
+  - mavam
+  - codex
+pr: 6241
+created: 2026-05-31T06:17:30.259084Z
+---
+
+Invalid lambda-valued `let` bindings now produce a focused diagnostic instead of cascading into a generic evaluation warning and an internal error.
+
+For example, `let $f = (x => x + 1)` now points at the lambda and suggests inlining it at the use site.

--- a/libtenzir/src/ir.cpp
+++ b/libtenzir/src/ir.cpp
@@ -743,6 +743,13 @@ auto ast::pipeline::compile(compile_ctx ctx) && -> failure_or<ir::pipeline> {
         return {};
       },
       [&](ast::let_stmt x) -> failure_or<void> {
+        if (try_as<ast::lambda_expr>(*x.expr.kind)) {
+          diagnostic::error("lambda-valued `let` bindings are not supported")
+            .primary(x.expr)
+            .hint("inline the lambda expression at the use site")
+            .emit(ctx);
+          return failure::promise();
+        }
         TRY(x.expr.bind(ctx));
         auto id = scope.let(std::string{x.name_without_dollar()});
         lets.emplace_back(std::move(x.name), std::move(x.expr), id);
@@ -788,6 +795,13 @@ auto ir::pipeline::substitute(substitute_ctx ctx, bool instantiate)
       // bindings might reference earlier ones.
       TRY(auto subst, let.expr.substitute(ctx.with_env(&env)));
       TENZIR_ASSERT(subst == ast::substitute_result::no_remaining);
+      if (try_as<ast::lambda_expr>(*let.expr.kind)) {
+        diagnostic::error("lambda-valued `let` bindings are not supported")
+          .primary(let.expr)
+          .hint("inline the lambda expression at the use site")
+          .emit(ctx);
+        return failure::promise();
+      }
       TRY(auto value, const_eval(let.expr, ctx));
       // TODO: Clean this up. Should probably make `const_eval` return it.
       auto converted = match(

--- a/libtenzir/src/tql2/exec.cpp
+++ b/libtenzir/src/tql2/exec.cpp
@@ -240,9 +240,19 @@ public:
         ++it;
         continue;
       }
+      auto name = std::string{let->name_without_dollar()};
+      if (try_as<ast::lambda_expr>(*let->expr.kind)) {
+        diagnostic::error("lambda-valued `let` bindings are not supported")
+          .primary(let->expr)
+          .hint("inline the lambda expression at the use site")
+          .emit(ctx_);
+        failure_ = failure::promise();
+        map_[std::move(name)] = std::nullopt;
+        it = x.body.erase(it);
+        continue;
+      }
       visit(let->expr);
       auto value = const_eval(let->expr, ctx_);
-      auto name = std::string{let->name_without_dollar()};
       if (value) {
         map_[std::move(name)] = tenzir::match(
           std::move(*value),

--- a/test/tests/language/lambda/let_lambda.tql
+++ b/test/tests/language/lambda/let_lambda.tql
@@ -1,0 +1,7 @@
+---
+error: true
+---
+
+let $f = (x => $missing)
+from {xs: [1, 2, 3]}
+ys = xs.map($f)

--- a/test/tests/language/lambda/let_lambda.txt
+++ b/test/tests/language/lambda/let_lambda.txt
@@ -1,0 +1,7 @@
+error: lambda-valued `let` bindings are not supported
+ --> tests/language/lambda/let_lambda.tql:5:11
+  |
+5 | let $f = (x => $missing)
+  |           ^^^^^^^^^^^^^ 
+  |
+  = hint: inline the lambda expression at the use site


### PR DESCRIPTION
## 🔍 Problem

- Lambda-valued `let` bindings are invalid, but they currently fall through to constant evaluation.
- Users can see a generic eval warning, a misleading `expected a lambda` error, and an internal assertion instead of the actual problem.

## 🛠️ Solution

- Reject lambda-valued `let` bindings before constant evaluation.
- Point the diagnostic at the lambda and suggest inlining it at the use site.
- Cover the invalid binding with a regression test and changelog entry.

## 💬 Review

- Check the two let-resolution paths for consistent behavior.
- The change deliberately reports unsupported lambda storage rather than attempting to make lambdas first-class constants.