### PR TITLE
Support regex Kafka input topics

### DIFF
--- a/changelog/unreleased/regular-expression-topic-selection-for-from-kafka.md
+++ b/changelog/unreleased/regular-expression-topic-selection-for-from-kafka.md
@@ -26,9 +26,3 @@ partition assignments now follow group rebalances, so they may shift when
 pipelines with the same `group.id` start or stop. The `exit` option is not
 available for regex topics, because a regex subscription has no bounded set of
 partitions to reach the end of.
-
-To track offsets correctly across matching topics, `from_kafka` now stores
-checkpointed offsets by topic and partition. Checkpoints written by earlier
-versions are incompatible: pipelines restored from them fail instead of
-resuming. Restart these pipelines once after upgrading; they continue from
-Kafka's stored consumer group offsets.

--- a/changelog/unreleased/regular-expression-topic-selection-for-from-kafka.md
+++ b/changelog/unreleased/regular-expression-topic-selection-for-from-kafka.md
@@ -1,0 +1,16 @@
+---
+title: Regular expression topic selection for from_kafka
+type: feature
+authors:
+  - mavam
+  - codex
+created: 2026-06-08T07:08:34.266686Z
+---
+
+The `from_kafka` operator can now consume from topics selected by a regular expression when the topic argument starts with `^`:
+
+```tql
+from_kafka "^tenant-.*\\.alerts$", offset="beginning"
+```
+
+This lets one pipeline consume matching Kafka topics without listing each topic separately.

--- a/changelog/unreleased/regular-expression-topic-selection-for-from-kafka.md
+++ b/changelog/unreleased/regular-expression-topic-selection-for-from-kafka.md
@@ -7,10 +7,28 @@ authors:
 created: 2026-06-08T07:08:34.266686Z
 ---
 
-The `from_kafka` operator can now consume from topics selected by a regular expression when the topic argument starts with `^`:
+The `from_kafka` operator can now consume from topics selected by a regular
+expression when the topic argument starts with `^`:
 
 ```tql
 from_kafka "^tenant-.*\\.alerts$", offset="beginning"
 ```
 
-This lets one pipeline consume matching Kafka topics without listing each topic separately.
+This lets one pipeline consume matching Kafka topics without listing each topic
+separately.
+
+As part of this change, `from_kafka` now consumes all topics—exact and
+regex—through Kafka's consumer group subscription. This has two visible
+effects. First, pipelines that share a `group.id` (default: `tenzir`) now split
+the partitions of a topic among themselves instead of each receiving every
+message; give each pipeline its own `group.id` to keep full copies. Second,
+partition assignments now follow group rebalances, so they may shift when
+pipelines with the same `group.id` start or stop. The `exit` option is not
+available for regex topics, because a regex subscription has no bounded set of
+partitions to reach the end of.
+
+To track offsets correctly across matching topics, `from_kafka` now stores
+checkpointed offsets by topic and partition. Checkpoints written by earlier
+versions are incompatible: pipelines restored from them fail instead of
+resuming. Restart these pipelines once after upgrading; they continue from
+Kafka's stored consumer group offsets.

--- a/plugins/kafka/builtins/from_kafka.cpp
+++ b/plugins/kafka/builtins/from_kafka.cpp
@@ -11,6 +11,7 @@
 #include "kafka/librdkafka_utils.hpp"
 #include "kafka/message_builder.hpp"
 #include "kafka/operator_args.hpp"
+#include "tenzir/async/blocking_executor.hpp"
 #include "tenzir/async/notify.hpp"
 #include "tenzir/aws_iam.hpp"
 #include "tenzir/detail/enum.hpp"
@@ -456,6 +457,7 @@ public:
       worker_batch_size_{other.worker_batch_size_},
       emitted_messages_{other.emitted_messages_},
       pending_commit_offsets_{std::move(other.pending_commit_offsets_)},
+      consumer_closed_{other.consumer_closed_},
       assigned_partitions_{std::move(other.assigned_partitions_)},
       eof_partitions_{std::move(other.eof_partitions_)},
       perf_enabled_{other.perf_enabled_},
@@ -601,6 +603,7 @@ public:
       done_ = true;
       emit_perf_summary("end_of_stream");
       request_pipeline_stop();
+      co_await close_source_consumer(ctx.dh());
       co_return;
     }
     TENZIR_ASSERT(task_result.frame);
@@ -662,7 +665,7 @@ public:
   }
 
   auto commit_pending_offsets(diagnostic_handler* dh = nullptr) -> Task<void> {
-    if (pending_commit_offsets_.empty()) {
+    if (consumer_closed_ or pending_commit_offsets_.empty()) {
       co_return;
     }
     auto commit_keys = std::vector<TopicPartition>{};
@@ -697,9 +700,9 @@ public:
         co_await folly::coro::sleep(offset_commit_retry_delay);
       }
       if (err == RdKafka::ERR_NO_ERROR) {
-        auto const& committed = runtime_.sources[0]
-                                  .source_consumer->consumer_cfg
-                                  .committed_partitions;
+        auto const& committed
+          = runtime_.sources[0]
+              .source_consumer->consumer_cfg.committed_partitions;
         for (auto const& partition : commit_keys) {
           pending_commit_offsets_.erase(partition);
           if (committed) {
@@ -721,6 +724,34 @@ public:
                       partitions, RdKafka::err2str(err));
         }
       }
+    }
+  }
+
+  /// Leaves the consumer group so the coordinator can reassign partitions
+  /// without waiting for the session timeout.
+  auto close_source_consumer(diagnostic_handler& dh) -> Task<void> {
+    if (consumer_closed_ or runtime_.sources.empty()
+        or not runtime_.sources[0].source_consumer) {
+      co_return;
+    }
+    if (runtime_.live_fetchers.load() > 0
+        or runtime_.live_builders.load() > 0) {
+      // A cancelled run can reach end-of-stream while loops still wind down;
+      // closing would race their consume calls, so leave the group via the
+      // session timeout instead.
+      co_return;
+    }
+    // Flush consumed progress first; committing is impossible after close.
+    co_await commit_pending_offsets(&dh);
+    consumer_closed_ = true;
+    auto* consumer = &*runtime_.sources[0].source_consumer->consumer;
+    auto const err = co_await spawn_blocking([consumer] {
+      return consumer->close();
+    });
+    if (err != RdKafka::ERR_NO_ERROR) {
+      diagnostic::warning("from_kafka: failed to close consumer: {}",
+                          RdKafka::err2str(err))
+        .emit(dh);
     }
   }
 
@@ -1724,6 +1755,8 @@ private:
   size_t emitted_messages_ = 0;
   // Invariant: committed offsets are stored as "next offset to consume".
   TopicPartitionOffsets pending_commit_offsets_;
+  // Set once the group membership was closed; commits are impossible after.
+  bool consumer_closed_ = false;
   // Snapshot of the subscription's current assignment; only maintained for
   // `exit=true`, refreshed lazily when an EOF for an unknown partition arrives.
   TopicPartitionSet assigned_partitions_;

--- a/plugins/kafka/builtins/from_kafka.cpp
+++ b/plugins/kafka/builtins/from_kafka.cpp
@@ -34,6 +34,7 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <charconv>
 #include <chrono>
 #include <limits>
 #include <map>
@@ -328,11 +329,45 @@ auto parse_offset_value(located<data> const& input, int64_t& offset) -> bool {
     });
 }
 
