### PR TITLE
Drain HTTP source operators on stop

### DIFF
--- a/libtenzir/builtins/operators/accept_http.cpp
+++ b/libtenzir/builtins/operators/accept_http.cpp
@@ -38,7 +38,7 @@
 #include <proxygen/lib/http/coro/server/HTTPServer.h>
 #include <proxygen/lib/utils/URL.h>
 
-#include <charconv>
+#include <chrono>
 #include <cstddef>
 #include <limits>
 #include <thread>
@@ -301,6 +301,7 @@ public:
   auto start(OpCtx& ctx) -> Task<void> override {
     auto config = co_await make_config(ctx);
     if (not config) {
+      lifecycle_ = Lifecycle::done;
       co_return;
     }
     auto request_id_gen = Arc<Atomic<uint64_t>>{std::in_place, uint64_t{0}};
@@ -313,15 +314,12 @@ public:
                         std::move(server).unwrap_err())
         .primary(args_.endpoint)
         .emit(ctx);
+      lifecycle_ = Lifecycle::done;
       co_return;
     }
     server_ = Arc<http_server::ScopedServer>::from_non_null(
       std::move(server).unwrap());
-    // When the operator is forcefully stopped (e.g., by `head 1` finishing),
-    // the executor skips `finish_sub` and cancels the operator scope. Catch
-    // that cancellation, reply to already-accepted requests ourselves, then
-    // drain and destroy the server while the proxygen EventBase is still
-    // running.
+    // Forceful cancellation still bypasses the graceful drain path.
     ctx.spawn_task([this]() -> Task<void> {
       co_await catch_cancellation(wait_forever());
       force_stop();
@@ -330,6 +328,7 @@ public:
       = ctx.make_counter(MetricsLabel{"operator", "accept_http"},
                          MetricsDirection::read, MetricsVisibility::external_,
                          MetricsUnit::events);
+    lifecycle_ = Lifecycle::running;
     co_return;
   }
 
@@ -473,20 +472,36 @@ public:
   auto finalize(Push<table_slice>& push, OpCtx& ctx)
     -> Task<FinalizeBehavior> override {
     TENZIR_UNUSED(push, ctx);
-    co_return FinalizeBehavior::done;
+    if (lifecycle_ == Lifecycle::done) {
+      co_return FinalizeBehavior::done;
+    }
+    begin_draining();
+    maybe_finish_draining();
+    co_return lifecycle_ == Lifecycle::done ? FinalizeBehavior::done
+                                            : FinalizeBehavior::continue_;
   }
 
   auto stop(OpCtx& ctx) -> Task<void> override {
     TENZIR_UNUSED(ctx);
-    force_stop();
+    begin_draining();
+    maybe_finish_draining();
     co_return;
   }
 
   auto state() -> OperatorState override {
-    return not server_ ? OperatorState::done : OperatorState::normal;
+    maybe_finish_draining();
+    return lifecycle_ == Lifecycle::done ? OperatorState::done
+                                         : OperatorState::normal;
   }
 
 private:
+  enum class Lifecycle {
+    starting,
+    running,
+    draining,
+    done,
+  };
+
   struct ActiveRequest {
     RequestMetadata metadata;
     // Non-null only when the request carries a supported Content-Encoding.
@@ -497,14 +512,59 @@ private:
     MetricsCounter bytes_read;
   };
 
+  static constexpr auto drain_timeout = std::chrono::seconds{5};
+
   MetricsCounter events_read_counter_;
+  Lifecycle lifecycle_ = Lifecycle::starting;
+  Option<std::chrono::steady_clock::time_point> drain_deadline_ = None{};
 
   void force_stop() {
+    if (lifecycle_ == Lifecycle::done) {
+      return;
+    }
+    lifecycle_ = Lifecycle::done;
+    drain_deadline_ = None{};
     if (server_) {
       (*server_)->server().forceStop();
       // move server to a new thread, where it can call thread join
       std::thread([srv = std::exchange(server_, None{})] {}).detach();
     }
+  }
+
+  auto begin_draining() -> void {
+    if (lifecycle_ != Lifecycle::running) {
+      return;
+    }
+    lifecycle_ = Lifecycle::draining;
+    drain_deadline_ = std::chrono::steady_clock::now() + drain_timeout;
+    if (server_) {
+      (*server_)->server().drain();
+    }
+  }
+
+  auto maybe_finish_draining() -> void {
+    if (lifecycle_ != Lifecycle::draining) {
+      return;
+    }
+    if (drain_deadline_
+        and std::chrono::steady_clock::now() >= *drain_deadline_) {
+      force_stop();
+      return;
+    }
+    // A connection holds its permit from the moment it is accepted until its
+    // handler returns, i.e. until the response has been sent. While the permit
+    // is held the connection may still have request messages queued or a
+    // request in flight, so a full set of available permits is a sufficient
+    // signal that all accepted work has drained.
+    if (active_connections_->available_permits()
+        != detail::narrow<size_t>(args_.get_max_connections())) {
+      return;
+    }
+    drain_deadline_ = None{};
+    if (server_) {
+      std::thread([srv = std::exchange(server_, None{})] {}).detach();
+    }
+    lifecycle_ = Lifecycle::done;
   }
 
   auto make_config(OpCtx& ctx) const

--- a/libtenzir/builtins/operators/accept_opensearch.cpp
+++ b/libtenzir/builtins/operators/accept_opensearch.cpp
@@ -285,6 +285,7 @@ public:
     }
     auto response = co_await response_signal->recv();
     co_await folly::coro::co_reschedule_on_current_executor;
