### PR TITLE
Override `copy()` and `move()` for `SetIr`, `IfIr` and `GenericIr`

### DIFF
--- a/libtenzir/include/tenzir/ir.hpp
+++ b/libtenzir/include/tenzir/ir.hpp
@@ -189,6 +189,10 @@ public:
 
   auto name() const -> std::string override;
 
+  auto copy() const -> Box<Operator> override;
+
+  auto move() && -> Box<Operator> override;
+
   auto substitute(substitute_ctx ctx, bool instantiate)
     -> failure_or<void> override;
 

--- a/libtenzir/src/ir.cpp
+++ b/libtenzir/src/ir.cpp
@@ -221,6 +221,14 @@ auto ir::SetIr::name() const -> std::string {
   return "SetIr";
 }
 
+auto ir::SetIr::copy() const -> Box<ir::Operator> {
+  return SetIr{*this};
+}
+
+auto ir::SetIr::move() && -> Box<ir::Operator> {
+  return SetIr{std::move(*this)};
+}
+
 auto ir::SetIr::substitute(substitute_ctx ctx, bool instantiate)
   -> failure_or<void> {
   (void)instantiate;
@@ -506,6 +514,14 @@ public:
 
   auto name() const -> std::string override {
     return "If";
+  }
+
+  auto copy() const -> Box<ir::Operator> override {
+    return IfIr{args_};
+  }
+
+  auto move() && -> Box<ir::Operator> override {
+    return IfIr{std::move(args_)};
   }
 
   auto substitute(substitute_ctx ctx, bool instantiate)

--- a/libtenzir/src/operator_plugin.cpp
+++ b/libtenzir/src/operator_plugin.cpp
@@ -354,6 +354,14 @@ public:
     return "GenericIr";
   }
 
+  auto copy() const -> Box<ir::Operator> override {
+    return GenericIr{*this};
+  }
+
+  auto move() && -> Box<ir::Operator> override {
+    return GenericIr{std::move(*this)};
+  }
+
   auto infer_type(element_type_tag input, diagnostic_handler& dh) const
     -> failure_or<std::optional<element_type_tag>> override {
     if (desc_->spawner) {


### PR DESCRIPTION
Resolves TNZ-691.