### PR TITLE
Normalize v6 changelog PR metadata

### DIFF
--- a/changelog/releases/v6.0.0/entries/arrow-ipc-file-support-in-read-feather.md
+++ b/changelog/releases/v6.0.0/entries/arrow-ipc-file-support-in-read-feather.md
@@ -4,7 +4,8 @@ type: bugfix
 authors:
   - tobim
   - codex
-pr: 6087
+prs:
+  - 6087
 created: 2026-04-28T21:21:22.51495Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/avoid-redundant-partition-rewrites-during-compaction.md
+++ b/changelog/releases/v6.0.0/entries/avoid-redundant-partition-rewrites-during-compaction.md
@@ -3,6 +3,8 @@ title: Reduce disk I/O of time-based compaction
 type: bugfix
 authors:
   - lava
+prs:
+  - 6169
 created: 2026-05-12T13:32:50.629468Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/compaction-resolves-package-udos-at-startup.md
+++ b/changelog/releases/v6.0.0/entries/compaction-resolves-package-udos-at-startup.md
@@ -2,7 +2,8 @@
 title: Compaction resolves package UDOs at startup
 type: bugfix
 author: raxyte
-pr: 6210
+prs:
+  - 6210
 created: 2026-05-20T17:40:00.000000Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/dedicated-ftp-source-and-sink-operators.md
+++ b/changelog/releases/v6.0.0/entries/dedicated-ftp-source-and-sink-operators.md
@@ -2,7 +2,8 @@
 title: Dedicated FTP source and sink operators
 type: breaking
 author: mavam
-pr: 6044
+prs:
+  - 6044
 created: 2026-04-30T12:58:47.461872Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/diagnostics-for-lambda-valued-let-bindings.md
+++ b/changelog/releases/v6.0.0/entries/diagnostics-for-lambda-valued-let-bindings.md
@@ -4,7 +4,8 @@ type: bugfix
 authors:
   - mavam
   - codex
-pr: 6241
+prs:
+  - 6241
 created: 2026-05-31T06:17:30.259084Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/dns-result-caching-in-dns-lookup.md
+++ b/changelog/releases/v6.0.0/entries/dns-result-caching-in-dns-lookup.md
@@ -2,7 +2,8 @@
 title: DNS result caching in `dns_lookup`
 type: feature
 author: mavam
-pr: 6034
+prs:
+  - 6034
 created: 2026-04-30T13:02:07.277857Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/event-throughput-metrics-for-the-new-executor.md
+++ b/changelog/releases/v6.0.0/entries/event-throughput-metrics-for-the-new-executor.md
@@ -4,6 +4,8 @@ type: feature
 authors:
   - mavam
   - codex
+prs:
+  - 6160
 created: 2026-05-12T10:26:00.599424Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/faster-drop-null-fields-on-heterogeneous-data.md
+++ b/changelog/releases/v6.0.0/entries/faster-drop-null-fields-on-heterogeneous-data.md
@@ -5,7 +5,8 @@ authors:
   - jachris
   - mavam
   - codex
-pr: 5963
+prs:
+  - 5963
 created: 2026-03-31T10:34:08.17118Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/file-let-binding-for-filesystem-readers.md
+++ b/changelog/releases/v6.0.0/entries/file-let-binding-for-filesystem-readers.md
@@ -2,7 +2,8 @@
 title: '`$file` let-binding for filesystem readers'
 type: breaking
 author: raxyte
-pr: 6001
+prs:
+  - 6001
 created: 2026-04-30T13:00:47.360929Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/from-http-infers-parser.md
+++ b/changelog/releases/v6.0.0/entries/from-http-infers-parser.md
@@ -4,6 +4,8 @@ type: feature
 authors:
   - mavam
   - codex
+prs:
+  - 5953
 created: 2026-05-15T00:00:00Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/from-http-is-now-a-pure-http-client.md
+++ b/changelog/releases/v6.0.0/entries/from-http-is-now-a-pure-http-client.md
@@ -2,7 +2,8 @@
 title: '`from_http` is now a pure HTTP client'
 type: breaking
 author: aljazerzen
-pr: 5953
+prs:
+  - 5953
 created: 2026-04-30T13:00:30.348949Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/from-http-pagination-request-records.md
+++ b/changelog/releases/v6.0.0/entries/from-http-pagination-request-records.md
@@ -4,6 +4,8 @@ type: feature
 authors:
   - mavam
   - codex
+prs:
+  - 6193
 created: 2026-05-17T13:45:00Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/hec-metadata-and-raw-endpoint-support-in-to-splunk.md
+++ b/changelog/releases/v6.0.0/entries/hec-metadata-and-raw-endpoint-support-in-to-splunk.md
@@ -2,7 +2,8 @@
 title: HEC metadata and raw endpoint support in `to_splunk`
 type: feature
 author: mavam
-pr: 6074
+prs:
+  - 6074
 created: 2026-04-30T13:02:25.554018Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/high-level-filesystem-and-object-store-writers.md
