### PR TITLE
Fix TLS mTLS/password and demand.max-backoff config reads

### DIFF
--- a/changelog/unreleased/fix-tls-mtls-password-and-max-backoff-config.md
+++ b/changelog/unreleased/fix-tls-mtls-password-and-max-backoff-config.md
@@ -1,0 +1,27 @@
+---
+title: Fix mTLS enforcement, TLS key passwords, and `max-backoff`
+type: bugfix
+authors:
+  - zedoraps
+  - claude
+---
+
+Several TLS options were read incorrectly and are now honored:
+
+- `require-client-cert` (and the per-operator `tls={require_client_cert: true}`)
+  is now enforced for operators that build their TLS context on the folly path
+  (`accept_tcp`, `from_tcp`, `serve_tcp`, `to_tcp`, `to_http`, `to_opensearch2`,
+  `from_mysql`). Previously these operators loaded neither the client CA nor the
+  `fail-if-no-peer-cert` flag, so a client presenting no certificate was silently
+  accepted.
+- `tls.password` is now applied when loading an encrypted private key on the
+  folly path. For the HTTP-server-based operators (`accept_http`,
+  `accept_opensearch`, `serve_http`), an inline `tls.password` is now rejected
+  with a clear diagnostic instead of being silently misinterpreted as a password
+  file path.
+- `tls={password: "…"}` is no longer rejected as an unknown key in the operator
+  `tls` record.
+
+Additionally, `tenzir.demand.max-backoff` is now read from the correct
+configuration key. It previously read `min-backoff`, so the setting had no
+effect.

