### PR TITLE
Support selector defaults for UDO field parameters

### DIFF
--- a/changelog/unreleased/selector-defaults-for-udo-field-parameters.md
+++ b/changelog/unreleased/selector-defaults-for-udo-field-parameters.md
@@ -1,0 +1,27 @@
+---
+title: Selector defaults for UDO field parameters
+type: feature
+authors:
+  - mavam
+  - claude
+prs:
+  - 6352
+created: 2026-06-12T15:07:30.532323Z
+---
+
+Field-typed parameters of user-defined operators now accept selectors as defaults in the TQL frontmatter, such as `this`, `this.name`, or `foo.bar`. Previously, the only allowed default for a `field` parameter was `null`.
+
+For example, this operator wraps a field into a record and operates on the entire event when no argument is given:
+
+```tql
+---
+args:
+  named:
+    - name: field
+      type: field
+      default: this
+---
+this = {wrapped: $field}
+```
+
+Calling the operator without arguments wraps the whole event, while passing `field=name` wraps just that field. This makes it easy to write mapping operators that work on the full event by default but can be scoped to a subrecord on demand.

--- a/libtenzir/src/package.cpp
+++ b/libtenzir/src/package.cpp
@@ -1276,10 +1276,26 @@ auto build_package_operator_module(const package& pkg, diagnostic_handler& dh)
       return failure::promise();
     }
     if (is_field_path_type(param) and not is<caf::none_t>(*yaml_data)) {
-      diagnostic::error("default value for field parameter `{}` must be `null`",
-                        param.name)
-        .emit(dh);
-      return failure::promise();
+      auto invalid_selector = [&] {
+        diagnostic::error("default value for field parameter `{}` must be "
+                          "`null` or a selector",
+                          param.name)
+          .note("default value: {}", *param.default_)
+          .emit(dh);
+        return failure::promise();
+      };
+      const auto* str = try_as<std::string>(&*yaml_data);
+      if (not str) {
+        return invalid_selector();
+      }
+      auto expr = parse_expression_with_bad_diagnostics(*str, ctx);
+      if (expr.is_error()) {
+        return invalid_selector();
+      }
+      if (not ast::selector::try_from(ast::expression{*expr})) {
+        return invalid_selector();
+      }
+      return std::optional<ast::expression>{std::move(*expr)};
     }
     materialize_default_value(*yaml_data, value_type);
     auto expr = make_constant_expression(std::move(*yaml_data));

--- a/libtenzir/src/tql2/user_defined_operator.cpp
+++ b/libtenzir/src/tql2/user_defined_operator.cpp
@@ -35,6 +35,17 @@ auto parameter_default_string(const ast::expression& expr)
       return *yaml;
     }
   }
+  if (auto path = ast::field_path::try_from(ast::expression{expr})) {
+    if (path->path().empty()) {
+      return "this";
+    }
+    auto names_range
+      = path->path() | std::views::transform([](const auto& segment) {
+          return segment.id.name;
+        });
+    return fmt::format("{}{}", path->has_this() ? "this." : "",
+                       fmt::join(names_range, "."));
+  }
   return std::nullopt;
 }
 

--- a/test/inputs/package-roots/udo-args-field-default-failing/argspkg_field_default_failing/operators/bad_field_default.tql
+++ b/test/inputs/package-roots/udo-args-field-default-failing/argspkg_field_default_failing/operators/bad_field_default.tql
@@ -1,9 +1,9 @@
 ---
-description: "Invalid non-null default for a field parameter"
+description: "Invalid non-selector default for a field parameter"
 args:
   named:
     - name: field
       type: field
-      default: this.input
+      default: 1 + 2
 ---
 set marker = "should not load"

