### PR TITLE
Fix crash when passing a non-lambda to list functions

### DIFF
--- a/changelog/unreleased/crash-when-passing-a-non-lambda-to-map-or-where.md
+++ b/changelog/unreleased/crash-when-passing-a-non-lambda-to-map-or-where.md
@@ -1,0 +1,21 @@
+---
+title: Crash when passing a non-lambda to map or where
+type: bugfix
+authors:
+  - jachris
+prs:
+  - 6256
+created: 2026-06-05T15:32:00.144565Z
+---
+
+Calling the `map` or `where` list functions with a non-lambda argument now
+fails with a clear `expected a lambda` diagnostic instead of aborting the
+pipeline with an internal error.
+
+For example, the following pipeline previously crashed and now reports a
+proper error:
+
+```tql
+from {xs: [1, 2, 3]}
+xs = xs.map(null)
+```

--- a/libtenzir/builtins/operators/where_map.cpp
+++ b/libtenzir/builtins/operators/where_map.cpp
@@ -327,7 +327,7 @@ struct arguments {
     for (auto& diag : diags) {
       ctx.dh().emit(std::move(diag));
     }
-    return args;
+    return failure::promise();
   }
 };
 

--- a/test/tests/functions/list_map/non_lambda_argument.tql
+++ b/test/tests/functions/list_map/non_lambda_argument.tql
@@ -1,0 +1,11 @@
+---
+error: true
+---
+
+// Passing a non-lambda (here `null`) to `map` must fail cleanly with a
+// diagnostic instead of crashing with an internal error. Regression test for
+// an assertion failure in `expression::get_location()` reached via an empty
+// lambda body. See the original report:
+//   y = [1, ...x?.map(null) else [], 2]
+from {x: [1, 2, 3]}
+y = x.map(null)

--- a/test/tests/functions/list_map/non_lambda_argument.txt
+++ b/test/tests/functions/list_map/non_lambda_argument.txt
@@ -1,0 +1,8 @@
+error: expected a lambda
+  --> tests/functions/list_map/non_lambda_argument.tql:11:11
+   |
+11 | y = x.map(null)
+   |           ^^^^ 
+   |
+   = usage: map(list:list, function:any -> any)
+   = docs: https://docs.tenzir.com/reference/functions/map

--- a/test/tests/functions/list_where/non_lambda_argument.tql
+++ b/test/tests/functions/list_where/non_lambda_argument.tql
@@ -1,0 +1,8 @@
+---
+error: true
+---
+
+// The list method `where` shares its argument parsing with `map`; passing a
+// non-lambda must fail cleanly instead of crashing with an internal error.
+from {x: [1, 2, 3]}
+y = x.where(null)

--- a/test/tests/functions/list_where/non_lambda_argument.txt
+++ b/test/tests/functions/list_where/non_lambda_argument.txt
@@ -1,0 +1,8 @@
+error: expected a lambda
+ --> tests/functions/list_where/non_lambda_argument.tql:8:13
+  |
+8 | y = x.where(null)
+  |             ^^^^ 
+  |
+  = usage: where(list:list, predicate:any => bool)
+  = docs: https://docs.tenzir.com/reference/functions/where


### PR DESCRIPTION
## 🔍 Problem

Passing a non-lambda to the `map` or `where` list functions crashed with an internal error instead of failing cleanly:

```tql
from {x: [3, 4, 5]}
y = [1, ...x?.map(null) else [], 2]
```

```text
error: unexpected internal error: assertion `current->kind` failed
  ...
  source: libtenzir/src/tql2/ast.cpp:298
```

The shared argument parser tries to parse the argument as a lambda, then falls back to the deprecated `x, y` form. When **both** attempts fail, it re-emitted the collected `expected a lambda` diagnostic but still returned a *successful* result holding a default-constructed `lambda_expr`. That empty body has no AST kind, so evaluating it later tripped the assertion in `expression::get_location()` and aborted.

## 🛠️ Solution

- Return a failure once both parse attempts fail, so the pipeline is rejected at compile time with the `expected a lambda` diagnostic.
- Add regression tests for `map` and `where` with a non-lambda argument.

## 💬 Review

- One-line fix in `arguments::parse`; the failure path now matches the other early-return error paths in the same function.
- Verified the original report input, the bare `map`/`where` cases, valid lambdas, and the deprecated `x, y` form. Full `tests/functions/` + `tests/language/` suite passes (272/272).

<sub>
🐛 Fixes the `current->kind` assertion at `libtenzir/src/tql2/ast.cpp:298`
</sub>
