### PR TITLE
Delay the PR build until the Codex review has no open issues

### DIFF
--- a/.github/workflows/codex-review-gate.yaml
+++ b/.github/workflows/codex-review-gate.yaml
@@ -56,27 +56,31 @@ jobs:
           grace_cutoff=$(date -u -d '30 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
 
           process_pr() {
+            # `set -e` is suppressed in functions called from a conditional,
+            # so fallible commands abort explicitly via `|| return`.
             local pr=$1
             local head_sha pushed thumb reviewed unresolved verdict clean
             local has_label
             # The label is sticky, so labeled PRs need no further checks.
             has_label=$(gh api "repos/$GH_REPO/issues/$pr" \
-              --jq "[.labels[].name] | any(. == \"$LABEL\")")
+              --jq "[.labels[].name] | any(. == \"$LABEL\")") || return
             if [[ "$has_label" == true ]]; then
               echo "PR #$pr: already labeled"
               return
             fi
-            head_sha=$(gh api "repos/$GH_REPO/pulls/$pr" --jq .head.sha)
+            head_sha=$(gh api "repos/$GH_REPO/pulls/$pr" --jq .head.sha) \
+              || return
             # The head commit's committer timestamp can predate the time it
             # was pushed to the PR, e.g., for pre-existing local commits, so
             # prefer the creation time of the earliest workflow run for the
             # head as the push time and only fall back to the commit.
             pushed=$(gh api \
               "repos/$GH_REPO/actions/runs?head_sha=$head_sha&per_page=100" \
-              --jq '[.workflow_runs[].created_at] | min // empty')
+              --jq '[.workflow_runs[].created_at] | min // empty') \
+              || return
             if [[ -z "$pushed" ]]; then
               pushed=$(gh api "repos/$GH_REPO/commits/$head_sha" \
-                --jq .commit.committer.date)
+                --jq .commit.committer.date) || return
             fi
             # Latest 👍 reaction by Codex on the PR description. `--slurp`
             # collects the pages into one array so that the filter runs once
@@ -86,12 +90,13 @@ jobs:
               "repos/$GH_REPO/issues/$pr/reactions" \
               | jq -r "[.[][] | select(.user.login == \"$CODEX_BOT\"
                                  and .content == \"+1\")
-                        | .created_at] | max // empty")
+                        | .created_at] | max // empty") || return
             # Reviews submitted by Codex against the current head commit.
             reviewed=$(gh api --paginate --slurp \
               "repos/$GH_REPO/pulls/$pr/reviews" \
               | jq -r "[.[][] | select(.user.login == \"$CODEX_BOT\"
-                                 and .commit_id == \"$head_sha\")] | length")
+                                 and .commit_id == \"$head_sha\")] | length") \
+              || return
             # Unresolved review threads opened by Codex. Thread resolution is
             # only exposed via GraphQL, where bot logins lack the `[bot]`
             # suffix. `--paginate` follows `pageInfo` via `$endCursor`, and
@@ -116,7 +121,7 @@ jobs:
                      | select(.isResolved | not)
                      | select((.comments.nodes[0].author.login // "")
                               | startswith("chatgpt-codex-connector"))]
-                    | length')
+                    | length') || return
             # Codex's verdict applies to the current head if it reviewed that
             # commit or its 👍 reaction postdates the last push. ISO-8601
             # timestamps compare lexicographically.
@@ -137,7 +142,7 @@ jobs:
             fi
             if [[ "$clean" == true ]]; then
               gh api -X POST "repos/$GH_REPO/issues/$pr/labels" \
-                -f "labels[]=$LABEL" --silent
+                -f "labels[]=$LABEL" --silent || return
               echo "PR #$pr: added $LABEL"
             else
               echo "PR #$pr: not clean"