--- a/test/inputs/package-roots/udo-args/argspkg/operators/field_default_selector.tql
+++ b/test/inputs/package-roots/udo-args/argspkg/operators/field_default_selector.tql
@@ -1,0 +1,10 @@
+---
+description: "Wrap a field into a record, defaulting to a field selector"
+args:
+  named:
+    - name: field
+      type: field
+      default: this.name
+      description: "Field selector defaulting to `this.name`"
+---
+this = {selected: $field}

--- a/test/inputs/package-roots/udo-args/argspkg/operators/field_default_this.tql
+++ b/test/inputs/package-roots/udo-args/argspkg/operators/field_default_this.tql
@@ -1,0 +1,10 @@
+---
+description: "Wrap a field into a record, defaulting to the whole event"
+args:
+  named:
+    - name: field
+      type: field
+      default: this
+      description: "Field selector defaulting to the whole event"
+---
+this = {wrapped: $field}

--- a/test/tests/operators/udo/args/udo-args-field-default-selector.tql
+++ b/test/tests/operators/udo/args/udo-args-field-default-selector.tql
@@ -1,0 +1,2 @@
+from {name: "Alice", age: 42}
+argspkg::field_default_selector

--- a/test/tests/operators/udo/args/udo-args-field-default-selector.txt
+++ b/test/tests/operators/udo/args/udo-args-field-default-selector.txt
@@ -1,0 +1,3 @@
+{
+  selected: "Alice",
+}

--- a/test/tests/operators/udo/args/udo-args-field-default-this-provided.tql
+++ b/test/tests/operators/udo/args/udo-args-field-default-this-provided.tql
@@ -1,0 +1,2 @@
+from {name: "Alice"}
+argspkg::field_default_this field=name

--- a/test/tests/operators/udo/args/udo-args-field-default-this-provided.txt
+++ b/test/tests/operators/udo/args/udo-args-field-default-this-provided.txt
@@ -1,0 +1,3 @@
+{
+  wrapped: "Alice",
+}

--- a/test/tests/operators/udo/args/udo-args-field-default-this.tql
+++ b/test/tests/operators/udo/args/udo-args-field-default-this.tql
@@ -1,0 +1,2 @@
+from {name: "Alice"}
+argspkg::field_default_this

--- a/test/tests/operators/udo/args/udo-args-field-default-this.txt
+++ b/test/tests/operators/udo/args/udo-args-field-default-this.txt
@@ -1,0 +1,5 @@
+{
+  wrapped: {
+    name: "Alice",
+  },
+}

--- a/test/tests/operators/udo/args_field_default_failing/udo-args-field-default-non-null.txt
+++ b/test/tests/operators/udo/args_field_default_failing/udo-args-field-default-non-null.txt
@@ -1,1 +1,2 @@
-error: default value for field parameter `field` must be `null`
+error: default value for field parameter `field` must be `null` or a selector
+ = note: default value: 1 + 2


### PR DESCRIPTION
## 🔍 Problem

Field-typed parameters of user-defined operators could only default to `null`. Frontmatter defaults were parsed as YAML constants, so a field parameter could not default to the whole event (`this`) or to another field.

## 🛠️ Solution

- Parse the `default:` value of `type: field` parameters as a TQL expression and accept any selector, e.g. `this`, `this.name`, or `foo.bar`.
- Reuse `ast::selector::try_from` for validation — the same predicate the instantiation path applies to explicitly passed field arguments, which already accepts a bare `this`.
- Render selector defaults (instead of `<expr>`) in the parameter table of UDO diagnostics.
- Non-selector defaults still fail at package load with an updated diagnostic.

## 💬 Review

- No instantiation-side changes were needed: defaults flow through the existing `ast::substitute_named_expressions` machinery, and `field_path::try_from` already treats `this` as a valid selector.
- Parse errors in a default emit the parser's diagnostics plus a wrapping error, mirroring the existing `parse_type_def_with_bad_diagnostics` pattern for parameter types.
- The previously failing fixture used `default: this.input`, which is now a feature; the negative test uses `default: 1 + 2` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sub>
📚 Docs PR: tenzir/docs#399
</sub>