+++ b/changelog/releases/v6.0.0/entries/high-level-filesystem-and-object-store-writers.md
@@ -2,7 +2,8 @@
 title: High-level filesystem and object store writers
 type: feature
 author: raxyte
-pr: 6053
+prs:
+  - 6053
 created: 2026-04-30T13:00:01.571739Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/internal-memory-size-function.md
+++ b/changelog/releases/v6.0.0/entries/internal-memory-size-function.md
@@ -4,6 +4,8 @@ type: feature
 authors:
   - IyeOnline
   - codex
+prs:
+  - 6152
 created: 2026-05-08T21:12:04.15977Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/keyed-routing-and-source-mode-for-parallel.md
+++ b/changelog/releases/v6.0.0/entries/keyed-routing-and-source-mode-for-parallel.md
@@ -2,7 +2,8 @@
 title: Keyed routing and source mode for `parallel`
 type: feature
 author: jachris
-pr: 5821
+prs:
+  - 5821
 created: 2026-04-30T13:01:14.07634Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/keyed-subpipeline-routing-with-group.md
+++ b/changelog/releases/v6.0.0/entries/keyed-subpipeline-routing-with-group.md
@@ -2,7 +2,8 @@
 title: Keyed subpipeline routing with `group`
 type: feature
 author: jachris
-pr: 5980
+prs:
+  - 5980
 created: 2026-04-30T12:56:38.660784Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/live-packet-capture-with-from-nic.md
+++ b/changelog/releases/v6.0.0/entries/live-packet-capture-with-from-nic.md
@@ -2,7 +2,8 @@
 title: Live packet capture with `from_nic`
 type: feature
 author: mavam
-pr: 6022
+prs:
+  - 6022
 created: 2026-04-30T12:59:02.933262Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/memory-mapped-reads-in-from-file.md
+++ b/changelog/releases/v6.0.0/entries/memory-mapped-reads-in-from-file.md
@@ -2,7 +2,8 @@
 title: Memory-mapped reads in `from_file`
 type: feature
 author: raxyte
-pr: 6036
+prs:
+  - 6036
 created: 2026-04-30T13:00:59.26973Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/mysql-source-operator.md
+++ b/changelog/releases/v6.0.0/entries/mysql-source-operator.md
@@ -4,7 +4,9 @@ type: feature
 authors:
   - mavam
   - claude
-pr: [5721, 5738]
+prs:
+  - 5721
+  - 5738
 created: 2026-02-06T08:53:45.097588Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/nats-jetstream-operators.md
+++ b/changelog/releases/v6.0.0/entries/nats-jetstream-operators.md
@@ -4,6 +4,8 @@ type: feature
 authors:
   - mavam
   - codex
+prs:
+  - 6047
 created: 2026-04-17T04:39:41.372977Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/odata-pagination-for-from-http.md
+++ b/changelog/releases/v6.0.0/entries/odata-pagination-for-from-http.md
@@ -4,6 +4,8 @@ type: feature
 authors:
   - mavam
   - codex
+prs:
+  - 6080
 created: 2026-04-24T15:28:40Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/opensearch-ingestion-with-accept-opensearch.md
+++ b/changelog/releases/v6.0.0/entries/opensearch-ingestion-with-accept-opensearch.md
@@ -2,7 +2,8 @@
 title: OpenSearch ingestion with `accept_opensearch`
 type: breaking
 author: aljazerzen
-pr: 6066
+prs:
+  - 6066
 created: 2026-04-30T12:59:18.006961Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/parse-tql-records-with-read-tql.md
+++ b/changelog/releases/v6.0.0/entries/parse-tql-records-with-read-tql.md
@@ -2,7 +2,8 @@
 title: Parse TQL records with `read_tql`
 type: feature
 author: mavam
-pr: 5707
+prs:
+  - 5707
 created: 2026-04-30T13:00:14.039139Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/per-event-subpipelines-with-each.md
+++ b/changelog/releases/v6.0.0/entries/per-event-subpipelines-with-each.md
@@ -2,7 +2,8 @@
 title: Per-event subpipelines with `each`
 type: feature
 author: jachris
-pr: 5981
+prs:
+  - 5981
 created: 2026-04-30T12:56:25.237501Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/preserve-categorical-chart-bar-order.md
+++ b/changelog/releases/v6.0.0/entries/preserve-categorical-chart-bar-order.md
@@ -2,6 +2,8 @@
 title: Preserve categorical order in `chart_bar`
 type: change
 author: mavam
+prs:
+  - 6158
 created: 2026-05-12T00:00:00Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/prometheus-shape-for-metrics.md
+++ b/changelog/releases/v6.0.0/entries/prometheus-shape-for-metrics.md
@@ -4,7 +4,8 @@ type: feature
 authors:
   - mavam
   - codex
-pr: 6190
+prs:
+  - 6190
 created: 2026-05-16T00:00:00Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/read-from-standard-input-with-from-stdin.md
+++ b/changelog/releases/v6.0.0/entries/read-from-standard-input-with-from-stdin.md
@@ -2,7 +2,8 @@
 title: Read from standard input with `from_stdin`
 type: feature
 author: raxyte
