### PR TITLE
Fix incorrect TLS and memory options in tenzir.yaml.example

### DIFF
--- a/changelog/unreleased/corrected-tls-and-memory-options-in-the-example-configuration.md
+++ b/changelog/unreleased/corrected-tls-and-memory-options-in-the-example-configuration.md
@@ -1,0 +1,21 @@
+---
+title: Corrected TLS and memory options in the example configuration
+type: bugfix
+authors:
+  - Zedoraps
+  - claude
+prs:
+  - 6365
+created: 2026-06-18T06:58:45.411704Z
+---
+
+The shipped example configuration now matches the options the node reads. The
+setting that requires clients to present a certificate is
+`tenzir.tls.require-client-cert`; the previously listed `tls-require-client-cert`
+had no effect. The example also documents `tenzir.tls.password`, which decrypts
+an encrypted `keyfile`, and no longer lists `tenzir.malloc-trim-interval`: the
+node reads the trim interval only from the `TENZIR_ALLOC_TRIM_INTERVAL`
+environment variable, never from the configuration file. The `plugins.platform`
+TLS block no longer lists the server-side client-certificate options, because
+the connection to the Tenzir Platform is an outbound client that does not use
+them.

--- a/changelog/unreleased/corrected-tls-and-memory-options-in-the-example-configuration.md
+++ b/changelog/unreleased/corrected-tls-and-memory-options-in-the-example-configuration.md
@@ -1,5 +1,5 @@
 ---
-title: Corrected TLS and memory options in the example configuration
+title: Corrected mismatched defaults and options in the example configuration
 type: bugfix
 authors:
   - Zedoraps
@@ -19,6 +19,10 @@ environment variable, never from the configuration file. The `plugins.platform`
 TLS block no longer lists the server-side client-certificate options, because
 the connection to the Tenzir Platform is an outbound client that does not use
 them.
+
+Two documented defaults were also wrong: `tenzir.retention.metrics` defaults to
+`16d` (not `7d`), and `tenzir.start.disk-budget-check-interval` defaults to `60`
+seconds (not `90`).
 
 The `tenzir-node --help` output also reported the wrong default for
 `rebuild-interval`. It now shows the actual default of `30min` instead of `2h`.

--- a/changelog/unreleased/corrected-tls-and-memory-options-in-the-example-configuration.md
+++ b/changelog/unreleased/corrected-tls-and-memory-options-in-the-example-configuration.md
@@ -19,3 +19,6 @@ environment variable, never from the configuration file. The `plugins.platform`
 TLS block no longer lists the server-side client-certificate options, because
 the connection to the Tenzir Platform is an outbound client that does not use
 them.
+
+The `tenzir-node --help` output also reported the wrong default for
+`rebuild-interval`. It now shows the actual default of `30min` instead of `2h`.