+    co_await queue_->enqueue(Noop{});
     co_return http_server::make_response(response.status, response.content_type,
                                          std::move(response.body));
   }

--- a/libtenzir/builtins/operators/accept_opensearch.cpp
+++ b/libtenzir/builtins/operators/accept_opensearch.cpp
@@ -37,6 +37,7 @@
 #include <proxygen/lib/http/coro/server/HTTPServer.h>
 #include <proxygen/lib/utils/URL.h>
 
+#include <chrono>
 #include <cstddef>
 #include <cstring>
 #include <limits>
@@ -322,6 +323,7 @@ public:
   auto start(OpCtx& ctx) -> Task<void> override {
     auto config = co_await make_config(ctx);
     if (not config) {
+      lifecycle_ = Lifecycle::done;
       co_return;
     }
     auto request_id_gen = Arc<Atomic<uint64_t>>{std::in_place, uint64_t{0}};
@@ -334,15 +336,12 @@ public:
                         std::move(server).unwrap_err())
         .primary(args_.url)
         .emit(ctx);
+      lifecycle_ = Lifecycle::done;
       co_return;
     }
     server_ = Arc<http_server::ScopedServer>::from_non_null(
       std::move(server).unwrap());
-    // When the operator is forcefully stopped (e.g., by `head 1` finishing),
-    // the executor skips `finish_sub` and cancels the operator scope. Catch
-    // that cancellation, reply to already-accepted requests ourselves, then
-    // drain and destroy the server while the proxygen EventBase is still
-    // running.
+    // Forceful cancellation still bypasses the graceful drain path.
     ctx.spawn_task([this]() -> Task<void> {
       co_await catch_cancellation(wait_forever());
       force_stop();
@@ -355,6 +354,7 @@ public:
       = ctx.make_counter(MetricsLabel{"operator", "accept_opensearch"},
                          MetricsDirection::read, MetricsVisibility::external_,
                          MetricsUnit::events);
+    lifecycle_ = Lifecycle::running;
     co_return;
   }
 
@@ -392,6 +392,7 @@ public:
                             .is_action = true,
                             .failed = failed,
                           });
+        active_request_count_.fetch_add(1, std::memory_order_relaxed);
       },
       [&](RequestBody msg) -> Task<void> {
         auto response_signal = Option<Arc<ResponseSignal>>{None{}};
@@ -472,6 +473,7 @@ public:
           }
           req = std::move(it->second);
           active_requests_.erase(it);
