### PR TITLE
Validate static pipelines before startup

### DIFF
--- a/changelog/unreleased/static-pipeline-startup-validation.md
+++ b/changelog/unreleased/static-pipeline-startup-validation.md
@@ -1,0 +1,12 @@
+---
+title: Static pipeline startup validation
+type: bugfix
+authors:
+  - tobim
+  - codex
+prs:
+  - 6248
+created: 2026-06-02T10:53:53.017453Z
+---
+
+Tenzir now validates all configured and packaged pipelines before starting any of them during node startup. Previously, a deployment with multiple configured pipelines could start some valid pipelines and only then abort after discovering that a later pipeline was invalid.

--- a/test/tests/node/pipeline_manager/configured_startup_preflight.py
+++ b/test/tests/node/pipeline_manager/configured_startup_preflight.py
@@ -47,6 +47,7 @@ tenzir:
             f"--config={config}",
             f"--state-directory={root / 'state'}",
             f"--cache-directory={root / 'cache'}",
+            "--endpoint=false",
             "--console-verbosity=error",
         ],
         stdout=subprocess.PIPE,

--- a/test/tests/node/pipeline_manager/configured_startup_preflight.py
+++ b/test/tests/node/pipeline_manager/configured_startup_preflight.py
@@ -54,7 +54,7 @@ tenzir:
         stderr=subprocess.PIPE,
         text=True,
     )
-    deadline = time.monotonic() + 10
+    deadline = time.monotonic() + 60
     while proc.poll() is None and time.monotonic() < deadline:
         time.sleep(0.1)
     if proc.poll() is None:
@@ -64,7 +64,12 @@ tenzir:
         except subprocess.TimeoutExpired:
             proc.kill()
             proc.wait(timeout=5)
-        raise AssertionError("node kept running despite invalid configured pipeline")
+        stdout, stderr = proc.communicate()
+        raise AssertionError(
+            "node kept running despite invalid configured pipeline\n"
+            f"stdout:\n{stdout}\n"
+            f"stderr:\n{stderr}"
+        )
     stdout, stderr = proc.communicate()
     assert proc.returncode != 0, (proc.returncode, stdout, stderr)
     assert not marker.exists(), (

--- a/test/tests/node/pipeline_manager/configured_startup_preflight.py
+++ b/test/tests/node/pipeline_manager/configured_startup_preflight.py
@@ -43,7 +43,6 @@ tenzir:
     proc = subprocess.Popen(
         [
             *_node_binary(),
-            "--plugins=bundled",
             f"--config={config}",
             f"--state-directory={root / 'state'}",
             f"--cache-directory={root / 'cache'}",

--- a/test/tests/node/pipeline_manager/configured_startup_preflight.py
+++ b/test/tests/node/pipeline_manager/configured_startup_preflight.py
@@ -43,7 +43,6 @@ tenzir:
     proc = subprocess.Popen(
         [
             *_node_binary(),
-            "--bare-mode",
             "--plugins=bundled",
             f"--config={config}",
             f"--state-directory={root / 'state'}",

--- a/test/tests/node/pipeline_manager/configured_startup_preflight.py
+++ b/test/tests/node/pipeline_manager/configured_startup_preflight.py
@@ -1,0 +1,75 @@
+# runner: python
+
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+
+def _node_binary() -> list[str]:
+    if env_value := os.environ.get("TENZIR_NODE_BINARY"):
+        return shlex.split(env_value)
+    if binary := shutil.which("tenzir-node"):
+        return [binary]
+    raise RuntimeError("tenzir-node executable not found")
+
+
+with tempfile.TemporaryDirectory() as tmp:
+    root = Path(tmp)
+    marker = root / "started.ndjson"
+    config = root / "tenzir.yaml"
+    config.write_text(
+        f"""
+tenzir:
+  pipelines:
+    a_good:
+      definition: |
+        from {{x: 1}}
+        to_file "{marker}" {{
+          write_ndjson
+        }}
+    z_bad:
+      definition: |
+        this_operator_does_not_exist
+        discard
+""".lstrip(),
+        encoding="utf-8",
+    )
+    proc = subprocess.Popen(
+        [
+            *_node_binary(),
+            "--bare-mode",
+            "--plugins=bundled",
+            f"--config={config}",
+            f"--state-directory={root / 'state'}",
+            f"--cache-directory={root / 'cache'}",
+            "--console-verbosity=error",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    deadline = time.monotonic() + 10
+    while proc.poll() is None and time.monotonic() < deadline:
+        time.sleep(0.1)
+    if proc.poll() is None:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)
+        raise AssertionError("node kept running despite invalid configured pipeline")
+    stdout, stderr = proc.communicate()
+    assert proc.returncode != 0, (proc.returncode, stdout, stderr)
+    assert not marker.exists(), (
+        marker.read_text(encoding="utf-8") if marker.exists() else ""
+    )
+    assert "this_operator_does_not_exist" in stderr, stderr
+
+print("configured-startup-preflight: ok")

--- a/test/tests/node/pipeline_manager/configured_startup_preflight.txt
+++ b/test/tests/node/pipeline_manager/configured_startup_preflight.txt
@@ -1,0 +1,1 @@
+configured-startup-preflight: ok


### PR DESCRIPTION
## 🔍 Problem

- A deployment with multiple static pipelines could start valid configured pipelines before discovering that a later configured or packaged pipeline was invalid.
- The node then aborted after some static pipelines had already produced side effects.

## 🛠️ Solution

- Bump `contrib/tenzir-plugins` to preflight static autostart pipelines before starting any of them.
- Add regression coverage for a bad configured pipeline preventing earlier configured pipelines from producing output during startup.

## 💬 Review

- The plugin PR contains the behavioral change; this PR carries the submodule update, regression test, and changelog.

<sub>
📎 Related: tenzir/tenzir-plugins#561
</sub>
