### PR TITLE
Fix assertion in where/map lambda over multi-part fields

### DIFF
--- a/libtenzir/builtins/operators/where_map.cpp
+++ b/libtenzir/builtins/operators/where_map.cpp
@@ -337,7 +337,10 @@ auto make_where_function(function_invocation inv, session ctx)
       arguments::parse("where", "predicate", "any => bool", inv, ctx));
   return function_use::make(
     [args = std::move(args)](function_plugin::evaluator eval, session ctx) {
+      auto field_offset = int64_t{0};
       return map_series(eval(args.field), [&](series field) -> multi_series {
+        auto current_field_offset = field_offset;
+        field_offset += field.length();
         return match(
           field.type,
           [&](const null_type&) -> series {
@@ -355,7 +358,8 @@ auto make_where_function(function_invocation inv, session ctx)
             // itself is `null`. This is very unlikely to happen in practice,
             // and one proper fix for this would be passing in a null bitmap to
             // the call to evaluate to indicate which rows not to evaluate.
-            for (const auto& result : eval(args.lambda, lists)) {
+            for (const auto& result :
+                 eval(args.lambda, lists, current_field_offset)) {
               match(
                 result.type,
                 [&](const bool_type&) {
@@ -504,7 +508,10 @@ auto make_map_function(function_invocation inv, session ctx)
   TRY(auto args, arguments::parse("map", "function", "any -> any", inv, ctx));
   return function_use::make([args = std::move(args)](
                               function_plugin::evaluator eval, session ctx) {
+    auto field_offset = int64_t{0};
     return map_series(eval(args.field), [&](series field) -> multi_series {
+      auto current_field_offset = field_offset;
+      field_offset += field.length();
       if (field.as<null_type>()) {
         return field;
       }
@@ -539,7 +546,7 @@ auto make_map_function(function_invocation inv, session ctx)
         }
         return b.finish_assert_one_array();
       }
-      auto ms = eval(args.lambda, *field_list);
+      auto ms = eval(args.lambda, *field_list, current_field_offset);
       TENZIR_ASSERT(not ms.parts().empty());
       // If there were no conflicts in the result, we are in the happy case
       // Here we just need to take that slice and re-join it with the offsets

--- a/libtenzir/include/tenzir/tql2/plugin.hpp
+++ b/libtenzir/include/tenzir/tql2/plugin.hpp
@@ -127,6 +127,10 @@ public:
     auto operator()(const ast::lambda_expr& expr,
                     const basic_series<list_type>& input) const -> multi_series;
 
+    auto operator()(const ast::lambda_expr& expr,
+                    const basic_series<list_type>& input,
+                    int64_t input_offset) const -> multi_series;
+
     auto length() const -> int64_t;
 
     auto get_input() const -> std::optional<table_slice>;

--- a/libtenzir/src/tql2/plugin.cpp
+++ b/libtenzir/src/tql2/plugin.cpp
@@ -39,6 +39,15 @@ auto function_use::evaluator::operator()(
   return static_cast<tenzir::evaluator*>(self_)->eval(expr, input);
 }
 
+auto function_use::evaluator::operator()(const ast::lambda_expr& expr,
+                                         const basic_series<list_type>& input,
+                                         int64_t input_offset) const
+  -> multi_series {
+  auto* evaluator = static_cast<tenzir::evaluator*>(self_);
+  return evaluator->slice(input_offset, input_offset + input.length())
+    .eval(expr, input);
+}
+
 auto aggregation_plugin::make_function(function_invocation inv,
                                        session ctx) const
   -> failure_or<function_ptr> {

--- a/test/tests/functions/where_function/multipart_field.tql
+++ b/test/tests/functions/where_function/multipart_field.tql
@@ -1,0 +1,19 @@
+// Regression: when the field expression evaluates to a multi-part multi_series
+// (e.g. because `x? else ""` creates two type-split parts), each part must be
+// evaluated against the correct row range of the parent slice.  Without the
+// fix, the second part would either hit a rows-vs-length assertion or resolve
+// captured fields from the wrong rows.
+//
+// Three cases in one pipeline:
+//   y        – no captures, asserts row count is consistent
+//   filtered – captures `keep`; must resolve to each row's own value
+//   mapped   – map() with captures, same fix as where()
+from {rows: [
+  {x: "a,b,c", keep: "a", suffix: "!"},
+  {x: null,    keep: "b", suffix: "?"},
+]}
+unroll rows
+this = rows
+y        = (x? else "").split(",").where(a => a != "")
+filtered = (x? else "a,b").split(",").where(a => a == keep)
+mapped   = (x? else "").split(",").map(a => a + suffix)

--- a/test/tests/functions/where_function/multipart_field.txt
+++ b/test/tests/functions/where_function/multipart_field.txt
@@ -1,0 +1,30 @@
+{
+  x: "a,b,c",
+  keep: "a",
+  suffix: "!",
+  y: [
+    "a",
+    "b",
+    "c",
+  ],
+  filtered: [
+    "a",
+  ],
+  mapped: [
+    "a!",
+    "b!",
+    "c!",
+  ],
+}
+{
+  x: null,
+  keep: "b",
+  suffix: "?",
+  y: [],
+  filtered: [
+    "b",
+  ],
+  mapped: [
+    "?",
+  ],
+}


### PR DESCRIPTION
## 🔍 Problem

When a field expression such as `x? else ""` evaluates to a **multi-part `multi_series`** (different type slots for different row ranges), `map_series` calls the lambda callback once per part. Each part covers only a contiguous slice of the parent rows, but the lambda evaluator still held a reference to the full `table_slice`. This caused two bugs:

1. **Assertion crash**: `evaluator::eval(lambda, input)` asserts `slice->rows() == input.length()`. For any part after the first, the full-slice row count exceeds the part length, triggering an abort.
2. **Silent wrong reads**: Lambdas that capture outer fields expand them via `arrow::compute::Take` using local indices `[0, part_len)` into the *full* slice, silently reading values from the wrong rows for all parts except the first.

Both bugs are reproduced by:
```tql
from {rows: [{x: "a,b"}, {x: null}]}
unroll rows
this = rows
y = (x? else "").split(",").where(a => a != "")
```

## 🛠️ Solution

Track a cumulative `field_offset` across `map_series` parts and pass it to the lambda evaluator. A new 3-argument `evaluator::operator()(lambda, input, offset)` overload slices the evaluator's `table_slice` to the exact row range `[offset, offset + input.length())` before evaluating. The fix is applied to both `where()` and `map()`.

## 💬 Review

- The 3-arg overload reuses `evaluator::slice()`, which already short-circuits for full-range slices and asserts bounds.
- The existing 2-arg overload is unchanged and implicitly correct for single-part cases (offset 0, full length).
- A new regression test covers: no-capture assertion crash, capture-alignment correctness for `where()`, and capture-alignment correctness for `map()` — all in a single pipeline.

Resolves TNZ-683