### PR TITLE
Backfill recent changelog PR metadata

### DIFF
--- a/changelog/releases/v5.35.2/entries/configured-pipelines-with-package-operators.md
+++ b/changelog/releases/v5.35.2/entries/configured-pipelines-with-package-operators.md
@@ -4,6 +4,8 @@ type: bugfix
 authors:
   - mavam
   - codex
+prs:
+  - 6113
 created: 2026-05-04T13:54:37.228784Z
 ---
 

--- a/changelog/releases/v5.35.2/entries/slash-delimited-udo-defaults.md
+++ b/changelog/releases/v5.35.2/entries/slash-delimited-udo-defaults.md
@@ -4,7 +4,8 @@ type: bugfix
 authors:
   - mavam
   - codex
-pr: 6108
+prs:
+  - 6108
 created: 2026-05-02T14:43:20.745759Z
 ---
 

--- a/changelog/releases/v5.36.0/entries/lossless-int64uint64-merging-during-parsing.md
+++ b/changelog/releases/v5.36.0/entries/lossless-int64uint64-merging-during-parsing.md
@@ -4,6 +4,8 @@ type: change
 authors:
   - IyeOnline
   - claude
+prs:
+  - 6125
 created: 2026-05-05T16:34:33.815786Z
 ---
 

--- a/changelog/releases/v5.36.0/entries/ocsf-enum-list-derivation.md
+++ b/changelog/releases/v5.36.0/entries/ocsf-enum-list-derivation.md
@@ -5,7 +5,8 @@ authors:
   - jachris
   - mavam
   - codex
-pr: 5354
+prs:
+  - 5354
 created: 2026-04-30T16:47:58.705871Z
 ---
 

--- a/changelog/releases/v6.1.0/entries/ai-prompt-operator.md
+++ b/changelog/releases/v6.1.0/entries/ai-prompt-operator.md
@@ -4,7 +4,8 @@ type: feature
 authors:
   - mavam
   - codex
-pr: 6260
+prs:
+  - 6260
 created: 2026-05-28T07:18:56.000000Z
 ---
 

--- a/changelog/releases/v6.1.0/entries/chunk-stream-operators.md
+++ b/changelog/releases/v6.1.0/entries/chunk-stream-operators.md
@@ -4,6 +4,8 @@ type: feature
 authors:
   - aljazerzen
   - codex
+prs:
+  - 6243
 created: 2026-06-01T09:09:37.255561Z
 ---
 

--- a/changelog/releases/v6.1.0/entries/decrypt-cryptopan.md
+++ b/changelog/releases/v6.1.0/entries/decrypt-cryptopan.md
@@ -4,8 +4,9 @@ type: feature
 authors:
   - mavam
   - codex
+prs:
+  - 6259
 created: 2026-06-06T00:00:00Z
-pr: 6259
 ---
 
 The new `decrypt_cryptopan` function decrypts IP addresses that were encrypted

--- a/changelog/releases/v6.1.0/entries/fix-where-substring-in-pushdown.md
+++ b/changelog/releases/v6.1.0/entries/fix-where-substring-in-pushdown.md
@@ -3,6 +3,8 @@ title: "Fix `where` substring filters dropping all events from `subscribe`"
 type: bugfix
 authors:
   - jachris
+prs:
+  - 6265
 created: 2026-06-09T00:00:00.000000Z
 ---
 

--- a/changelog/releases/v6.1.0/entries/microsoft-sql-server-source-operator.md
+++ b/changelog/releases/v6.1.0/entries/microsoft-sql-server-source-operator.md
@@ -4,6 +4,8 @@ type: feature
 authors:
   - tobim
   - codex
+prs:
+  - 6221
 created: 2026-05-26T08:14:41.788782Z
 ---
 

--- a/changelog/releases/v6.1.0/entries/null-list-spread-warnings.md
+++ b/changelog/releases/v6.1.0/entries/null-list-spread-warnings.md
@@ -4,6 +4,8 @@ type: change
 authors:
   - mavam
   - codex
+prs:
+  - 6258
 created: 2026-06-06T04:37:42.295012Z
 ---
 

--- a/changelog/releases/v6.1.0/entries/prometheus-remote-write-sink.md
+++ b/changelog/releases/v6.1.0/entries/prometheus-remote-write-sink.md
@@ -4,6 +4,8 @@ type: feature
 authors:
   - mavam
   - codex
+prs:
+  - 6189
 created: 2026-05-15T19:37:02.326776Z
 ---
 


### PR DESCRIPTION
## 🔍 Problem

- Several recent release changelog entries still lacked PR metadata.
- A few older entries used the singular `pr` key instead of the current `prs` shape.

## 🛠️ Solution

- Backfill clear one-to-one PR references for entries in `v6.1.0`, `v5.36.0`, and `v5.35.2`.
- Normalize singular `pr` fields in those touched entries to `prs`.

## 💬 Review

- Review the PR number mappings.
- I intentionally did not mass-edit `v6.0.0`; many entries there are part of the large major-release queue and need more careful provenance checks.
- `uvx tenzir-ship validate` passes.