### PR TITLE
Prepare changelog for minor release

### DIFF
--- a/changelog/unreleased/drop-null-fields-function.md
+++ b/changelog/unreleased/drop-null-fields-function.md
@@ -4,6 +4,8 @@ type: feature
 authors:
   - zedoraps
   - claude
+prs:
+  - 6261
 created: 2026-06-05T19:42:25Z
 ---
 

--- a/changelog/unreleased/google-secops-chronicle-import-api.md
+++ b/changelog/unreleased/google-secops-chronicle-import-api.md
@@ -1,6 +1,6 @@
 ---
 title: Google SecOps Chronicle import API
-type: breaking
+type: change
 authors:
   - raxyte
   - codex

--- a/changelog/unreleased/regular-expression-topic-selection-for-from-kafka.md
+++ b/changelog/unreleased/regular-expression-topic-selection-for-from-kafka.md
@@ -4,6 +4,8 @@ type: feature
 authors:
   - mavam
   - codex
+prs:
+  - 6262
 created: 2026-06-08T07:08:34.266686Z
 ---
 


### PR DESCRIPTION
## 🔍 Problem

- The unreleased changelog queue inferred a major release because the Google SecOps Chronicle API entry was classified as breaking.
- Two unreleased entries were missing their originating PR numbers.

## 🛠️ Solution

- Reclassify the Google SecOps Chronicle API entry as a regular change.
- Add PR metadata for the `drop_null_fields` function and regex Kafka topic entries.
- Keep `tenzir-ship` inference on the minor release path.

## 💬 Review

- Verify that the SecOps entry should ship as a minor-release change.
- `uvx tenzir-ship validate` passes and `uvx tenzir-ship stats` now reports `Next v6.2.0`.