### PR TITLE
Fix `where` dropping all events for pushed-down substring filters

### DIFF
--- a/changelog/unreleased/fix-where-substring-in-pushdown.md
+++ b/changelog/unreleased/fix-where-substring-in-pushdown.md
@@ -1,0 +1,11 @@
+---
+title: "Fix `where` substring filters dropping all events from `subscribe`"
+type: bugfix
+authors:
+  - jachris
+created: 2026-06-09T00:00:00.000000Z
+---
+
+A `where` filter that checks for a substring with the literal on the left, such
+as `where "TRAFFIC" in log`, incorrectly removed every event when reading from
+`subscribe`. Such filters now match correctly again.

--- a/libtenzir/src/expression_visitors.cpp
+++ b/libtenzir/src/expression_visitors.cpp
@@ -17,6 +17,7 @@
 #include "tenzir/concept/printable/to_string.hpp"
 #include "tenzir/data.hpp"
 #include "tenzir/detail/assert.hpp"
+#include "tenzir/detail/scope_guard.hpp"
 #include "tenzir/ids.hpp"
 #include "tenzir/logger.hpp"
 #include "tenzir/table_slice.hpp"
@@ -447,6 +448,17 @@ type_resolver::operator()(const type_extractor& ex, const data& d) {
 
 caf::expected<expression>
 type_resolver::operator()(const data& d, const type_extractor& ex) {
+  // Swapping the operands moves the extractor to the left-hand side, so the
+  // operator must be flipped to preserve the predicate's meaning. Inputs are
+  // normally aligned before they reach us, but we flip here as well so that an
+  // unaligned predicate resolves correctly instead of silently inverting
+  // asymmetric operators such as `in`. The flip is a no-op for symmetric
+  // operators like `==`. We restore `op_` on the way out so the mutation stays
+  // local to this delegated call.
+  auto guard = detail::scope_guard{[this, previous = op_]() noexcept {
+    op_ = previous;
+  }};
+  op_ = flip(op_);
   return (*this)(ex, d);
 }
 
@@ -477,6 +489,12 @@ type_resolver::operator()(const field_extractor& ex, const data& d) {
 
 caf::expected<expression>
 type_resolver::operator()(const data& d, const field_extractor& ex) {
+  // See the `type_extractor` overload above: flipping the operator keeps the
+  // predicate's meaning intact when the extractor moves to the left-hand side.
+  auto guard = detail::scope_guard{[this, previous = op_]() noexcept {
+    op_ = previous;
+  }};
+  op_ = flip(op_);
   return (*this)(ex, d);
 }
 

--- a/libtenzir/src/tql2/ast.cpp
+++ b/libtenzir/src/tql2/ast.cpp
@@ -656,11 +656,12 @@ auto split_legacy_expression(const ast::expression& x)
         }
         auto result
           = expression{predicate{std::move(*left), *rel_op, std::move(*right)}};
-        if (not normalize_and_validate(result)) {
+        auto normalized = normalize_and_validate(std::move(result));
+        if (not normalized) {
           return std::pair{trivially_true_expression(), x};
         }
         return std::pair{
-          std::move(result),
+          std::move(*normalized),
           ast::expression{ast::constant{true, location::unknown}},
         };
       }

--- a/libtenzir/test/expression.cpp
+++ b/libtenzir/test/expression.cpp
@@ -8,6 +8,7 @@
 
 #include "tenzir/expression.hpp"
 
+#include "tenzir/bitmap_algorithms.hpp"
 #include "tenzir/concept/parseable/tenzir/expression.hpp"
 #include "tenzir/concept/parseable/tenzir/schema.hpp"
 #include "tenzir/concept/parseable/tenzir/subnet.hpp"
@@ -20,7 +21,10 @@
 #include "tenzir/detail/serialize.hpp"
 #include "tenzir/detail/stable_map.hpp"
 #include "tenzir/expression_visitors.hpp"
+#include "tenzir/ids.hpp"
 #include "tenzir/module.hpp"
+#include "tenzir/series_builder.hpp"
+#include "tenzir/table_slice.hpp"
 #include "tenzir/test/test.hpp"
 
 #include <string>
@@ -345,6 +349,40 @@ WITH_FIXTURE(fixture) {
     concat(expected, resolve_pred("x == 5", {0, 1, 0}, t));
     concat(expected, resolve_pred("y == false", {0, 1, 1}, t));
     CHECK_EQUAL(xs, expected);
+  }
+
+  TEST("tailor flips unaligned substring in predicate") {
+    // Regression test: an unaligned `"needle" in field` predicate (literal on
+    // the left) must still resolve and evaluate correctly. `tailor` does not
+    // normalize its input, so it has to flip the operator itself when moving
+    // the extractor to the left-hand side; otherwise the substring check is
+    // inverted and matches nothing.
+    auto b = series_builder{};
+    b.record().field("log").data("contains ,TRAFFIC,end, here");
+    b.record().field("log").data("nothing of interest");
+    auto slices = b.finish_as_table_slice("test");
+    REQUIRE_EQUAL(slices.size(), 1u);
+    const auto& slice = slices[0];
+    // Construct the predicate directly so that it is *not* aligned by
+    // `normalize` first.
+    auto expr = expression{predicate{
+      data{",TRAFFIC,end,"},
+      relational_operator::in,
+      field_extractor{"log"},
+    }};
+    auto tailored = tailor(expr, slice.schema());
+    REQUIRE(tailored);
+    // The extractor must have moved to the left-hand side with the operator
+    // flipped from `in` to `ni`.
+    const auto* p = try_as<predicate>(&tailored->get_data());
+    REQUIRE(p);
+    CHECK(is<data_extractor>(p->lhs));
+    CHECK_EQUAL(p->op, relational_operator::ni);
+    // Evaluation must select exactly the one matching row. The slice was built
+    // directly and has no offset assigned, so `evaluate` treats its offset as
+    // zero; the hints therefore span `[0, rows)`.
+    auto result = evaluate(*tailored, slice, make_ids({{0, slice.rows()}}));
+    CHECK_EQUAL(rank(result), 1u);
   }
 
   TEST("parse print roundtrip") {

--- a/libtenzir/test/optimizations.cpp
+++ b/libtenzir/test/optimizations.cpp
@@ -41,3 +41,25 @@ TEST("optimize now") {
   test("now() + 100d < x", true);
   test("100d + now() < x", true);
 }
+
+TEST("split aligns substring in predicate") {
+  // Regression test: when a predicate with a literal on the left-hand side is
+  // split off for predicate pushdown, the result must be normalized so that the
+  // extractor ends up on the left with the operator flipped accordingly.
+  // Otherwise pushing the filter into a source that does not re-normalize it
+  // (e.g. `subscribe`) inverts the substring check and filters out everything.
+  auto dh = collecting_diagnostic_handler{};
+  auto provider = session_provider::make(dh);
+  auto s = session{provider};
+  auto expr
+    = parse_expression_with_bad_diagnostics(R"("needle" in haystack)", s);
+  REQUIRE(expr);
+  const auto& [legacy, remainder]
+    = split_legacy_expression(std::move(expr).unwrap());
+  CHECK(is_true_literal(remainder));
+  const auto* p = try_as<predicate>(&legacy.get_data());
+  REQUIRE(p);
+  CHECK_EQUAL(p->lhs, operand{field_extractor{"haystack"}});
+  CHECK_EQUAL(p->op, relational_operator::ni);
+  CHECK_EQUAL(p->rhs, operand{data{std::string{"needle"}}});
+}


### PR DESCRIPTION
## 🔍 Problem

A `where` filter testing for a substring with the literal on the left-hand side (e.g. `where "TRAFFIC" in log`) dropped **every** event when pushed into `subscribe`.

- `split_legacy_expression` called `normalize_and_validate` only for its boolean result and **discarded the normalized expression it returns**, pushing down the un-aligned `data in extractor` predicate.
- Sources that re-normalize the pushed filter are fine; `subscribe` ships it to the broker as-is. `tailor` then resolves `data in field` into `data_extractor in data` by swapping operands **without flipping the operator** (`type_resolver`), so evaluation computes `needle.find(haystack)` instead of `haystack.find(needle)` — `false` for every row.
- `export` is unaffected because `export_bridge` re-runs `normalize_and_validate` before tailoring, which re-aligns the predicate.

## 🛠️ Solution

Two commits, root cause first:

1. **Root cause** — `split_legacy_expression` now uses the normalized expression returned by `normalize_and_validate`, so the extractor is aligned to the left-hand side with the operator flipped (`in` to `ni`), matching what the evaluation layer asserts it receives.
2. **Defense in depth** — `type_resolver`'s two operand-swapping overloads (`data <op> extractor`) now flip the operator when moving the extractor to the LHS, restoring `op_` afterwards via a scope guard so the mutation stays local to the delegated call. The swap-without-flip was only correct for symmetric operators and silently inverted asymmetric ones like `in`; the flip is a no-op for symmetric operators, so aligned inputs are unchanged.

## 💬 Review

- Two small behavioral fixes; the rest is regression tests.
- `optimizations.cpp`: asserts `split_legacy_expression` returns the aligned form. Verified it **fails** on the pre-fix code (`lhs: "needle"`, `op: in`).
- `expression.cpp`: tailors **and** evaluates an unaligned `"needle" in field` predicate directly (bypassing normalization); asserts the extractor lands on the LHS with `ni` and that exactly the matching row survives. Verified it **fails** when the `type_resolver` flip is reverted (`op: in`, `rank: 0`).
- Reproduced end-to-end against a live node: pre-fix `subscribe … | where "…" in log` yielded **0 rows**; post-fix all matching rows pass and non-matching rows are dropped.
- Full unit suite green (only the unrelated `subprocess` sandbox test fails locally).
