### PR TITLE
[Experimental] Add `--external-catalog` for on-demand partition synopses

### DIFF
--- a/changelog/unreleased/external-catalog.md
+++ b/changelog/unreleased/external-catalog.md
@@ -1,0 +1,14 @@
+---
+title: Track partitions out-of-core with `--external-catalog`
+type: feature
+authors:
+  - lava
+created: 2026-06-18T00:00:00.000000Z
+---
+
+The new `--external-catalog` option points the node at a JSON manifest that
+lists partitions together with their schemas, import time ranges, and per-type
+min/max synopses. The node keeps only this lightweight metadata in memory and
+prunes queries directly from it, without reading the partitions' `.mdx` synopsis
+files. This keeps the catalog's memory footprint small for nodes that track a
+large number of partitions.

--- a/libtenzir/include/tenzir/external_catalog.hpp
+++ b/libtenzir/include/tenzir/external_catalog.hpp
@@ -1,0 +1,86 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2025 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "tenzir/fwd.hpp"
+
+#include "tenzir/data.hpp"
+#include "tenzir/synopsis.hpp"
+#include "tenzir/time.hpp"
+#include "tenzir/type.hpp"
+#include "tenzir/uuid.hpp"
+
+#include <caf/expected.hpp>
+
+#include <filesystem>
+#include <vector>
+
+namespace tenzir {
+
+/// A min/max range synopsis for one concrete type, mirroring the type synopses
+/// stored in a partition's `.mdx` file.
+struct external_synopsis {
+  /// The concrete type the synopsis applies to, e.g. `type{int64_type{}}`.
+  type field_type;
+  /// The minimum and maximum values, stored as the matching `data` alternative.
+  data min;
+  data max;
+};
+
+/// A partition described by an external catalog manifest. It carries the
+/// lightweight metadata and min/max synopses the catalog needs for pruning,
+/// making the partition usable without reading its `.mdx` file.
+struct external_partition {
+  /// The partition id.
+  uuid id;
+
+  /// The homogeneous schema of the partition.
+  type schema;
+
+  /// The number of events in the partition.
+  uint64_t events = 0;
+
+  /// The import time range covered by the partition.
+  time min_import_time;
+  time max_import_time;
+
+  /// The partition version.
+  uint64_t version = 0;
+
+  /// The per-type min/max synopses for the partition.
+  std::vector<external_synopsis> synopses;
+};
+
+/// Builds a min/max range synopsis for a concrete type from its bounds.
+/// @param t The concrete type (e.g. `type{int64_type{}}`).
+/// @param min The minimum value, as the `data` alternative matching `t`.
+/// @param max The maximum value, as the `data` alternative matching `t`.
+/// @returns The synopsis, or a null pointer if `t` has no range synopsis.
+auto make_min_max_synopsis(const type& t, const data& min, const data& max)
+  -> synopsis_ptr;
+
+/// Parses an external catalog manifest from a JSON file.
+///
+/// The manifest is either a JSON object with a `partitions` array or a bare
+/// JSON array. Each entry is an object with the fields:
+///   - `id`: the partition uuid (string)
+///   - `schema`: the partition schema as base64-encoded type flatbuffer bytes
+///   - `events`: the number of events (integer)
+///   - `min_import_time`, `max_import_time`: ISO 8601 timestamps
+///   - `version`: the partition version (integer)
+///   - `synopses`: an array of `{type, min, max}` objects, where `type` is one
+///     of `int64`, `uint64`, `double`, `duration`, or `time`, and `min`/`max`
+///     are the bounds (numbers, or ISO 8601 / duration strings)
+///
+/// @param path The path to the manifest file.
+/// @returns The parsed partitions, or an error.
+auto load_external_catalog(const std::filesystem::path& path)
+  -> caf::expected<std::vector<external_partition>>;
+
+} // namespace tenzir

