### PR TITLE
Add chunk stream operators

### DIFF
--- a/changelog/unreleased/chunk-stream-operators.md
+++ b/changelog/unreleased/chunk-stream-operators.md
@@ -1,0 +1,22 @@
+---
+title: Chunk stream operators
+type: feature
+authors:
+  - aljazerzen
+  - codex
+created: 2026-06-01T09:09:37.255561Z
+---
+
+TQL now includes `read_chunks` and `write_chunks` for converting between byte streams and records with a `bytes` field.
+
+For example, you can capture arbitrary output as records and turn it back into a byte stream later:
+
+```tql
+from {line: "hello"}, {line: "world"}
+write_lines
+read_chunks
+write_chunks
+read_lines
+```
+
+This makes it easier to inspect, buffer, transform, and roundtrip chunked byte streams inside a pipeline.

--- a/libtenzir/builtins/operators/read_chunks.cpp
+++ b/libtenzir/builtins/operators/read_chunks.cpp
@@ -1,0 +1,87 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <tenzir/as_bytes.hpp>
+#include <tenzir/async/pusher.hpp>
+#include <tenzir/operator_plugin.hpp>
+#include <tenzir/plugin/register.hpp>
+#include <tenzir/series_builder.hpp>
+
+namespace tenzir::plugins::read_chunks {
+
+namespace {
+
+struct ReadChunksArgs {
+  location operator_location;
+};
+
+class ReadChunks final : public Operator<chunk_ptr, table_slice> {
+public:
+  explicit ReadChunks(ReadChunksArgs args) : args_{args} {
+  }
+
+  auto process(chunk_ptr input, Push<table_slice>& push, OpCtx&)
+    -> Task<void> override {
+    if (input->size() == 0) {
+      co_return;
+    }
+    builder_.record().field("bytes", as_bytes(input));
+    co_await pusher_.push(builder_.yield_ready(type_name), push);
+  }
+
+  auto await_task(diagnostic_handler&) const -> Task<Any> override {
+    co_await pusher_.wait();
+    co_return {};
+  }
+
+  auto process_task(Any, Push<table_slice>& push, OpCtx&)
+    -> Task<void> override {
+    co_await pusher_.push(builder_.yield_ready(type_name), push);
+  }
+
+  auto finalize(Push<table_slice>& push, OpCtx&)
+    -> Task<FinalizeBehavior> override {
+    if (builder_.length() > 0) {
+      co_await push(builder_.finish_assert_one_slice(type_name));
+    }
+    co_return FinalizeBehavior::done;
+  }
+
+  auto prepare_snapshot(Push<table_slice>& push, OpCtx&)
+    -> Task<void> override {
+    if (builder_.length() > 0) {
+      co_await push(builder_.finish_assert_one_slice(type_name));
+    }
+  }
+
+private:
+  constexpr static auto type_name = "tenzir.chunk";
+
+  ReadChunksArgs args_;
+  series_builder builder_;
+  SeriesPusher pusher_;
+};
+
+class plugin final : public virtual OperatorPlugin {
+public:
+  auto name() const -> std::string override {
+    return "tql2.read_chunks";
+  }
+
+  auto describe() const -> Description override {
+    auto d = Describer<ReadChunksArgs, ReadChunks>{};
+    d.operator_location(&ReadChunksArgs::operator_location);
+    return d.without_optimize();
+  }
+};
+
+} // namespace
+
+} // namespace tenzir::plugins::read_chunks
+
+TENZIR_REGISTER_PLUGIN(tenzir::plugins::read_chunks::plugin)

--- a/libtenzir/builtins/operators/read_chunks.cpp
+++ b/libtenzir/builtins/operators/read_chunks.cpp
@@ -30,7 +30,7 @@ public:
     if (input->size() == 0) {
       co_return;
     }
-    builder_.record().field("bytes", as_bytes(input));
+    builder_.record().field("data", as_bytes(input));
     co_await pusher_.push(builder_.yield_ready(type_name), push);
   }
 

