### PR TITLE
Change parallel so filters cannot escape it

### DIFF
--- a/changelog/releases/v6.2.0/entries/filters-escaping-parallel-subpipelines.md
+++ b/changelog/releases/v6.2.0/entries/filters-escaping-parallel-subpipelines.md
@@ -1,0 +1,24 @@
+---
+title: Filters escaping parallel subpipelines
+type: bugfix
+authors:
+  - aljazerzen
+  - claude
+prs:
+  - 6270
+created: 2026-06-10T07:02:07.874738Z
+---
+
+Filters inside a `parallel { … }` subpipeline no longer escape past the
+`parallel` operator during optimization.
+
+Previously, a filter such as the `where` below was lifted out of the
+subpipeline and applied before `parallel`:
+
+```tql
+parallel { where x > 1 | ... }
+```
+
+The filter now stays inside the subpipeline, where it belongs, so it runs
+distributed across the parallel jobs. Filters from downstream of `parallel` are
+still pushed into the subpipeline as before.

--- a/libtenzir/builtins/operators/parallel2.cpp
+++ b/libtenzir/builtins/operators/parallel2.cpp
@@ -427,7 +427,9 @@ public:
         .emit(ctx);
       return failure::promise();
     });
-    return d.invariant_order_filter();
+    // We use `invariant_order()` so that residual filters do not escape, but
+    // are reinserted at the front of the subpipeline instead.
+    return d.invariant_order();
   }
 };
 

--- a/test/tests/compiler/opt/parallel_filter.diff
+++ b/test/tests/compiler/opt/parallel_filter.diff
@@ -6,7 +6,7 @@
      GenericIr {
        op: {
          path: [
-           `export` @ 69..75
+           `export` @ 75..81
          ],
          ref: std::export/op
        },
@@ -15,15 +15,7 @@
          
        ],
        filter: [
--        
-+        binary_expr {
-+          left: root_field {
-+            id: `x` @ 93..94,
-+            has_question_mark: false
-+          },
-+          op: "gt" @ 95..96,
-+          right: constant int64 1 @ 97..98
-+        }
+         
        ],
 -      order: "ordered",
 +      order: "unordered",
@@ -34,7 +26,7 @@
      GenericIr {
        op: {
          path: [
-           `parallel` @ 76..84
+           `parallel` @ 82..90
          ],
          ref: std::parallel/op
        },
@@ -56,21 +48,22 @@
              
            ],
            operators: [
--            where_ir {
--              self: 87..92,
--              predicate: binary_expr {
--                left: root_field {
--                  id: `x` @ 93..94,
--                  has_question_mark: false
--                },
--                op: "gt" @ 95..96,
--                right: constant int64 1 @ 97..98
--              }
--            },
+             where_ir {
+-              self: 93..98,
++              self: 0..0,
+               predicate: binary_expr {
+                 left: root_field {
+                   id: `x` @ 99..100,
+                   has_question_mark: false
+                 },
+                 op: "gt" @ 101..102,
+                 right: constant int64 1 @ 103..104
+               }
+             },
              GenericIr {
                op: {
                  path: [
-                   `discard` @ 101..108
+                   `discard` @ 107..114
                  ],
                  ref: std::discard/op
                },
@@ -87,7 +80,7 @@
                ]
              }
            ]
-         } @ 85..110,
+         } @ 91..116,
          let_ids: {
            
          }

--- a/test/tests/compiler/opt/parallel_filter.tql
+++ b/test/tests/compiler/opt/parallel_filter.tql
@@ -1,3 +1,3 @@
-// A filter inside a parallel subpipeline should be pushed upstream.
+// A filter inside a parallel subpipeline must not escape past `parallel`.
 export
 parallel { where x > 1 | discard }


### PR DESCRIPTION
## 🔍 Problem

Filters inside a `parallel { … }` subpipeline escaped upstream past the
`parallel` operator during optimization. A filter meant to run inside the
subpipeline (and be distributed across jobs) was lifted out and applied before
`parallel`, which is incorrect for an operator that splits and transforms its
input.

## 🛠️ Solution

- `parallel` keeps `SubOptimize::from_downstream`, so downstream filters are
  still pushed *into* the subpipeline.
- Switched the operator's own optimizer from `invariant_order_filter()` to
  `invariant_order()`. Residual filters now go entirely to `filter_self`, which
  the `from_downstream` path reinserts at the front of the subpipeline, so
  `filter_upstream` stays empty and nothing escapes.
- No new `SubOptimize` strategy was needed.

## 💬 Review

- Behavior change is captured in `test/tests/compiler/opt/parallel_filter`:
  the `where` now stays inside the subpipeline and the upstream `export` filter
  is empty.
