### PR TITLE
Fix tenzir-test Python subprocess imports

### DIFF
--- a/nix/test-dependencies.nix
+++ b/nix/test-dependencies.nix
@@ -37,28 +37,23 @@ rec {
     # `python -m tenzir_test._python_runner`). Those subprocesses do not inherit
     # the package's embedded Python path, so add the site-packages they need
     # here as well.
-    postFixup = ''
-      wrapProgram $out/bin/tenzir-test \
-        --prefix PYTHONPATH : "$out/${python3Packages.python.sitePackages}:${
-          python3Packages.makePythonPath [
-            python3Packages.click
-            python3Packages.pyyaml
-            python3Packages.boto3
-            python3Packages.pyarrow
-            python3Packages.python-box
-            python3Packages.pymysql
-            python3Packages.pyzmq
-            python3Packages.trustme
+    postFixup =
+      let
+        pythonDeps = import ./python-dependencies.nix;
+        subprocessDeps =
+          with python3Packages;
+          [
+            click
+            pyyaml
           ]
-        }"
-    '';
+          ++ pythonDeps.integration python3Packages
+          ++ pythonDeps.integration-container python3Packages;
+      in
+      ''
+        wrapProgram $out/bin/tenzir-test \
+          --prefix PYTHONPATH : "$out/${python3Packages.python.sitePackages}:${python3Packages.makePythonPath subprocessDeps}"
+      '';
   });
-
-  pythonPkgsFn = ps: [
-    ps.trustme
-    ps.pymysql
-    ps.pyzmq
-  ];
 
   tenzir-integration-test-deps = [
     curl

--- a/nix/test-dependencies.nix
+++ b/nix/test-dependencies.nix
@@ -31,6 +31,27 @@ rec {
       click
       pyyaml
     ];
+
+    # `tenzir-test` itself is already wrapped with its direct dependencies, but
+    # it also spawns plain Python subprocesses (for example via
+    # `python -m tenzir_test._python_runner`). Those subprocesses do not inherit
+    # the package's embedded Python path, so add the site-packages they need
+    # here as well.
+    postFixup = ''
+      wrapProgram $out/bin/tenzir-test \
+        --prefix PYTHONPATH : "$out/${python3Packages.python.sitePackages}:${
+          python3Packages.makePythonPath [
+            python3Packages.click
+            python3Packages.pyyaml
+            python3Packages.boto3
+            python3Packages.pyarrow
+            python3Packages.python-box
+            python3Packages.pymysql
+            python3Packages.pyzmq
+            python3Packages.trustme
+          ]
+        }"
+    '';
   });
 
   pythonPkgsFn = ps: [


### PR DESCRIPTION
## 🔍 Problem

- `just test --match pipeline_manager` fails in the Nix dev shell.
- `tenzir-test` spawns plain Python subprocesses that cannot import
  `tenzir_test` and other test dependencies.

## 🛠️ Solution

- Wrap the Nix-packaged `tenzir-test` with the Python site-packages its
  subprocesses need.
- Document why this wrapper is needed for spawned subprocesses rather than for
  `tenzir-test` itself.

## 💬 Review

- The main thing to verify is whether the wrapped Python path covers the test
  subprocess environment without broadening the shell environment globally.
