### PR TITLE
Fix null matching empty string in bloom

### DIFF
--- a/changelog/unreleased/correct-null-handling-in-bloom-filter-context-lookups.md
+++ b/changelog/unreleased/correct-null-handling-in-bloom-filter-context-lookups.md
@@ -1,0 +1,11 @@
+---
+title: Correct null handling in bloom-filter context lookups
+type: bugfix
+authors:
+  - IyeOnline
+  - claude
+created: 2026-06-03T14:20:38.490452Z
+---
+
+The `bloom-filter` context no longer matches `null` values when the filter was populated with empty strings. Now null
+values no longer match the context.

--- a/libtenzir/include/tenzir/bloom_filter.hpp
+++ b/libtenzir/include/tenzir/bloom_filter.hpp
@@ -10,10 +10,11 @@
 
 #include "tenzir/bitvector.hpp"
 #include "tenzir/bloom_filter_parameters.hpp"
+#include "tenzir/data.hpp"
 #include "tenzir/detail/operators.hpp"
 #include "tenzir/hash/hasher.hpp"
-#include "tenzir/legacy_type.hpp"
 #include "tenzir/logger.hpp"
+#include "tenzir/view3.hpp"
 
 #include <climits>
 #include <cstddef>
@@ -60,15 +61,28 @@ public:
   /// @param x The element to add.
   /// @returns `false` iff *x* already exists in the filter.
   template <class T>