+auto is_topic_regex(std::string_view topic) -> bool {
+  return topic.starts_with('^');
+}
+
+auto topic_partition_key(std::string_view topic, int32_t partition)
+  -> std::string {
+  return fmt::format("{}\n{}", topic, partition);
+}
+
+struct TopicPartition {
+  std::string topic;
+  int32_t partition = -1;
+};
+
+auto parse_topic_partition_key(std::string_view key)
+  -> std::optional<TopicPartition> {
+  auto const pos = key.rfind('\n');
+  if (pos == std::string_view::npos) {
+    return std::nullopt;
+  }
+  auto partition = int32_t{};
+  auto const partition_text = key.substr(pos + 1);
+  auto const* first = partition_text.data();
+  auto const* last = first + partition_text.size();
+  auto [ptr, ec] = std::from_chars(first, last, partition);
+  if (ec != std::errc{} or ptr != last) {
+    return std::nullopt;
+  }
+  return TopicPartition{
+    .topic = std::string{key.substr(0, pos)},
+    .partition = partition,
+  };
+}
+
 /// Represents one polled Kafka message batch plus control metadata.
 struct MessageBatch {
   uint64_t seq = 0;
   std::vector<AsyncConsumerQueue::Message> messages;
-  std::vector<int32_t> eof_partitions;
+  std::vector<std::string> eof_partitions;
   std::optional<std::string> fatal_error;
   bool reached_count = false;
   size_t payload_bytes = 0;
@@ -342,9 +377,9 @@ struct MessageBatch {
 struct TableSliceFrame {
   uint64_t seq = 0;
   std::vector<table_slice> slices;
-  std::unordered_map<int32_t, int64_t> max_offsets;
+  std::unordered_map<std::string, int64_t> max_offsets;
   size_t message_count = 0;
-  std::vector<int32_t> eof_partitions;
+  std::vector<std::string> eof_partitions;
   std::optional<std::string> fatal_error;
   std::vector<diagnostic> diagnostics;
 };
@@ -382,7 +417,8 @@ auto build_table_slice(MessageBatch& batch, multi_series_builder& builder,
     }
     auto payload = std::move(payload_bytes).unwrap();
     process_payload(payload);
-    frame.max_offsets[message.partition()] = message.offset();
+    frame.max_offsets[topic_partition_key(message.topic(), message.partition())]
+      = message.offset();
     ++frame.message_count;
   }
   if (flush) {
@@ -414,8 +450,6 @@ public:
       perf_start_{other.perf_start_},
       done_{other.done_} {
     runtime_.partition_sources = std::move(other.runtime_.partition_sources);
-    runtime_.partition_source_by_id
-      = std::move(other.runtime_.partition_source_by_id);
     runtime_.message_queue = std::move(other.runtime_.message_queue);
     runtime_.table_slice_queue = std::move(other.runtime_.table_slice_queue);
     runtime_.ordered_slices = std::move(other.runtime_.ordered_slices);
@@ -469,6 +503,13 @@ public:
     }
     auto offset = resolve_start_offset(ctx);
     if (not offset) {
+      done_ = true;
+      co_return;
+    }
+    if (is_topic_regex(args_.topic) and args_.exit) {
+      diagnostic::error("`exit` is incompatible with regex topic subscriptions")
+        .primary(*args_.exit)
+        .emit(ctx);
       done_ = true;
       co_return;
     }
@@ -577,8 +618,12 @@ public:
       add_perf_counter(perf_.emitted_messages,
                        static_cast<uint64_t>(frame.message_count));
     }
-    for (auto partition : frame.eof_partitions) {
+    for (auto const& partition : frame.eof_partitions) {
       add_perf_counter(perf_.eof_events);
+      if (args_.exit and not is_topic_regex(args_.topic)
+          and not assigned_partitions_.contains(partition)) {
+        refresh_assigned_partitions(ctx.dh());
+      }
       mark_partition_eof(partition);
     }
     if (frame.fatal_error) {
@@ -604,33 +649,34 @@ public:
       co_return;
     }
     struct OffsetsForSource {
-      std::vector<int32_t> partitions;
+      std::vector<std::string> partitions;
       std::vector<std::unique_ptr<RdKafka::TopicPartition>> offsets;
     };
     auto offsets_by_source = std::unordered_map<size_t, OffsetsForSource>{};
-    auto clear_pending = std::vector<int32_t>{};
-    for (auto const& [partition, offset] : checkpoint_pending_offsets_) {
-      auto source_it = runtime_.partition_source_by_id.find(partition);
-      if (source_it == runtime_.partition_source_by_id.end()) {
+    auto clear_pending = std::vector<std::string>{};
+    for (auto const& [partition_key, offset] : checkpoint_pending_offsets_) {
+      auto topic_partition = parse_topic_partition_key(partition_key);
+      if (not topic_partition) {
         if (dh) {
-          diagnostic::warning("from_kafka: no source for partition {} while "
-                              "committing",
-                              partition)
-            .hint("this typically means checkpointed offsets refer to a "
-                  "partition that is no longer assigned (for example after a "
-                  "topic partition-count change or stale recovery state)")
+          diagnostic::warning("from_kafka: invalid topic partition key {} "
+                              "while committing",
+                              partition_key)
             .emit(*dh);
         } else {
-          TENZIR_WARN("from_kafka: no source for partition {} while committing",
-                      partition);
+          TENZIR_WARN("from_kafka: invalid topic partition key {} while "
+                      "committing",
+                      partition_key);
         }
-        clear_pending.push_back(partition);
+        clear_pending.push_back(partition_key);
         continue;
       }
-      auto& source_offsets = offsets_by_source[source_it->second];
-      source_offsets.partitions.push_back(partition);
-      source_offsets.offsets.emplace_back(
-        RdKafka::TopicPartition::create(args_.topic, partition, offset));
+      if (runtime_.partition_sources.empty()) {
+        break;
+      }
+      auto& source_offsets = offsets_by_source[0];
+      source_offsets.partitions.push_back(partition_key);
+      source_offsets.offsets.emplace_back(RdKafka::TopicPartition::create(
+        topic_partition->topic, topic_partition->partition, offset));
     }
     for (auto& [source_index, source_offsets] : offsets_by_source) {
       if (source_offsets.offsets.empty()
@@ -669,17 +715,18 @@ public:
         = tenzir::detail::join(source_offsets.partitions, ", ");
       if (dh) {
         diagnostic::warning("from_kafka: failed to commit offsets")
-          .note("partitions: {}", partitions)
+          .note("topic partitions: {}", partitions)
           .note("librdkafka error: {}", RdKafka::err2str(err))
           .emit(*dh);
       } else {
-        TENZIR_WARN("from_kafka: failed to commit offsets for partition(s) "
+        TENZIR_WARN("from_kafka: failed to commit offsets for topic "
+                    "partition(s) "
                     "{}: {}",
                     partitions, RdKafka::err2str(err));
       }
     }
-    for (auto partition : clear_pending) {
-      checkpoint_pending_offsets_.erase(partition);
+    for (auto const& partition_key : clear_pending) {
+      checkpoint_pending_offsets_.erase(partition_key);
     }
   }
 
@@ -715,6 +762,7 @@ private:
 
   /// Owns one partition source (consumer plus async queue wrapper).
   struct PartitionSource {
+    std::string topic;
     int32_t partition = -1;
     std::optional<SourceConsumer> source_consumer;
     Option<Box<AsyncConsumerQueue>> queue;
@@ -723,7 +771,6 @@ private:
   /// Owns mutable runtime state for source/build/emit stages.
   struct RuntimeState {
     std::vector<PartitionSource> partition_sources;
-    std::unordered_map<int32_t, size_t> partition_source_by_id;
     std::shared_ptr<MessageQueue> message_queue;
     std::shared_ptr<TableSliceQueue> table_slice_queue;
     std::map<uint64_t, TableSliceFrame> ordered_slices;
@@ -831,126 +878,7 @@ private:
     co_return source_consumer;
   }
 
-  /// Discovers all partition ids for `args_.topic` from broker metadata.
-  auto
-  discover_topic_partitions(SourceConsumer& source,
-                            ResolvedAwsIamAuth const& auth, OpCtx& ctx) const
-    -> std::optional<std::vector<int32_t>> {
-    auto& consumer = *source.consumer;
-    auto serve_oauth_refresh_callbacks = [&](duration budget) -> void {
-      if (not source.consumer_cfg.oauth_callback
-          or source.consumer_cfg.oauth_background_callbacks_active) {
-        return;
-      }
-      auto const deadline = std::chrono::steady_clock::now() + budget;
-      while (std::chrono::steady_clock::now() < deadline) {
-        if (consumer.poll(50) > 0) {
-          return;
-        }
-      }
-    };
-    auto oauth_callback_servicing = [&]() -> std::string_view {
-      if (not source.consumer_cfg.oauth_callback) {
-        return "disabled";
-      }
-      if (source.consumer_cfg.oauth_background_callbacks_active) {
-        return "background";
-      }
-      return "poll_fallback";
-    };
-    auto* metadata = static_cast<RdKafka::Metadata*>(nullptr);
-    auto query_metadata = [&]() {
-      metadata = nullptr;
-      return consumer.metadata(false, nullptr, &metadata, 5000);
-    };
-    // Primary path: background callbacks are already active and refresh happens
-    // on librdkafka's background thread. Fallback path: when background setup
-    // is unavailable, drive callback progress with short manual polls before
-    // metadata queries so the first token can still be minted in time.
-    if (source.consumer_cfg.oauth_callback
-        and not source.consumer_cfg.oauth_background_callbacks_active) {
-      serve_oauth_refresh_callbacks(1s);
-    }
-    auto err = query_metadata();
-    if (err != RdKafka::ERR_NO_ERROR and source.consumer_cfg.oauth_callback
-        and not source.consumer_cfg.oauth_background_callbacks_active) {
-      // Poll fallback retry: give one extra poll window and retry metadata once
-      // before surfacing diagnostics.
-      serve_oauth_refresh_callbacks(1500ms);
-      err = query_metadata();
-    }
-    if (err != RdKafka::ERR_NO_ERROR) {
-      auto out
-        = diagnostic::error("failed to query topic metadata for `{}`: {}",
-                            args_.topic, RdKafka::err2str(err));
-      out = add_kafka_connection_diagnostic_notes(
-        std::move(out), source.consumer_cfg.conf.get());
-      if (source.consumer_cfg.oauth_callback) {
-        out = std::move(out).note("oauth.callback_servicing={}",
-                                  oauth_callback_servicing());
-        if (not source.consumer_cfg.oauth_background_setup_note.empty()) {
-          out = std::move(out).note(
-            "oauth.background_setup={}",
-            source.consumer_cfg.oauth_background_setup_note);
-        }
-      }
-      if (auth.options and auth.credentials) {
-        out = add_kafka_aws_iam_diagnostic_notes(std::move(out),
-                                                 auth.credentials);
-        std::move(out)
-          .hint("verify bootstrap broker reachability, TLS trust/cert setup, "
-                "and IAM/SASL settings (region, mechanism, and assume-role "
-                "inputs)")
-          .emit(ctx);
-      } else {
-        std::move(out)
-          .hint("verify bootstrap broker reachability and that "
-                "`security.protocol`/`sasl.mechanism` match broker "
-                "requirements")
-          .emit(ctx);
-      }
-      return std::nullopt;
-    }
-    auto metadata_guard = std::unique_ptr<RdKafka::Metadata>{metadata};
-    TENZIR_ASSERT(metadata_guard);
-    auto partitions = std::vector<int32_t>{};
-    for (auto const& topic_meta : *metadata_guard->topics()) {
-      if (topic_meta == nullptr or topic_meta->topic() != args_.topic) {
-        continue;
-      }
-      if (topic_meta->err() != RdKafka::ERR_NO_ERROR) {
-        diagnostic::error("failed to get topic metadata for `{}`: {}",
-                          args_.topic, RdKafka::err2str(topic_meta->err()))
-          .emit(ctx);
-        return std::nullopt;
-      }
-      partitions.reserve(topic_meta->partitions()->size());
-      for (auto const& partition_meta : *topic_meta->partitions()) {
-        if (partition_meta == nullptr) {
-          continue;
-        }
-        if (partition_meta->err() != RdKafka::ERR_NO_ERROR) {
-          diagnostic::warning("ignoring partition {} due to metadata error: {}",
-                              partition_meta->id(),
-                              RdKafka::err2str(partition_meta->err()))
-            .emit(ctx);
-          continue;
-        }
-        partitions.push_back(partition_meta->id());
-      }
-      break;
-    }
-    if (partitions.empty()) {
-      diagnostic::error("topic `{}` has no discoverable partitions",
-                        args_.topic)
-        .emit(ctx);
-      return std::nullopt;
-    }
-    std::ranges::sort(partitions);
-    return partitions;
-  }
-
-  /// Builds one dedicated source consumer+queue pair for each topic partition.
+  /// Builds one source that lets librdkafka manage the topic subscription.
   auto make_partition_sources(OpCtx& ctx, ResolvedAwsIamAuth const& auth,
                               int64_t offset) -> Task<bool> {
     auto config = source_global_defaults();
@@ -963,65 +891,36 @@ private:
       config["enable.partition.eof"] = "true";
     }
     runtime_.partition_sources.clear();
-    runtime_.partition_source_by_id.clear();
     assigned_partitions_.clear();
     eof_partitions_.clear();
-    auto bootstrap_consumer
+    auto source_consumer
       = co_await make_source_consumer(ctx, config, auth, offset);
-    if (not bootstrap_consumer) {
+    if (not source_consumer) {
       co_return false;
     }
-    auto partitions = discover_topic_partitions(*bootstrap_consumer, auth, ctx);
-    if (not partitions) {
-      co_return false;
-    }
-    runtime_.partition_sources.reserve(partitions->size());
-    auto* evb = folly::getGlobalIOExecutor()->getEventBase();
-    for (auto i = size_t{0}; i < partitions->size(); ++i) {
-      auto partition = (*partitions)[i];
-      auto next_consumer = std::optional<SourceConsumer>{};
-      if (i == 0) {
-        next_consumer = std::move(*bootstrap_consumer);
-      } else {
-        next_consumer
-          = co_await make_source_consumer(ctx, config, auth, offset);
-      }
-      if (not next_consumer) {
-        co_return false;
-      }
-      auto assignment = std::vector<RdKafka::TopicPartition*>{
-        RdKafka::TopicPartition::create(args_.topic, partition, offset),
-      };
-      auto assign_err = next_consumer->consumer->assign(assignment);
-      RdKafka::TopicPartition::destroy(assignment);
-      if (assign_err != RdKafka::ERR_NO_ERROR) {
-        diagnostic::error("failed to assign partition {}: {}", partition,
-                          RdKafka::err2str(assign_err))
-          .emit(ctx);
-        co_return false;
-      }
-      auto queue = AsyncConsumerQueue::make(*evb, *next_consumer->consumer);
-      if (queue.is_err()) {
-        diagnostic::error("failed to create async consumer queue for partition "
-                          "{}: {}",
-                          partition, std::move(queue).unwrap_err())
-          .emit(ctx);
-        co_return false;
-      }
-      auto source = PartitionSource{};
-      source.partition = partition;
-      source.source_consumer = std::move(*next_consumer);
-      source.queue.emplace(std::move(queue).unwrap());
-      assigned_partitions_.insert(partition);
-      runtime_.partition_source_by_id.emplace(
-        partition, runtime_.partition_sources.size());
-      runtime_.partition_sources.emplace_back(std::move(source));
-    }
-    if (runtime_.partition_sources.empty()) {
-      diagnostic::error("topic `{}` has no assignable partitions", args_.topic)
+    auto subscribe_err = source_consumer->consumer->subscribe(
+      std::vector<std::string>{args_.topic});
+    if (subscribe_err != RdKafka::ERR_NO_ERROR) {
+      diagnostic::error("failed to subscribe to topic `{}`: {}", args_.topic,
+                        RdKafka::err2str(subscribe_err))
         .emit(ctx);
       co_return false;
     }
+    auto* evb = folly::getGlobalIOExecutor()->getEventBase();
+    auto queue = AsyncConsumerQueue::make(*evb, *source_consumer->consumer);
+    if (queue.is_err()) {
+      diagnostic::error("failed to create async consumer queue for topic "
+                        "`{}`: {}",
+                        args_.topic, std::move(queue).unwrap_err())
+        .emit(ctx);
+      co_return false;
+    }
+    auto source = PartitionSource{};
+    source.topic = args_.topic;
+    source.partition = -1;
+    source.source_consumer = std::move(*source_consumer);
+    source.queue.emplace(std::move(queue).unwrap());
+    runtime_.partition_sources.emplace_back(std::move(source));
     co_return true;
   }
 
@@ -1281,7 +1180,8 @@ private:
         }
         case RD_KAFKA_RESP_ERR__PARTITION_EOF: {
           if (args_.exit) {
-            batch.eof_partitions.push_back(message.partition());
+            batch.eof_partitions.push_back(
+              topic_partition_key(message.topic(), message.partition()));
           }
           break;
         }
@@ -1698,15 +1598,48 @@ private:
   }
 
   /// Moves per-partition offsets from one emitted batch into checkpoint state.
-  auto advance_checkpoint(std::unordered_map<int32_t, int64_t> const& offsets)
+  auto
+  advance_checkpoint(std::unordered_map<std::string, int64_t> const& offsets)
     -> void {
-    for (auto const& [partition, offset] : offsets) {
-      checkpoint_pending_offsets_[partition] = offset + 1;
+    for (auto const& [partition_key, offset] : offsets) {
+      checkpoint_pending_offsets_[partition_key] = offset + 1;
+    }
+  }
+
+  /// Refreshes the current assignment for exact-topic EOF tracking.
+  auto refresh_assigned_partitions(diagnostic_handler& dh) -> void {
+    if (runtime_.partition_sources.empty()) {
+      return;
+    }
+    auto& source = runtime_.partition_sources[0];
+    if (not source.source_consumer) {
+      return;
+    }
+    auto partitions = std::vector<RdKafka::TopicPartition*>{};
+    auto err = source.source_consumer->consumer->assignment(partitions);
+    auto guard = tenzir::detail::scope_guard{[&]() noexcept {
+      RdKafka::TopicPartition::destroy(partitions);
+    }};
+    if (err != RdKafka::ERR_NO_ERROR) {
+      diagnostic::warning("from_kafka: failed to get current assignment: {}",
+                          RdKafka::err2str(err))
+        .emit(dh);
+      return;
+    }
+    assigned_partitions_.clear();
+    eof_partitions_.clear();
+    for (auto* partition : partitions) {
+      if (partition == nullptr or partition->partition() < 0
+          or partition->topic() != args_.topic) {
+        continue;
+      }
+      assigned_partitions_.insert(
+        topic_partition_key(partition->topic(), partition->partition()));
     }
   }
 
   /// Tracks partition EOF notifications and marks the source done if complete.
-  auto mark_partition_eof(int32_t partition) -> void {
+  auto mark_partition_eof(std::string const& partition) -> void {
     if (not args_.exit or not assigned_partitions_.contains(partition)) {
       return;
     }
@@ -1726,11 +1659,11 @@ private:
   // Number of records emitted so far; used for `count=` resumption.
   size_t emitted_messages_ = 0;
   // Invariant: committed offsets are stored as "next offset to consume".
-  std::unordered_map<int32_t, int64_t> checkpoint_pending_offsets_;
+  std::unordered_map<std::string, int64_t> checkpoint_pending_offsets_;
   // Invariant: fixed partition set assigned at startup.
-  std::unordered_set<int32_t> assigned_partitions_;
+  std::unordered_set<std::string> assigned_partitions_;
   // Invariant: contains only partitions from `assigned_partitions_`.
-  std::unordered_set<int32_t> eof_partitions_;
+  std::unordered_set<std::string> eof_partitions_;
   // Optional counters for benchmarking; enabled via env flag.
   mutable FromKafkaPerfCounters perf_;
   mutable MetricsCounter read_bytes_counter_;

--- a/plugins/kafka/builtins/from_kafka.cpp
+++ b/plugins/kafka/builtins/from_kafka.cpp
@@ -457,7 +457,7 @@ public:
       worker_count_{other.worker_count_},
       worker_batch_size_{other.worker_batch_size_},
       emitted_messages_{other.emitted_messages_},
-      checkpoint_pending_offsets_{std::move(other.checkpoint_pending_offsets_)},
+      pending_commit_offsets_{std::move(other.pending_commit_offsets_)},
       assigned_partitions_{std::move(other.assigned_partitions_)},
       eof_partitions_{std::move(other.eof_partitions_)},
       perf_enabled_{other.perf_enabled_},
@@ -626,7 +626,7 @@ public:
       }
     }
     if (frame.message_count > 0) {
-      advance_checkpoint(frame.max_offsets);
+      record_pending_offsets(frame.max_offsets);
       co_await commit_pending_offsets(&ctx.dh());
       emitted_messages_ += frame.message_count;
       add_perf_counter(perf_.emitted_batches);
@@ -660,14 +660,14 @@ public:
   }
 
   auto commit_pending_offsets(diagnostic_handler* dh = nullptr) -> Task<void> {
-    if (checkpoint_pending_offsets_.empty()) {
+    if (pending_commit_offsets_.empty()) {
       co_return;
     }
     auto clear_pending = std::vector<std::string>{};
     auto commit_keys = std::vector<std::string>{};
     auto commit_labels = std::vector<std::string>{};
     auto offsets = std::vector<std::unique_ptr<RdKafka::TopicPartition>>{};
-    for (auto const& [partition_key, offset] : checkpoint_pending_offsets_) {
+    for (auto const& [partition_key, offset] : pending_commit_offsets_) {
       auto topic_partition = parse_topic_partition_key(partition_key);
       if (not topic_partition) {
         if (dh) {
@@ -728,14 +728,14 @@ public:
       }
     }
     for (auto const& partition_key : clear_pending) {
-      checkpoint_pending_offsets_.erase(partition_key);
+      pending_commit_offsets_.erase(partition_key);
     }
   }
 
   auto snapshot(Serde& serde) -> void override {
     // Persist only recovery state that reflects consumed progress.
     serde("emitted_messages", emitted_messages_);
-    serde("checkpoint_pending_offsets", checkpoint_pending_offsets_);
+    serde("pending_commit_offsets", pending_commit_offsets_);
   }
 
   /// Stops background tasks as soon as the runner asks this source to stop.
@@ -1595,12 +1595,11 @@ private:
     }
   }
 
-  /// Moves per-partition offsets from one emitted batch into checkpoint state.
-  auto
-  advance_checkpoint(std::unordered_map<std::string, int64_t> const& offsets)
-    -> void {
+  /// Moves per-partition offsets from one emitted batch into commit state.
+  auto record_pending_offsets(
+    std::unordered_map<std::string, int64_t> const& offsets) -> void {
     for (auto const& [partition_key, offset] : offsets) {
-      checkpoint_pending_offsets_[partition_key] = offset + 1;
+      pending_commit_offsets_[partition_key] = offset + 1;
     }
   }
 
@@ -1672,7 +1671,7 @@ private:
   // Number of records emitted so far; used for `count=` resumption.
   size_t emitted_messages_ = 0;
   // Invariant: committed offsets are stored as "next offset to consume".
-  std::unordered_map<std::string, int64_t> checkpoint_pending_offsets_;
+  std::unordered_map<std::string, int64_t> pending_commit_offsets_;
   // Snapshot of the subscription's current assignment; only maintained for
   // `exit=true`, refreshed lazily when an EOF for an unknown partition arrives.
   std::unordered_set<std::string> assigned_partitions_;

--- a/plugins/kafka/builtins/from_kafka.cpp
+++ b/plugins/kafka/builtins/from_kafka.cpp
@@ -1694,7 +1694,7 @@ private:
 
   /// Requests pipeline stop once every assigned partition reached EOF.
   auto check_eof_exit() -> void {
-    if (not args_.exit or assigned_partitions_.empty()) {
+    if (not args_.exit) {
       return;
     }
     if (eof_partitions_.size() == assigned_partitions_.size()) {

--- a/plugins/kafka/builtins/from_kafka.cpp
+++ b/plugins/kafka/builtins/from_kafka.cpp
@@ -140,11 +140,13 @@ private:
 ///
 /// Source granularity is one subscription (one consumer), for exact and regex
 /// topics alike: the broker owns partition assignment, and regex matching is
-/// resolved broker-side and dynamically. Should fetch-side parallelism become
-/// the bottleneck, fan out per-assigned-partition queues from this single
-/// subscription (`rd_kafka_queue_get_partition` from the rebalance callback)
-/// instead of adding consumers; `RuntimeState::sources` stays a vector to
-/// leave room for that.
+/// resolved broker-side and dynamically. Measured locally, the fetch stage is
+/// bound by the consumer's single in-flight fetch request per broker — not by
+/// queue draining — so larger per-partition fetches (see the throughput
+/// defaults below) are the first lever. If more fetch parallelism is ever
+/// needed, subscribe additional consumers as members of the same group and
+/// let the broker split partitions across them; `RuntimeState::sources` stays
+/// a vector to leave room for that.
 
 /// Default delay before flushing a partial batch.
 constexpr auto default_batch_timeout = 100ms;
@@ -170,12 +172,15 @@ auto from_kafka_throughput_defaults()
   using entry = std::pair<std::string, std::string>;
   // Performance note: these defaults intentionally bias towards low broker-side
   // holdback (`fetch.min.bytes=1`, `fetch.wait.max.ms=500`) while increasing
-  // client queue depth. Local 10M-message fixture runs showed this combination
-  // avoids source stalls better than aggressive "large batch" defaults.
+  // client queue depth. The subscribed consumer keeps roughly one fetch
+  // request in flight per broker, so its drain rate is bound by bytes per
+  // fetch round trip: local 1M/4M-message runs against a single broker showed
+  // `max.partition.fetch.bytes=8Mi` roughly doubles throughput over the 1Mi
+  // value tuned for the earlier consumer-per-partition layout.
   static const auto defaults = std::array<entry, 5>{
     entry{"fetch.min.bytes", std::to_string(1)},
     entry{"fetch.wait.max.ms", std::to_string(500)},
-    entry{"max.partition.fetch.bytes", std::to_string(1_Mi)},
+    entry{"max.partition.fetch.bytes", std::to_string(8_Mi)},
     entry{"queued.min.messages", std::to_string(200_k)},
     entry{"queued.max.messages.kbytes", std::to_string(256_k)},
   };

--- a/plugins/kafka/builtins/from_kafka.cpp
+++ b/plugins/kafka/builtins/from_kafka.cpp
@@ -384,6 +384,7 @@ struct MessageBatch {
   std::vector<AsyncConsumerQueue::Message> messages;
   std::vector<std::string> eof_partitions;
   std::optional<std::string> fatal_error;
+  bool assignment_changed = false;
   bool reached_count = false;
   size_t payload_bytes = 0;
 };
@@ -396,6 +397,7 @@ struct TableSliceFrame {
   size_t message_count = 0;
   std::vector<std::string> eof_partitions;
   std::optional<std::string> fatal_error;
+  bool assignment_changed = false;
   std::vector<diagnostic> diagnostics;
 };
 
@@ -421,6 +423,7 @@ auto build_table_slice(MessageBatch& batch, multi_series_builder& builder,
   frame.seq = batch.seq;
   frame.eof_partitions = std::move(batch.eof_partitions);
   frame.fatal_error = std::move(batch.fatal_error);
+  frame.assignment_changed = batch.assignment_changed;
   for (auto& message : batch.messages) {
     auto payload_bytes = message.payload();
     if (payload_bytes.is_err()) {
@@ -633,6 +636,10 @@ public:
       add_perf_counter(perf_.emitted_messages,
                        static_cast<uint64_t>(frame.message_count));
     }
+    if (frame.assignment_changed and args_.exit
+        and not is_topic_regex(args_.topic)) {
+      refresh_assigned_partitions(ctx.dh());
+    }
     for (auto const& partition : frame.eof_partitions) {
       add_perf_counter(perf_.eof_events);
       if (args_.exit and not is_topic_regex(args_.topic)
@@ -766,6 +773,7 @@ private:
   struct SubscriptionSource {
     std::optional<SourceConsumer> source_consumer;
     Option<Box<AsyncConsumerQueue>> queue;
+    uint64_t observed_assignment_generation = 0;
   };
 
   /// Owns mutable runtime state for source/build/emit stages.
@@ -1160,10 +1168,12 @@ private:
   }
 
   /// Converts polled Kafka messages into one source payload batch.
-  auto to_fetched_batch(
-    std::vector<AsyncConsumerQueue::Message> fetched_messages) const
+  auto
+  to_fetched_batch(std::vector<AsyncConsumerQueue::Message> fetched_messages,
+                   bool assignment_changed) const
     -> std::optional<MessageBatch> {
     auto batch = MessageBatch{};
+    batch.assignment_changed = assignment_changed;
     batch.messages.reserve(fetched_messages.size());
     auto reached_count = false;
     for (auto& message : fetched_messages) {
@@ -1200,16 +1210,51 @@ private:
     }
     batch.reached_count = reached_count;
     if (batch.messages.empty() and batch.eof_partitions.empty()
-        and not batch.fatal_error and not batch.reached_count) {
+        and not batch.fatal_error and not batch.assignment_changed
+        and not batch.reached_count) {
       return std::nullopt;
     }
     batch.seq = runtime_.next_fetch_seq.fetch_add(1, std::memory_order_relaxed);
     return batch;
   }
 
+  /// Returns true when the rebalance callback changed the source assignment.
+  auto take_assignment_change(SubscriptionSource& source) const -> bool {
+    if (not args_.exit or is_topic_regex(args_.topic)
+        or not source.source_consumer) {
+      return false;
+    }
+    auto const& generation
+      = source.source_consumer->consumer_cfg.assignment_generation;
+    if (not generation) {
+      return false;
+    }
+    auto current = generation->load(std::memory_order_acquire);
+    if (current == source.observed_assignment_generation) {
+      return false;
+    }
+    source.observed_assignment_generation = current;
+    return true;
+  }
+
+  /// Returns true without consuming a pending assignment-change notification.
+  auto has_assignment_change(SubscriptionSource const& source) const -> bool {
+    if (not args_.exit or is_topic_regex(args_.topic)
+        or not source.source_consumer) {
+      return false;
+    }
+    auto const& generation
+      = source.source_consumer->consumer_cfg.assignment_generation;
+    if (not generation) {
+      return false;
+    }
+    auto current = generation->load(std::memory_order_acquire);
+    return current != source.observed_assignment_generation;
+  }
+
   /// Collects one source poll window with adaptive timeout/backoff behavior.
-  auto
-  collect_fetch_window(AsyncConsumerQueue& queue, size_t max_messages) const
+  auto collect_fetch_window(AsyncConsumerQueue& queue, size_t max_messages,
+                            SubscriptionSource const& source) const
     -> Task<std::vector<AsyncConsumerQueue::Message>> {
     auto pending_messages = std::vector<AsyncConsumerQueue::Message>{};
     pending_messages.reserve(max_messages);
@@ -1270,6 +1315,9 @@ private:
             if (std::chrono::steady_clock::now() < *state.batch_deadline) {
               continue;
             }
+            break;
+          }
+          if (has_assignment_change(source)) {
             break;
           }
           continue;
@@ -1366,14 +1414,16 @@ private:
           break;
         }
         auto pending_messages
-          = co_await collect_fetch_window(**source.queue, max_messages);
-        if (pending_messages.empty()) {
-          if (is_pipeline_stopping()) {
-            break;
-          }
+          = co_await collect_fetch_window(**source.queue, max_messages, source);
+        if (pending_messages.empty() and is_pipeline_stopping()) {
+          break;
+        }
+        auto assignment_changed = take_assignment_change(source);
+        if (pending_messages.empty() and not assignment_changed) {
           continue;
         }
-        auto fetched = to_fetched_batch(std::move(pending_messages));
+        auto fetched
+          = to_fetched_batch(std::move(pending_messages), assignment_changed);
         if (not fetched) {
           continue;
         }

--- a/plugins/kafka/builtins/from_kafka.cpp
+++ b/plugins/kafka/builtins/from_kafka.cpp
@@ -66,6 +66,7 @@ auto is_transient_offset_commit_error(RdKafka::ErrorCode err) -> bool {
     case RdKafka::ERR_COORDINATOR_LOAD_IN_PROGRESS:
     case RdKafka::ERR_COORDINATOR_NOT_AVAILABLE:
     case RdKafka::ERR_NOT_COORDINATOR:
+    case RdKafka::ERR_REBALANCE_IN_PROGRESS:
       return true;
     default:
       return false;
@@ -96,8 +97,9 @@ private:
 /// Concurrent stage layout (executor domains on the right):
 ///
 ///   ┌───────────────────────────────┐
-///   │ ×P poll loops (`fetch_loop`)  │                [I/O executor]
-///   │   1 source per partition      │
+///   │ poll loop (`fetch_loop`)      │                [I/O executor]
+///   │   1 subscribed source; the    │
+///   │   broker assigns partitions   │
 ///   └───────────────────────────────┘
 ///                   │
 ///                   │ MessageBatch
@@ -126,15 +128,23 @@ private:
 /// Invariants:
 /// 1. Backpressure is bounded by both `runtime_.message_queue` capacity and
 ///    `prefetch_bytes` accounting (`runtime_.in_flight_fetch_bytes`).
-/// 2. `seq` is assigned in source-arrival order across all partition sources;
-///    only ordered mode re-establishes that order before emitting slices.
+/// 2. `seq` is assigned in source-arrival order; only ordered mode
+///    re-establishes that order before emitting slices.
 /// 3. Source polling (`fetch_wait_timeout`) is independent from slice
 ///    flush latency (`batch_timeout`) to avoid timeout-coupling stalls.
 /// 4. Source ingress is typically the bottleneck. Raising worker concurrency
 ///    helps mostly in `optimization="unordered"` mode but does not remove
 ///    source-side wait on its own.
-/// 5. Per-partition record order is preserved by Kafka and by each single
-///    partition source loop, but there is no global cross-partition order.
+/// 5. Per-partition record order is preserved by Kafka and by the single
+///    source loop, but there is no global cross-partition order.
+///
+/// Source granularity is one subscription (one consumer), for exact and regex
+/// topics alike: the broker owns partition assignment, and regex matching is
+/// resolved broker-side and dynamically. Should fetch-side parallelism become
+/// the bottleneck, fan out per-assigned-partition queues from this single
+/// subscription (`rd_kafka_queue_get_partition` from the rebalance callback)
+/// instead of adding consumers; `RuntimeState::sources` stays a vector to
+/// leave room for that.
 
 /// Default delay before flushing a partial batch.
 constexpr auto default_batch_timeout = 100ms;
@@ -449,7 +459,7 @@ public:
       perf_started_{other.perf_started_},
       perf_start_{other.perf_start_},
       done_{other.done_} {
-    runtime_.partition_sources = std::move(other.runtime_.partition_sources);
+    runtime_.sources = std::move(other.runtime_.sources);
     runtime_.message_queue = std::move(other.runtime_.message_queue);
     runtime_.table_slice_queue = std::move(other.runtime_.table_slice_queue);
     runtime_.ordered_slices = std::move(other.runtime_.ordered_slices);
@@ -513,13 +523,13 @@ public:
       done_ = true;
       co_return;
     }
-    if (not co_await make_partition_sources(ctx, *auth, *offset)) {
+    if (not co_await make_subscription_source(ctx, *auth, *offset)) {
       done_ = true;
       co_return;
     }
     initialize_runtime_state();
-    for (auto source_index = size_t{0};
-         source_index < runtime_.partition_sources.size(); ++source_index) {
+    for (auto source_index = size_t{0}; source_index < runtime_.sources.size();
+         ++source_index) {
       ctx.spawn_task(folly::coro::co_withExecutor(ctx.io_executor(),
                                                   fetch_loop(source_index)));
     }
@@ -648,12 +658,10 @@ public:
     if (checkpoint_pending_offsets_.empty()) {
       co_return;
     }
-    struct OffsetsForSource {
-      std::vector<std::string> partitions;
-      std::vector<std::unique_ptr<RdKafka::TopicPartition>> offsets;
-    };
-    auto offsets_by_source = std::unordered_map<size_t, OffsetsForSource>{};
     auto clear_pending = std::vector<std::string>{};
+    auto commit_keys = std::vector<std::string>{};
+    auto commit_labels = std::vector<std::string>{};
+    auto offsets = std::vector<std::unique_ptr<RdKafka::TopicPartition>>{};
     for (auto const& [partition_key, offset] : checkpoint_pending_offsets_) {
       auto topic_partition = parse_topic_partition_key(partition_key);
       if (not topic_partition) {
@@ -670,32 +678,24 @@ public:
         clear_pending.push_back(partition_key);
         continue;
       }
-      if (runtime_.partition_sources.empty()) {
-        break;
-      }
-      auto& source_offsets = offsets_by_source[0];
-      source_offsets.partitions.push_back(partition_key);
-      source_offsets.offsets.emplace_back(RdKafka::TopicPartition::create(
+      commit_keys.push_back(partition_key);
+      commit_labels.push_back(fmt::format("{}[{}]", topic_partition->topic,
+                                          topic_partition->partition));
+      offsets.emplace_back(RdKafka::TopicPartition::create(
         topic_partition->topic, topic_partition->partition, offset));
     }
-    for (auto& [source_index, source_offsets] : offsets_by_source) {
-      if (source_offsets.offsets.empty()
-          or source_index >= runtime_.partition_sources.size()) {
-        continue;
+    if (not offsets.empty() and not runtime_.sources.empty()
+        and runtime_.sources[0].source_consumer) {
+      auto raw_offsets = std::vector<RdKafka::TopicPartition*>{};
+      raw_offsets.reserve(offsets.size());
+      for (auto const& offset : offsets) {
+        raw_offsets.push_back(offset.get());
       }
-      auto offsets = std::vector<RdKafka::TopicPartition*>{};
-      offsets.reserve(source_offsets.offsets.size());
-      for (auto const& offset : source_offsets.offsets) {
-        offsets.push_back(offset.get());
-      }
-      auto& source = runtime_.partition_sources[source_index];
-      if (not source.source_consumer) {
-        continue;
-      }
+      auto& consumer = *runtime_.sources[0].source_consumer->consumer;
       auto err = RdKafka::ERR_NO_ERROR;
       for (auto attempt = size_t{0}; attempt <= max_offset_commit_retries;
            ++attempt) {
-        err = source.source_consumer->consumer->commitSync(offsets);
+        err = consumer.commitSync(raw_offsets);
         if (err == RdKafka::ERR_NO_ERROR) {
           break;
         }
@@ -706,23 +706,20 @@ public:
         co_await folly::coro::sleep(offset_commit_retry_delay);
       }
       if (err == RdKafka::ERR_NO_ERROR) {
-        clear_pending.insert(clear_pending.end(),
-                             source_offsets.partitions.begin(),
-                             source_offsets.partitions.end());
-        continue;
-      }
-      auto const partitions
-        = tenzir::detail::join(source_offsets.partitions, ", ");
-      if (dh) {
-        diagnostic::warning("from_kafka: failed to commit offsets")
-          .note("topic partitions: {}", partitions)
-          .note("librdkafka error: {}", RdKafka::err2str(err))
-          .emit(*dh);
+        clear_pending.insert(clear_pending.end(), commit_keys.begin(),
+                             commit_keys.end());
       } else {
-        TENZIR_WARN("from_kafka: failed to commit offsets for topic "
-                    "partition(s) "
-                    "{}: {}",
-                    partitions, RdKafka::err2str(err));
+        auto const partitions = tenzir::detail::join(commit_labels, ", ");
+        if (dh) {
+          diagnostic::warning("from_kafka: failed to commit offsets")
+            .note("topic partitions: {}", partitions)
+            .note("librdkafka error: {}", RdKafka::err2str(err))
+            .emit(*dh);
+        } else {
+          TENZIR_WARN("from_kafka: failed to commit offsets for topic "
+                      "partition(s) {}: {}",
+                      partitions, RdKafka::err2str(err));
+        }
       }
     }
     for (auto const& partition_key : clear_pending) {
@@ -760,17 +757,16 @@ private:
     Box<RdKafka::KafkaConsumer> consumer;
   };
 
-  /// Owns one partition source (consumer plus async queue wrapper).
-  struct PartitionSource {
-    std::string topic;
-    int32_t partition = -1;
+  /// Owns one subscribed source (consumer plus async queue wrapper).
+  struct SubscriptionSource {
     std::optional<SourceConsumer> source_consumer;
     Option<Box<AsyncConsumerQueue>> queue;
   };
 
   /// Owns mutable runtime state for source/build/emit stages.
   struct RuntimeState {
-    std::vector<PartitionSource> partition_sources;
+    // Holds exactly one element today; see the granularity note above.
+    std::vector<SubscriptionSource> sources;
     std::shared_ptr<MessageQueue> message_queue;
     std::shared_ptr<TableSliceQueue> table_slice_queue;
     std::map<uint64_t, TableSliceFrame> ordered_slices;
@@ -879,8 +875,8 @@ private:
   }
 
   /// Builds one source that lets librdkafka manage the topic subscription.
-  auto make_partition_sources(OpCtx& ctx, ResolvedAwsIamAuth const& auth,
-                              int64_t offset) -> Task<bool> {
+  auto make_subscription_source(OpCtx& ctx, ResolvedAwsIamAuth const& auth,
+                                int64_t offset) -> Task<bool> {
     auto config = source_global_defaults();
     if (not config.contains("group.id")) {
       config["group.id"] = "tenzir";
@@ -890,7 +886,7 @@ private:
     if (args_.exit) {
       config["enable.partition.eof"] = "true";
     }
-    runtime_.partition_sources.clear();
+    runtime_.sources.clear();
     assigned_partitions_.clear();
     eof_partitions_.clear();
     auto source_consumer
@@ -915,12 +911,10 @@ private:
         .emit(ctx);
       co_return false;
     }
-    auto source = PartitionSource{};
-    source.topic = args_.topic;
-    source.partition = -1;
+    auto source = SubscriptionSource{};
     source.source_consumer = std::move(*source_consumer);
     source.queue.emplace(std::move(queue).unwrap());
-    runtime_.partition_sources.emplace_back(std::move(source));
+    runtime_.sources.emplace_back(std::move(source));
     co_return true;
   }
 
@@ -944,7 +938,7 @@ private:
     runtime_.next_fetch_seq.store(0);
     runtime_.scheduled_messages.store(emitted_messages_);
     runtime_.message_queue_closed.store(false);
-    runtime_.live_fetchers.store(runtime_.partition_sources.size());
+    runtime_.live_fetchers.store(runtime_.sources.size());
     runtime_.live_builders.store(worker_count_);
     runtime_.pipeline_stop_requested.store(false);
     {
@@ -981,7 +975,7 @@ private:
     auto emitted_messages = load(perf_.emitted_messages);
     auto eps = static_cast<double>(emitted_messages) / elapsed_s;
     auto queue_perf = AsyncConsumerQueue::ConsumePerfSnapshot{};
-    for (auto const& source : runtime_.partition_sources) {
+    for (auto const& source : runtime_.sources) {
       if (not source.queue) {
         continue;
       }
@@ -1091,7 +1085,7 @@ private:
     if (runtime_.pipeline_stop_requested.exchange(true)) {
       return;
     }
-    for (auto& source : runtime_.partition_sources) {
+    for (auto& source : runtime_.sources) {
       if (source.queue) {
         (*source.queue)->request_stop();
       }
@@ -1342,7 +1336,7 @@ private:
     co_return not is_pipeline_stopping();
   }
 
-  /// Polls one partition source and hands message batches to build workers.
+  /// Polls one subscribed source and hands message batches to build workers.
   auto fetch_loop(size_t source_index) const -> Task<void> {
     auto finish_fetcher = [this]() -> Task<void> {
       if (runtime_.live_fetchers.fetch_sub(1) == 1) {
@@ -1350,12 +1344,11 @@ private:
       }
       co_return;
     };
-    if (not runtime_.message_queue
-        or source_index >= runtime_.partition_sources.size()) {
+    if (not runtime_.message_queue or source_index >= runtime_.sources.size()) {
       co_await finish_fetcher();
       co_return;
     }
-    auto& source = runtime_.partition_sources[source_index];
+    auto& source = runtime_.sources[source_index];
     if (not source.queue) {
       co_await finish_fetcher();
       co_return;
@@ -1608,10 +1601,10 @@ private:
 
   /// Refreshes the current assignment for exact-topic EOF tracking.
   auto refresh_assigned_partitions(diagnostic_handler& dh) -> void {
-    if (runtime_.partition_sources.empty()) {
+    if (runtime_.sources.empty()) {
       return;
     }
-    auto& source = runtime_.partition_sources[0];
+    auto& source = runtime_.sources[0];
     if (not source.source_consumer) {
       return;
     }
@@ -1627,7 +1620,6 @@ private:
       return;
     }
     assigned_partitions_.clear();
-    eof_partitions_.clear();
     for (auto* partition : partitions) {
       if (partition == nullptr or partition->partition() < 0
           or partition->topic() != args_.topic) {
@@ -1635,6 +1627,26 @@ private:
       }
       assigned_partitions_.insert(
         topic_partition_key(partition->topic(), partition->partition()));
+    }
+    // Keep EOF marks for partitions that remain assigned: librdkafka emits
+    // `PARTITION_EOF` when the fetch position reaches the end, not continuously
+    // while parked there, so a dropped mark may never be delivered again.
+    std::erase_if(eof_partitions_, [&](std::string const& partition) {
+      return not assigned_partitions_.contains(partition);
+    });
+    // A shrinking assignment can complete the EOF set without a new EOF event.
+    check_eof_exit();
+  }
+
+  /// Requests pipeline stop once every assigned partition reached EOF.
+  auto check_eof_exit() -> void {
+    if (not args_.exit or assigned_partitions_.empty()) {
+      return;
+    }
+    if (eof_partitions_.size() == assigned_partitions_.size()) {
+      // Don't set done_ here; let the pipeline drain so the build_loop
+      // can finalize and flush any buffered data from the builder.
+      request_pipeline_stop();
     }
   }
 
@@ -1644,11 +1656,7 @@ private:
       return;
     }
     eof_partitions_.insert(partition);
-    if (eof_partitions_.size() == assigned_partitions_.size()) {
-      // Don't set done_ here; let the pipeline drain so the build_loop
-      // can finalize and flush any buffered data from the builder.
-      request_pipeline_stop();
-    }
+    check_eof_exit();
   }
 
   FromKafkaArgs args_;
@@ -1660,7 +1668,8 @@ private:
   size_t emitted_messages_ = 0;
   // Invariant: committed offsets are stored as "next offset to consume".
   std::unordered_map<std::string, int64_t> checkpoint_pending_offsets_;
-  // Invariant: fixed partition set assigned at startup.
+  // Snapshot of the subscription's current assignment; only maintained for
+  // `exit=true`, refreshed lazily when an EOF for an unknown partition arrives.
   std::unordered_set<std::string> assigned_partitions_;
   // Invariant: contains only partitions from `assigned_partitions_`.
   std::unordered_set<std::string> eof_partitions_;

--- a/plugins/kafka/builtins/from_kafka.cpp
+++ b/plugins/kafka/builtins/from_kafka.cpp
@@ -697,8 +697,16 @@ public:
         co_await folly::coro::sleep(offset_commit_retry_delay);
       }
       if (err == RdKafka::ERR_NO_ERROR) {
+        auto const& committed = runtime_.sources[0]
+                                  .source_consumer->consumer_cfg
+                                  .committed_partitions;
         for (auto const& partition : commit_keys) {
           pending_commit_offsets_.erase(partition);
+          if (committed) {
+            // Lets the rebalance callback resume from committed offsets for
+            // partitions whose progress stems from this run.
+            committed->insert(partition.topic, partition.partition);
+          }
         }
       } else {
         auto const partitions = tenzir::detail::join(commit_labels, ", ");

--- a/plugins/kafka/builtins/from_kafka.cpp
+++ b/plugins/kafka/builtins/from_kafka.cpp
@@ -17,6 +17,7 @@
 #include "tenzir/detail/env.hpp"
 #include "tenzir/detail/scope_guard.hpp"
 #include "tenzir/detail/string.hpp"
+#include "tenzir/hash/hash.hpp"
 #include "tenzir/json_parser.hpp"
 #include "tenzir/si_literals.hpp"
 
@@ -34,7 +35,6 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
-#include <charconv>
 #include <chrono>
 #include <limits>
 #include <map>
@@ -348,41 +348,35 @@ auto is_topic_regex(std::string_view topic) -> bool {
   return topic.starts_with('^');
 }
 
-auto topic_partition_key(std::string_view topic, int32_t partition)
-  -> std::string {
-  return fmt::format("{}\n{}", topic, partition);
-}
-
+/// Identifies one Kafka partition; hashable for direct use as container key.
 struct TopicPartition {
   std::string topic;
   int32_t partition = -1;
+
+  auto operator==(TopicPartition const&) const -> bool = default;
+
+  friend auto inspect(auto& f, TopicPartition& x) -> bool {
+    return f.object(x).fields(f.field("topic", x.topic),
+                              f.field("partition", x.partition));
+  }
 };
 
-auto parse_topic_partition_key(std::string_view key)
-  -> std::optional<TopicPartition> {
-  auto const pos = key.rfind('\n');
-  if (pos == std::string_view::npos) {
-    return std::nullopt;
+struct TopicPartitionHash {
+  auto operator()(TopicPartition const& x) const -> size_t {
+    return tenzir::hash(x.topic, x.partition);
   }
-  auto partition = int32_t{};
-  auto const partition_text = key.substr(pos + 1);
-  auto const* first = partition_text.data();
-  auto const* last = first + partition_text.size();
-  auto [ptr, ec] = std::from_chars(first, last, partition);
-  if (ec != std::errc{} or ptr != last) {
-    return std::nullopt;
-  }
-  return TopicPartition{
-    .topic = std::string{key.substr(0, pos)},
-    .partition = partition,
-  };
-}
+};
+
+using TopicPartitionSet
+  = std::unordered_set<TopicPartition, TopicPartitionHash>;
+using TopicPartitionOffsets
+  = std::unordered_map<TopicPartition, int64_t, TopicPartitionHash>;
 
 /// Represents one polled Kafka message batch plus control metadata.
 struct MessageBatch {
   uint64_t seq = 0;
   std::vector<AsyncConsumerQueue::Message> messages;
-  std::vector<std::string> eof_partitions;
+  std::vector<TopicPartition> eof_partitions;
   std::optional<std::string> fatal_error;
   bool assignment_changed = false;
   bool reached_count = false;
@@ -393,9 +387,9 @@ struct MessageBatch {
 struct TableSliceFrame {
   uint64_t seq = 0;
   std::vector<table_slice> slices;
-  std::unordered_map<std::string, int64_t> max_offsets;
+  TopicPartitionOffsets max_offsets;
   size_t message_count = 0;
-  std::vector<std::string> eof_partitions;
+  std::vector<TopicPartition> eof_partitions;
   std::optional<std::string> fatal_error;
   bool assignment_changed = false;
   std::vector<diagnostic> diagnostics;
@@ -435,7 +429,7 @@ auto build_table_slice(MessageBatch& batch, multi_series_builder& builder,
     }
     auto payload = std::move(payload_bytes).unwrap();
     process_payload(payload);
-    frame.max_offsets[topic_partition_key(message.topic(), message.partition())]
+    frame.max_offsets[TopicPartition{message.topic(), message.partition()}]
       = message.offset();
     ++frame.message_count;
   }
@@ -670,31 +664,15 @@ public:
     if (pending_commit_offsets_.empty()) {
       co_return;
     }
-    auto clear_pending = std::vector<std::string>{};
-    auto commit_keys = std::vector<std::string>{};
+    auto commit_keys = std::vector<TopicPartition>{};
     auto commit_labels = std::vector<std::string>{};
     auto offsets = std::vector<std::unique_ptr<RdKafka::TopicPartition>>{};
-    for (auto const& [partition_key, offset] : pending_commit_offsets_) {
-      auto topic_partition = parse_topic_partition_key(partition_key);
-      if (not topic_partition) {
-        if (dh) {
-          diagnostic::warning("from_kafka: invalid topic partition key {} "
-                              "while committing",
-                              partition_key)
-            .emit(*dh);
-        } else {
-          TENZIR_WARN("from_kafka: invalid topic partition key {} while "
-                      "committing",
-                      partition_key);
-        }
-        clear_pending.push_back(partition_key);
-        continue;
-      }
-      commit_keys.push_back(partition_key);
-      commit_labels.push_back(fmt::format("{}[{}]", topic_partition->topic,
-                                          topic_partition->partition));
+    for (auto const& [partition, offset] : pending_commit_offsets_) {
+      commit_keys.push_back(partition);
+      commit_labels.push_back(
+        fmt::format("{}[{}]", partition.topic, partition.partition));
       offsets.emplace_back(RdKafka::TopicPartition::create(
-        topic_partition->topic, topic_partition->partition, offset));
+        partition.topic, partition.partition, offset));
     }
     if (not offsets.empty() and not runtime_.sources.empty()
         and runtime_.sources[0].source_consumer) {
@@ -718,8 +696,9 @@ public:
         co_await folly::coro::sleep(offset_commit_retry_delay);
       }
       if (err == RdKafka::ERR_NO_ERROR) {
-        clear_pending.insert(clear_pending.end(), commit_keys.begin(),
-                             commit_keys.end());
+        for (auto const& partition : commit_keys) {
+          pending_commit_offsets_.erase(partition);
+        }
       } else {
         auto const partitions = tenzir::detail::join(commit_labels, ", ");
         if (dh) {
@@ -733,9 +712,6 @@ public:
                       partitions, RdKafka::err2str(err));
         }
       }
-    }
-    for (auto const& partition_key : clear_pending) {
-      pending_commit_offsets_.erase(partition_key);
     }
   }
 
@@ -1190,7 +1166,7 @@ private:
         case RD_KAFKA_RESP_ERR__PARTITION_EOF: {
           if (args_.exit) {
             batch.eof_partitions.push_back(
-              topic_partition_key(message.topic(), message.partition()));
+              TopicPartition{message.topic(), message.partition()});
           }
           break;
         }
@@ -1646,10 +1622,9 @@ private:
   }
 
   /// Moves per-partition offsets from one emitted batch into commit state.
-  auto record_pending_offsets(
-    std::unordered_map<std::string, int64_t> const& offsets) -> void {
-    for (auto const& [partition_key, offset] : offsets) {
-      pending_commit_offsets_[partition_key] = offset + 1;
+  auto record_pending_offsets(TopicPartitionOffsets const& offsets) -> void {
+    for (auto const& [partition, offset] : offsets) {
+      pending_commit_offsets_[partition] = offset + 1;
     }
   }
 
@@ -1680,12 +1655,12 @@ private:
         continue;
       }
       assigned_partitions_.insert(
-        topic_partition_key(partition->topic(), partition->partition()));
+        TopicPartition{partition->topic(), partition->partition()});
     }
     // Keep EOF marks for partitions that remain assigned: librdkafka emits
     // `PARTITION_EOF` when the fetch position reaches the end, not continuously
     // while parked there, so a dropped mark may never be delivered again.
-    std::erase_if(eof_partitions_, [&](std::string const& partition) {
+    std::erase_if(eof_partitions_, [&](TopicPartition const& partition) {
       return not assigned_partitions_.contains(partition);
     });
     // A shrinking assignment can complete the EOF set without a new EOF event.
@@ -1705,7 +1680,7 @@ private:
   }
 
   /// Tracks partition EOF notifications and marks the source done if complete.
-  auto mark_partition_eof(std::string const& partition) -> void {
+  auto mark_partition_eof(TopicPartition const& partition) -> void {
     if (not args_.exit or not assigned_partitions_.contains(partition)) {
       return;
     }
@@ -1721,12 +1696,12 @@ private:
   // Number of records emitted so far; used for `count=` resumption.
   size_t emitted_messages_ = 0;
   // Invariant: committed offsets are stored as "next offset to consume".
-  std::unordered_map<std::string, int64_t> pending_commit_offsets_;
+  TopicPartitionOffsets pending_commit_offsets_;
   // Snapshot of the subscription's current assignment; only maintained for
   // `exit=true`, refreshed lazily when an EOF for an unknown partition arrives.
-  std::unordered_set<std::string> assigned_partitions_;
+  TopicPartitionSet assigned_partitions_;
   // Invariant: contains only partitions from `assigned_partitions_`.
-  std::unordered_set<std::string> eof_partitions_;
+  TopicPartitionSet eof_partitions_;
   // Optional counters for benchmarking; enabled via env flag.
   mutable FromKafkaPerfCounters perf_;
   mutable MetricsCounter read_bytes_counter_;

--- a/plugins/kafka/builtins/from_kafka.cpp
+++ b/plugins/kafka/builtins/from_kafka.cpp
@@ -30,6 +30,7 @@
 #include <folly/coro/Sleep.h>
 #include <folly/coro/ViaIfAsync.h>
 #include <folly/executors/GlobalExecutor.h>
+#include <librdkafka/rdkafka.h>
 #include <librdkafka/rdkafkacpp.h>
 
 #include <algorithm>
@@ -853,6 +854,24 @@ private:
           source_consumer.consumer_cfg.oauth_background_setup_note
             = fmt::format("sasl_background_callbacks_enable failed: {}",
                           err_guard->str());
+          // Fallback: nothing else services the dedicated SASL queue once
+          // background callbacks are unavailable, so forward it to the
+          // consumer queue that the fetch loop drains continuously. The
+          // consume calls then run the OAUTH refresh callback and the first
+          // token can still be minted.
+          auto* client = source_consumer.consumer->c_ptr();
+          auto* sasl_queue
+            = client != nullptr ? rd_kafka_queue_get_sasl(client) : nullptr;
+          if (sasl_queue != nullptr) {
+            if (auto* consumer_queue = rd_kafka_queue_get_consumer(client)) {
+              rd_kafka_queue_forward(sasl_queue, consumer_queue);
+              rd_kafka_queue_destroy(consumer_queue);
+              source_consumer.consumer_cfg.oauth_background_setup_note
+                += "; servicing OAUTH refresh callbacks via the consumer "
+                   "queue";
+            }
+            rd_kafka_queue_destroy(sasl_queue);
+          }
         }
       } else if (source_consumer.consumer_cfg.oauth_background_setup_note
                    .empty()) {

--- a/plugins/kafka/include/kafka/async_consumer.hpp
+++ b/plugins/kafka/include/kafka/async_consumer.hpp
@@ -271,6 +271,14 @@ public:
       return message_ ? message_->partition : -1;
     }
 
+    /// Returns the source topic name.
+    [[nodiscard]] auto topic() const -> std::string {
+      if (not message_ or not message_->rkt) {
+        return {};
+      }
+      return rd_kafka_topic_name(message_->rkt);
+    }
+
     /// Returns the source offset for this message.
     [[nodiscard]] auto offset() const -> int64_t {
       return message_ ? message_->offset : 0;

--- a/plugins/kafka/include/kafka/librdkafka_utils.hpp
+++ b/plugins/kafka/include/kafka/librdkafka_utils.hpp
@@ -20,11 +20,37 @@
 
 #include <cstdint>
 #include <memory>
+#include <mutex>
 #include <optional>
+#include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace tenzir::plugins::kafka {
+
+/// Tracks partitions whose offsets the current consumer run has committed.
+///
+/// The operator's commit path writes from executor tasks while librdkafka's
+/// rebalance callback reads from whichever thread serves the consumer queue.
+/// The callback cannot await a coroutine mutex, so a plain lock guards the
+/// tiny critical sections instead.
+class committed_partition_set {
+public:
+  auto insert(std::string topic, int32_t partition) -> void {
+    auto guard = std::scoped_lock{mutex_};
+    partitions_.emplace(std::move(topic), partition);
+  }
+
+  auto contains(std::string const& topic, int32_t partition) const -> bool {
+    auto guard = std::scoped_lock{mutex_};
+    return partitions_.contains({topic, partition});
+  }
+
+private:
+  mutable std::mutex mutex_;
+  std::set<std::pair<std::string, int32_t>> partitions_;
+};
 
 /// Owns librdkafka consumer config and callback objects with shared lifetime.
 struct consumer_configuration {
@@ -33,6 +59,7 @@ struct consumer_configuration {
   std::shared_ptr<RdKafka::EventCb> event_callback;
   std::shared_ptr<RdKafka::RebalanceCb> rebalance_callback;
   std::shared_ptr<Atomic<uint64_t>> assignment_generation;
+  std::shared_ptr<committed_partition_set> committed_partitions;
   // `enable_sasl_queue(true)` is configured on `Conf` before consumer
   // creation. This is required to later attach OAUTH callback servicing to
   // librdkafka's background thread.

--- a/plugins/kafka/include/kafka/librdkafka_utils.hpp
+++ b/plugins/kafka/include/kafka/librdkafka_utils.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <tenzir/atomic.hpp>
 #include <tenzir/aws_iam.hpp>
 #include <tenzir/diagnostics.hpp>
 #include <tenzir/location.hpp>
@@ -17,6 +18,7 @@
 #include <caf/expected.hpp>
 #include <librdkafka/rdkafkacpp.h>
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
@@ -30,6 +32,7 @@ struct consumer_configuration {
   std::shared_ptr<RdKafka::OAuthBearerTokenRefreshCb> oauth_callback;
   std::shared_ptr<RdKafka::EventCb> event_callback;
   std::shared_ptr<RdKafka::RebalanceCb> rebalance_callback;
+  std::shared_ptr<Atomic<uint64_t>> assignment_generation;
   // `enable_sasl_queue(true)` is configured on `Conf` before consumer
   // creation. This is required to later attach OAUTH callback servicing to
   // librdkafka's background thread.

--- a/plugins/kafka/src/librdkafka_utils.cpp
+++ b/plugins/kafka/src/librdkafka_utils.cpp
@@ -32,16 +32,12 @@
 
 #include <atomic>
 #include <chrono>
-#include <set>
 #include <string>
 #include <string_view>
-#include <utility>
 
 namespace tenzir::plugins::kafka {
 
 namespace {
-
-constexpr auto committed_offsets_timeout_ms = 5000;
 
 auto aws_iam_mode(std::optional<resolved_aws_credentials> const& creds) -> const
   char* {
@@ -310,10 +306,12 @@ private:
 class rebalance_callback final : public RdKafka::RebalanceCb {
 public:
   /// Constructs a callback that uses `offset` for uncommitted partitions.
-  rebalance_callback(int64_t offset,
-                     std::shared_ptr<Atomic<uint64_t>> assignment_generation)
+  rebalance_callback(
+    int64_t offset, std::shared_ptr<Atomic<uint64_t>> assignment_generation,
+    std::shared_ptr<committed_partition_set> committed_partitions)
     : offset_{offset},
-      assignment_generation_{std::move(assignment_generation)} {
+      assignment_generation_{std::move(assignment_generation)},
+      committed_partitions_{std::move(committed_partitions)} {
   }
 
   /// Handles assign/revoke events while preserving cooperative semantics.
@@ -321,7 +319,7 @@ public:
                     std::vector<RdKafka::TopicPartition*>& partitions)
     -> void override {
     if (err == RdKafka::ERR__ASSIGN_PARTITIONS) {
-      apply_start_offsets(*consumer, partitions);
+      apply_start_offsets(partitions);
       if (consumer->rebalance_protocol() == "COOPERATIVE") {
         if (auto* e = consumer->incremental_assign(partitions)) {
           auto err_guard = std::unique_ptr<RdKafka::Error>{e};
@@ -362,81 +360,24 @@ public:
   }
 
 private:
-  auto apply_start_offsets(RdKafka::KafkaConsumer& consumer,
-                           std::vector<RdKafka::TopicPartition*>& partitions)
+  auto apply_start_offsets(std::vector<RdKafka::TopicPartition*>& partitions)
     -> void {
     if (offset_ == RdKafka::Topic::OFFSET_INVALID) {
       return;
     }
-    if (offset_ == RdKafka::Topic::OFFSET_STORED) {
-      for (auto* partition : partitions) {
-        if (partition != nullptr) {
-          partition->set_offset(offset_);
-        }
-      }
-      return;
-    }
-    apply_explicit_start_offsets(consumer, partitions);
-  }
-
-  auto apply_explicit_start_offsets(
-    RdKafka::KafkaConsumer& consumer,
-    std::vector<RdKafka::TopicPartition*>& partitions) -> void {
-    // The user-provided offset defines where consumption starts, so it must
-    // win over previously committed group offsets when a partition is first
-    // assigned. Only re-assignments after a later rebalance resume from the
-    // offsets this consumer committed in the meantime.
-    auto assigned_partitions = std::vector<RdKafka::TopicPartition*>{};
-    auto committed_offsets
-      = std::vector<std::unique_ptr<RdKafka::TopicPartition>>{};
-    auto raw_committed_offsets = std::vector<RdKafka::TopicPartition*>{};
-    assigned_partitions.reserve(partitions.size());
-    committed_offsets.reserve(partitions.size());
-    raw_committed_offsets.reserve(partitions.size());
+    // The user-provided offset defines where consumption starts, so it wins
+    // until this run has committed its own progress for a partition. After
+    // that, leaving the offset invalid makes librdkafka resume from the
+    // committed offset, which preserves progress across later rebalances.
     for (auto* partition : partitions) {
       if (partition == nullptr) {
         continue;
       }
-      auto const first_assignment
-        = seeded_partitions_.emplace(partition->topic(), partition->partition())
-            .second;
-      if (first_assignment) {
+      if (offset_ == RdKafka::Topic::OFFSET_STORED or not committed_partitions_
+          or not committed_partitions_->contains(partition->topic(),
+                                                 partition->partition())) {
         partition->set_offset(offset_);
-        continue;
       }
-      assigned_partitions.push_back(partition);
-      committed_offsets.emplace_back(RdKafka::TopicPartition::create(
-        partition->topic(), partition->partition()));
-      TENZIR_ASSERT(committed_offsets.back());
-      raw_committed_offsets.push_back(committed_offsets.back().get());
-    }
-    if (raw_committed_offsets.empty()) {
-      return;
-    }
-    auto const err
-      = consumer.committed(raw_committed_offsets, committed_offsets_timeout_ms);
-    if (err != RdKafka::ERR_NO_ERROR) {
-      TENZIR_WARN("failed to fetch committed Kafka offsets during rebalance: "
-                  "{}; leaving assignment offsets unchanged",
-                  RdKafka::err2str(err));
-      return;
-    }
-    for (auto index = size_t{0}; index < raw_committed_offsets.size();
-         ++index) {
-      auto* partition = assigned_partitions[index];
-      auto* committed_offset = raw_committed_offsets[index];
-      auto const committed_err = committed_offset->err();
-      if (committed_err != RdKafka::ERR_NO_ERROR
-          and committed_err != RdKafka::ERR__NO_OFFSET) {
-        TENZIR_WARN("failed to fetch committed Kafka offset for {}[{}]: {}; "
-                    "leaving assignment offset unchanged",
-                    partition->topic(), partition->partition(),
-                    RdKafka::err2str(committed_err));
-        continue;
-      }
-      auto const committed = committed_offset->offset();
-      partition->set_offset(
-        committed == RdKafka::Topic::OFFSET_INVALID ? offset_ : committed);
     }
   }
 
@@ -448,10 +389,7 @@ private:
 
   int64_t offset_ = RdKafka::Topic::OFFSET_INVALID;
   std::shared_ptr<Atomic<uint64_t>> assignment_generation_;
-  // Partitions that already received the explicit start offset once; only
-  // mutated from rebalance callbacks, which librdkafka serializes per
-  // consumer.
-  std::set<std::pair<std::string, int32_t>> seeded_partitions_;
+  std::shared_ptr<committed_partition_set> committed_partitions_;
 };
 
 /// Converts one librdkafka conf set result into a typed `caf::error`.
@@ -590,8 +528,9 @@ auto make_consumer_configuration(record const& options,
   }
 
   cfg.assignment_generation = std::make_shared<Atomic<uint64_t>>(0);
-  cfg.rebalance_callback
-    = std::make_shared<rebalance_callback>(offset, cfg.assignment_generation);
+  cfg.committed_partitions = std::make_shared<committed_partition_set>();
+  cfg.rebalance_callback = std::make_shared<rebalance_callback>(
+    offset, cfg.assignment_generation, cfg.committed_partitions);
   if (auto err = set_conf_callback(*cfg.conf, "rebalance_cb",
                                    cfg.rebalance_callback.get());
       err) {

--- a/plugins/kafka/src/librdkafka_utils.cpp
+++ b/plugins/kafka/src/librdkafka_utils.cpp
@@ -32,8 +32,10 @@
 
 #include <atomic>
 #include <chrono>
+#include <set>
 #include <string>
 #include <string_view>
+#include <utility>
 
 namespace tenzir::plugins::kafka {
 
@@ -360,9 +362,8 @@ public:
   }
 
 private:
-  auto
-  apply_start_offsets(RdKafka::KafkaConsumer& consumer,
-                      std::vector<RdKafka::TopicPartition*>& partitions) const
+  auto apply_start_offsets(RdKafka::KafkaConsumer& consumer,
+                           std::vector<RdKafka::TopicPartition*>& partitions)
     -> void {
     if (offset_ == RdKafka::Topic::OFFSET_INVALID) {
       return;
@@ -380,7 +381,11 @@ private:
 
   auto apply_explicit_start_offsets(
     RdKafka::KafkaConsumer& consumer,
-    std::vector<RdKafka::TopicPartition*>& partitions) const -> void {
+    std::vector<RdKafka::TopicPartition*>& partitions) -> void {
+    // The user-provided offset defines where consumption starts, so it must
+    // win over previously committed group offsets when a partition is first
+    // assigned. Only re-assignments after a later rebalance resume from the
+    // offsets this consumer committed in the meantime.
     auto assigned_partitions = std::vector<RdKafka::TopicPartition*>{};
     auto committed_offsets
       = std::vector<std::unique_ptr<RdKafka::TopicPartition>>{};
@@ -390,6 +395,13 @@ private:
     raw_committed_offsets.reserve(partitions.size());
     for (auto* partition : partitions) {
       if (partition == nullptr) {
+        continue;
+      }
+      auto const first_assignment
+        = seeded_partitions_.emplace(partition->topic(), partition->partition())
+            .second;
+      if (first_assignment) {
+        partition->set_offset(offset_);
         continue;
       }
       assigned_partitions.push_back(partition);
@@ -436,6 +448,10 @@ private:
 
   int64_t offset_ = RdKafka::Topic::OFFSET_INVALID;
   std::shared_ptr<Atomic<uint64_t>> assignment_generation_;
+  // Partitions that already received the explicit start offset once; only
+  // mutated from rebalance callbacks, which librdkafka serializes per
+  // consumer.
+  std::set<std::pair<std::string, int32_t>> seeded_partitions_;
 };
 
 /// Converts one librdkafka conf set result into a typed `caf::error`.

--- a/plugins/kafka/src/librdkafka_utils.cpp
+++ b/plugins/kafka/src/librdkafka_utils.cpp
@@ -30,6 +30,7 @@
 #include <boost/algorithm/string/trim.hpp>
 #include <fmt/format.h>
 
+#include <atomic>
 #include <chrono>
 #include <string>
 #include <string_view>
@@ -305,7 +306,10 @@ private:
 class rebalance_callback final : public RdKafka::RebalanceCb {
 public:
   /// Constructs a callback that assigns `offset` for new partitions.
-  explicit rebalance_callback(int64_t offset) : offset_{offset} {
+  rebalance_callback(int64_t offset,
+                     std::shared_ptr<Atomic<uint64_t>> assignment_generation)
+    : offset_{offset},
+      assignment_generation_{std::move(assignment_generation)} {
   }
 
   /// Handles assign/revoke events while preserving cooperative semantics.
@@ -330,6 +334,7 @@ public:
                        RdKafka::err2str(assign_err));
         }
       }
+      mark_assignment_changed();
       return;
     }
     if (err == RdKafka::ERR__REVOKE_PARTITIONS) {
@@ -344,6 +349,7 @@ public:
         TENZIR_ERROR("failed to unassign partitions: {}",
                      RdKafka::err2str(unassign_err));
       }
+      mark_assignment_changed();
       return;
     }
     TENZIR_ERROR("rebalancing error: {}", RdKafka::err2str(err));
@@ -352,10 +358,18 @@ public:
       TENZIR_ERROR("failed to unassign partitions: {}",
                    RdKafka::err2str(unassign_err));
     }
+    mark_assignment_changed();
   }
 
 private:
+  auto mark_assignment_changed() const -> void {
+    if (assignment_generation_) {
+      assignment_generation_->fetch_add(1, std::memory_order_release);
+    }
+  }
+
   int64_t offset_ = RdKafka::Topic::OFFSET_INVALID;
+  std::shared_ptr<Atomic<uint64_t>> assignment_generation_;
 };
 
 /// Converts one librdkafka conf set result into a typed `caf::error`.
@@ -493,7 +507,9 @@ auto make_consumer_configuration(record const& options,
     return err;
   }
 
-  cfg.rebalance_callback = std::make_shared<rebalance_callback>(offset);
+  cfg.assignment_generation = std::make_shared<Atomic<uint64_t>>(0);
+  cfg.rebalance_callback
+    = std::make_shared<rebalance_callback>(offset, cfg.assignment_generation);
   if (auto err = set_conf_callback(*cfg.conf, "rebalance_cb",
                                    cfg.rebalance_callback.get());
       err) {

--- a/plugins/kafka/src/librdkafka_utils.cpp
+++ b/plugins/kafka/src/librdkafka_utils.cpp
@@ -39,6 +39,8 @@ namespace tenzir::plugins::kafka {
 
 namespace {
 
+constexpr auto committed_offsets_timeout_ms = 5000;
+
 auto aws_iam_mode(std::optional<resolved_aws_credentials> const& creds) -> const
   char* {
   if (not creds) {
@@ -302,10 +304,10 @@ private:
   diagnostic_handler& dh_;
 };
 
-/// Callback that assigns explicit offsets during partition rebalance.
+/// Callback that preserves committed offsets during partition rebalance.
 class rebalance_callback final : public RdKafka::RebalanceCb {
 public:
-  /// Constructs a callback that assigns `offset` for new partitions.
+  /// Constructs a callback that uses `offset` for uncommitted partitions.
   rebalance_callback(int64_t offset,
                      std::shared_ptr<Atomic<uint64_t>> assignment_generation)
     : offset_{offset},
@@ -317,11 +319,7 @@ public:
                     std::vector<RdKafka::TopicPartition*>& partitions)
     -> void override {
     if (err == RdKafka::ERR__ASSIGN_PARTITIONS) {
-      if (offset_ != RdKafka::Topic::OFFSET_INVALID) {
-        for (auto* partition : partitions) {
-          partition->set_offset(offset_);
-        }
-      }
+      apply_start_offsets(*consumer, partitions);
       if (consumer->rebalance_protocol() == "COOPERATIVE") {
         if (auto* e = consumer->incremental_assign(partitions)) {
           auto err_guard = std::unique_ptr<RdKafka::Error>{e};
@@ -362,6 +360,74 @@ public:
   }
 
 private:
+  auto
+  apply_start_offsets(RdKafka::KafkaConsumer& consumer,
+                      std::vector<RdKafka::TopicPartition*>& partitions) const
+    -> void {
+    if (offset_ == RdKafka::Topic::OFFSET_INVALID) {
+      return;
+    }
+    if (offset_ == RdKafka::Topic::OFFSET_STORED) {
+      for (auto* partition : partitions) {
+        if (partition != nullptr) {
+          partition->set_offset(offset_);
+        }
+      }
+      return;
+    }
+    apply_explicit_start_offsets(consumer, partitions);
+  }
+
+  auto apply_explicit_start_offsets(
+    RdKafka::KafkaConsumer& consumer,
+    std::vector<RdKafka::TopicPartition*>& partitions) const -> void {
+    auto assigned_partitions = std::vector<RdKafka::TopicPartition*>{};
+    auto committed_offsets
+      = std::vector<std::unique_ptr<RdKafka::TopicPartition>>{};
+    auto raw_committed_offsets = std::vector<RdKafka::TopicPartition*>{};
+    assigned_partitions.reserve(partitions.size());
+    committed_offsets.reserve(partitions.size());
+    raw_committed_offsets.reserve(partitions.size());
+    for (auto* partition : partitions) {
+      if (partition == nullptr) {
+        continue;
+      }
+      assigned_partitions.push_back(partition);
+      committed_offsets.emplace_back(RdKafka::TopicPartition::create(
+        partition->topic(), partition->partition()));
+      TENZIR_ASSERT(committed_offsets.back());
+      raw_committed_offsets.push_back(committed_offsets.back().get());
+    }
+    if (raw_committed_offsets.empty()) {
+      return;
+    }
+    auto const err
+      = consumer.committed(raw_committed_offsets, committed_offsets_timeout_ms);
+    if (err != RdKafka::ERR_NO_ERROR) {
+      TENZIR_WARN("failed to fetch committed Kafka offsets during rebalance: "
+                  "{}; leaving assignment offsets unchanged",
+                  RdKafka::err2str(err));
+      return;
+    }
+    for (auto index = size_t{0}; index < raw_committed_offsets.size();
+         ++index) {
+      auto* partition = assigned_partitions[index];
+      auto* committed_offset = raw_committed_offsets[index];
+      auto const committed_err = committed_offset->err();
+      if (committed_err != RdKafka::ERR_NO_ERROR
+          and committed_err != RdKafka::ERR__NO_OFFSET) {
+        TENZIR_WARN("failed to fetch committed Kafka offset for {}[{}]: {}; "
+                    "leaving assignment offset unchanged",
+                    partition->topic(), partition->partition(),
+                    RdKafka::err2str(committed_err));
+        continue;
+      }
+      auto const committed = committed_offset->offset();
+      partition->set_offset(
+        committed == RdKafka::Topic::OFFSET_INVALID ? offset_ : committed);
+    }
+  }
+
   auto mark_assignment_changed() const -> void {
     if (assignment_generation_) {
       assignment_generation_->fetch_add(1, std::memory_order_release);

--- a/test/fixtures/kafka.py
+++ b/test/fixtures/kafka.py
@@ -90,6 +90,9 @@ GO_BUILD_PREREQUISITE_MARKERS = (
 class KafkaOptions:
     mode: str = "plain"
     topic: str = "tenzir_test"
+    # Comma-separated additional topics, each created with the same partition
+    # count and seeded with the same messages as `topic` (plain mode only).
+    extra_topics: str = ""
     partitions: int = 1
     messages: int = 0
     compression: str = "none"
@@ -99,6 +102,10 @@ class KafkaOptions:
     access_key_id: str = "AKIA_TEST_ACCESS_KEY"
     secret_access_key: str = "test-secret-key"
     session_token: str = ""
+
+
+def _parse_extra_topics(spec: str) -> list[str]:
+    return [topic.strip() for topic in spec.split(",") if topic.strip()]
 
 
 def _resolve_project_relative_path(path: str) -> Path:
@@ -593,14 +600,15 @@ def kafka() -> Iterator[dict[str, str]]:
         try:
             container = _start_kafka(runtime, port, opts.image, payload_file)
             _wait_for_kafka(container, KAFKA_STARTUP_TIMEOUT)
-            _create_topic(container, opts.topic, opts.partitions)
-            _seed_topic(
-                container,
-                opts.topic,
-                opts.messages,
-                compression,
-                payload_file,
-            )
+            for topic in [opts.topic, *_parse_extra_topics(opts.extra_topics)]:
+                _create_topic(container, topic, opts.partitions)
+                _seed_topic(
+                    container,
+                    topic,
+                    opts.messages,
+                    compression,
+                    payload_file,
+                )
             bootstrap = f"127.0.0.1:{port}"
             env: dict[str, str] = {
                 "KAFKA_HOST": "127.0.0.1",
@@ -620,6 +628,10 @@ def kafka() -> Iterator[dict[str, str]]:
     if compression != "none":
         raise RuntimeError(
             "kafka fixture option `compression` must be `none` in `aws_iam` mode"
+        )
+    if opts.extra_topics:
+        raise RuntimeError(
+            "kafka fixture option `extra_topics` is not supported in `aws_iam` mode"
         )
     if opts.payload_file:
         raise RuntimeError(

--- a/test/tests/operators/from_kafka/error_exit_with_regex_topic.tql
+++ b/test/tests/operators/from_kafka/error_exit_with_regex_topic.tql
@@ -1,0 +1,6 @@
+---
+error: true
+---
+
+from_kafka "^topic-.*",
+           exit=true

--- a/test/tests/operators/from_kafka/error_exit_with_regex_topic.txt
+++ b/test/tests/operators/from_kafka/error_exit_with_regex_topic.txt
@@ -1,0 +1,6 @@
+error: `exit` is incompatible with regex topic subscriptions
+ --> tests/operators/from_kafka/error_exit_with_regex_topic.tql:6:17
+  |
+6 |            exit=true
+  |                 ^^^^ 
+  |

--- a/test/tests/operators/from_kafka/regex/multi_topic_count.tql
+++ b/test/tests/operators/from_kafka/regex/multi_topic_count.tql
@@ -1,0 +1,11 @@
+// Consume all seeded messages from two topics matched by one regex. Each
+// topic holds two messages, so four results prove both topics matched, and
+// the overlapping partition ids exercise topic-keyed offset commits.
+from_kafka "^regex_topic_.*",
+           count=4,
+           offset="beginning",
+           options={
+             "bootstrap.servers": env("KAFKA_BOOTSTRAP_SERVERS"),
+             "group.id": "tenzir-test-from-kafka-regex-multi"
+           }
+sort message

--- a/test/tests/operators/from_kafka/regex/multi_topic_count.txt
+++ b/test/tests/operators/from_kafka/regex/multi_topic_count.txt
@@ -1,0 +1,12 @@
+{
+  message: "message-0001",
+}
+{
+  message: "message-0001",
+}
+{
+  message: "message-0002",
+}
+{
+  message: "message-0002",
+}

--- a/test/tests/operators/from_kafka/regex/test.yaml
+++ b/test/tests/operators/from_kafka/regex/test.yaml
@@ -1,0 +1,7 @@
+suite: from-kafka-regex
+fixtures:
+  - kafka:
+      topic: regex_topic_a
+      extra_topics: regex_topic_b
+      partitions: 1
+      messages: 2

--- a/test/tests/operators/from_kafka/string/regex_count.tql
+++ b/test/tests/operators/from_kafka/string/regex_count.tql
@@ -1,0 +1,8 @@
+// Consume two seeded messages from a topic selected by regex.
+from_kafka "^" + env("KAFKA_TOPIC") + "$",
+           count=2,
+           offset="beginning",
+           options={
+             "bootstrap.servers": env("KAFKA_BOOTSTRAP_SERVERS"),
+             "group.id": "tenzir-test-from-kafka-regex"
+           }

--- a/test/tests/operators/from_kafka/string/regex_count.txt
+++ b/test/tests/operators/from_kafka/string/regex_count.txt
@@ -1,0 +1,6 @@
+{
+  message: "message-0001",
+}
+{
+  message: "message-0002",
+}


### PR DESCRIPTION
## 🔍 Problem

- The neo `from_kafka` path accepted one topic string, but implemented consumption by discovering metadata and assigning partitions directly.
- That bypassed librdkafka's native `subscribe()` path, so topic strings starting with `^` were not interpreted as Kafka regex subscriptions.
- Users expect regex topic selection to follow librdkafka/Kafka consumer semantics. Producers do not have equivalent native regex fanout semantics, so `to_kafka` stays exact-topic only.

## 🛠️ Solution

- Route the neo `from_kafka` path through `RdKafka::KafkaConsumer::subscribe()` for every topic argument, exact or regex.
- Preserve the existing operator UX: a topic beginning with `^` is handled transparently by librdkafka as a regex subscription; all other topic strings remain exact subscriptions.
- Create one subscribed Kafka source for the operator's topic argument. For regex topics, that one source may consume records from multiple concrete Kafka topics as librdkafka updates assignment through normal metadata refresh and rebalances.
- Commit offsets by concrete record topic plus partition, because a regex subscription can produce records from multiple topics with overlapping partition numbers.
- Reject `exit=true` for regex subscriptions. Exact-topic `exit=true` still exits after EOF across the current subscribed assignment, but regex subscriptions do not have a stable bounded assignment set.

## 💬 Review

Please focus review on the semantic move from manual assignment to Kafka subscription semantics in the neo executor path:

- Exact topics now also use `subscribe()` instead of startup metadata discovery plus explicit `assign()`. Confirm that normal consumer-group subscription behavior is the desired baseline for both exact and regex topics.
- Regex support intentionally relies on librdkafka detection for topic strings starting with `^`; we do not pre-compile or validate the regex ourselves.
- Offset accounting now uses the concrete topic from each consumed message. Please check that commit behavior stays correct across rebalances and across regex matches with overlapping partition IDs.
- `exit=true` remains supported for exact topics but is rejected for regex topics. Please check whether that user-facing constraint is acceptable.
- The Kafka fixture test was added, but I could not run it locally because Docker was not running.

<sub>
📚 Docs PR: tenzir/docs#390
</sub>