--- a/.github/workflows/codex-review-gate.yaml
+++ b/.github/workflows/codex-review-gate.yaml
@@ -1,0 +1,135 @@
+# Periodically sweeps open PRs and applies the `ci-ready` label to PRs where
+# the Codex review has no open issues, i.e., either Codex left a 👍 reaction
+# (its "no comments" verdict) or all review threads it opened are resolved.
+# The signal must apply to the current head: a review must reference the head
+# commit, and a reaction must postdate the time the head was pushed.
+#
+# The label is only ever added, never removed: delaying the build is a CI
+# cost optimization, while merge safety comes from the `Tenzir CI` commit
+# status and required conversation resolution. Applying the label manually
+# unlocks the build without waiting for Codex.
+#
+# This needs to be a cron sweep because GitHub emits no webhook events for
+# reactions. The label is applied with a GitHub App token so that it can
+# trigger `pull_request: labeled` workflows, which events created by the
+# default `GITHUB_TOKEN` cannot.
+name: Codex Review Gate
+on:
+  schedule:
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  sweep:
+    name: Sweep
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate an app token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.TENZIR_AUTOBUMPER_APP_ID }}
+          private-key: ${{ secrets.TENZIR_AUTOBUMPER_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - name: Sweep open PRs
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          CODEX_BOT: chatgpt-codex-connector[bot]
+          LABEL: ci-ready
+        run: |
+          set -euo pipefail
+
+          gh label create "$LABEL" --force --color 2EA44F \
+            --description "Unlocks the CI build; applied when the Codex review is clean"
+
+          process_pr() {
+            local pr=$1
+            local head_sha pushed thumb reviewed unresolved clean has_label
+            # The label is sticky, so labeled PRs need no further checks.
+            has_label=$(gh api "repos/$GH_REPO/issues/$pr" \
+              --jq "[.labels[].name] | any(. == \"$LABEL\")")
+            if [[ "$has_label" == true ]]; then
+              echo "PR #$pr: already labeled"
+              return
+            fi
+            head_sha=$(gh api "repos/$GH_REPO/pulls/$pr" --jq .head.sha)
+            # The head commit's committer timestamp can predate the time it
+            # was pushed to the PR, e.g., for pre-existing local commits, so
+            # prefer the creation time of the earliest workflow run for the
+            # head as the push time and only fall back to the commit.
+            pushed=$(gh api \
+              "repos/$GH_REPO/actions/runs?head_sha=$head_sha&per_page=100" \
+              --jq '[.workflow_runs[].created_at] | min // empty')
+            if [[ -z "$pushed" ]]; then
+              pushed=$(gh api "repos/$GH_REPO/commits/$head_sha" \
+                --jq .commit.committer.date)
+            fi
+            # Latest 👍 reaction by Codex on the PR description. `--slurp`
+            # collects the pages into one array so that the filter runs once
+            # over all of them rather than once per page; it does not combine
+            # with `--jq`, so pipe to jq instead.
+            thumb=$(gh api --paginate --slurp \
+              "repos/$GH_REPO/issues/$pr/reactions" \
+              | jq -r "[.[][] | select(.user.login == \"$CODEX_BOT\"
+                                 and .content == \"+1\")
+                        | .created_at] | max // empty")
+            # Reviews submitted by Codex against the current head commit.
+            reviewed=$(gh api --paginate --slurp \
+              "repos/$GH_REPO/pulls/$pr/reviews" \
+              | jq -r "[.[][] | select(.user.login == \"$CODEX_BOT\"
+                                 and .commit_id == \"$head_sha\")] | length")
+            # Unresolved review threads opened by Codex. Thread resolution is
+            # only exposed via GraphQL, where bot logins lack the `[bot]`
+            # suffix.
+            unresolved=$(gh api graphql \
+              -F owner="${GH_REPO%/*}" -F name="${GH_REPO#*/}" -F number="$pr" \
+              -f query='
+                query($owner: String!, $name: String!, $number: Int!) {
+                  repository(owner: $owner, name: $name) {
+                    pullRequest(number: $number) {
+                      reviewThreads(first: 100) {
+                        nodes {
+                          isResolved
+                          comments(first: 1) { nodes { author { login } } }
+                        }
+                      }
+                    }
+                  }
+                }' \
+              --jq '[.data.repository.pullRequest.reviewThreads.nodes[]
+                     | select(.isResolved | not)
+                     | select((.comments.nodes[0].author.login // "")
+                              | startswith("chatgpt-codex-connector"))]
+                    | length')
+            # Clean if Codex reviewed the current head or its 👍 reaction
+            # postdates the last push, and no Codex threads are unresolved.
+            # ISO-8601 timestamps compare lexicographically.
+            clean=false
+            if [[ "$unresolved" -eq 0 ]] \
+               && { [[ "$reviewed" -gt 0 ]] \
+                    || [[ -n "$thumb" && "$thumb" > "$pushed" ]]; }; then
+              clean=true
+            fi
+            if [[ "$clean" == true ]]; then
+              gh api -X POST "repos/$GH_REPO/issues/$pr/labels" \
+                -f "labels[]=$LABEL" --silent
+              echo "PR #$pr: added $LABEL"
+            else
+              echo "PR #$pr: not clean"
+            fi
+          }
+
+          for pr in $(gh pr list --state open --limit 200 \
+                        --json number --jq '.[].number'); do
+            if ! process_pr "$pr"; then
+              echo "::warning::Failed to process PR #$pr"
+            fi
+          done

--- a/.github/workflows/codex-review-gate.yaml
+++ b/.github/workflows/codex-review-gate.yaml
@@ -88,14 +88,16 @@ jobs:
                                  and .commit_id == \"$head_sha\")] | length")
             # Unresolved review threads opened by Codex. Thread resolution is
             # only exposed via GraphQL, where bot logins lack the `[bot]`
-            # suffix.
-            unresolved=$(gh api graphql \
+            # suffix. `--paginate` follows `pageInfo` via `$endCursor`, and
+            # `--slurp` collects the pages into one array.
+            unresolved=$(gh api graphql --paginate --slurp \
               -F owner="${GH_REPO%/*}" -F name="${GH_REPO#*/}" -F number="$pr" \
               -f query='
-                query($owner: String!, $name: String!, $number: Int!) {
+                query($owner: String!, $name: String!, $number: Int!, $endCursor: String) {
                   repository(owner: $owner, name: $name) {
                     pullRequest(number: $number) {
-                      reviewThreads(first: 100) {
+                      reviewThreads(first: 100, after: $endCursor) {
+                        pageInfo { hasNextPage endCursor }
                         nodes {
                           isResolved
                           comments(first: 1) { nodes { author { login } } }
@@ -104,7 +106,7 @@ jobs:
                     }
                   }
                 }' \
-              --jq '[.data.repository.pullRequest.reviewThreads.nodes[]
+              | jq '[.[].data.repository.pullRequest.reviewThreads.nodes[]
                      | select(.isResolved | not)
                      | select((.comments.nodes[0].author.login // "")
                               | startswith("chatgpt-codex-connector"))]

--- a/.github/workflows/codex-review-gate.yaml
+++ b/.github/workflows/codex-review-gate.yaml
@@ -7,7 +7,9 @@
 # The label is only ever added, never removed: delaying the build is a CI
 # cost optimization, while merge safety comes from the `Tenzir CI` commit
 # status and required conversation resolution. Applying the label manually
-# unlocks the build without waiting for Codex.
+# unlocks the build without waiting for Codex. As a fail-safe, a PR whose
+# head has no Codex verdict 30 minutes after the push is treated as clean,
+# so that an unavailable Codex does not hold up CI.
 #
 # This needs to be a cron sweep because GitHub emits no webhook events for
 # reactions. The label is applied with a GitHub App token so that it can
@@ -50,9 +52,13 @@ jobs:
           gh label create "$LABEL" --force --color 2EA44F \
             --description "Unlocks the CI build; applied when the Codex review is clean"
 
+          # Heads pushed before this without a Codex verdict unlock the build.
+          grace_cutoff=$(date -u -d '30 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
+
           process_pr() {
             local pr=$1
-            local head_sha pushed thumb reviewed unresolved clean has_label
+            local head_sha pushed thumb reviewed unresolved verdict clean
+            local has_label
             # The label is sticky, so labeled PRs need no further checks.
             has_label=$(gh api "repos/$GH_REPO/issues/$pr" \
               --jq "[.labels[].name] | any(. == \"$LABEL\")")
@@ -111,14 +117,23 @@ jobs:
                      | select((.comments.nodes[0].author.login // "")
                               | startswith("chatgpt-codex-connector"))]
                     | length')
-            # Clean if Codex reviewed the current head or its 👍 reaction
-            # postdates the last push, and no Codex threads are unresolved.
-            # ISO-8601 timestamps compare lexicographically.
+            # Codex's verdict applies to the current head if it reviewed that
+            # commit or its 👍 reaction postdates the last push. ISO-8601
+            # timestamps compare lexicographically.
+            verdict=false
+            if [[ "$reviewed" -gt 0 ]] \
+               || [[ -n "$thumb" && "$thumb" > "$pushed" ]]; then
+              verdict=true
+            fi
             clean=false
-            if [[ "$unresolved" -eq 0 ]] \
-               && { [[ "$reviewed" -gt 0 ]] \
-                    || [[ -n "$thumb" && "$thumb" > "$pushed" ]]; }; then
+            if [[ "$verdict" == true && "$unresolved" -eq 0 ]]; then
               clean=true
+            elif [[ "$verdict" == false && "$pushed" < "$grace_cutoff" ]]; then
+              # Fail-safe: no verdict within the grace period means Codex is
+              # down or out of tokens, so unlock the build. Unresolved
+              # threads from earlier heads still block the merge.
+              clean=true
+              echo "PR #$pr: no Codex verdict within grace period"
             fi
             if [[ "$clean" == true ]]; then
               gh api -X POST "repos/$GH_REPO/issues/$pr/labels" \

--- a/.github/workflows/tenzir.yaml
+++ b/.github/workflows/tenzir.yaml
@@ -74,6 +74,11 @@ on:
     types:
       - opened
       - synchronize
+      # The build is delayed until the Codex review has no open issues, which
+      # the `codex-review-gate` workflow signals by applying the `ci-ready`
+      # label. Applying the label manually unlocks the build without waiting
+      # for Codex.
+      - labeled
   merge_group:
     types:
       - checks_requested
@@ -90,7 +95,14 @@ concurrency:
   # it's running smoothly for all users.
   group: ${{ github.workflow }}-${{ github.ref }}
   # Cancel all in-progress runs of this action for the same pull request.
-  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+  # Label events never cancel: runs for unrelated labels are no-ops, and the
+  # `ci-ready` run that starts the build can only fire while previous runs
+  # were no-ops as well, since the label is never removed.
+  cancel-in-progress: >-
+    ${{ github.event_name == 'merge_group' ||
+        (github.event_name == 'pull_request' &&
+         (github.event.action == 'opened' ||
+          github.event.action == 'synchronize')) }}
 
 env:
   CCACHE_MAXSIZE: "5G"
@@ -117,6 +129,18 @@ jobs:
   configure:
     name: Configure
     runs-on: ubuntu-latest
+    # On PRs, wait for the Codex review to have no open issues: the
+    # `codex-review-gate` workflow applies the `ci-ready` label, whose
+    # `labeled` event starts the build. The label is sticky: once present,
+    # later pushes build right away. All other jobs depend on this one's
+    # outputs, so skipping it skips the entire workflow. Events for unrelated
+    # labels are ignored to avoid spurious rebuilds.
+    if: >-
+      github.event_name != 'pull_request' ||
+      (contains(github.event.pull_request.labels.*.name, 'ci-ready') &&
+       (github.event.action == 'opened' ||
+        github.event.action == 'synchronize' ||
+        github.event.label.name == 'ci-ready'))
     outputs:
       version-matrix: ${{ steps.configure.outputs.version-matrix }}
       build-version: ${{ steps.configure.outputs.build-version }}
@@ -1306,12 +1330,42 @@ jobs:
     runs-on: ubuntu-latest
     name: Pass Branch Protections
     steps:
-      - name: Failure
-        if: contains(join(needs.*.result, ','), 'failure') || contains(join(needs.*.result, ','), 'cancelled')
+      - name: Publish commit status
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # On PRs, publish on the head commit rather than the merge commit.
+          SHA: >-
+            ${{ github.event_name == 'pull_request'
+                && github.event.pull_request.head.sha
+                || github.sha }}
         run: |
-          # This check runs after any other job failed.
-          exit 1
-      - name: Success
-        run: |
-          # This check runs after all other jobs are done or skipped
-          exit 0
+          # Branch protection requires the `Tenzir CI` commit status instead
+          # of this job's check run: label events for unrelated labels
+          # trigger no-op runs whose check run would overwrite the one
+          # published by the real build for this head, whereas a commit
+          # status only changes when a run explicitly sets it.
+          if ${{ contains(join(needs.*.result, ','), 'failure') || contains(join(needs.*.result, ','), 'cancelled') }}; then
+            state=failure
+            description="A required job failed or was cancelled."
+          elif ${{ github.event_name == 'pull_request' && needs.configure.result == 'skipped' }}; then
+            # The build is gated on the `ci-ready` label, which the
+            # `codex-review-gate` workflow applies. Without the label, mark
+            # the head as awaiting review; applying the label triggers a real
+            # run. With the label, this is a no-op run for an unrelated label
+            # event, so leave the status of the real build untouched.
+            if ${{ contains(github.event.pull_request.labels.*.name, 'ci-ready') }}; then
+              echo "No-op run for an unrelated label event; keeping the status."
+              exit 0
+            fi
+            state=pending
+            description="The build starts once the Codex review is clean; apply the ci-ready label to skip the wait."
+          else
+            state=success
+            description="All required jobs succeeded."
+          fi
+          gh api "repos/$GITHUB_REPOSITORY/statuses/$SHA" \
+            -f "state=$state" \
+            -f "context=Tenzir CI" \
+            -f "description=$description" \
+            -f "target_url=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          [[ "$state" == success ]]


### PR DESCRIPTION
### What

Delays the heavy C++ build on PRs until the Codex review comes back clean, in two parts:

1. **A new `codex-review-gate` workflow** that sweeps all open PRs every 5 minutes and applies the `codex-approved` label when the latest Codex signal — its 👍 reaction (the "no comments" verdict) or a submitted review — postdates the last push *and* no review threads opened by Codex are unresolved. The label is removed again when that stops holding (e.g., after a new push). A cron sweep is required because GitHub emits no webhook events for reactions. The label is applied with the autobumper app token so that the `labeled` event can trigger workflows, which events created by the default `GITHUB_TOKEN` cannot.

2. **A gate in the Tenzir workflow:** on PRs, the Configure job (and therefore everything downstream) only runs when the `codex-approved` label is present; adding the label starts the build. While gated, *Pass Branch Protections* fails with an "Awaiting Codex Approval" step so the PR is not mergeable on the back of a skipped build. The `merge_group` run is unaffected and remains the enforcement backstop.

### Notes

- The detection logic was validated read-only against recent PRs (#6273, #6274, #6269, #6264) and produced the expected verdict for each combination of stale/fresh signals and unresolved threads.
- The autobumper app needs *Pull requests* (or *Issues*) write permission for the label calls — please double-check before merging.
- Known race: a push shortly after a Codex approval builds immediately if the sweep hasn't removed the stale label yet (worst case one premature build; correctness is unaffected).
- Additions of unrelated labels do not trigger rebuilds.