--- a/libtenzir/builtins/operators/write_all.cpp
+++ b/libtenzir/builtins/operators/write_all.cpp
@@ -109,6 +109,10 @@ public:
     auto d = Describer<WriteAllArgs, WriteAll>{};
     auto field = d.positional("field", &WriteAllArgs::field, "field");
     d.validate([=](DescribeCtx& ctx) -> Empty {
+      diagnostic::warning("`write_all` is deprecated")
+        .primary(ctx.operator_location())
+        .hint("use `write_chunks` instead")
+        .emit(ctx);
       auto value = ctx.get(field);
       if (value and value->path().empty()) {
         diagnostic::error("cannot write all of `this`")

--- a/libtenzir/builtins/operators/write_all.cpp
+++ b/libtenzir/builtins/operators/write_all.cpp
@@ -109,10 +109,6 @@ public:
     auto d = Describer<WriteAllArgs, WriteAll>{};
     auto field = d.positional("field", &WriteAllArgs::field, "field");
     d.validate([=](DescribeCtx& ctx) -> Empty {
-      diagnostic::warning("`write_all` is deprecated")
-        .primary(ctx.operator_location())
-        .hint("use `write_chunks` instead")
-        .emit(ctx);
       auto value = ctx.get(field);
       if (value and value->path().empty()) {
         diagnostic::error("cannot write all of `this`")

--- a/libtenzir/builtins/operators/write_chunks.cpp
+++ b/libtenzir/builtins/operators/write_chunks.cpp
@@ -30,7 +30,7 @@ auto emit_resolve_error(resolve_error const& err, diagnostic_handler& dh)
 }
 
 struct WriteChunksArgs {
-  Option<ast::field_path> field;
+  ast::field_path field;
   location operator_location;
 };
 
@@ -68,31 +68,32 @@ public:
   }
 
 private:
-  auto select_field(const table_slice& slice, OpCtx& ctx) -> Option<series> {
-    if (args_.field) {
-      auto resolved = resolve(*args_.field, slice);
+  auto select_field(const table_slice& slice, OpCtx& ctx)
+    -> std::optional<series> {
+    if (not args_.field.path().empty()) {
+      auto resolved = resolve(args_.field, slice);
       if (auto* error = std::get_if<resolve_error>(&resolved)) {
         emit_resolve_error(*error, ctx);
-        return None;
+        return std::nullopt;
       }
       return std::get<series>(std::move(resolved));
     }
-    // Default: look up the "bytes" field.
+    // Default: look up the "data" field.
     auto batch = to_record_batch(slice);
     auto column = batch->GetColumnByName("data");
     if (not column) {
       diagnostic::warning("expected a field named `data`")
         .primary(args_.operator_location)
         .emit(ctx);
-      return None;
+      return std::nullopt;
     }
     auto rt = try_as<record_type>(slice.schema());
     if (not rt) {
-      return None;
+      return std::nullopt;
     }
     auto ty = rt->field("data");
     if (not ty) {
-      return None;
+      return std::nullopt;
     }
     return series{*ty, column};
   }

--- a/libtenzir/builtins/operators/write_chunks.cpp
+++ b/libtenzir/builtins/operators/write_chunks.cpp
@@ -9,19 +9,34 @@
 #include <tenzir/operator_plugin.hpp>
 #include <tenzir/plugin/register.hpp>
 #include <tenzir/table_slice.hpp>
+#include <tenzir/tql2/ast.hpp>
+#include <tenzir/tql2/eval.hpp>
 #include <tenzir/view3.hpp>
 
 namespace tenzir::plugins::write_chunks {
 
 namespace {
 
+auto emit_resolve_error(resolve_error const& err, diagnostic_handler& dh)
+  -> void {
+  err.reason.match([&](resolve_error::field_not_found const&) {},
+                   [&](resolve_error::field_not_found_no_error const&) {},
+                   [&](resolve_error::field_of_non_record const& reason) {
+                     diagnostic::error("type `{}` has no field `{}`",
+                                       reason.type.kind(), err.ident.name)
+                       .primary(err.ident)
+                       .emit(dh);
+                   });
+}
+
 struct WriteChunksArgs {
+  Option<ast::field_path> field;
   location operator_location;
 };
 
 class WriteChunks final : public Operator<table_slice, chunk_ptr> {
 public:
-  explicit WriteChunks(WriteChunksArgs args) : args_{args} {
+  explicit WriteChunks(WriteChunksArgs args) : args_{std::move(args)} {
   }
 
   auto process(table_slice slice, Push<chunk_ptr>& push, OpCtx& ctx)
@@ -29,28 +44,15 @@ public:
     if (slice.rows() == 0) {
       co_return;
     }
-    auto batch = to_record_batch(slice);
-    auto column = batch->GetColumnByName("bytes");
-    if (not column) {
-      diagnostic::warning("expected a field named `bytes`")
-        .primary(args_.operator_location)
-        .emit(ctx);
+    auto selected = select_field(slice, ctx);
+    if (not selected) {
       co_return;
     }
-    auto rt = try_as<record_type>(slice.schema());
-    if (not rt) {
+    if (selected->type.kind().is<null_type>()) {
       co_return;
     }
-    auto ty = rt->field("bytes");
-    if (not ty) {
-      co_return;
-    }
-    auto selected = series{*ty, column};
-    if (selected.type.kind().is<null_type>()) {
-      co_return;
-    }
-    if (selected.type.kind().is<blob_type>()) {
-      for (auto value : selected.values3<blob_type>()) {
+    if (selected->type.kind().is<blob_type>()) {
+      for (auto value : selected->values3<blob_type>()) {
         if (not value) {
           continue;
         }
@@ -58,15 +60,43 @@ public:
       }
       co_return;
     }
-    diagnostic::error("field `bytes` has unsupported type `{}`",
-                      selected.type.kind())
+    diagnostic::error("field has unsupported type `{}`", selected->type.kind())
       .primary(args_.operator_location)
-      .hint("`write_chunks` expects the `bytes` field to have type `blob`")
+      .hint("`write_chunks` expects a field of type `blob`")
       .emit(ctx);
     co_return;
   }
 
 private:
+  auto select_field(const table_slice& slice, OpCtx& ctx) -> Option<series> {
+    if (args_.field) {
+      auto resolved = resolve(*args_.field, slice);
+      if (auto* error = std::get_if<resolve_error>(&resolved)) {
+        emit_resolve_error(*error, ctx);
+        return None;
+      }
+      return std::get<series>(std::move(resolved));
+    }
+    // Default: look up the "bytes" field.
+    auto batch = to_record_batch(slice);
+    auto column = batch->GetColumnByName("data");
+    if (not column) {
+      diagnostic::warning("expected a field named `data`")
+        .primary(args_.operator_location)
+        .emit(ctx);
+      return None;
+    }
+    auto rt = try_as<record_type>(slice.schema());
+    if (not rt) {
+      return None;
+    }
+    auto ty = rt->field("data");
+    if (not ty) {
+      return None;
+    }
+    return series{*ty, column};
+  }
+
   WriteChunksArgs args_;
 };
 
@@ -78,6 +108,7 @@ public:
 
   auto describe() const -> Description override {
     auto d = Describer<WriteChunksArgs, WriteChunks>{};
+    d.optional_positional("field", &WriteChunksArgs::field, "field");
     d.operator_location(&WriteChunksArgs::operator_location);
     return d.without_optimize();
   }

--- a/libtenzir/builtins/operators/write_chunks.cpp
+++ b/libtenzir/builtins/operators/write_chunks.cpp
@@ -1,0 +1,90 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <tenzir/operator_plugin.hpp>
+#include <tenzir/plugin/register.hpp>
+#include <tenzir/table_slice.hpp>
+#include <tenzir/view3.hpp>
+
+namespace tenzir::plugins::write_chunks {
+
+namespace {
+
+struct WriteChunksArgs {
+  location operator_location;
+};
+
+class WriteChunks final : public Operator<table_slice, chunk_ptr> {
+public:
+  explicit WriteChunks(WriteChunksArgs args) : args_{args} {
+  }
+
+  auto process(table_slice slice, Push<chunk_ptr>& push, OpCtx& ctx)
+    -> Task<void> override {
+    if (slice.rows() == 0) {
+      co_return;
+    }
+    auto batch = to_record_batch(slice);
+    auto column = batch->GetColumnByName("bytes");
+    if (not column) {
+      diagnostic::warning("expected a field named `bytes`")
+        .primary(args_.operator_location)
+        .emit(ctx);
+      co_return;
+    }
+    auto rt = try_as<record_type>(slice.schema());
+    if (not rt) {
+      co_return;
+    }
+    auto ty = rt->field("bytes");
+    if (not ty) {
+      co_return;
+    }
+    auto selected = series{*ty, column};
+    if (selected.type.kind().is<null_type>()) {
+      co_return;
+    }
+    if (selected.type.kind().is<blob_type>()) {
+      for (auto value : selected.values3<blob_type>()) {
+        if (not value) {
+          continue;
+        }
+        co_await push(chunk::copy(*value));
+      }
+      co_return;
+    }
+    diagnostic::error("field `bytes` has unsupported type `{}`",
+                      selected.type.kind())
+      .primary(args_.operator_location)
+      .hint("`write_chunks` expects the `bytes` field to have type `blob`")
+      .emit(ctx);
+    co_return;
+  }
+
+private:
+  WriteChunksArgs args_;
+};
+
+class plugin final : public virtual OperatorPlugin {
+public:
+  auto name() const -> std::string override {
+    return "tql2.write_chunks";
+  }
+
+  auto describe() const -> Description override {
+    auto d = Describer<WriteChunksArgs, WriteChunks>{};
+    d.operator_location(&WriteChunksArgs::operator_location);
+    return d.without_optimize();
+  }
+};
+
+} // namespace
+
+} // namespace tenzir::plugins::write_chunks
+
+TENZIR_REGISTER_PLUGIN(tenzir::plugins::write_chunks::plugin)

--- a/test/tests/operators/read_chunks.tql
+++ b/test/tests/operators/read_chunks.tql
@@ -1,0 +1,3 @@
+from {line: "hello"}, {line: "world"}
+write_lines
+read_chunks

--- a/test/tests/operators/read_chunks.txt
+++ b/test/tests/operators/read_chunks.txt
@@ -1,3 +1,6 @@
 {
-  bytes: b"hello\nworld\n",
+  bytes: b"hello\n",
+}
+{
+  bytes: b"world\n",
 }

--- a/test/tests/operators/read_chunks.txt
+++ b/test/tests/operators/read_chunks.txt
@@ -1,6 +1,6 @@
 {
-  bytes: b"hello\n",
+  data: b"hello\n",
 }
 {
-  bytes: b"world\n",
+  data: b"world\n",
 }

--- a/test/tests/operators/read_chunks.txt
+++ b/test/tests/operators/read_chunks.txt
@@ -1,0 +1,3 @@
+{
+  bytes: b"hello\nworld\n",
+}

--- a/test/tests/operators/write_chunks/01_blob_stdout.tql
+++ b/test/tests/operators/write_chunks/01_blob_stdout.tql
@@ -1,0 +1,4 @@
+from {bytes: b"hello"}, {bytes: b" "}, {bytes: b"world"}
+to_stdout {
+  write_chunks
+}

--- a/test/tests/operators/write_chunks/01_blob_stdout.tql
+++ b/test/tests/operators/write_chunks/01_blob_stdout.tql
@@ -1,4 +1,4 @@
-from {bytes: b"hello"}, {bytes: b" "}, {bytes: b"world"}
+from {data: b"hello"}, {data: b" "}, {data: b"world"}
 to_stdout {
   write_chunks
 }

--- a/test/tests/operators/write_chunks/01_blob_stdout.txt
+++ b/test/tests/operators/write_chunks/01_blob_stdout.txt
@@ -1,0 +1,1 @@
+hello world

--- a/test/tests/operators/write_chunks/02_string_stdout.tql
+++ b/test/tests/operators/write_chunks/02_string_stdout.tql
@@ -2,7 +2,7 @@
 error: true
 ---
 
-from {bytes: "not a blob"}
+from {data: "not a blob"}
 to_stdout {
   write_chunks
 }

--- a/test/tests/operators/write_chunks/02_string_stdout.tql
+++ b/test/tests/operators/write_chunks/02_string_stdout.tql
@@ -1,0 +1,8 @@
+---
+error: true
+---
+
+from {bytes: "not a blob"}
+to_stdout {
+  write_chunks
+}

--- a/test/tests/operators/write_chunks/02_string_stdout.txt
+++ b/test/tests/operators/write_chunks/02_string_stdout.txt
@@ -1,0 +1,1 @@
+error: field `bytes` has unsupported type `string`

--- a/test/tests/operators/write_chunks/02_string_stdout.txt
+++ b/test/tests/operators/write_chunks/02_string_stdout.txt
@@ -1,1 +1,7 @@
 error: field `bytes` has unsupported type `string`
+ --> tests/operators/write_chunks/02_string_stdout.tql:7:3
+  |
+7 |   write_chunks
+  |   ^^^^^^^^^^^^ 
+  |
+  = hint: `write_chunks` expects the `bytes` field to have type `blob`

--- a/test/tests/operators/write_chunks/02_string_stdout.txt
+++ b/test/tests/operators/write_chunks/02_string_stdout.txt
@@ -1,7 +1,7 @@
-error: field `data` has unsupported type `string`
+error: field has unsupported type `string`
  --> tests/operators/write_chunks/02_string_stdout.tql:7:3
   |
 7 |   write_chunks
   |   ^^^^^^^^^^^^ 
   |
-  = hint: `write_chunks` expects the `bytes` field to have type `blob`
+  = hint: `write_chunks` expects a field of type `blob`

--- a/test/tests/operators/write_chunks/02_string_stdout.txt
+++ b/test/tests/operators/write_chunks/02_string_stdout.txt
@@ -1,4 +1,4 @@
-error: field `bytes` has unsupported type `string`
+error: field `data` has unsupported type `string`
  --> tests/operators/write_chunks/02_string_stdout.tql:7:3
   |
 7 |   write_chunks

--- a/test/tests/operators/write_chunks/03_roundtrip.tql
+++ b/test/tests/operators/write_chunks/03_roundtrip.tql
@@ -1,0 +1,5 @@
+from {line: "hello"}, {line: "world"}
+write_lines
+read_chunks
+write_chunks
+read_lines

--- a/test/tests/operators/write_chunks/03_roundtrip.txt
+++ b/test/tests/operators/write_chunks/03_roundtrip.txt
@@ -1,0 +1,6 @@
+{
+  line: "hello",
+}
+{
+  line: "world",
+}

--- a/test/tests/operators/write_chunks/04_custom_field.tql
+++ b/test/tests/operators/write_chunks/04_custom_field.tql
@@ -1,0 +1,4 @@
+from {payload: b"hello"}, {payload: b" "}, {payload: b"world"}
+to_stdout {
+  write_chunks payload
+}

--- a/test/tests/operators/write_chunks/04_custom_field.txt
+++ b/test/tests/operators/write_chunks/04_custom_field.txt
@@ -1,0 +1,1 @@
+hello world

--- a/test/tests/operators/write_chunks/test.yaml
+++ b/test/tests/operators/write_chunks/test.yaml
@@ -1,0 +1,2 @@
+suite: write-chunks
+timeout: 30


### PR DESCRIPTION
## 🔍 Problem

There is no streaming alternative to `read_all` and `write_all` that avoids buffering the entire input/output.

## 🛠️ Solution

- Add `read_chunks`: a streaming parser that emits one `{data: <blob>}` event per incoming chunk, using `series_builder::yield_ready()` for batching.
- Add `write_chunks`: a streaming printer that emits one chunk per event's blob field. Accepts an optional field path argument (defaults to `data`).
- Deprecate `write_all` with a hint to use `write_chunks` instead.

## 💬 Review

- `read_chunks` follows the `read_delimited` pattern with `SeriesPusher` + `yield_ready()`.
- `write_chunks` follows `write_all` for the field path argument but emits per-row instead of buffering.

<sub>
📚 Docs PR: tenzir/docs#372
</sub>