+          active_request_count_.fetch_sub(1, std::memory_order_relaxed);
         }
         if (req->response_signal->has_sent()) {
           co_return;
@@ -521,30 +523,90 @@ public:
   auto finalize(Push<table_slice>& push, OpCtx& ctx)
     -> Task<FinalizeBehavior> override {
     TENZIR_UNUSED(push, ctx);
-    co_return FinalizeBehavior::done;
+    if (lifecycle_ == Lifecycle::done) {
+      co_return FinalizeBehavior::done;
+    }
+    begin_draining();
+    maybe_finish_draining();
+    co_return lifecycle_ == Lifecycle::done ? FinalizeBehavior::done
+                                            : FinalizeBehavior::continue_;
   }
 
   auto stop(OpCtx& ctx) -> Task<void> override {
     TENZIR_UNUSED(ctx);
-    force_stop();
+    begin_draining();
+    maybe_finish_draining();
     co_return;
   }
 
   auto state() -> OperatorState override {
-    return not server_ ? OperatorState::done : OperatorState::normal;
+    maybe_finish_draining();
+    return lifecycle_ == Lifecycle::done ? OperatorState::done
+                                         : OperatorState::normal;
   }
 
 private:
+  enum class Lifecycle {
+    starting,
+    running,
+    draining,
+    done,
+  };
+
   static auto get_max_connections() -> uint64_t {
     return 10;
   }
 
+  static constexpr auto drain_timeout = std::chrono::seconds{5};
+
   void force_stop() {
+    if (lifecycle_ == Lifecycle::done) {
+      return;
+    }
+    lifecycle_ = Lifecycle::done;
+    drain_deadline_ = None{};
     if (server_) {
       (*server_)->server().forceStop();
       // move server to a new thread, where it can call thread join
       std::thread([srv = std::exchange(server_, None{})] {}).detach();
     }
+  }
+
+  auto begin_draining() -> void {
+    if (lifecycle_ != Lifecycle::running) {
+      return;
+    }
+    lifecycle_ = Lifecycle::draining;
+    drain_deadline_ = std::chrono::steady_clock::now() + drain_timeout;
+    if (server_) {
+      (*server_)->server().drain();
+    }
+  }
+
+  auto maybe_finish_draining() -> void {
+    if (lifecycle_ != Lifecycle::draining) {
+      return;
+    }
+    if (drain_deadline_
+        and std::chrono::steady_clock::now() >= *drain_deadline_) {
+      force_stop();
+      return;
+    }
+    if (active_request_count_.load(std::memory_order_relaxed) != 0) {
+      return;
+    }
+    if (active_connections_->available_permits()
+        != detail::narrow<size_t>(get_max_connections())) {
+      return;
+    }
+    if (not message_queue_->empty()) {
+      return;
+    }
+    drain_deadline_ = None{};
+    if (server_) {
+      std::thread([srv = std::exchange(server_, None{})] {}).detach();
+    }
+    lifecycle_ = Lifecycle::done;
   }
 
   auto make_config(OpCtx& ctx) const
@@ -609,6 +671,9 @@ private:
   MetricsCounter bytes_read_counter_;
   MetricsCounter events_read_counter_;
   mutable Arc<MessageQueue> message_queue_{std::in_place, uint32_t{64}};
+  Lifecycle lifecycle_ = Lifecycle::starting;
+  Atomic<uint64_t> active_request_count_ = 0;
+  Option<std::chrono::steady_clock::time_point> drain_deadline_ = None{};
 };
 
 class AcceptOpenSearchPlugin : public virtual OperatorPlugin {


### PR DESCRIPTION
## 🔍 Problem

- `accept_http` and `accept_opensearch` handled `stop()` as a hard stop.
- That dropped accepted requests instead of letting in-flight work drain.

## 🛠️ Solution

- switch both operators to a draining lifecycle on `stop()`
- call `server().drain()` instead of `forceStop()` for graceful shutdown
- wait for active requests, connection permits, and queued messages to clear
- keep a bounded timeout and preserve the hard-stop path for cancellation

## 💬 Review

- Focus on the new drain completion conditions and fallback timeout.
- No changelog entry per request; this is an internal shutdown fix.

<sub>✅ Closes TNZ-662</sub>
