### PR TITLE
Preserve negation in expression deduplicator

### DIFF
--- a/libtenzir/src/expression_visitors.cpp
+++ b/libtenzir/src/expression_visitors.cpp
@@ -223,7 +223,7 @@ expression deduplicator::operator()(const disjunction& d) const {
 }
 
 expression deduplicator::operator()(const negation& n) const {
-  return match(n.expr(), *this);
+  return negation{match(n.expr(), *this)};
 }
 
 expression deduplicator::operator()(const predicate& p) const {


### PR DESCRIPTION
## 🔍 Problem

`deduplicator::operator()(const negation&)` returned only the deduplicated child of a `negation`, dropping the negation node itself and inverting the predicate's meaning (`not P` → `P`).

- Masked today: `normalize()` runs `denegator` before `deduplicator`, so all `negation` nodes are already eliminated before deduplication runs — the overload is effectively dead code.
- Still a latent hazard: the visitor is incorrect in isolation, so it breaks if the normalization order changes or `deduplicator` is reused standalone.

## 🛠️ Solution

- Re-wrap the deduplicated child in `negation{}`, matching the other structure-preserving visitors (`aligner`, `meta_pruner`).

## 💬 Review

- One-line change; no behavioral change in the current `normalize()` pipeline since the path is unreachable. This is defensive correctness hardening of the visitor.
- No changelog entry (no user-facing behavior change).