--- a/libtenzir/src/application.cpp
+++ b/libtenzir/src/application.cpp
@@ -97,7 +97,7 @@ void add_root_opts(command& cmd) {
                             "forcibly flushed (default: 30s)");
   cmd.options.add<duration>("?tenzir", "rebuild-interval",
                             "timespan after which an automatic rebuild is "
-                            "triggered (default: 2h)");
+                            "triggered (default: 30min)");
 }
 
 auto make_start_command() {

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -406,7 +406,7 @@ tenzir:
       # The definition of the pipeline. Configured pipelines that fail to start
       # cause the node to fail to start.
       definition: |
-        load_tcp "0.0.0.0:34343" { read_suricata schema_only=true }
+        accept_tcp "0.0.0.0:34343" { read_suricata schema_only=true }
         | where event_type != "stats"
         | publish "suricata"
       # Pipelines that encounter an error stop running and show an error state.

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -30,7 +30,7 @@ tenzir:
     # entirely.
     # WARNING: A low retention period may negatively impact the usability of
     # pipeline activity in the Tenzir Platform.
-    #metrics: 7d
+    #metrics: 16d
 
     # How long to keep legacy operator metrics for. Set to 0s to avoid storing
     # these heavy metrics while still making live metrics available.
@@ -356,7 +356,7 @@ tenzir:
     disk-budget-low: 0GiB
 
     # Seconds between successive disk space checks.
-    disk-budget-check-interval: 90
+    disk-budget-check-interval: 60
 
     # When erasing, how many partitions to erase in one go before rechecking
     # the size of the database directory.

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -58,52 +58,49 @@ tenzir:
     # minimum total cache capacity of 64MiB.
     #capacity: 1Gi
 
-  # TLS configuration options globally applies to all operators that support TLS.
-  # Arguments passed to the operator itself will always take precedence over these
-  # configuration values.
+  # A certificate file used as the default for operators accepting a `cacert`
+  # option. This will default to an appropriate directory for the system. For
+  # example:
+  #   - /etc/ssl/certs/ca-bundle.crt on RedHat
+  #   - /etc/ssl/certs/ca-certificates.crt on Ubuntu
+  #cacert:
+
+  # TLS configuration that applies to all operators supporting TLS, such as
+  # from_http, accept_tcp, to_tcp, to_opensearch, from_opensearch, to_splunk,
+  # save_email, and to_fluent_bit. Operators can override these settings
+  # individually via their `tls` option.
   tls:
     # Enable TLS on all operators that support it.
-    #enable: true
+    #enable: false
 
-    # Skip SSL peer verification.
-    skip-peer-verification: false
+    # Disable certificate verification (not recommended for production).
+    #skip-peer-verification: false
 
-    # A certificate file used as the default for operators accepting a `cacert`
-    # option. This will default to an appropriate directory for the system. For
-    # example:
-    #   - /etc/ssl/certs/ca-bundle.crt on RedHat
-    #   - /etc/ssl/certs/ca-certificates.crt on Ubuntu
+    # Path to a CA certificate bundle for server verification.
     #cacert:
 
-    # A certificate file used as the default for operators
+    # Path to a client certificate file.
     #certfile:
 
-    # A key file used as the default for operators
+    # Path to a client private key file.
     #keyfile:
 
-    # A password for the keyfile
+    # Password to decrypt the private key in `keyfile`, if it is encrypted.
     #password:
 
-    # Minimum TLS protocol version to accept/use.
-    # Valid values: "1.0", "1.1", "1.2", "1.3"
-    # Recommended: "1.2" or higher for security.
+    # Minimum TLS protocol version.
+    # Valid values: "1.0", "1.1", "1.2", "1.3".
     #tls-min-version:
 
-    # OpenSSL cipher list to use for TLS connections.
-    # This is a colon-separated string of cipher suites.
-    # Example: "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256"
-    # See OpenSSL documentation for cipher list format.
-    #ciphers:
+    # OpenSSL cipher list string.
+    #tls-ciphers:
 
-    # Path to a CA certificate file for validating client certificates (server mode only).
-    # When set along with `tls_require_client_cert`, the server will verify client
-    # certificates against this CA.
-    #client-ca:
+    # Path to a CA certificate for validating client certificates (mTLS).
+    # Only applies to operators that accept incoming connections.
+    #tls-client-ca:
 
-    # Require clients to present valid certificates (server mode only). When enabled,
-    # clients MUST present a certificate signed by the CA specified in `tls-client-ca`,
-    # otherwise the connection will be rejected. This enables mutual TLS (mTLS)
-    # authentication.
+    # Require clients to present valid certificates signed by the client CA
+    # (mTLS). Only applies to operators that accept incoming connections.
     #require-client-cert: false
 
   # The file system path used for persistent state.
@@ -443,8 +440,21 @@ tenzir:
   secrets:
     # my-secret-name: my-secret-value
 
-  # Configure the interval for experimental trimming of unused memory.
-  malloc-trim-interval: 10min
+# Plugin-specific configuration.
+plugins:
+  # TLS settings for the connection from the node to the Tenzir Platform.
+  # These options share the semantics of the corresponding node-level
+  # tenzir.tls settings, but apply only to the node <-> platform connection and
+  # override the matching node-level setting. The node connects to the platform
+  # as an outbound client, so the server-side mTLS options (`tls-client-ca`,
+  # `require-client-cert`) and the `enable` toggle do not apply here.
+  platform:
+    #skip-peer-verification:
+    #cacert:
+    #certfile:
+    #keyfile:
+    #tls-min-version:
+    #tls-ciphers:
 
 # The below settings are internal to CAF, and aren't checked by Tenzir directly.
 # Please be careful when changing these options. Note that some CAF options may


### PR DESCRIPTION
## 🔍 Problem

`tenzir.yaml.example` and the `tenzir-node --help` output documented values the node does not use. Verified against the source and empirically against a running node (v6.2.0):

- `tenzir.tls.tls-require-client-cert` — wrong key. The code reads `require-client-cert`; the prefixed name is silently ignored, so configured mTLS was never enforced (confirmed: a client with no cert was accepted).
- `tenzir.tls.password` — a real option (decrypts an encrypted `keyfile`) that was missing.
- `tenzir.malloc-trim-interval` — not a configuration-file option at all; the interval is read only from `TENZIR_ALLOC_TRIM_INTERVAL` (default `1min`).
- `plugins.platform` listed `enable`, `tls-client-ca`, `tls-require-client-cert` — none are honored; the platform link is an outbound client with no server-side mTLS.
- The TLS comment referenced the removed `load_tcp`/`save_tcp` operators.
- Two documented defaults were wrong: `tenzir.retention.metrics` (`7d` → actual `16d`) and `tenzir.start.disk-budget-check-interval` (`90` → actual `60`).
- `tenzir-node --help` reported the `rebuild-interval` default as `2h`; the node uses `30min`.

## 🛠️ Solution

- Correct the key name to `require-client-cert` and document `password`.
- Remove the dead `malloc-trim-interval` key.
- Trim the `plugins.platform` block to the options it actually honors and clarify the comment.
- Refer to `accept_tcp`/`to_tcp`.
- Fix the `retention.metrics` (`16d`) and `disk-budget-check-interval` (`60`) defaults.
- Fix the `rebuild-interval` default in the CLI help text.

## 💬 Review

- The rest of the example was cross-checked against the source: every option key exists, and the connection/partition/buffer/demand/logging/cache/index/disk-budget defaults all match. The `caf.*` block is CAF-internal and not verified against Tenzir source.
- The example file ships in packages and is rendered on docs.tenzir.com; the companion PR keeps the docs copy byte-identical and fixes the matching guide pages.
- Out of scope (follow-up, TNZ-728): the code ignores `require-client-cert`/`tls-client-ca` on the folly TLS path and mis-wires `password` for `accept_http`. A separate copy-paste bug at `execution_node.cpp:461` reads the `min-backoff` key for `max_backoff`.

<sub>
📚 Docs PR: tenzir/docs#404<br>
🎫 References TNZ-728
</sub>
