### PR TITLE
Fix node crash when an HTTP server fails to bind

### DIFF
--- a/changelog/unreleased/http-server-operators-no-longer-crash-the-node-on-bind-failure.md
+++ b/changelog/unreleased/http-server-operators-no-longer-crash-the-node-on-bind-failure.md
@@ -1,0 +1,23 @@
+---
+title: HTTP server operators no longer crash the node on bind failure
+type: bugfix
+authors:
+  - Zedoraps
+prs:
+  - 6267
+created: 2026-06-09T11:48:35.337776Z
+---
+
+The `accept_http`, `accept_opensearch`, and `serve_http` operators no longer
+abort the node when they fail to bind their endpoint. Starting a second
+pipeline on a port that is already in use—or restarting one before the
+previous instance has released its socket—previously crashed the entire node
+process. Now the operator emits a regular diagnostic:
+
+```text
+error: failed to start HTTP server: failed to bind to async server socket:
+0.0.0.0:8774: Address already in use
+```
+
+The pipeline that hit the conflict exits with an error while every other
+pipeline running on the node keeps going.

--- a/libtenzir/builtins/operators/accept_http.cpp
+++ b/libtenzir/builtins/operators/accept_http.cpp
@@ -36,7 +36,6 @@
 #include <proxygen/lib/http/coro/HTTPFixedSource.h>
 #include <proxygen/lib/http/coro/HTTPSourceReader.h>
 #include <proxygen/lib/http/coro/server/HTTPServer.h>
-#include <proxygen/lib/http/coro/server/ScopedHTTPServer.h>
 #include <proxygen/lib/utils/URL.h>
 
 #include <charconv>