--- a/libtenzir/include/tenzir/index.hpp
+++ b/libtenzir/include/tenzir/index.hpp
@@ -301,6 +301,10 @@ struct index_state {
   /// The directory for in-progress partition transforms.
   std::filesystem::path markersdir = {};
 
+  /// Path to a JSON manifest of externally-cataloged partitions whose synopses
+  /// are loaded on demand. Empty when the feature is disabled.
+  std::filesystem::path external_catalog = {};
+
   /// List of actors that wait for the next flush event.
   std::vector<flush_listener_actor> flush_listeners = {};
 
@@ -354,6 +358,8 @@ struct index_state {
 /// @param catalog_dir The directory used by the catalog.
 /// @param index_config The meta-index configuration of the false-positives
 /// rates for the types and fields.
+/// @param external_catalog Path to a JSON manifest of externally-cataloged
+/// partitions whose synopses are loaded on demand, or empty to disable.
 /// @pre `partition_capacity > 0
 //  TODO: Use a settings struct for the various parameters.
 index_actor::behavior_type
@@ -363,6 +369,7 @@ index(index_actor::stateful_pointer<index_state> self,
       size_t max_buffered_events, size_t partition_capacity,
       duration active_partition_timeout, size_t max_inmem_partitions,
       size_t max_concurrent_partition_lookups,
-      const std::filesystem::path& catalog_dir, index_config index_config);
+      const std::filesystem::path& catalog_dir, index_config index_config,
+      std::filesystem::path external_catalog = {});
 
 } // namespace tenzir

--- a/libtenzir/src/application.cpp
+++ b/libtenzir/src/application.cpp
@@ -59,6 +59,10 @@ void add_root_opts(command& cmd) {
     "?tenzir", "package-dirs", "additional directories containing packages");
   cmd.options.add<std::string>("?tenzir", "state-directory,d",
                                "directory for persistent state");
+  cmd.options.add<std::string>(
+    "?tenzir", "external-catalog",
+    "path to a JSON manifest of externally-cataloged "
+    "partitions whose synopses are loaded on demand");
   cmd.options.add<std::string>("?tenzir", "cache-directory",
                                "directory for runtime state");
   cmd.options.add<std::string>("?tenzir", "log-file", "log filename");

