### PR TITLE
Fix from_http parser changelog PR

### DIFF
--- a/changelog/releases/v6.0.0/entries/from-http-infers-parser.md
+++ b/changelog/releases/v6.0.0/entries/from-http-infers-parser.md
@@ -5,7 +5,7 @@ authors:
   - mavam
   - codex
 prs:
-  - 5953
+  - 6186
 created: 2026-05-15T00:00:00Z
 ---
 


### PR DESCRIPTION
## 🔍 Problem

- Review feedback on #6355 pointed out that the `from_http` parser inference changelog entry referenced PR #5953.
- That feature was introduced by PR #6186; #5953 belongs to the separate pure HTTP client entry.

## 🛠️ Solution

- Point the parser inference changelog entry at PR #6186.

## 💬 Review

- This directly addresses https://github.com/tenzir/tenzir/pull/6355#discussion_r3405042765.
- `uvx tenzir-ship validate` passes.