### PR TITLE
Try and fix Neo PubSub tests

### DIFF
--- a/.github/workflows/tenzir.yaml
+++ b/.github/workflows/tenzir.yaml
@@ -338,9 +338,8 @@ jobs:
           run_if_changed_default regression-tests $run_docker_tenzir
           run_if_changed_default tenzir-nix $run_python \
             "${TENZIR_SOURCES[@]}" plugins/ contrib/tenzir-plugins/ flake.nix flake.lock nix/ \
-            ".github/workflows/nix.nu" \
-            ".github/workflows/nix.yaml" \
-            ".github/workflows/nix-config-base.json"
+            ".github/workflows/nix-build.py" \
+            ".github/workflows/nix-build-job.yaml"
       - name: Configure Docker
         id: docker
         if: steps.configure.outputs.run-docker-tenzir == 'true'

--- a/nix/test-dependencies.nix
+++ b/nix/test-dependencies.nix
@@ -15,14 +15,14 @@
 rec {
   tenzir-test = python3Packages.buildPythonPackage (finalAttrs: {
     pname = "tenzir-test";
-    version = "1.10.2";
+    version = "1.10.3";
     pyproject = true;
 
     src = fetchFromGitHub {
       owner = "tenzir";
       repo = "test";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-02W4vP6cAGANzCtIwF9N/r5OKBGz+11yyINC35Nqcwc=";
+      hash = "sha256-qk1Cjo6r7XZYNz2f8FSCucOK0Rbje3xj63kMZs+3LF0=";
     };
 
     build-system = with python3Packages; [ hatchling ];

--- a/test/tests/node/pubsub/mpmc/test.yaml
+++ b/test/tests/node/pubsub/mpmc/test.yaml
@@ -1,3 +1,4 @@
 suite:
   name: mpmc-parallel
   mode: parallel
+  min_jobs: 4

--- a/test/tests/node/pubsub/mpsc/test.yaml
+++ b/test/tests/node/pubsub/mpsc/test.yaml
@@ -1,3 +1,4 @@
 suite:
   name: mpsc-parallel
   mode: parallel
+  min_jobs: 3

--- a/test/tests/node/pubsub/spmc/test.yaml
+++ b/test/tests/node/pubsub/spmc/test.yaml
@@ -1,3 +1,4 @@
 suite:
   name: spmc-parallel
   mode: parallel
+  min_jobs: 3

--- a/test/tests/node/pubsub/spsc/test.yaml
+++ b/test/tests/node/pubsub/spsc/test.yaml
@@ -1,3 +1,4 @@
 suite:
   name: spsc-parallel
   mode: parallel
+  min_jobs: 2

--- a/test/tests/node/pubsub/test.yaml
+++ b/test/tests/node/pubsub/test.yaml
@@ -2,4 +2,3 @@ fixtures:
   - node
 retry: 2
 timeout: 60
-skip: "Too racy for arm docker"


### PR DESCRIPTION
Enable neo pub/sub integration tests, following a fix in tenzir-test to remove the race condition in the parallel suite.

Also correctly runs the nix CI when its changed.

tenzir-test PR: https://github.com/tenzir/test/pull/50