-pr: 5731
+prs:
+  - 5731
 created: 2026-04-30T12:58:15.747791Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/recursive-record-sorting.md
+++ b/changelog/releases/v6.0.0/entries/recursive-record-sorting.md
@@ -4,6 +4,8 @@ type: feature
 authors:
   - mavam
   - codex
+prs:
+  - 6237
 created: 2026-05-28T15:46:20Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/removed-real-time-argument-from-measure.md
+++ b/changelog/releases/v6.0.0/entries/removed-real-time-argument-from-measure.md
@@ -2,7 +2,8 @@
 title: Removed `real_time` argument from `measure`
 type: breaking
 author: aljazerzen
-pr: 5880
+prs:
+  - 5880
 created: 2026-04-30T13:01:39.565524Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/renamed-from-gcs-to-from-google-cloud-storage.md
+++ b/changelog/releases/v6.0.0/entries/renamed-from-gcs-to-from-google-cloud-storage.md
@@ -2,7 +2,8 @@
 title: Renamed `from_gcs` to `from_google_cloud_storage`
 type: breaking
 author: raxyte
-pr: 5766
+prs:
+  - 5766
 created: 2026-04-30T13:03:17.226108Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/repeat-string-function.md
+++ b/changelog/releases/v6.0.0/entries/repeat-string-function.md
@@ -4,7 +4,8 @@ type: feature
 authors:
   - mavam
   - codex
-pr: 6181
+prs:
+  - 6181
 created: 2026-05-15T06:50:18.449675000Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/send-events-to-webhooks-with-to-http.md
+++ b/changelog/releases/v6.0.0/entries/send-events-to-webhooks-with-to-http.md
@@ -2,7 +2,8 @@
 title: Send events to webhooks with `to_http`
 type: feature
 author: aljazerzen
-pr: 6019
+prs:
+  - 6019
 created: 2026-04-30T12:59:46.103696Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/sentinelone-data-lake-sink-support-in-the-new-executor.md
+++ b/changelog/releases/v6.0.0/entries/sentinelone-data-lake-sink-support-in-the-new-executor.md
@@ -4,7 +4,8 @@ type: bugfix
 authors:
   - mavam
   - codex
-pr: 6081
+prs:
+  - 6081
 created: 2026-04-24T18:42:39.346763Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/stream-pipeline-output-with-serve-http.md
+++ b/changelog/releases/v6.0.0/entries/stream-pipeline-output-with-serve-http.md
@@ -2,7 +2,8 @@
 title: Stream pipeline output with `serve_http`
 type: feature
 author: aljazerzen
-pr: 6070
+prs:
+  - 6070
 created: 2026-04-30T12:59:33.02497Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/to-kafka-defaults-to-ndjson-encoded-messages.md
+++ b/changelog/releases/v6.0.0/entries/to-kafka-defaults-to-ndjson-encoded-messages.md
@@ -2,7 +2,8 @@
 title: '`to_kafka` defaults to NDJSON-encoded messages'
 type: breaking
 author: lava
-pr: 5742
+prs:
+  - 5742
 created: 2026-04-30T13:02:38.652347Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/top-level-package-metadata.md
+++ b/changelog/releases/v6.0.0/entries/top-level-package-metadata.md
@@ -4,7 +4,8 @@ type: bugfix
 authors:
   - tobim
   - codex
-pr: 6149
+prs:
+  - 6149
 created: 2026-05-08T15:43:35.152192Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/uncompressed-feather-output.md
+++ b/changelog/releases/v6.0.0/entries/uncompressed-feather-output.md
@@ -2,7 +2,8 @@
 title: Uncompressed Feather output
 type: feature
 author: mavam
-pr: 6045
+prs:
+  - 6045
 created: 2026-04-30T13:02:52.129138Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/unix-domain-socket-operators.md
+++ b/changelog/releases/v6.0.0/entries/unix-domain-socket-operators.md
@@ -4,6 +4,8 @@ type: feature
 authors:
   - mavam
   - codex
+prs:
+  - 6240
 created: 2026-05-30T00:00:00Z
 ---
 

--- a/changelog/releases/v6.0.0/entries/yara-requires-finite-input.md
+++ b/changelog/releases/v6.0.0/entries/yara-requires-finite-input.md
@@ -2,7 +2,8 @@
 title: '`yara` requires finite input'
 type: breaking
 author: mavam
-pr: 6035
+prs:
+  - 6035
 created: 2026-04-30T13:01:54.70296Z
 ---
 


### PR DESCRIPTION
## 🔍 Problem

- Several `v6.0.0` changelog entries still used the old singular `pr` metadata shape.
- A few entries in the same release lacked PR metadata despite having clear originating PRs.

## 🛠️ Solution

- Normalize touched `v6.0.0` entries to the current `prs` list shape.
- Backfill clear missing PR references from merged PR history.

## 💬 Review

- Review the PR number mappings and the `pr` to `prs` normalization.
- `uvx tenzir-ship validate` passes.