### PR TITLE
Silence null list spread warnings

### DIFF
--- a/changelog/unreleased/null-list-spread-warnings.md
+++ b/changelog/unreleased/null-list-spread-warnings.md
@@ -1,0 +1,17 @@
+---
+title: Null list spread warnings
+type: bugfix
+authors:
+  - mavam
+  - codex
+created: 2026-06-06T04:37:42.295012Z
+---
+
+Spreading `null` into a list no longer emits a warning. This makes optional list-building expressions work without an explicit `else []` fallback:
+
+```tql
+from {xs: null}
+items = [1, ...xs, 2]
+```
+
+The expression produces `[1, 2]`, and `concatenate`, `append`, and `prepend` follow the same warning-free behavior for `null` list inputs.

--- a/changelog/unreleased/null-list-spread-warnings.md
+++ b/changelog/unreleased/null-list-spread-warnings.md
@@ -1,6 +1,6 @@
 ---
 title: Null list spread warnings
-type: bugfix
+type: change
 authors:
   - mavam
   - codex

--- a/libtenzir/src/tql2/eval_impl.cpp
+++ b/libtenzir/src/tql2/eval_impl.cpp
@@ -284,6 +284,9 @@ auto evaluator::eval(ast::list const& x, ActiveRows const& active)
         [&](const ast::spread& spread) {
           auto list = array.as<list_type>();
           if (not list) {
+            if (array.type.kind().is<null_type>()) {
+              return;
+            }
             diagnostic::warning("expected list, got `{}` instead",
                                 array.type.kind())
               .primary(spread.expr)

--- a/test/tests/language/expr/list_spread_null.tql
+++ b/test/tests/language/expr/list_spread_null.tql
@@ -1,0 +1,25 @@
+from (
+  {
+    x: null,
+    am: {},
+  },
+  {
+    x: [1, 2],
+    am: {sections: {dns: {ipv4: [1.1.1.1]}}},
+  },
+)
+literal = [0, ...x, 3]
+concat_left = concatenate([0], x)
+concat_right = concatenate(x, [3])
+appended = append(x, 4)
+prepended = prepend(x, 5)
+answers = [
+  ...am.sections?.dns?.ipv4?.map(ip => {
+    class: "IN",
+    type: "A",
+    rdata: ip.string(),
+  }),
+  {
+    class: "static",
+  },
+]

--- a/test/tests/language/expr/list_spread_null.tql
+++ b/test/tests/language/expr/list_spread_null.tql
@@ -1,13 +1,10 @@
-from (
-  {
-    x: null,
-    am: {},
-  },
-  {
-    x: [1, 2],
-    am: {sections: {dns: {ipv4: [1.1.1.1]}}},
-  },
-)
+from {
+  x: null,
+  am: {},
+}, {
+  x: [1, 2],
+  am: {sections: {dns: {ipv4: [1.1.1.1]}}},
+}
 literal = [0, ...x, 3]
 concat_left = concatenate([0], x)
 concat_right = concatenate(x, [3])

--- a/test/tests/language/expr/list_spread_null.txt
+++ b/test/tests/language/expr/list_spread_null.txt
@@ -1,0 +1,78 @@
+{
+  x: null,
+  am: {},
+  literal: [
+    0,
+    3,
+  ],
+  concat_left: [
+    0,
+  ],
+  concat_right: [
+    3,
+  ],
+  appended: [
+    4,
+  ],
+  prepended: [
+    5,
+  ],
+  answers: [
+    {
+      class: "static",
+    },
+  ],
+}
+{
+  x: [
+    1,
+    2,
+  ],
+  am: {
+    sections: {
+      dns: {
+        ipv4: [
+          1.1.1.1,
+        ],
+      },
+    },
+  },
+  literal: [
+    0,
+    1,
+    2,
+    3,
+  ],
+  concat_left: [
+    0,
+    1,
+    2,
+  ],
+  concat_right: [
+    1,
+    2,
+    3,
+  ],
+  appended: [
+    1,
+    2,
+    4,
+  ],
+  prepended: [
+    5,
+    1,
+    2,
+  ],
+  answers: [
+    {
+      class: "IN",
+      type: "A",
+      rdata: "1.1.1.1",
+    },
+    {
+      class: "static",
+      type: null,
+      rdata: null,
+    },
+  ],
+}


### PR DESCRIPTION
## 🔍 Problem

- Optional list-building expressions like `...foo?.bar?.map(...)` already contributed no items when the chain yielded `null`, but still emitted a warning.
- This forced explicit `else []` fallbacks and made spread noisy compared with list concatenation helpers.

## 🛠️ Solution

- Treat `null` as an empty contribution in list spread.
- Preserve warnings for non-null, non-list spread inputs.
- Add regression coverage for direct spread, optional-chain spread, `concatenate`, `append`, and `prepend`.

## 💬 Review

- Focus on the null-vs-non-list boundary in list spread evaluation.
- `map(null)` remains unchanged and warning-free.

<sub>
📚 Docs PR: tenzir/docs#383<br>
✅ Closes TNZ-692
</sub>