--- a/libtenzir/src/external_catalog.cpp
+++ b/libtenzir/src/external_catalog.cpp
@@ -1,0 +1,340 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2025 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "tenzir/external_catalog.hpp"
+
+#include "tenzir/chunk.hpp"
+#include "tenzir/concept/parseable/tenzir/time.hpp"
+#include "tenzir/concept/parseable/tenzir/uuid.hpp"
+#include "tenzir/concept/parseable/to.hpp"
+#include "tenzir/data.hpp"
+#include "tenzir/detail/base64.hpp"
+#include "tenzir/detail/overload.hpp"
+#include "tenzir/double_synopsis.hpp"
+#include "tenzir/duration_synopsis.hpp"
+#include "tenzir/error.hpp"
+#include "tenzir/int64_synopsis.hpp"
+#include "tenzir/io/read.hpp"
+#include "tenzir/time_synopsis.hpp"
+#include "tenzir/uint64_synopsis.hpp"
+
+#include <string_view>
+
+namespace tenzir {
+
+namespace {
+
+auto get_uint(const record& r, std::string_view field)
+  -> std::optional<uint64_t> {
+  if (const auto* v = get_if<uint64_t>(&r, field)) {
+    return *v;
+  }
+  if (const auto* v = get_if<int64_t>(&r, field); v and *v >= 0) {
+    return static_cast<uint64_t>(*v);
+  }
+  return std::nullopt;
+}
+
+auto get_time(const record& r, std::string_view field) -> std::optional<time> {
+  if (const auto* v = get_if<time>(&r, field)) {
+    return *v;
+  }
+  if (const auto* v = get_if<std::string>(&r, field)) {
+    if (auto parsed = to<time>(*v)) {
+      return *parsed;
+    }
+  }
+  return std::nullopt;
+}
+
+/// Coerces a JSON-parsed bound into the `data` alternative matching `t`.
+auto coerce_bound(const type& t, const data& raw) -> caf::expected<data> {
+  return match(
+    t, detail::overload{
+         [&](const int64_type&) -> caf::expected<data> {
+           if (const auto* v = try_as<int64_t>(&raw)) {
+             return data{*v};
+           }
+           if (const auto* v = try_as<uint64_t>(&raw)) {
+             return data{static_cast<int64_t>(*v)};
+           }
+           return caf::make_error(ec::parse_error, "expected an integer bound");
+         },
+         [&](const uint64_type&) -> caf::expected<data> {
+           if (const auto* v = try_as<uint64_t>(&raw)) {
+             return data{*v};
+           }
+           if (const auto* v = try_as<int64_t>(&raw); v and *v >= 0) {
+             return data{static_cast<uint64_t>(*v)};
+           }
+           return caf::make_error(ec::parse_error,
+                                  "expected a non-negative integer bound");
+         },
+         [&](const double_type&) -> caf::expected<data> {
+           if (const auto* v = try_as<double>(&raw)) {
+             return data{*v};
+           }
+           if (const auto* v = try_as<int64_t>(&raw)) {
+             return data{static_cast<double>(*v)};
+           }
+           if (const auto* v = try_as<uint64_t>(&raw)) {
+             return data{static_cast<double>(*v)};
+           }
+           return caf::make_error(ec::parse_error, "expected a numeric bound");
+         },
+         [&](const time_type&) -> caf::expected<data> {
+           if (const auto* v = try_as<time>(&raw)) {
+             return data{*v};
+           }
+           if (const auto* v = try_as<std::string>(&raw)) {
+             if (auto parsed = to<time>(*v)) {
+               return data{*parsed};
+             }
+           }
+           return caf::make_error(ec::parse_error, "expected a time bound");
+         },
+         [&](const duration_type&) -> caf::expected<data> {
+           if (const auto* v = try_as<duration>(&raw)) {
+             return data{*v};
+           }
+           if (const auto* v = try_as<std::string>(&raw)) {
+             if (auto parsed = to<duration>(*v)) {
+               return data{*parsed};
+             }
+           }
+           return caf::make_error(ec::parse_error, "expected a duration bound");
+         },
+         [&](const auto&) -> caf::expected<data> {
+           return caf::make_error(ec::parse_error,
+                                  "unsupported synopsis type; expected one of "
+                                  "int64, uint64, double, duration, time");
+         },
+       });
+}
+
+auto parse_synopsis(const record& r) -> caf::expected<external_synopsis> {
+  const auto* kind = get_if<std::string>(&r, "type");
+  if (not kind) {
+    return caf::make_error(ec::parse_error,
+                           "synopsis entry is missing a string `type`");
+  }
+  auto t = type{};
+  if (*kind == "int64") {
+    t = type{int64_type{}};
+  } else if (*kind == "uint64") {
+    t = type{uint64_type{}};
+  } else if (*kind == "double") {
+    t = type{double_type{}};
+  } else if (*kind == "duration") {
+    t = type{duration_type{}};
+  } else if (*kind == "time") {
+    t = type{time_type{}};
+  } else {
+    return caf::make_error(ec::parse_error,
+                           fmt::format("unsupported synopsis type `{}`; "
+                                       "expected one of int64, "
+                                       "uint64, double, duration, time",
+                                       *kind));
+  }
+  const auto* min = r.find("min") != r.end() ? &r.at("min") : nullptr;
+  const auto* max = r.find("max") != r.end() ? &r.at("max") : nullptr;
+  if (not min or not max) {
+    return caf::make_error(ec::parse_error,
+                           "synopsis entry is missing `min` or `max`");
+  }
+  auto min_data = coerce_bound(t, *min);
+  if (not min_data) {
+    return std::move(min_data.error());
+  }
+  auto max_data = coerce_bound(t, *max);
+  if (not max_data) {
+    return std::move(max_data.error());
+  }
+  return external_synopsis{std::move(t), std::move(*min_data),
+                           std::move(*max_data)};
+}
+
+auto parse_entry(const record& r) -> caf::expected<external_partition> {
+  auto result = external_partition{};
+  const auto* id = get_if<std::string>(&r, "id");
+  if (not id) {
+    return caf::make_error(ec::parse_error,
+                           "external catalog entry is missing a string `id`");
+  }
+  if (not parsers::uuid(*id, result.id)) {
+    return caf::make_error(
+      ec::parse_error,
+      fmt::format("external catalog entry has an invalid `id`: {}", *id));
+  }
+  const auto* schema = get_if<std::string>(&r, "schema");
+  if (not schema) {
+    return caf::make_error(ec::parse_error,
+                           fmt::format("external catalog entry {} is missing a "
+                                       "base64 `schema`",
+                                       result.id));
+  }
+  auto decoded = detail::base64::try_decode<std::string>(*schema);
+  if (not decoded) {
+    return caf::make_error(ec::parse_error,
+                           fmt::format("external catalog entry {} has an "
+                                       "invalid base64 `schema`",
+                                       result.id));
+  }
+  result.schema = type{chunk::copy(decoded->data(), decoded->size())};
+  if (not result.schema) {
+    return caf::make_error(ec::parse_error,
+                           fmt::format("external catalog entry {} has an empty "
+                                       "`schema`",
+                                       result.id));
+  }
+  if (auto events = get_uint(r, "events")) {
+    result.events = *events;
+  } else {
+    return caf::make_error(ec::parse_error,
+                           fmt::format("external catalog entry {} is missing "
+                                       "an integer `events`",
+                                       result.id));
+  }
+  if (auto t = get_time(r, "min_import_time")) {
+    result.min_import_time = *t;
+  } else {
+    return caf::make_error(ec::parse_error,
+                           fmt::format("external catalog entry {} is missing "
+                                       "`min_import_time`",
+                                       result.id));
+  }
+  if (auto t = get_time(r, "max_import_time")) {
+    result.max_import_time = *t;
+  } else {
+    return caf::make_error(ec::parse_error,
+                           fmt::format("external catalog entry {} is missing "
+                                       "`max_import_time`",
+                                       result.id));
+  }
+  if (result.min_import_time > result.max_import_time) {
+    return caf::make_error(ec::parse_error,
+                           fmt::format("external catalog entry {} has "
+                                       "min_import_time > "
+                                       "max_import_time",
+                                       result.id));
+  }
+  if (auto version = get_uint(r, "version")) {
+    result.version = *version;
+  } else {
+    return caf::make_error(ec::parse_error,
+                           fmt::format("external catalog entry {} is missing "
+                                       "an integer `version`",
+                                       result.id));
+  }
+  if (const auto* synopses = get_if<list>(&r, "synopses")) {
+    result.synopses.reserve(synopses->size());
+    for (const auto& entry : *synopses) {
+      const auto* rec = try_as<record>(&entry);
+      if (not rec) {
+        return caf::make_error(ec::parse_error,
+                               fmt::format("external catalog entry {} has a "
+                                           "non-object synopsis",
+                                           result.id));
+      }
+      auto parsed = parse_synopsis(*rec);
+      if (not parsed) {
+        return caf::make_error(ec::parse_error,
+                               fmt::format("external catalog entry {}: {}",
+                                           result.id, parsed.error()));
+      }
+      result.synopses.push_back(std::move(*parsed));
+    }
+  }
+  return result;
+}
+
+} // namespace
+
+auto make_min_max_synopsis(const type& t, const data& min, const data& max)
+  -> synopsis_ptr {
+  return match(
+    t, detail::overload{
+         [&](const int64_type&) -> synopsis_ptr {
+           return std::make_unique<int64_synopsis>(as<int64_t>(min),
+                                                   as<int64_t>(max));
+         },
+         [&](const uint64_type&) -> synopsis_ptr {
+           return std::make_unique<uint64_synopsis>(as<uint64_t>(min),
+                                                    as<uint64_t>(max));
+         },
+         [&](const double_type&) -> synopsis_ptr {
+           return std::make_unique<double_synopsis>(as<double>(min),
+                                                    as<double>(max));
+         },
+         [&](const duration_type&) -> synopsis_ptr {
+           return std::make_unique<duration_synopsis>(as<duration>(min),
+                                                      as<duration>(max));
+         },
+         [&](const time_type&) -> synopsis_ptr {
+           return std::make_unique<time_synopsis>(as<time>(min), as<time>(max));
+         },
+         [&](const auto&) -> synopsis_ptr {
+           return nullptr;
+         },
+       });
+}
+
+auto load_external_catalog(const std::filesystem::path& path)
+  -> caf::expected<std::vector<external_partition>> {
+  auto bytes = io::read(path);
+  if (not bytes) {
+    return caf::make_error(ec::filesystem_error,
+                           fmt::format("failed to read external catalog {}: {}",
+                                       path, bytes.error()));
+  }
+  auto json = from_json(std::string_view{
+    reinterpret_cast<const char*>(bytes->data()), bytes->size()});
+  if (not json) {
+    return caf::make_error(ec::parse_error,
+                           fmt::format("failed to parse external catalog {} as "
+                                       "JSON: {}",
+                                       path, json.error()));
+  }
+  // The manifest is either a record with a `partitions` list or a bare list.
+  const list* entries = nullptr;
+  if (const auto* rec = try_as<record>(&*json)) {
+    entries = get_if<list>(rec, "partitions");
+    if (not entries) {
+      return caf::make_error(
+        ec::parse_error, fmt::format("external catalog {} object is missing "
+                                     "a `partitions` array",
+                                     path));
+    }
+  } else if (const auto* lst = try_as<list>(&*json)) {
+    entries = lst;
+  } else {
+    return caf::make_error(ec::parse_error,
+                           fmt::format("external catalog {} must be a JSON "
+                                       "object or array",
+                                       path));
+  }
+  auto result = std::vector<external_partition>{};
+  result.reserve(entries->size());
+  for (const auto& entry : *entries) {
+    const auto* rec = try_as<record>(&entry);
+    if (not rec) {
+      return caf::make_error(ec::parse_error,
+                             fmt::format("external catalog {} contains a "
+                                         "non-object partition entry",
+                                         path));
+    }
+    auto parsed = parse_entry(*rec);
+    if (not parsed) {
+      return std::move(parsed.error());
+    }
+    result.push_back(std::move(*parsed));
+  }
+  return result;
+}
+
+} // namespace tenzir