--- a/libtenzir/src/execution_node.cpp
+++ b/libtenzir/src/execution_node.cpp
@@ -459,7 +459,7 @@ struct exec_node_state {
     max_backoff
       = demand_settings.max_backoff
           ? *demand_settings.max_backoff
-          : read_config("min-backoff", min_backoff, max_backoff, false);
+          : read_config("max-backoff", min_backoff, max_backoff, false);
     backoff_rate = demand_settings.backoff_rate
                      ? *demand_settings.backoff_rate
                      : read_config("backoff-rate", 1.0, backoff_rate, false);

--- a/libtenzir/src/http_server.cpp
+++ b/libtenzir/src/http_server.cpp
@@ -48,6 +48,19 @@ auto make_ssl_context_config(TlsConfig const& tls, location primary,
     return failure::promise();
   }
   auto& certfile = *tls.certfile;
+  // wangle's `SSLContextConfig` only accepts a password *file path*, not an
+  // inline secret, and proxygen offers no hook to install a custom password
+  // collector. Rather than silently misinterpreting the password as a filename,
+  // reject it with a clear diagnostic.
+  if (auto& password = tls.password) {
+    diagnostic::error("inline `tls.password` is not supported for this operator")
+      .primary(*password)
+      .note("the underlying HTTP server can only read the key password from a "
+            "file")
+      .hint("use a private key in `tls.keyfile` that is not password-protected")
+      .emit(dh);
+    return failure::promise();
+  }
   auto config = proxygen::coro::HTTPServer::getDefaultTLSConfig();
   if (auto& min = tls.tls_min_version) {
     if (not min->inner.empty()) {
@@ -65,7 +78,7 @@ auto make_ssl_context_config(TlsConfig const& tls, location primary,
   try {
     config.setCertificate(certfile.inner,
                           tls.keyfile ? tls.keyfile->inner : certfile.inner,
-                          tls.password ? tls.password->inner : "");
+                          /*passwordPath=*/"");
   } catch (std::exception const& ex) {
     diagnostic::error("failed to load TLS certificate: {}", ex.what())
       .primary(certfile)

--- a/libtenzir/src/http_server.cpp
+++ b/libtenzir/src/http_server.cpp
@@ -53,7 +53,8 @@ auto make_ssl_context_config(TlsConfig const& tls, location primary,
   // collector. Rather than silently misinterpreting the password as a filename,
   // reject it with a clear diagnostic.
   if (auto& password = tls.password) {
-    diagnostic::error("inline `tls.password` is not supported for this operator")
+    diagnostic::error(
+      "inline `tls.password` is not supported for this operator")
       .primary(*password)
       .note("the underlying HTTP server can only read the key password from a "
             "file")

--- a/libtenzir/src/tls_options.cpp
+++ b/libtenzir/src/tls_options.cpp
@@ -17,6 +17,7 @@
 #include <caf/net/ssl/context.hpp>
 #include <curl/curl.h>
 #include <folly/io/async/SSLContext.h>
+#include <folly/ssl/PasswordCollector.h>
 #include <openssl/ssl.h>
 
 #include <algorithm>
@@ -38,11 +39,12 @@ tls_options::tls_options(located<data> tls_val, options opts)
 namespace {
 
 // Valid keys for the tls record (snake_case, no tls_ prefix)
-constexpr std::array<std::string_view, 8> valid_tls_record_keys = {
+constexpr std::array<std::string_view, 9> valid_tls_record_keys = {
   "skip_peer_verification",
   "cacert",
   "certfile",
   "keyfile",
+  "password",
   "min_version",
   "ciphers",
   "client_ca",
@@ -54,6 +56,28 @@ enum class tls_version {
   v1_1,
   v1_2,
   v1_3,
+};
+
+// A password collector that hands OpenSSL an in-memory password instead of
+// reading it from a file. folly only ships `PasswordInFile`, but our `password`
+// option carries the secret inline.
+class inline_password_collector final : public folly::ssl::PasswordCollector {
+public:
+  explicit inline_password_collector(std::string password)
+    : password_{std::move(password)} {
+  }
+
+  void getPassword(std::string& password, int /*size*/) const override {
+    password = password_;
+  }
+
+  auto describe() const -> const std::string& override {
+    static const auto description = std::string{"inline TLS key password"};
+    return description;
+  }
+
+private:
+  std::string password_;
 };
 
 auto parse_tls_version(std::string_view version) -> caf::expected<tls_version> {
@@ -806,6 +830,24 @@ auto TlsConfig::make_folly_ssl_context(diagnostic_handler& dh,
       return failure::promise();
     }
   }
+  // When acting as a server that requires client certificates, load the client
+  // CA so presented certificates can be validated, and advertise it in the
+  // `CertificateRequest` sent to clients. This mirrors the asio and http_server
+  // paths; without it, `require-client-cert` is silently not enforced.
+  if (require_cert and tls_client_ca) {
+    TRY(auto path, resolve_regular_file(*tls_client_ca, "client_ca", dh));
+    try {
+      ctx->loadTrustedCertificates(path.c_str());
+    } catch (std::exception const& ex) {
+      diagnostic::error("failed to load client CA certificate: {}", ex.what())
+        .primary(*tls_client_ca)
+        .emit(dh);
+      return failure::promise();
+    }
+    if (auto* names = SSL_load_client_CA_file(path.c_str())) {
+      SSL_CTX_set_client_CA_list(ctx->getSSLCtx(), names);
+    }
+  }
   // Load certificate chain.
   if (certfile) {
     TRY(auto path, resolve_regular_file(*certfile, "certfile", dh));
@@ -817,6 +859,12 @@ auto TlsConfig::make_folly_ssl_context(diagnostic_handler& dh,
         .emit(dh);
       return failure::promise();
     }
+  }
+  // Apply the private key password, if any, before loading the key. OpenSSL
+  // queries this collector when the key file is encrypted.
+  if (password) {
+    ctx->passwordCollector(
+      std::make_shared<inline_password_collector>(password->inner));
   }
   // Load private key. If `keyfile` is omitted, try reading it from `certfile`.
   if (auto& private_key_file = keyfile ? keyfile : certfile) {
@@ -852,8 +900,18 @@ auto TlsConfig::make_folly_ssl_context(diagnostic_handler& dh,
       return failure::promise();
     }
   }
-  // Set verification mode.
-  if (skip_verify) {
+  // Set verification mode. Requiring a client certificate takes precedence over
+  // `skip_peer_verification`: a server that demands mTLS must reject clients
+  // that present no certificate (`SSL_VERIFY_FAIL_IF_NO_PEER_CERT`).
+  if (require_cert) {
+    ctx->setVerificationOption(
+      folly::SSLContext::SSLVerifyPeerEnum::VERIFY_REQ_CLIENT_CERT);
+    if (not cacert and not tls_client_ca
+        and SSL_CTX_set_default_verify_paths(ctx->getSSLCtx()) != 1) {
+      diagnostic::error("failed to enable default verify paths").emit(dh);
+      return failure::promise();
+    }
+  } else if (skip_verify) {
     ctx->setVerificationOption(folly::SSLContext::SSLVerifyPeerEnum::NO_VERIFY);
   } else {
     ctx->setVerificationOption(folly::SSLContext::SSLVerifyPeerEnum::VERIFY);


### PR DESCRIPTION
## 🔍 Problem

Three TLS options and one demand setting were read incorrectly (verified on `main`/v6.2.0; see TNZ-728):

- **mTLS silently not enforced** on the folly TLS path. `make_folly_ssl_context` never loaded `tls_client_ca` nor set `fail-if-no-peer-cert`, so `require-client-cert` was ignored for `accept_tcp`, `from_tcp`, `serve_tcp`, `to_tcp`, `to_http`, `to_opensearch2`, `from_mysql` — a cert-less client was accepted.
- **`tls.password` ignored** on the folly path (`loadPrivateKey` was called without the password), and on the http-server path the inline password was passed where wangle expects a password-*file path*, so it was misinterpreted as a filename.
- **`tls={password: "…"}` rejected** — `password` was missing from `valid_tls_record_keys`, making `get_password()`'s record read dead code.
- **`demand.max-backoff` had no effect** — `execution_node.cpp` read the `min-backoff` key for `max_backoff` (copy-paste bug).

## 🛠️ Solution

- `make_folly_ssl_context`: load the client CA into the trust store, advertise it in the `CertificateRequest`, and set `VERIFY_REQ_CLIENT_CERT` when `require-client-cert` is set (takes precedence over `skip_peer_verification`).
- Apply `tls.password` on the folly path via an inline `PasswordCollector` before loading an encrypted key.
- Reject inline `tls.password` on the wangle/http-server path (`accept_http`, `accept_opensearch`, `serve_http`) with a clear diagnostic — proxygen/wangle only accept a password *file* and expose no hook for an in-memory password or prebuilt context.
- Add `password` to `valid_tls_record_keys`.
- Read `max-backoff` for `demand.max-backoff`.

## 💬 Review

- **Draft / not built locally:** this environment has no configured build, so the changes are unbuilt and untested. CI build + a review pass are needed before un-drafting.
- **Tests still TODO:** the issue asks for mTLS-enforcement and encrypted-keyfile coverage for at least one folly operator and `accept_http`. Golden `.txt` files must be generated by the test runner (needs a build), so they are deliberately not hand-authored here.
- **Design decision:** inline `tls.password` on the http-server path is rejected rather than materialized to a temp file (avoids writing a secret to disk + lifecycle plumbing across three operators). Folly path and asio path support inline passwords.
- Focus points: `tls_options.cpp` `make_folly_ssl_context` verification/CA logic, and the new `inline_password_collector`.

<sub>
✅ Closes TNZ-728<br>
📎 Related: tenzir/tenzir#6365, tenzir/docs#404
</sub>