@@ -308,10 +307,10 @@ public:
     auto request_handler = std::make_shared<RequestHandler>(
       args_, message_queue_, request_id_gen, active_connections_);
     try {
-      auto server = proxygen::coro::ScopedHTTPServer::start(
+      auto server = http_server::scoped_server::start(
         std::move(config.unwrap()), std::move(request_handler));
-      server_ = Arc<proxygen::coro::ScopedHTTPServer>::from_non_null(
-        std::move(server));
+      server_
+        = Arc<http_server::scoped_server>::from_non_null(std::move(server));
     } catch (std::exception const& ex) {
       diagnostic::error("failed to start HTTP server: {}", ex.what())
         .primary(args_.endpoint)
@@ -575,7 +574,7 @@ private:
   AcceptHttpArgs args_;
   // --- transient ---
   mutable Arc<MessageQueue> message_queue_{std::in_place, uint32_t{64}};
-  Option<Arc<proxygen::coro::ScopedHTTPServer>> server_;
+  Option<Arc<http_server::scoped_server>> server_;
   Mutex<std::unordered_map<uint64_t, ActiveRequest>> active_requests_{{}};
   Arc<Semaphore> active_connections_;
 };

--- a/libtenzir/builtins/operators/accept_http.cpp
+++ b/libtenzir/builtins/operators/accept_http.cpp
@@ -306,17 +306,17 @@ public:
     auto request_id_gen = Arc<Atomic<uint64_t>>{std::in_place, uint64_t{0}};
     auto request_handler = std::make_shared<RequestHandler>(
       args_, message_queue_, request_id_gen, active_connections_);
-    try {
-      auto server = http_server::scoped_server::start(
-        std::move(config.unwrap()), std::move(request_handler));
-      server_
-        = Arc<http_server::scoped_server>::from_non_null(std::move(server));
-    } catch (std::exception const& ex) {
-      diagnostic::error("failed to start HTTP server: {}", ex.what())
+    auto server = http_server::ScopedServer::start(std::move(config.unwrap()),
+                                                   std::move(request_handler));
+    if (server.is_err()) {
+      diagnostic::error("failed to start HTTP server: {}",
+                        std::move(server).unwrap_err())
         .primary(args_.endpoint)
         .emit(ctx);
       co_return;
     }
+    server_ = Arc<http_server::ScopedServer>::from_non_null(
+      std::move(server).unwrap());
     // When the operator is forcefully stopped (e.g., by `head 1` finishing),
     // the executor skips `finish_sub` and cancels the operator scope. Catch
     // that cancellation, reply to already-accepted requests ourselves, then
@@ -503,7 +503,7 @@ private:
 
   void force_stop() {
     if (server_) {
-      (*server_)->getServer().forceStop();
+      (*server_)->server().forceStop();
       // move server to a new thread, where it can call thread join
       std::thread([srv = std::exchange(server_, None{})] {}).detach();
     }
@@ -574,7 +574,7 @@ private:
   AcceptHttpArgs args_;
   // --- transient ---
   mutable Arc<MessageQueue> message_queue_{std::in_place, uint32_t{64}};
-  Option<Arc<http_server::scoped_server>> server_;
+  Option<Arc<http_server::ScopedServer>> server_;
   Mutex<std::unordered_map<uint64_t, ActiveRequest>> active_requests_{{}};
   Arc<Semaphore> active_connections_;
 };

--- a/libtenzir/builtins/operators/accept_opensearch.cpp
+++ b/libtenzir/builtins/operators/accept_opensearch.cpp
@@ -327,17 +327,17 @@ public:
     auto request_id_gen = Arc<Atomic<uint64_t>>{std::in_place, uint64_t{0}};
     auto request_handler = std::make_shared<RequestHandler>(
       args_, message_queue_, request_id_gen, active_connections_);
-    try {
-      auto server = http_server::scoped_server::start(
-        std::move(config.unwrap()), std::move(request_handler));
-      server_
-        = Arc<http_server::scoped_server>::from_non_null(std::move(server));
-    } catch (std::exception const& ex) {
-      diagnostic::error("failed to start HTTP server: {}", ex.what())
+    auto server = http_server::ScopedServer::start(std::move(config.unwrap()),
+                                                   std::move(request_handler));
+    if (server.is_err()) {
+      diagnostic::error("failed to start HTTP server: {}",
+                        std::move(server).unwrap_err())
         .primary(args_.url)
         .emit(ctx);
       co_return;
     }
+    server_ = Arc<http_server::ScopedServer>::from_non_null(
+      std::move(server).unwrap());
     // When the operator is forcefully stopped (e.g., by `head 1` finishing),
     // the executor skips `finish_sub` and cancels the operator scope. Catch
     // that cancellation, reply to already-accepted requests ourselves, then
@@ -541,7 +541,7 @@ private:
 
   void force_stop() {
     if (server_) {
-      (*server_)->getServer().forceStop();
+      (*server_)->server().forceStop();
       // move server to a new thread, where it can call thread join
       std::thread([srv = std::exchange(server_, None{})] {}).detach();
     }
@@ -604,7 +604,7 @@ private:
   AcceptOpenSearchArgs args_;
   // --- transient ---
   Arc<Semaphore> active_connections_;
-  Option<Arc<http_server::scoped_server>> server_;
+  Option<Arc<http_server::ScopedServer>> server_;
   std::unordered_map<uint64_t, InFlightRequest> active_requests_{{}};
   MetricsCounter bytes_read_counter_;
   MetricsCounter events_read_counter_;

--- a/libtenzir/builtins/operators/accept_opensearch.cpp
+++ b/libtenzir/builtins/operators/accept_opensearch.cpp
@@ -35,7 +35,6 @@
 #include <proxygen/lib/http/coro/HTTPFixedSource.h>
 #include <proxygen/lib/http/coro/HTTPSourceReader.h>
 #include <proxygen/lib/http/coro/server/HTTPServer.h>
-#include <proxygen/lib/http/coro/server/ScopedHTTPServer.h>
 #include <proxygen/lib/utils/URL.h>
 
 #include <cstddef>
@@ -329,10 +328,10 @@ public:
     auto request_handler = std::make_shared<RequestHandler>(
       args_, message_queue_, request_id_gen, active_connections_);
     try {
-      auto server = proxygen::coro::ScopedHTTPServer::start(
+      auto server = http_server::scoped_server::start(
         std::move(config.unwrap()), std::move(request_handler));
-      server_ = Arc<proxygen::coro::ScopedHTTPServer>::from_non_null(
-        std::move(server));
+      server_
+        = Arc<http_server::scoped_server>::from_non_null(std::move(server));
     } catch (std::exception const& ex) {
       diagnostic::error("failed to start HTTP server: {}", ex.what())
         .primary(args_.url)
@@ -605,7 +604,7 @@ private:
   AcceptOpenSearchArgs args_;
   // --- transient ---
   Arc<Semaphore> active_connections_;
-  Option<Arc<proxygen::coro::ScopedHTTPServer>> server_;
+  Option<Arc<http_server::scoped_server>> server_;
   std::unordered_map<uint64_t, InFlightRequest> active_requests_{{}};
   MetricsCounter bytes_read_counter_;
   MetricsCounter events_read_counter_;

--- a/libtenzir/builtins/operators/serve_http.cpp
+++ b/libtenzir/builtins/operators/serve_http.cpp
@@ -337,18 +337,18 @@ public:
     }
     auto request_handler
       = std::make_shared<RequestHandler>(message_queue_, active_connections_);
-    try {
-      auto server = http_server::scoped_server::start(
-        std::move(config.unwrap()), std::move(request_handler));
-      server_
-        = Arc<http_server::scoped_server>::from_non_null(std::move(server));
-    } catch (std::exception const& ex) {
-      diagnostic::error("failed to start HTTP server: {}", ex.what())
+    auto server = http_server::ScopedServer::start(std::move(config.unwrap()),
+                                                   std::move(request_handler));
+    if (server.is_err()) {
+      diagnostic::error("failed to start HTTP server: {}",
+                        std::move(server).unwrap_err())
         .primary(args_.endpoint)
         .emit(ctx);
       lifecycle_ = Lifecycle::done;
       co_return;
     }
+    server_ = Arc<http_server::ScopedServer>::from_non_null(
+      std::move(server).unwrap());
     ctx.spawn_task([this]() -> Task<void> {
       co_await catch_cancellation(wait_forever());
       co_await force_stop();
@@ -492,7 +492,7 @@ private:
     }
     lifecycle_ = Lifecycle::draining;
     if (server_) {
-      (*server_)->getServer().drain();
+      (*server_)->server().drain();
     }
   }
 
@@ -532,7 +532,7 @@ private:
     }
     if (clients_.empty() and message_queue_->empty()) {
       if (server_) {
-        (*server_)->getServer().forceStop();
+        (*server_)->server().forceStop();
         // move server to a new thread, where it can call thread join
         std::thread([srv = std::exchange(server_, None{})] {}).detach();
       }
@@ -624,7 +624,7 @@ private:
   // --- transient ---
   data sub_key_ = data{int64_t{0}};
   mutable Arc<MessageQueue> message_queue_{std::in_place, 64};
-  Option<Arc<http_server::scoped_server>> server_;
+  Option<Arc<http_server::ScopedServer>> server_;
   Arc<Semaphore> active_connections_;
   std::vector<Arc<Client>> clients_;
   // --- state ---

--- a/libtenzir/builtins/operators/serve_http.cpp
+++ b/libtenzir/builtins/operators/serve_http.cpp
@@ -35,7 +35,6 @@
 #include <proxygen/lib/http/coro/HTTPSourceHolder.h>
 #include <proxygen/lib/http/coro/HTTPStreamSource.h>
 #include <proxygen/lib/http/coro/server/HTTPServer.h>
-#include <proxygen/lib/http/coro/server/ScopedHTTPServer.h>
 
 #include <limits>
 #include <memory>
@@ -339,10 +338,10 @@ public:
     auto request_handler
       = std::make_shared<RequestHandler>(message_queue_, active_connections_);
     try {
-      auto server = proxygen::coro::ScopedHTTPServer::start(
+      auto server = http_server::scoped_server::start(
         std::move(config.unwrap()), std::move(request_handler));
-      server_ = Arc<proxygen::coro::ScopedHTTPServer>::from_non_null(
-        std::move(server));
+      server_
+        = Arc<http_server::scoped_server>::from_non_null(std::move(server));
     } catch (std::exception const& ex) {
       diagnostic::error("failed to start HTTP server: {}", ex.what())
         .primary(args_.endpoint)
@@ -625,7 +624,7 @@ private:
   // --- transient ---
   data sub_key_ = data{int64_t{0}};
   mutable Arc<MessageQueue> message_queue_{std::in_place, 64};
-  Option<Arc<proxygen::coro::ScopedHTTPServer>> server_;
+  Option<Arc<http_server::scoped_server>> server_;
   Arc<Semaphore> active_connections_;
   std::vector<Arc<Client>> clients_;
   // --- state ---

--- a/libtenzir/include/tenzir/http_server.hpp
+++ b/libtenzir/include/tenzir/http_server.hpp
@@ -18,12 +18,15 @@
 #include "tenzir/tls_options.hpp"
 
 #include <proxygen/lib/http/coro/HTTPSourceHolder.h>
+#include <proxygen/lib/http/coro/server/HTTPServer.h>
 #include <wangle/ssl/SSLContextConfig.h>
 
 #include <charconv>
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <string_view>
+#include <thread>
 
 namespace tenzir::http_server {
 
@@ -63,5 +66,37 @@ auto is_tls_enabled(Option<located<data>> const& tls,
 
 auto make_response(uint16_t status, const std::string& content_type,
                    std::string body) -> proxygen::coro::HTTPSourceHolder;
+
+/// Drop-in replacement for `proxygen::coro::ScopedHTTPServer` whose destructor
+/// is safe when `start()` fails. The upstream version joins its IO thread both
+/// in `start()` (after a bind failure) and again in the destructor, which
+/// throws `std::system_error` during stack unwinding and terminates the
+/// process.
+class scoped_server {
+public:
+  static auto start(proxygen::coro::HTTPServer::Config config,
+                    std::shared_ptr<proxygen::coro::HTTPHandler> handler)
+    -> std::unique_ptr<scoped_server>;
+
+  ~scoped_server();
+
+  scoped_server(scoped_server const&) = delete;
+  scoped_server(scoped_server&&) = delete;
+  auto operator=(scoped_server const&) -> scoped_server& = delete;
+  auto operator=(scoped_server&&) -> scoped_server& = delete;
+
+  auto getServer() -> proxygen::coro::HTTPServer& {
+    return server_;
+  }
+
+private:
+  scoped_server(proxygen::coro::HTTPServer::Config config,
+                std::shared_ptr<proxygen::coro::HTTPHandler> handler);
+
+  void start_impl();
+
+  proxygen::coro::HTTPServer server_;
+  std::thread thread_;
+};
 
 } // namespace tenzir::http_server

--- a/libtenzir/include/tenzir/http_server.hpp
+++ b/libtenzir/include/tenzir/http_server.hpp
@@ -15,6 +15,7 @@
 
 #include "tenzir/diagnostics.hpp"
 #include "tenzir/option.hpp"
+#include "tenzir/result.hpp"
 #include "tenzir/tls_options.hpp"
 
 #include <proxygen/lib/http/coro/HTTPSourceHolder.h>
@@ -67,31 +68,31 @@ auto is_tls_enabled(Option<located<data>> const& tls,
 auto make_response(uint16_t status, const std::string& content_type,
                    std::string body) -> proxygen::coro::HTTPSourceHolder;
 
-/// Drop-in replacement for `proxygen::coro::ScopedHTTPServer` whose destructor
-/// is safe when `start()` fails. The upstream version joins its IO thread both
-/// in `start()` (after a bind failure) and again in the destructor, which
-/// throws `std::system_error` during stack unwinding and terminates the
-/// process.
-class scoped_server {
+/// RAII wrapper around `proxygen::coro::HTTPServer` that runs the server on a
+/// dedicated IO thread and tears it down on destruction. Unlike upstream's
+/// `proxygen::coro::ScopedHTTPServer`, `start()` catches bind failures and
+/// returns an error instead of throwing across the API, and the destructor is
+/// safe even when the server never reached the running state.
+class ScopedServer {
 public:
   static auto start(proxygen::coro::HTTPServer::Config config,
                     std::shared_ptr<proxygen::coro::HTTPHandler> handler)
-    -> std::unique_ptr<scoped_server>;
+    -> Result<std::unique_ptr<ScopedServer>, std::string>;
 
-  ~scoped_server();
+  ~ScopedServer();
 
-  scoped_server(scoped_server const&) = delete;
-  scoped_server(scoped_server&&) = delete;
-  auto operator=(scoped_server const&) -> scoped_server& = delete;
-  auto operator=(scoped_server&&) -> scoped_server& = delete;
+  ScopedServer(ScopedServer const&) = delete;
+  ScopedServer(ScopedServer&&) = delete;
+  auto operator=(ScopedServer const&) -> ScopedServer& = delete;
+  auto operator=(ScopedServer&&) -> ScopedServer& = delete;
 
-  auto getServer() -> proxygen::coro::HTTPServer& {
+  auto server() -> proxygen::coro::HTTPServer& {
     return server_;
   }
 
 private:
-  scoped_server(proxygen::coro::HTTPServer::Config config,
-                std::shared_ptr<proxygen::coro::HTTPHandler> handler);
+  ScopedServer(proxygen::coro::HTTPServer::Config config,
+               std::shared_ptr<proxygen::coro::HTTPHandler> handler);
 
   void start_impl();
 

--- a/libtenzir/src/http_server.cpp
+++ b/libtenzir/src/http_server.cpp
@@ -175,22 +175,25 @@ auto make_response(uint16_t status, const std::string& content_type,
   return proxygen::coro::HTTPSourceHolder{source};
 }
 
-scoped_server::scoped_server(
-  proxygen::coro::HTTPServer::Config config,
-  std::shared_ptr<proxygen::coro::HTTPHandler> handler)
+ScopedServer::ScopedServer(proxygen::coro::HTTPServer::Config config,
+                           std::shared_ptr<proxygen::coro::HTTPHandler> handler)
   : server_{std::move(config), std::move(handler)} {
 }
 
-auto scoped_server::start(proxygen::coro::HTTPServer::Config config,
-                          std::shared_ptr<proxygen::coro::HTTPHandler> handler)
-  -> std::unique_ptr<scoped_server> {
-  auto s = std::unique_ptr<scoped_server>{
-    new scoped_server{std::move(config), std::move(handler)}};
-  s->start_impl();
+auto ScopedServer::start(proxygen::coro::HTTPServer::Config config,
+                         std::shared_ptr<proxygen::coro::HTTPHandler> handler)
+  -> Result<std::unique_ptr<ScopedServer>, std::string> {
+  auto s = std::unique_ptr<ScopedServer>{
+    new ScopedServer{std::move(config), std::move(handler)}};
+  try {
+    s->start_impl();
+  } catch (std::exception const& ex) {
+    return Err{std::string{ex.what()}};
+  }
   return s;
 }
 
-void scoped_server::start_impl() {
+void ScopedServer::start_impl() {
   std::exception_ptr eptr;
   folly::Baton baton;
   thread_ = std::thread{[&] {
@@ -213,7 +216,7 @@ void scoped_server::start_impl() {
   }
 }
 
-scoped_server::~scoped_server() {
+ScopedServer::~ScopedServer() {
   if (not thread_.joinable()) {
     // `start_impl()` failed and already joined the IO thread. Calling
     // `drain()`/`forceStop()` on a server that never reached RUNNING is

--- a/libtenzir/src/http_server.cpp
+++ b/libtenzir/src/http_server.cpp
@@ -10,9 +10,13 @@
 
 #include "tenzir/concept/parseable/tenzir/endpoint.hpp"
 
+#include <folly/synchronization/Baton.h>
 #include <proxygen/lib/http/coro/HTTPFixedSource.h>
 #include <proxygen/lib/http/coro/server/HTTPServer.h>
 #include <proxygen/lib/utils/URL.h>
+
+#include <exception>
+#include <utility>
 
 namespace tenzir::http_server {
 
@@ -169,6 +173,56 @@ auto make_response(uint16_t status, const std::string& content_type,
                                    content_type);
   }
   return proxygen::coro::HTTPSourceHolder{source};
+}
+
+scoped_server::scoped_server(
+  proxygen::coro::HTTPServer::Config config,
+  std::shared_ptr<proxygen::coro::HTTPHandler> handler)
+  : server_{std::move(config), std::move(handler)} {
+}
+
+auto scoped_server::start(proxygen::coro::HTTPServer::Config config,
+                          std::shared_ptr<proxygen::coro::HTTPHandler> handler)
+  -> std::unique_ptr<scoped_server> {
+  auto s = std::unique_ptr<scoped_server>{
+    new scoped_server{std::move(config), std::move(handler)}};
+  s->start_impl();
+  return s;
+}
+
+void scoped_server::start_impl() {
+  std::exception_ptr eptr;
+  folly::Baton baton;
+  thread_ = std::thread{[&] {
+    server_.start(
+      [&] {
+        baton.post();
+      },
+      [&](std::exception_ptr ex) {
+        eptr = ex;
+        baton.post();
+      });
+  }};
+  baton.wait();
+  if (eptr) {
+    // The IO thread returned without starting the server; join it here. The
+    // destructor checks `joinable()` so it will not try to join again while
+    // unwinding the exception we are about to rethrow.
+    thread_.join();
+    std::rethrow_exception(eptr);
+  }
+}
+
+scoped_server::~scoped_server() {
+  if (not thread_.joinable()) {
+    // `start_impl()` failed and already joined the IO thread. Calling
+    // `drain()`/`forceStop()` on a server that never reached RUNNING is
+    // unnecessary, and `thread_.join()` would throw `std::system_error`.
+    return;
+  }
+  server_.drain();
+  server_.forceStop();
+  thread_.join();
 }
 
 } // namespace tenzir::http_server


### PR DESCRIPTION
## 🔍 Problem

Restarting an `accept_http`, `accept_opensearch`, or `serve_http` pipeline while another instance still listens on the same endpoint crashes the node instead of emitting a diagnostic. The bind failure is raised correctly, but a second exception thrown from the underlying HTTP server's destructor during stack unwinding terminates the process.

Reproducer:

```tql
accept_http "0.0.0.0:8774" { read_ndjson }
```

Run twice; the second invocation aborts the node.

## 🛠️ Solution

`proxygen::coro::ScopedHTTPServer::start()` joins the IO thread after a bind failure and then rethrows. The `unique_ptr<ScopedHTTPServer>` returned by the factory is destroyed during unwinding, and `~ScopedHTTPServer()` calls `thread_.join()` again on the now non-joinable thread — `std::system_error("Invalid argument")` propagates during unwinding and `terminate()` runs.

Wrap `proxygen::coro::HTTPServer` directly in `tenzir::http_server::scoped_server`, whose destructor guards `drain()` / `forceStop()` / `join()` with `thread_.joinable()`. Bind failures now propagate cleanly to the operators' existing `try/catch`, which emits a TQL diagnostic.

## 💬 Review

- `libtenzir/src/http_server.cpp`: `scoped_server::start_impl()` mirrors upstream's logic; the destructor is the actual fix.
- Behavior on the success path is identical to upstream (`thread_` is still joinable, so `drain/forceStop/join` run as before).
- On a never-started server, skipping `drain/forceStop` is consistent with the upstream `HTTPServer` contract ("only after `start()` has called `onSuccess`"). `~HTTPServer()` only does `XCHECK(!eventBase_.isRunning())`, which holds because the event loop never started.
- All three call sites (`accept_http`, `accept_opensearch`, `serve_http`) switch to the wrapper.
- Verified locally: two `accept_http` pipelines on the same port — the second now emits `error: failed to start HTTP server: ... Address already in use` and exits 1; the first stays alive. Existing `accept_http` integration tests pass.
- The same bug exists upstream; worth filing a proxygen PR separately.

<sub>
🤖 Generated with [Claude Code](https://claude.com/claude-code)
</sub>