--- a/libtenzir/src/index.cpp
+++ b/libtenzir/src/index.cpp
@@ -30,6 +30,7 @@
 #include "tenzir/detail/narrow.hpp"
 #include "tenzir/detail/weak_run_delayed.hpp"
 #include "tenzir/error.hpp"
+#include "tenzir/external_catalog.hpp"
 #include "tenzir/fbs/index.hpp"
 #include "tenzir/fbs/partition.hpp"
 #include "tenzir/fbs/partition_transform.hpp"
@@ -370,11 +371,62 @@ caf::error index_state::load_from_disk() {
   // We dont use the filesystem actor here because this function is only
   // called once during startup, when no other actors exist yet.
   std::error_code err{};
+  // Load externally-cataloged partitions (pruning metadata only). We do not
+  // read their .mdx files here; the catalog loads them on demand during lookup.
+  // The partition files themselves are expected to live under the index
+  // directory and are loaded through the regular query path.
+  auto external = std::vector<external_partition>{};
+  if (not external_catalog.empty()) {
+    auto parsed = load_external_catalog(external_catalog);
+    if (not parsed) {
+      return std::move(parsed.error());
+    }
+    external = std::move(*parsed);
+    TENZIR_VERBOSE("{} loaded {} externally-cataloged partitions from {}",
+                   *self, external.size(), external_catalog);
+  }
+  // Builds a synopsis from a manifest entry and registers the partition so it
+  // can be queried through the regular path. The synopsis carries the
+  // manifest's min/max type synopses plus a `field -> nullptr` mapping for
+  // every leaf, so the catalog can prune exactly as it would for a partition
+  // loaded from disk, without ever reading the `.mdx`.
+  auto make_external_synopsis
+    = [this](external_partition& e) -> partition_synopsis_pair {
+    auto ps = caf::make_copy_on_write<partition_synopsis>();
+    auto& u = ps.unshared();
+    u.schema = e.schema;
+    u.events = e.events;
+    u.min_import_time = e.min_import_time;
+    u.max_import_time = e.max_import_time;
+    u.version = e.version;
+    // The catalog relies on a `field -> nullptr` mapping for every leaf field
+    // during lookup; see partition_synopsis::add().
+    if (const auto* rt = try_as<record_type>(&e.schema)) {
+      for (const auto& leaf : rt->leaves()) {
+        u.field_synopses_.emplace(qualified_record_field{e.schema, leaf.index},
+                                  nullptr);
+      }
+    }
+    // Install the min/max type synopses from the manifest.
+    for (auto& syn : e.synopses) {
+      if (auto s = make_min_max_synopsis(syn.field_type, syn.min, syn.max)) {
+        u.type_synopses_[syn.field_type] = std::move(s);
+      }
+    }
+    persisted_partitions.emplace(e.id);
+    return partition_synopsis_pair{e.id, std::move(ps)};
+  };
   auto const file_exists = std::filesystem::exists(dir, err);
   if (not file_exists) {
-    TENZIR_VERBOSE("{} found no prior state, starting with a clean slate",
-                   *self);
-    self->mail(atom::start_v, std::vector<partition_synopsis_pair>{})
+    TENZIR_VERBOSE("{} found no prior state, starting with {} externally-"
+                   "cataloged partitions",
+                   *self, external.size());
+    auto synopses = std::vector<partition_synopsis_pair>{};
+    synopses.reserve(external.size());
+    for (auto& e : external) {
+      synopses.push_back(make_external_synopsis(e));
+    }
+    self->mail(atom::start_v, std::move(synopses))
       .request(catalog, caf::infinite)
       .then([](atom::ok) {},
             [this](caf::error err) {
@@ -382,6 +434,14 @@ caf::error index_state::load_from_disk() {
             });
     return caf::none;
   }
+  // The sorted set of externally-cataloged partition ids, used to exclude them
+  // from the regular full-synopsis load and from orphan cleanup.
+  auto external_ids = std::vector<uuid>{};
+  external_ids.reserve(external.size());
+  for (const auto& e : external) {
+    external_ids.push_back(e.id);
+  }
+  std::sort(external_ids.begin(), external_ids.end());
   // Start by finishing up any in-progress transforms.
   if (std::filesystem::is_directory(markersdir, err)) {
     auto error = [&]() -> caf::error {
@@ -500,6 +560,12 @@ caf::error index_state::load_from_disk() {
     }
     auto ext = entry.path().extension();
     if (ext.empty()) {
+      // Externally-cataloged partitions are loaded lazily from the manifest, so
+      // we skip them in the regular full-synopsis load.
+      if (std::binary_search(external_ids.begin(), external_ids.end(),
+                             partition_uuid)) {
+        continue;
+      }
       // Newer partitions are not limited to FLATBUFFERS_MAX_BUFFER_SIZE,
       // this is only a problem for older ones that still have `fbs::Partition`
       // as root type.
@@ -523,9 +589,14 @@ caf::error index_state::load_from_disk() {
   }
   std::sort(partition_ids.begin(), partition_ids.end());
   std::sort(synopsis_files.begin(), synopsis_files.end());
+  // Treat both regular and externally-cataloged partitions as known, so we
+  // don't delete synopsis files that belong to externally-cataloged partitions.
+  auto known_ids = partition_ids;
+  known_ids.insert(known_ids.end(), external_ids.begin(), external_ids.end());
+  std::sort(known_ids.begin(), known_ids.end());
   auto orphans = std::vector<uuid>{};
   std::set_difference(synopsis_files.begin(), synopsis_files.end(),
-                      partition_ids.begin(), partition_ids.end(),
+                      known_ids.begin(), known_ids.end(),
                       std::back_inserter(orphans));
   // Do a bit of housekeeping. MDX files without matching partitions shouldn't
   // be there in the first place.
@@ -639,6 +710,10 @@ caf::error index_state::load_from_disk() {
       TENZIR_VERBOSE("{} failed to load partition {}: {}", *self,
                      partition_uuid, error);
     }
+  }
+  // Append the synopses for externally-cataloged partitions.
+  for (auto& e : external) {
+    synopses.push_back(make_external_synopsis(e));
   }
   // Recommend the user to run 'tenzir-ctl rebuild' if any partition syopses
   // are outdated. We need to nudge them a bit so we can drop support for older
@@ -1159,7 +1234,8 @@ index(index_actor::stateful_pointer<index_state> self,
       size_t max_buffered_events, size_t partition_capacity,
       duration active_partition_timeout, size_t max_inmem_partitions,
       size_t max_concurrent_partition_lookups,
-      const std::filesystem::path& catalog_dir, index_config index_config) {
+      const std::filesystem::path& catalog_dir, index_config index_config,
+      std::filesystem::path external_catalog) {
   TENZIR_TRACE("index {} {} {} {} {} {} {} {} {}", TENZIR_ARG(self->id()),
                TENZIR_ARG(filesystem), TENZIR_ARG(dir),
                TENZIR_ARG(partition_capacity),
@@ -1200,6 +1276,7 @@ index(index_actor::stateful_pointer<index_state> self,
   self->state().dir = dir;
   self->state().synopsisdir = catalog_dir;
   self->state().markersdir = dir / "markers";
+  self->state().external_catalog = std::move(external_catalog);
   self->state().partition_capacity = partition_capacity;
   self->state().max_buffered_events = max_buffered_events;
   self->state().active_partition_timeout = active_partition_timeout;

--- a/libtenzir/src/node.cpp
+++ b/libtenzir/src/node.cpp
@@ -201,7 +201,9 @@ auto spawn_index(node_actor::stateful_pointer<node_state> self,
       get_or(settings, "tenzir.active-partition-timeout",
              defaults::active_partition_timeout),
       defaults::max_in_mem_partitions, defaults::num_query_supervisors,
-      self->state().dir / "index", std::move(index_config));
+      self->state().dir / "index", std::move(index_config),
+      std::filesystem::path{
+        get_or(settings, "tenzir.external-catalog", std::string{})});
   }();
   TENZIR_ASSERT(index);
   if (auto err

--- a/libtenzir/test/external_catalog.cpp
+++ b/libtenzir/test/external_catalog.cpp
@@ -1,0 +1,172 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2025 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "tenzir/external_catalog.hpp"
+
+#include "tenzir/detail/base64.hpp"
+#include "tenzir/operator.hpp"
+#include "tenzir/test/test.hpp"
+#include "tenzir/type.hpp"
+#include "tenzir/view.hpp"
+
+#include <filesystem>
+#include <fstream>
+
+using namespace tenzir;
+
+namespace {
+
+auto encode_schema(const type& schema) -> std::string {
+  return detail::base64::encode(as_bytes(schema));
+}
+
+auto write_temp(std::string_view content, std::string_view name)
+  -> std::filesystem::path {
+  auto path = std::filesystem::temp_directory_path()
+              / fmt::format("tenzir-external-catalog-test-{}", name);
+  auto out = std::ofstream{path, std::ios::binary | std::ios::trunc};
+  out.write(content.data(), static_cast<std::streamsize>(content.size()));
+  REQUIRE(out.good());
+  return path;
+}
+
+const type test_schema{
+  "zeek.conn",
+  record_type{
+    {"id", uint64_type{}},
+    {"msg", string_type{}},
+  },
+};
+
+} // namespace
+
+TEST("parse external catalog with min/max synopses") {
+  const auto manifest = fmt::format(R"json(
+    {{
+      "partitions": [
+        {{
+          "id": "00000000-0000-0000-0000-000000000001",
+          "schema": "{}",
+          "events": 42,
+          "min_import_time": "2021-01-01T00:00:00Z",
+          "max_import_time": "2021-01-02T00:00:00Z",
+          "version": 3,
+          "synopses": [
+            {{ "type": "uint64", "min": 0, "max": 99 }},
+            {{ "type": "time", "min": "2021-01-01T00:00:00Z",
+               "max": "2021-01-02T00:00:00Z" }}
+          ]
+        }}
+      ]
+    }})json",
+                                    encode_schema(test_schema));
+  const auto path = write_temp(manifest, "object.json");
+  auto parsed = load_external_catalog(path);
+  std::filesystem::remove(path);
+  REQUIRE(parsed);
+  REQUIRE_EQUAL(parsed->size(), 1u);
+  const auto& p = parsed->front();
+  CHECK_EQUAL(p.events, 42u);
+  CHECK_EQUAL(p.version, 3u);
+  CHECK_EQUAL(p.schema, test_schema);
+  REQUIRE_EQUAL(p.synopses.size(), 2u);
+  CHECK_EQUAL(p.synopses[0].field_type, (type{uint64_type{}}));
+  CHECK_EQUAL(as<uint64_t>(p.synopses[0].min), 0u);
+  CHECK_EQUAL(as<uint64_t>(p.synopses[0].max), 99u);
+  CHECK_EQUAL(p.synopses[1].field_type, (type{time_type{}}));
+}
+
+TEST("parse external catalog as bare array without synopses") {
+  const auto manifest = fmt::format(R"json(
+    [
+      {{
+        "id": "00000000-0000-0000-0000-000000000002",
+        "schema": "{}",
+        "events": 7,
+        "min_import_time": "2021-01-01T00:00:00Z",
+        "max_import_time": "2021-01-02T00:00:00Z",
+        "version": 3
+      }}
+    ])json",
+                                    encode_schema(test_schema));
+  const auto path = write_temp(manifest, "array.json");
+  auto parsed = load_external_catalog(path);
+  std::filesystem::remove(path);
+  REQUIRE(parsed);
+  REQUIRE_EQUAL(parsed->size(), 1u);
+  CHECK_EQUAL(parsed->front().events, 7u);
+  CHECK(parsed->front().synopses.empty());
+}
+
+TEST("external catalog rejects entry with missing fields") {
+  const auto manifest = R"json(
+    [
+      {
+        "id": "00000000-0000-0000-0000-000000000003"
+      }
+    ])json";
+  const auto path = write_temp(manifest, "missing.json");
+  auto parsed = load_external_catalog(path);
+  std::filesystem::remove(path);
+  CHECK(not parsed);
+}
+
+TEST("external catalog rejects unsupported synopsis type") {
+  const auto manifest = fmt::format(R"json(
+    [
+      {{
+        "id": "00000000-0000-0000-0000-000000000004",
+        "schema": "{}",
+        "events": 1,
+        "min_import_time": "2021-01-01T00:00:00Z",
+        "max_import_time": "2021-01-02T00:00:00Z",
+        "version": 3,
+        "synopses": [ {{ "type": "string", "min": "a", "max": "z" }} ]
+      }}
+    ])json",
+                                    encode_schema(test_schema));
+  const auto path = write_temp(manifest, "badsyn.json");
+  auto parsed = load_external_catalog(path);
+  std::filesystem::remove(path);
+  CHECK(not parsed);
+}
+
+TEST("make_min_max_synopsis prunes out-of-range values") {
+  auto syn = make_min_max_synopsis(type{int64_type{}}, data{int64_t{10}},
+                                   data{int64_t{20}});
+  REQUIRE(syn);
+  // Equality with a value below the range is prunable.
+  CHECK_EQUAL(syn->lookup(relational_operator::equal,
+                          make_view(data{int64_t{5}})),
+              std::optional{false});
+  // Equality with a value above the range is prunable.
+  CHECK_EQUAL(syn->lookup(relational_operator::equal,
+                          make_view(data{int64_t{25}})),
+              std::optional{false});
+  // Equality with an in-range value cannot be ruled out.
+  {
+    const auto r
+      = syn->lookup(relational_operator::equal, make_view(data{int64_t{15}}));
+    CHECK(not r or *r);
+  }
+  // `> 25` is prunable because the maximum is 20.
+  CHECK_EQUAL(syn->lookup(relational_operator::greater,
+                          make_view(data{int64_t{25}})),
+              std::optional{false});
+  // `> 5` cannot be ruled out.
+  {
+    const auto r
+      = syn->lookup(relational_operator::greater, make_view(data{int64_t{5}}));
+    CHECK(not r or *r);
+  }
+}
+
+TEST("make_min_max_synopsis returns null for non-range types") {
+  CHECK(make_min_max_synopsis(type{string_type{}}, data{"a"}, data{"z"})
+        == nullptr);
+}


### PR DESCRIPTION
## Summary

Adds a `--external-catalog` node option that points at a JSON manifest listing partitions together with their schemas, import time ranges, and **per-type min/max synopses**. The node keeps only this lightweight metadata resident in the catalog and prunes queries directly from it — it never reads the partitions' `.mdx` synopsis files. This keeps the catalog's memory footprint small for nodes that track a large number of partitions.

Scope is pruning metadata only: the partition files themselves are expected to live under the state directory and are loaded for querying through the regular path.

## Manifest format

A JSON object with a `partitions` array (or a bare array). Each entry:

```json
{
  "id": "<uuid>",
  "schema": "<base64-encoded type flatbuffer bytes>",
  "events": 1000,
  "min_import_time": "2024-01-01T00:00:00Z",
  "max_import_time": "2024-01-02T00:00:00Z",
  "version": 3,
  "synopses": [
    { "type": "uint64", "min": 0, "max": 99 },
    { "type": "time", "min": "2024-01-01T00:00:00Z", "max": "2024-01-02T00:00:00Z" }
  ]
}
```

`synopses` carries the min/max range synopses — the most relevant pruning data in a partition's `.mdx`. Supported types: `int64`, `uint64`, `double`, `duration`, `time`.

## How it works

- **Option plumbing**: `tenzir.external-catalog` is parsed in `application.cpp` and threaded through `spawn_index` into the index actor.
- **Manifest** (`external_catalog.{hpp,cpp}`): parses the JSON into `external_partition` records and exposes `make_min_max_synopsis` to build a range synopsis from bounds.
- **Index `load_from_disk`**: reads the manifest, skips the listed partitions during the regular full-synopsis load and from orphan `.mdx` cleanup, registers them as persisted, and builds a synopsis for each — a `field -> nullptr` mapping for every leaf (mirroring `partition_synopsis::add`) plus the min/max type synopses from the manifest.
- **Catalog**: unchanged. It prunes these partitions exactly as it would for ones loaded from disk; schema/import-time and numeric/time range predicates prune from the in-memory min/max, while predicates with no matching synopsis (e.g. string equality) conservatively keep the partition.

## Tests

`libtenzir/test/external_catalog.cpp` covers the manifest parser (object/array forms, the `synopses` array, validation errors, rejecting non-range synopsis types) and `make_min_max_synopsis` (range pruning decisions, null for unsupported types).

## Notes

- Per request, this was **not built locally**; relying on CI for the full build + tests. Changed files were individually compiled in an earlier iteration; the final revision is verified by review.
- A docs companion PR is still needed (no local `.docs/` checkout in this environment).