### PR TITLE
OpenTelemetry tracing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,13 @@ FROM build-base AS rdkafka-package
 COPY scripts/debian/build-rdkafka-package.sh .
 RUN ./build-rdkafka-package.sh
 
+# -- opentelemetry-cpp-package -------------------------------------------------
+
+FROM build-base AS opentelemetry-cpp-package
+
+COPY scripts/debian/build-opentelemetry-cpp-package.sh .
+RUN ./build-opentelemetry-cpp-package.sh
+
 # -- fluent-bit-package --------------------------------------------------------
 
 FROM build-base AS fluent-bit-package
@@ -94,9 +101,10 @@ COPY --from=jemalloc-package /tmp/*.deb /tmp/custom-packages/
 COPY --from=google-cloud-cpp-package /tmp/*.deb /tmp/custom-packages/
 COPY --from=arrow-adbc-package /tmp/*.deb /tmp/custom-packages/
 COPY --from=rdkafka-package /tmp/*.deb /tmp/custom-packages/
+COPY --from=opentelemetry-cpp-package /tmp/*.deb /tmp/custom-packages/
 
 COPY ./scripts/debian/install-dev-dependencies.sh ./scripts/debian/
-RUN ./scripts/debian/install-dev-dependencies.sh && \
+RUN TENZIR_SKIP_OPENTELEMETRY_BUILD=1 ./scripts/debian/install-dev-dependencies.sh && \
     apt-get -y --no-install-recommends install /tmp/custom-packages/*.deb && \
     rm -rf /tmp/custom-packages && \
     rm -rf /var/lib/apt/lists/*
@@ -199,6 +207,7 @@ COPY --from=jemalloc-package /tmp/*.deb /tmp/custom-packages/
 COPY --from=google-cloud-cpp-package /tmp/*.deb /tmp/custom-packages/
 COPY --from=arrow-adbc-package /tmp/*.deb /tmp/custom-packages/
 COPY --from=rdkafka-package /tmp/*.deb /tmp/custom-packages/
+COPY --from=opentelemetry-cpp-package /tmp/*.deb /tmp/custom-packages/
 
 RUN apt-get update && \
     apt-get -y --no-install-recommends install \

--- a/changelog/unreleased/opentelemetry-tracing.md
+++ b/changelog/unreleased/opentelemetry-tracing.md
@@ -1,0 +1,24 @@
+---
+title: OpenTelemetry tracing
+type: feature
+authors:
+  - jachris
+  - claude
+prs:
+  - 6273
+created: 2026-06-10T11:51:20.695295Z
+---
+
+Tenzir nodes can now emit OpenTelemetry traces over OTLP/HTTP. Point the node at
+an OpenTelemetry collector to enable it:
+
+```yaml
+tenzir:
+  opentelemetry:
+    endpoint: http://localhost:4318/v1/traces
+```
+
+Tracing is disabled until an endpoint is configured. Once enabled, the node
+traces control-plane pipeline operations—creating, updating, deleting, and
+launching pipelines—and propagates W3C trace context so these spans link to the
+upstream request that triggered them.

--- a/libtenzir/CMakeLists.txt
+++ b/libtenzir/CMakeLists.txt
@@ -434,6 +434,21 @@ string(APPEND TENZIR_FIND_DEPENDENCY_LIST
 target_link_libraries(libtenzir PUBLIC spdlog::spdlog)
 dependency_summary("spdlog" spdlog::spdlog "Dependencies")
 
+# Link against OpenTelemetry for emitting traces via the OTLP/HTTP exporter.
+# opentelemetry-cpp is provided on all platforms (nixpkgs, Homebrew, and a
+# from-source build on Debian/Docker), so we treat it as a regular dependency.
+# The API is header-only; we link it PUBLIC so that plugins can instrument
+# through libtenzir without depending on opentelemetry-cpp directly. Only
+# libtenzir configures the tracer provider, so the SDK and the exporter are
+# PRIVATE.
+find_package(opentelemetry-cpp CONFIG REQUIRED)
+string(APPEND TENZIR_FIND_DEPENDENCY_LIST
+       "\nfind_package(opentelemetry-cpp CONFIG REQUIRED)")
+target_link_libraries(libtenzir PUBLIC opentelemetry-cpp::api)
+target_link_libraries(libtenzir PRIVATE opentelemetry-cpp::sdk
+                                        opentelemetry-cpp::otlp_http_exporter)
+dependency_summary("OpenTelemetry" opentelemetry-cpp::api "Dependencies")
+
 # Link against simdjson
 option(TENZIR_ENABLE_BUNDLED_SIMDJSON "Use the simdjson submodule"
        "${TENZIR_ENABLE_BUNDLED_DEPENDENCIES}")

--- a/libtenzir/include/tenzir/http_api.hpp
+++ b/libtenzir/include/tenzir/http_api.hpp
@@ -182,12 +182,16 @@ public:
   /// The POST JSON body, if it existed.
   std::string json_body;
 
+  /// The W3C `traceparent` header, if it was present.
+  std::string traceparent;
+
   template <class Inspector>
   friend auto inspect(Inspector& f, http_request_description& e) {
     return f.object(e)
       .pretty_name("tenzir.http_request_description")
       .fields(f.field("canonical_path", e.canonical_path),
-              f.field("json_body", e.json_body));
+              f.field("json_body", e.json_body),
+              f.field("traceparent", e.traceparent));
   }
 };
 

--- a/libtenzir/include/tenzir/opentelemetry.hpp
+++ b/libtenzir/include/tenzir/opentelemetry.hpp
@@ -1,0 +1,57 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <caf/settings.hpp>
+
+#include <utility>
+
+namespace tenzir {
+
+/// Owns the global OpenTelemetry tracer provider. On destruction it flushes
+/// pending spans and shuts the provider down. Only meaningful when tracing was
+/// actually enabled; a default-constructed guard does nothing.
+class OpenTelemetryGuard {
+public:
+  OpenTelemetryGuard() noexcept = default;
+
+  explicit OpenTelemetryGuard(bool active) noexcept : active_{active} {
+  }
+
+  OpenTelemetryGuard(const OpenTelemetryGuard&) = delete;
+  auto operator=(const OpenTelemetryGuard&) -> OpenTelemetryGuard& = delete;
+
+  OpenTelemetryGuard(OpenTelemetryGuard&& other) noexcept
+    : active_{std::exchange(other.active_, false)} {
+  }
+
+  auto operator=(OpenTelemetryGuard&& other) noexcept -> OpenTelemetryGuard& {
+    if (this != &other) {
+      reset();
+      active_ = std::exchange(other.active_, false);
+    }
+    return *this;
+  }
+
+  ~OpenTelemetryGuard();
+
+private:
+  void reset() noexcept;
+
+  bool active_ = false;
+};
+
+/// Initializes the global OpenTelemetry tracer provider from the configuration
+/// under the `tenzir.opentelemetry` key. Tracing remains a no-op unless an
+/// OTLP/HTTP endpoint is configured. The returned guard flushes and shuts the
+/// provider down when it goes out of scope.
+[[nodiscard]] auto initialize_opentelemetry(const caf::settings& config)
+  -> OpenTelemetryGuard;
+
+} // namespace tenzir

--- a/libtenzir/include/tenzir/trace.hpp
+++ b/libtenzir/include/tenzir/trace.hpp
@@ -1,0 +1,43 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <opentelemetry/context/context.h>
+#include <opentelemetry/nostd/shared_ptr.h>
+#include <opentelemetry/trace/span.h>
+#include <opentelemetry/trace/tracer.h>
+
+#include <string>
+#include <string_view>
+
+namespace tenzir {
+
+/// Returns the global "tenzir" tracer. Spans created from it are no-ops unless
+/// a tracer provider was installed via `initialize_opentelemetry`.
+auto otel_tracer()
+  -> opentelemetry::nostd::shared_ptr<opentelemetry::trace::Tracer>;
+
+/// Parses a W3C `traceparent` header into a context that can be used as the
+/// parent of a new span. Returns the current context unchanged when the string
+/// is empty or malformed, so a span started from the result becomes a fresh
+/// root in that case.
+auto extract_trace_context(std::string_view traceparent)
+  -> opentelemetry::context::Context;
+
+/// Serializes the span contained in `context` into a W3C `traceparent` header.
+auto inject_trace_context(const opentelemetry::context::Context& context)
+  -> std::string;
+
+/// Serializes `span` into a W3C `traceparent` header so it can be propagated to
+/// another actor or node.
+auto inject_trace_context(
+  const opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span>& span)
+  -> std::string;
+
+} // namespace tenzir

--- a/libtenzir/src/node.cpp
+++ b/libtenzir/src/node.cpp
@@ -619,6 +619,12 @@ auto node(node_actor::stateful_pointer<node_state> self,
         }
         rp.deliver(std::move(*response));
       };
+      // Forward the W3C trace context to the handler. We inject it here, after
+      // the metrics closure captured its own copy of the parameters, so it does
+      // not interfere with the typed api metrics.
+      if (not desc.traceparent.empty()) {
+        (*params)["traceparent"] = desc.traceparent;
+      }
       self->mail(atom::http_request_v, endpoint.endpoint_id, *params)
         .request(handler, caf::infinite)
         .then(

--- a/libtenzir/src/node.cpp
+++ b/libtenzir/src/node.cpp
@@ -578,8 +578,7 @@ auto node(node_actor::stateful_pointer<node_state> self,
                                          params.error());
       }
       auto rp = self->make_response_promise<rest_response>();
-      auto deliver = [rp, self, desc, params, endpoint,
-                      request_id = std::move(request_id),
+      auto deliver = [rp, self, desc, params, endpoint, request_id,
                       start_time = std::chrono::steady_clock::now()](
                        caf::expected<rest_response> response) mutable {
         auto it = self->state().api_metrics_builders.find(desc.canonical_path);
@@ -624,6 +623,9 @@ auto node(node_actor::stateful_pointer<node_state> self,
       // not interfere with the typed api metrics.
       if (not desc.traceparent.empty()) {
         (*params)["traceparent"] = desc.traceparent;
+      }
+      if (not request_id.empty()) {
+        (*params)["request_id"] = request_id;
       }
       self->mail(atom::http_request_v, endpoint.endpoint_id, *params)
         .request(handler, caf::infinite)

--- a/libtenzir/src/opentelemetry.cpp
+++ b/libtenzir/src/opentelemetry.cpp
@@ -1,0 +1,93 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "tenzir/opentelemetry.hpp"
+
+#include "tenzir/config.hpp"
+#include "tenzir/logger.hpp"
+
+#include <opentelemetry/exporters/otlp/otlp_http_exporter_factory.h>
+#include <opentelemetry/exporters/otlp/otlp_http_exporter_options.h>
+#include <opentelemetry/sdk/resource/resource.h>
+#include <opentelemetry/sdk/trace/batch_span_processor_factory.h>
+#include <opentelemetry/sdk/trace/batch_span_processor_options.h>
+#include <opentelemetry/sdk/trace/tracer_provider_factory.h>
+#include <opentelemetry/trace/noop.h>
+#include <opentelemetry/trace/provider.h>
+
+#include <memory>
+#include <string>
+
+namespace tenzir {
+namespace {
+
+namespace otlp = opentelemetry::exporter::otlp;
+namespace trace_api = opentelemetry::trace;
+namespace trace_sdk = opentelemetry::sdk::trace;
+namespace otel_resource = opentelemetry::sdk::resource;
+
+// Keeps the active provider so that we can flush and shut it down later. The
+// SDK type (rather than the API type) is retained because only it exposes
+// `ForceFlush` and `Shutdown`.
+std::shared_ptr<trace_sdk::TracerProvider> current_provider = {};
+
+} // namespace
+
+auto initialize_opentelemetry(const caf::settings& config)
+  -> OpenTelemetryGuard {
+  const auto endpoint
+    = caf::get_or(config, "tenzir.opentelemetry.endpoint", std::string{});
+  if (endpoint.empty()) {
+    TENZIR_DEBUG("not initializing OpenTelemetry tracing: no endpoint "
+                 "configured under tenzir.opentelemetry.endpoint");
+    return OpenTelemetryGuard{false};
+  }
+  auto exporter_options = otlp::OtlpHttpExporterOptions{};
+  exporter_options.url = endpoint;
+  auto exporter = otlp::OtlpHttpExporterFactory::Create(exporter_options);
+  auto processor = trace_sdk::BatchSpanProcessorFactory::Create(
+    std::move(exporter), trace_sdk::BatchSpanProcessorOptions{});
+  // Omitting the sampler selects the SDK default (parent-based, always-on),
+  // which is what we want for the low-volume control plane.
+  auto resource = otel_resource::Resource::Create({
+    {"service.name", "tenzir"},
+    {"service.version", version::version},
+  });
+  current_provider
+    = trace_sdk::TracerProviderFactory::Create(std::move(processor), resource);
+  trace_api::Provider::SetTracerProvider(
+    std::shared_ptr<trace_api::TracerProvider>{current_provider});
+  TENZIR_INFO("initialized OpenTelemetry tracing with OTLP/HTTP endpoint {}",
+              endpoint);
+  return OpenTelemetryGuard{true};
+}
+
+void OpenTelemetryGuard::reset() noexcept {
+  if (not active_) {
+    return;
+  }
+  active_ = false;
+  // Restore the no-op provider that the API installs by default instead of
+  // clearing it. `otel_tracer()` dereferences the global provider
+  // unconditionally, so a null one would turn any tracing call that outlives
+  // this guard—plugin teardown, for instance—into a null dereference.
+  trace_api::Provider::SetTracerProvider(
+    std::shared_ptr<trace_api::TracerProvider>{
+      new trace_api::NoopTracerProvider{}});
+  if (current_provider) {
+    current_provider->ForceFlush();
+    current_provider->Shutdown();
+    current_provider.reset();
+  }
+}
+
+OpenTelemetryGuard::~OpenTelemetryGuard() {
+  reset();
+}
+
+} // namespace tenzir

--- a/libtenzir/src/opentelemetry.cpp
+++ b/libtenzir/src/opentelemetry.cpp
@@ -49,6 +49,16 @@ auto initialize_opentelemetry(const caf::settings& config)
   }
   auto exporter_options = otlp::OtlpHttpExporterOptions{};
   exporter_options.url = endpoint;
+  if (const auto* headers
+      = caf::get_if<caf::settings>(&config, "tenzir.opentelemetry.headers")) {
+    for (const auto& [name, value] : *headers) {
+      if (auto str = caf::get_as<std::string>(value)) {
+        exporter_options.http_headers.emplace(name, std::move(*str));
+      } else {
+        TENZIR_WARN("ignoring non-string OpenTelemetry header '{}'", name);
+      }
+    }
+  }
   auto exporter = otlp::OtlpHttpExporterFactory::Create(exporter_options);
   auto processor = trace_sdk::BatchSpanProcessorFactory::Create(
     std::move(exporter), trace_sdk::BatchSpanProcessorOptions{});

--- a/libtenzir/src/trace.cpp
+++ b/libtenzir/src/trace.cpp
@@ -1,0 +1,89 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "tenzir/trace.hpp"
+
+#include <opentelemetry/context/propagation/text_map_propagator.h>
+#include <opentelemetry/context/runtime_context.h>
+#include <opentelemetry/trace/context.h>
+#include <opentelemetry/trace/propagation/http_trace_context.h>
+#include <opentelemetry/trace/provider.h>
+
+#include <string>
+
+namespace tenzir {
+namespace {
+
+namespace otel_ctx = opentelemetry::context;
+namespace otel_trace = opentelemetry::trace;
+
+/// A text-map carrier that holds a single W3C `traceparent` value. We do not
+/// need full header maps because Tenzir propagates the trace context as a lone
+/// string field through its actor messages.
+class TraceparentCarrier final : public otel_ctx::propagation::TextMapCarrier {
+public:
+  TraceparentCarrier() = default;
+
+  explicit TraceparentCarrier(std::string traceparent)
+    : traceparent_{std::move(traceparent)} {
+  }
+
+  auto Get(opentelemetry::nostd::string_view key) const noexcept
+    -> opentelemetry::nostd::string_view override {
+    if (key == "traceparent") {
+      return traceparent_;
+    }
+    return "";
+  }
+
+  void Set(opentelemetry::nostd::string_view key,
+           opentelemetry::nostd::string_view value) noexcept override {
+    if (key == "traceparent") {
+      traceparent_.assign(value.data(), value.size());
+    }
+  }
+
+  auto traceparent() const -> const std::string& {
+    return traceparent_;
+  }
+
+private:
+  std::string traceparent_;
+};
+
+} // namespace
+
+auto otel_tracer() -> opentelemetry::nostd::shared_ptr<otel_trace::Tracer> {
+  return otel_trace::Provider::GetTracerProvider()->GetTracer("tenzir");
+}
+
+auto extract_trace_context(std::string_view traceparent) -> otel_ctx::Context {
+  auto current = otel_ctx::RuntimeContext::GetCurrent();
+  if (traceparent.empty()) {
+    return current;
+  }
+  const auto carrier = TraceparentCarrier{std::string{traceparent}};
+  auto propagator = otel_trace::propagation::HttpTraceContext{};
+  return propagator.Extract(carrier, current);
+}
+
+auto inject_trace_context(const otel_ctx::Context& context) -> std::string {
+  auto carrier = TraceparentCarrier{};
+  auto propagator = otel_trace::propagation::HttpTraceContext{};
+  propagator.Inject(carrier, context);
+  return carrier.traceparent();
+}
+
+auto inject_trace_context(
+  const opentelemetry::nostd::shared_ptr<otel_trace::Span>& span)
+  -> std::string {
+  auto context = otel_ctx::Context{};
+  return inject_trace_context(otel_trace::SetSpan(context, span));
+}
+
+} // namespace tenzir

--- a/nix/dependencies.nix
+++ b/nix/dependencies.nix
@@ -24,6 +24,7 @@
   crc32c,
   grpc,
   icu,
+  opentelemetry-cpp,
   spdlog,
   simdjson,
   robin-map,
@@ -120,6 +121,7 @@ in
     nlohmann_json
     crc32c
     grpc
+    opentelemetry-cpp
     libmaxminddb
     jemalloc-tenzir
     mimalloc-tenzir

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -76,6 +76,10 @@ in
   musl = callFunction ./overrides/musl.nix { inherit (prevPkgs) musl; };
   mvfst = callFunction ./overrides/mvfst.nix { inherit (prevPkgs) mvfst; };
   ngtcp2 = callFunction ./overrides/ngtcp2.nix { inherit (prevPkgs) ngtcp2; };
+  # The upstream package builds without any exporters; enable the OTLP/HTTP
+  # exporter so we can actually emit telemetry. It only pulls in curl, which we
+  # already depend on.
+  opentelemetry-cpp = prevPkgs.opentelemetry-cpp.override { enableHttp = true; };
   protobufc = callFunction ./overrides/protobufc.nix { inherit (prevPkgs) protobufc; };
   rabbitmq-c = callFunction ./overrides/rabbitmq-c.nix { inherit (prevPkgs) rabbitmq-c; };
   restinio = callFunction ./overrides/restinio.nix { inherit (prevPkgs) restinio; };

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -78,8 +78,20 @@ in
   ngtcp2 = callFunction ./overrides/ngtcp2.nix { inherit (prevPkgs) ngtcp2; };
   # The upstream package builds without any exporters; enable the OTLP/HTTP
   # exporter so we can actually emit telemetry. It only pulls in curl, which we
-  # already depend on.
-  opentelemetry-cpp = prevPkgs.opentelemetry-cpp.override { enableHttp = true; };
+  # already depend on. We only need the libraries, so disable tests, examples,
+  # and functional tests: the singleton tests build shared objects (impossible
+  # under the static musl toolchain) and the OTLP/HTTP examples link curl
+  # statically without its transitive deps (nghttp2, ngtcp2, libpsl).
+  opentelemetry-cpp =
+    (prevPkgs.opentelemetry-cpp.override { enableHttp = true; }).overrideAttrs
+      (old: {
+        doCheck = false;
+        cmakeFlags = (old.cmakeFlags or [ ]) ++ [
+          "-DBUILD_TESTING:BOOL=OFF"
+          "-DWITH_EXAMPLES:BOOL=OFF"
+          "-DWITH_FUNC_TESTS:BOOL=OFF"
+        ];
+      });
   protobufc = callFunction ./overrides/protobufc.nix { inherit (prevPkgs) protobufc; };
   rabbitmq-c = callFunction ./overrides/rabbitmq-c.nix { inherit (prevPkgs) rabbitmq-c; };
   restinio = callFunction ./overrides/restinio.nix { inherit (prevPkgs) restinio; };

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -1,5 +1,5 @@
 {
-  "hash": "sha256-aZzYCnBsHQvoGtZbwcvH/2o4/SxtQk+6dFbFk7ZpRLk=",
+  "hash": "sha256-hGFaxFw7mztqPnC0z83NJOU4/2y7Ejz8LnC59k9DDw8=",
   "name": "tenzir-plugins.tar.gz",
-  "url": "https://github.com/tenzir/tenzir-plugins/archive/5a6f7fdd3cd07e7f262bb415c47c89b73ee40d92.tar.gz"
+  "url": "https://github.com/tenzir/tenzir-plugins/archive/14f9cf5b57ce9dc0e1ba9014563f35511befcf64.tar.gz"
 }

--- a/plugins/web/src/server_command.cpp
+++ b/plugins/web/src/server_command.cpp
@@ -206,6 +206,12 @@ request_dispatcher_actor::behavior_type request_dispatcher(
         return response->abort(
           422, "failed to parse endpoint parameters: ", params.error());
       }
+      // Forward the W3C trace context so that handlers can parent their spans
+      // to the caller's trace, mirroring what the node does for requests that
+      // arrive through the platform.
+      if (auto traceparent = header.opt_value_of("traceparent")) {
+        (*params)["traceparent"] = std::string{*traceparent};
+      }
       // Note that the handler should return a valid "error" response by itself
       // if possible (ie. invalid arguments), the error handler is to catch
       // timeouts and real internal errors.

--- a/scripts/debian/build-opentelemetry-cpp-package.sh
+++ b/scripts/debian/build-opentelemetry-cpp-package.sh
@@ -1,0 +1,76 @@
+#! /usr/bin/env bash
+
+: "${OPENTELEMETRY_CPP_VERSION=1.27.0}"
+: "${OPENTELEMETRY_CPP_SHA256=d09c2e8dd95bbc1d6ee493a89f32a4736879948d0eb59ad58c855022d1f55cc1}"
+# The OTLP exporter needs the opentelemetry-proto definitions, which are not
+# bundled in the release tarball, so we fetch them separately.
+: "${OPENTELEMETRY_PROTO_VERSION=1.10.0}"
+: "${OPENTELEMETRY_PROTO_SHA256=52c85df79badc45da7e6a8735e8090b05a961b0208756187e1492a40db2d1f5f}"
+
+set -euo pipefail
+
+apt-get -qq update
+apt-get install --no-install-recommends -y \
+  g++ \
+  gcc \
+  ca-certificates \
+  ccache \
+  checkinstall \
+  cmake \
+  curl \
+  dh-make \
+  make \
+  ninja-build \
+  pkg-config \
+  libcurl4-openssl-dev \
+  libprotobuf-dev \
+  nlohmann-json3-dev \
+  protobuf-compiler
+apt-get install -y --reinstall \
+  lsb-base \
+  lsb-release
+
+mkdir -p source
+pushd source
+curl -L "https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v${OPENTELEMETRY_CPP_VERSION}.tar.gz" -o opentelemetry-cpp.tar.gz
+echo "${OPENTELEMETRY_CPP_SHA256}  opentelemetry-cpp.tar.gz" | sha256sum -c -
+tar -xzf opentelemetry-cpp.tar.gz --strip-components=1
+rm opentelemetry-cpp.tar.gz
+
+curl -L "https://github.com/open-telemetry/opentelemetry-proto/archive/refs/tags/v${OPENTELEMETRY_PROTO_VERSION}.tar.gz" -o opentelemetry-proto.tar.gz
+echo "${OPENTELEMETRY_PROTO_SHA256}  opentelemetry-proto.tar.gz" | sha256sum -c -
+mkdir -p opentelemetry-proto
+tar -xzf opentelemetry-proto.tar.gz --strip-components=1 -C opentelemetry-proto
+rm opentelemetry-proto.tar.gz
+
+# We only need the OTLP/HTTP exporter; everything else (gRPC, Prometheus,
+# Elasticsearch, tests, examples) is disabled to keep the build lean.
+cmake -B build -G Ninja \
+  -DCMAKE_INSTALL_PREFIX=/usr/local \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DBUILD_SHARED_LIBS=ON \
+  -DOPENTELEMETRY_INSTALL=ON \
+  -DOTELCPP_PROTO_PATH="$(pwd)/opentelemetry-proto" \
+  -DWITH_OTLP_HTTP=ON \
+  -DWITH_OTLP_GRPC=OFF \
+  -DWITH_PROMETHEUS=OFF \
+  -DWITH_ELASTICSEARCH=OFF \
+  -DWITH_BENCHMARK=OFF \
+  -DWITH_EXAMPLES=OFF \
+  -DWITH_FUNC_TESTS=OFF \
+  -DBUILD_TESTING=OFF
+
+cmake --build build --parallel
+
+checkinstall \
+  --fstrans=no \
+  --pakdir /tmp \
+  --pkgsource="https://github.com/open-telemetry/opentelemetry-cpp" \
+  --pkglicense="Apache-2.0" \
+  --deldesc=no \
+  --nodoc \
+  --pkgversion="${OPENTELEMETRY_CPP_VERSION}" \
+  --pkgrelease="TENZIR" \
+  --pkgname=opentelemetry-cpp \
+  --requires="libc6,libstdc++6,libcurl4,libprotobuf32" \
+  cmake --install build

--- a/scripts/debian/install-dev-dependencies.sh
+++ b/scripts/debian/install-dev-dependencies.sh
@@ -87,3 +87,12 @@ curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_DIR=/usr/local/bin sh
 export POETRY_HOME=/opt/poetry
 curl -sSL https://install.python-poetry.org | python3 - --version 1.8.2
 ln -nsf /opt/poetry/bin/poetry /usr/local/bin/poetry
+
+# OpenTelemetry C++ is not packaged for Debian, so we build it from source.
+# In the Docker image it is provided as a prebuilt package instead, which sets
+# TENZIR_SKIP_OPENTELEMETRY_BUILD to avoid building it twice.
+if [ -z "${TENZIR_SKIP_OPENTELEMETRY_BUILD:-}" ]; then
+  script_dir="$(cd "$(dirname "$0")" && pwd)"
+  "${script_dir}/build-opentelemetry-cpp-package.sh"
+  apt-get -y --no-install-recommends install /tmp/opentelemetry-cpp_*.deb
+fi

--- a/scripts/macOS/install-dev-dependencies.sh
+++ b/scripts/macOS/install-dev-dependencies.sh
@@ -33,6 +33,7 @@ brew install --overwrite \
   mimalloc \
   ninja \
   nmap \
+  opentelemetry-cpp \
   pandoc \
   parallel \
   poetry \

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -104,6 +104,13 @@ tenzir:
     # minimum total cache capacity of 64MiB.
     #capacity: 1Gi
 
+  # Configure OpenTelemetry tracing. Tracing is disabled unless an endpoint is
+  # set; spans are exported over OTLP/HTTP.
+  opentelemetry:
+    # The OTLP/HTTP endpoint to export traces to, e.g. an OpenTelemetry
+    # Collector. Leave unset to disable tracing.
+    #endpoint: http://localhost:4318/v1/traces
+
   # A certificate file used as the default for operators accepting a `cacert`
   # option. This will default to an appropriate directory for the system. For
   # example:

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -111,6 +111,11 @@ tenzir:
     # Collector. Leave unset to disable tracing.
     #endpoint: http://localhost:4318/v1/traces
 
+    # Additional HTTP headers to send with every OTLP request, e.g. to
+    # authenticate against a hosted backend.
+    #headers:
+    #  authorization: Bearer YOUR_API_KEY
+
   # A certificate file used as the default for operators accepting a `cacert`
   # option. This will default to an appropriate directory for the system. For
   # example:

--- a/tenzir/tenzir.cpp
+++ b/tenzir/tenzir.cpp
@@ -20,6 +20,7 @@
 #include "tenzir/logger.hpp"
 #include "tenzir/module.hpp"
 #include "tenzir/modules.hpp"
+#include "tenzir/opentelemetry.hpp"
 #include "tenzir/plugin.hpp"
 #include "tenzir/proxy_settings.hpp"
 #include "tenzir/scope_linked.hpp"
@@ -190,6 +191,10 @@ auto main(int argc, char** argv) -> int try {
   if (not log_context) {
     return EXIT_FAILURE;
   }
+  // Set up OpenTelemetry tracing for nodes. This is a no-op unless an OTLP/HTTP
+  // endpoint is configured under `tenzir.opentelemetry.endpoint`.
+  auto opentelemetry_guard
+    = is_server ? initialize_opentelemetry(cfg.content) : OpenTelemetryGuard{};
   if (not is_server) {
     // Force the use of $TMPDIR as cache directory when running as a client.
     auto ec = std::error_code{};


### PR DESCRIPTION
## 🔍 Problem

A Tenzir node’s control-plane activity is opaque. There is no way to observe or time pipeline operations (create/update/delete/launch), nor to correlate them with upstream platform or client traces.

## 🛠️ Solution

- Add `opentelemetry-cpp` on every platform (nixpkgs with the OTLP/HTTP exporter, Homebrew, and a from-source build on Debian/Docker).
- Initialize a global tracer provider at node startup, configured via `tenzir.opentelemetry.endpoint` and exporting over OTLP/HTTP; off by default, flushed and shut down on exit.
- Add tracing helpers (tracer accessor, W3C `traceparent` extract/inject) that plugins use to propagate context across actor boundaries.
- Control-plane pipeline operations are traced (instrumentation lives in the companion `tenzir-plugins` PR).

## 💬 Review

- `opentelemetry-cpp` is now a required dependency. The API is linked PUBLIC so plugins can instrument through libtenzir; the SDK and exporter are PRIVATE (only libtenzir configures the provider).
- The submodule is bumped to the companion PR’s branch; the two must land together.
- Manager spans currently cover synchronous request admission; deeper async sub-spans are a planned follow-up.

<sub>
📎 Companion: tenzir/tenzir-plugins#565
</sub>