### PR TITLE
Speed up Platform connection startup

### DIFF
--- a/changelog/unreleased/platform-connection-during-node-startup.md
+++ b/changelog/unreleased/platform-connection-during-node-startup.md
@@ -1,0 +1,14 @@
+---
+title: Platform connection during node startup
+type: bugfix
+authors:
+  - tobim
+  - codex
+prs:
+  - 6268
+created: 2026-06-09T12:51:34.44394Z
+---
+
+Tenzir Nodes now connect to the Tenzir Platform during startup before waiting
+for the local index to become available. Previously, Platform connectivity
+could be delayed while the index was still initializing.

--- a/libtenzir/src/detail/signal_handlers.cpp
+++ b/libtenzir/src/detail/signal_handlers.cpp
@@ -33,6 +33,15 @@
 
 #include <dlfcn.h>
 
+#ifndef __has_feature
+#  define __has_feature(x) 0
+#endif
+
+#if (__has_feature(address_sanitizer) or defined(__SANITIZE_ADDRESS__))        \
+  and __has_include(<sanitizer/lsan_interface.h>)
+#  include <sanitizer/lsan_interface.h>
+#endif
+
 namespace {
 
 // Async-signal-safe write wrapper.
@@ -311,6 +320,10 @@ __attribute__((constructor(102))) void early_install_signal_handlers() {
   // Set up alternate signal stack to handle stack overflow scenarios.
   stack_t ss{};
   ss.ss_sp = malloc(SIGSTKSZ);
+#if (__has_feature(address_sanitizer) or defined(__SANITIZE_ADDRESS__))        \
+  and __has_include(<sanitizer/lsan_interface.h>)
+  __lsan_ignore_object(ss.ss_sp);
+#endif
   ss.ss_size = SIGSTKSZ;
   sigaltstack(&ss, nullptr);
 


### PR DESCRIPTION
## 🔍 Problem

- Nodes can delay connecting to the Tenzir Platform while waiting for the local index to become available.
- LSAN reports the alternate signal stack allocation even though it is intentionally kept for the lifetime of the process.

## 🛠️ Solution

- Advance the plugins submodule to start the Platform connection without waiting for the index.
- Mark the alternate signal stack allocation as ignored when LeakSanitizer support is available.

## 💬 Review

- Check the Platform startup ordering change in the plugins PR.
- Check that the sanitizer include and call stay conditional for non-ASAN builds.

<sub>
📎 Related: tenzir/tenzir-plugins#563
</sub>

Fixes TNZ-416.
Fixes TNZ-421.