### PR TITLE
Fix docs link in neo executor

### DIFF
--- a/libtenzir/src/operator_plugin.cpp
+++ b/libtenzir/src/operator_plugin.cpp
@@ -757,7 +757,12 @@ auto OperatorPlugin::describe_shared() const
       desc->name.erase(0, tql2_prefix.size());
     }
     if (desc->docs.empty()) {
-      desc->docs = "https://docs.tenzir.com/reference/operators/" + desc->name;
+      auto docs_path = desc->name;
+      for (auto pos = docs_path.find("::"); pos != std::string::npos;
+           pos = docs_path.find("::")) {
+        docs_path.replace(pos, 2, "/");
+      }
+      desc->docs = "https://docs.tenzir.com/reference/operators/" + docs_path;
     }
     cached_desc_ = std::move(desc);
   });

--- a/scripts/regression-tests.sh
+++ b/scripts/regression-tests.sh
@@ -18,7 +18,7 @@ docker run \
 
 sleep 3
 
-docker exec -e TENZIR_TQL2=true tenzir-regression \
+docker exec -i -e TENZIR_TQL2=true tenzir-regression \
   tenzir 'read_suricata | import' \
   <test/inputs/suricata/eve.json
 


### PR DESCRIPTION
An auto-generated docs for a neo-operator, such as `package::add`
would point to the incorrect `[..]/operators/package::add`.

This adds the correct replacement to `/`.