+    requires(not std::same_as<std::remove_cvref_t<T>, data>
+             and not std::same_as<std::remove_cvref_t<T>, data_view3>)
   bool add(T&& x) {
-    auto& digests = hasher_(std::forward<T>(x));
-    auto unique = false;
-    for (size_t i = 0; i < digests.size(); ++i) {
-      auto bit = bits_[position(i, digests[i])];
-      unique |= bit == false;
-      bit = true;
+    if constexpr (std::same_as<std::remove_cvref_t<T>, caf::none_t>) {
+      return false;
+    } else {
+      return add_impl(std::forward<T>(x));
     }
-    return unique;
+  }
+
+  bool add(const data_view3& x) {
+    if (is<caf::none_t>(x)) {
+      return false;
+    }
+    return add_impl(x);
+  }
+
+  bool add(const data& x) {
+    if (is<caf::none_t>(x)) {
+      return false;
+    }
+    return add_impl(x);
   }
 
   /// Test whether an element exists in the Bloom filter.
@@ -76,14 +90,28 @@ public:
   /// @returns `false` if the *x* is not in the set and `true` if *x* may exist
   ///          according to the false-positive probability of the filter.
   template <class T>
+    requires(not std::same_as<std::remove_cvref_t<T>, data>
+             and not std::same_as<std::remove_cvref_t<T>, data_view3>)
   bool lookup(T&& x) const {
-    auto& digests = hasher_(std::forward<T>(x));
-    for (size_t i = 0; i < digests.size(); ++i) {
-      if (not bits_[position(i, digests[i])]) {
-        return false;
-      }
+    if constexpr (std::same_as<std::remove_cvref_t<T>, caf::none_t>) {
+      return false;
+    } else {
+      return lookup_impl(std::forward<T>(x));
     }
-    return true;
+  }
+
+  bool lookup(const data_view3& x) const {
+    if (is<caf::none_t>(x)) {
+      return false;
+    }
+    return lookup_impl(x);
+  }
+
+  bool lookup(const data& x) const {
+    if (is<caf::none_t>(x)) {
+      return false;
+    }
+    return lookup_impl(x);
   }
 
   /// @returns The number of cells in the underlying bit vector.
@@ -127,6 +155,29 @@ public:
   }
 
 private:
+  template <class T>
+  bool add_impl(T&& x) {
+    auto& digests = hasher_(std::forward<T>(x));
+    auto unique = false;
+    for (size_t i = 0; i < digests.size(); ++i) {
+      auto bit = bits_[position(i, digests[i])];
+      unique |= bit == false;
+      bit = true;
+    }
+    return unique;
+  }
+
+  template <class T>
+  bool lookup_impl(T&& x) const {
+    auto& digests = hasher_(std::forward<T>(x));
+    for (size_t i = 0; i < digests.size(); ++i) {
+      if (not bits_[position(i, digests[i])]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   template <class Digest>
   size_t position([[maybe_unused]] size_t i, Digest x) const {
     if constexpr (partitioning_policy == policy::partitioning::no) {
@@ -142,9 +193,38 @@ private:
   bitvector<uint64_t> bits_;
 };
 
+/// A hasher type that can be constructed with a seed vector in addition to k.
+template <class H>
+concept seeded_hasher = std::is_constructible_v<H, size_t, std::vector<size_t>>;
+
+namespace detail {
+
+template <class HashFunction, template <class> class Hasher,
+          policy::partitioning Partitioning>
+auto make_bloom_filter_impl(bloom_filter_parameters ys,
+                            std::vector<size_t> seeds)
+  -> std::optional<bloom_filter<HashFunction, Hasher, Partitioning>> {
+  using result_type = bloom_filter<HashFunction, Hasher, Partitioning>;
+  using hasher_type = typename result_type::hasher_type;
+  TENZIR_TRACE("evaluated bloom filter parameters: {} {} {} {}",
+               TENZIR_ARG(ys.k), TENZIR_ARG(ys.m), TENZIR_ARG(ys.n),
+               TENZIR_ARG(ys.p));
+  if (*ys.m == 0 or *ys.k == 0) {
+    return {};
+  }
+  if constexpr (seeded_hasher<hasher_type>) {
+    return result_type{*ys.m, hasher_type{*ys.k, std::move(seeds)}};
+  } else {
+    return result_type{*ys.m, hasher_type{*ys.k}};
+  }
+}
+
+} // namespace detail
+
 /// Constructs a Bloom filter for a given set of parameters.
 /// @tparam HashFunction The hash function to use in the hasher.
-/// @tparam Hasher The hasher type to generate digests.
+/// @tparam Hasher The hasher type to generate digests. Must satisfy
+/// `seeded_hasher`.
 /// @tparam Partitioning The partitioning policy.
 /// @param xs The Bloom filter parameters.
 /// @param seeds The seeds for the hash functions. If empty, ascending
@@ -152,30 +232,47 @@ private:
 /// @relates bloom_filter bloom_filter_parameters
 template <class HashFunction, template <class> class Hasher = double_hasher,
           policy::partitioning Partitioning = policy::partitioning::no>
-std::optional<bloom_filter<HashFunction, Hasher, Partitioning>>
-make_bloom_filter(bloom_filter_parameters xs, std::vector<size_t> seeds = {}) {
-  using result_type = bloom_filter<HashFunction, Hasher, Partitioning>;
-  using hasher_type = typename result_type::hasher_type;
-  if (auto ys = evaluate(xs)) {
-    TENZIR_TRACE("evaluated bloom filter parameters: {} {} {} {}",
-                 TENZIR_ARG(ys->k), TENZIR_ARG(ys->m), TENZIR_ARG(ys->n),
-                 TENZIR_ARG(ys->p));
-    if (*ys->m == 0 or *ys->k == 0) {
-      return {};
-    }
-    if (seeds.empty()) {
-      if constexpr (std::is_same_v<hasher_type, double_hasher<HashFunction>>) {
-        seeds = {0, 1};
-      } else {
-        seeds.resize(*ys->k);
-        std::iota(seeds.begin(), seeds.end(), 0);
-      }
-    } else if (seeds.size() != *ys->k) {
-      return {};
-    }
-    return result_type{*ys->m, hasher_type{*ys->k, std::move(seeds)}};
+  requires seeded_hasher<Hasher<HashFunction>>
+auto make_bloom_filter(bloom_filter_parameters xs, std::vector<size_t> seeds
+                                                   = {})
+  -> std::optional<bloom_filter<HashFunction, Hasher, Partitioning>> {
+  using hasher_type = Hasher<HashFunction>;
+  auto ys = evaluate(xs);
+  if (not ys) {
+    return {};
   }
-  return {};
+  if (seeds.empty()) {
+    if constexpr (std::is_same_v<hasher_type, double_hasher<HashFunction>>) {
+      seeds = {0, 1};
+    } else {
+      seeds.resize(*ys->k);
+      std::iota(seeds.begin(), seeds.end(), 0);
+    }
+  } else if (seeds.size() != *ys->k) {
+    return {};
+  }
+  return detail::make_bloom_filter_impl<HashFunction, Hasher, Partitioning>(
+    *ys, std::move(seeds));
+}
+
+/// Constructs a Bloom filter for a given set of parameters.
+/// @tparam HashFunction The hash function to use in the hasher.
+/// @tparam Hasher The hasher type to generate digests. Must not satisfy
+/// `seeded_hasher`.
+/// @tparam Partitioning The partitioning policy.
+/// @param xs The Bloom filter parameters.
+/// @relates bloom_filter bloom_filter_parameters
+template <class HashFunction, template <class> class Hasher,
+          policy::partitioning Partitioning = policy::partitioning::no>
+  requires(not seeded_hasher<Hasher<HashFunction>>)
+auto make_bloom_filter(bloom_filter_parameters xs)
+  -> std::optional<bloom_filter<HashFunction, Hasher, Partitioning>> {
+  auto ys = evaluate(xs);
+  if (not ys) {
+    return {};
+  }
+  return detail::make_bloom_filter_impl<HashFunction, Hasher, Partitioning>(*ys,
+                                                                            {});
 }
 
 } // namespace tenzir

--- a/libtenzir/test/bloom_filter.cpp
+++ b/libtenzir/test/bloom_filter.cpp
@@ -9,12 +9,16 @@
 #include "tenzir/bloom_filter.hpp"
 
 #include "tenzir/bloom_filter_parameters.hpp"
+#include "tenzir/data.hpp"
+#include "tenzir/dcso_bloom_hasher.hpp"
 #include "tenzir/detail/legacy_deserialize.hpp"
 #include "tenzir/detail/serialize.hpp"
+#include "tenzir/hash/fnv.hpp"
 #include "tenzir/hash/hash_append.hpp"
 #include "tenzir/hash/xxhash.hpp"
 #include "tenzir/si_literals.hpp"
 #include "tenzir/test/test.hpp"
+#include "tenzir/view3.hpp"
 
 #include <caf/actor_system.hpp>
 #include <caf/actor_system_config.hpp>
@@ -218,4 +222,25 @@ TEST("bloom filter - duplicate tracking") {
   CHECK(x.add(42));
   CHECK(x.lookup(42));
   CHECK(not x.add(42));
+}
+
+TEST("null does not collide with empty string") {
+  bloom_filter_parameters params;
+  params.n = 100;
+  params.p = 0.01;
+  auto filter = tenzir::test::unbox(
+    make_bloom_filter<fnv1<64>, dcso_bloom_hasher>(params));
+  // Insert an empty string so the "" bucket is populated.
+  filter.add(data{std::string{""}});
+  // Inserting null must not populate the "" bucket additionally.
+  filter.add(data{caf::none});
+  // A genuine empty-string lookup must match.
+  CHECK_EQUAL(filter.lookup(data{std::string{""}}), true);
+  // Null lookups always return false, even though "" is in the filter.
+  CHECK_EQUAL(filter.lookup(caf::none_t{}), false);
+  CHECK_EQUAL(filter.lookup(data{caf::none}), false);
+  // Normal string inserts are unaffected.
+  filter.add(data{std::string{"hello"}});
+  CHECK_EQUAL(filter.lookup(data{std::string{"hello"}}), true);
+  CHECK_EQUAL(filter.lookup(data{std::string{"world"}}), false);
 }


### PR DESCRIPTION
This fixes an issue in the bloom filter, where `null`  would be hashed the same as `""`, matching it. This can lead to unexpected outcomes if the empty string accidentally ends up in the filter's keys.