### PR TITLE
Add ignore_case to string functions

### DIFF
--- a/changelog/unreleased/case-insensitive-text-functions.md
+++ b/changelog/unreleased/case-insensitive-text-functions.md
@@ -1,0 +1,18 @@
+---
+title: Case-insensitive text functions
+type: feature
+authors:
+  - aljazerzen
+created: 2026-06-22T00:00:00.000000Z
+---
+
+String functions now accept an `ignore_case` argument for case-insensitive
+matching, removing the need to call `to_lower()` on both sides of a
+comparison. It is available on `starts_with`, `ends_with`, `contains`,
+`replace`, and `split`, and defaults to `false`. Comparison uses full Unicode
+case folding, so `"Aljaž".starts_with("aljaž", ignore_case=true)` is `true` and
+`equals("STRASSE", "straße", ignore_case=true)` is `true`.
+
+The new `equals(x, y, ignore_case=false)` function performs string equality
+with optional case folding, covering the case-insensitive equivalent of the
+`==` operator.

--- a/cmake/TenzirMacDependencyPaths.cmake
+++ b/cmake/TenzirMacDependencyPaths.cmake
@@ -23,6 +23,12 @@ if (NOT _MAC_DEPENDENCY_PATHS)
       list(INSERT CMAKE_PREFIX_PATH 0 "${HOMEBREW_PREFIX}/opt/openssl")
       # Find libpcap correctly.
       list(INSERT CMAKE_PREFIX_PATH 0 "${HOMEBREW_PREFIX}/opt/libpcap")
+      # Find ICU correctly. Homebrew installs `icu4c` as a keg-only formula,
+      # so CMake will not discover it through the top-level Homebrew prefix.
+      if (EXISTS "${HOMEBREW_PREFIX}/opt/icu4c")
+        list(INSERT CMAKE_PREFIX_PATH 0 "${HOMEBREW_PREFIX}/opt/icu4c")
+        set(ICU_ROOT "${HOMEBREW_PREFIX}/opt/icu4c")
+      endif ()
       # Find libunwind-headers correctly. The headers must be installed
       # separately; the library is available as under the umbrealla framework
       # System.framework. Directly linking against libunwind at its location

--- a/libtenzir/CMakeLists.txt
+++ b/libtenzir/CMakeLists.txt
@@ -156,6 +156,13 @@ find_package(
 find_package(re2 REQUIRED)
 provide_find_module(re2)
 
+# -- ICU (Unicode case folding) ------------------------------------------------
+
+find_package(
+  ICU
+  COMPONENTS uc
+  REQUIRED)
+
 # -- reproc --------------------------------------------------------------------
 
 find_package(reproc++ REQUIRED)
@@ -531,6 +538,12 @@ dependency_summary("Boost" Boost::headers "Dependencies")
 target_link_libraries(libtenzir PUBLIC re2::re2)
 string(APPEND TENZIR_FIND_DEPENDENCY_LIST "\nfind_package(re2 REQUIRED)")
 dependency_summary("re2" re2::re2 "Dependencies")
+
+# Link against ICU for Unicode case folding.
+target_link_libraries(libtenzir PRIVATE ICU::uc)
+string(APPEND TENZIR_FIND_DEPENDENCY_LIST
+       "\nfind_package(ICU COMPONENTS uc REQUIRED)")
+dependency_summary("ICU" ICU::uc "Dependencies")
 
 # Link against folly.
 if (TENZIR_ENABLE_BUNDLED_FACEBOOK_LIBS)

--- a/libtenzir/builtins/functions/contains.cpp
+++ b/libtenzir/builtins/functions/contains.cpp
@@ -8,12 +8,14 @@
 
 #include "tenzir/arrow_utils.hpp"
 #include "tenzir/detail/enumerate.hpp"
+#include "tenzir/detail/string.hpp"
 #include "tenzir/multi_series.hpp"
 #include "tenzir/plugin/register.hpp"
 #include "tenzir/tql2/plugin.hpp"
 #include "tenzir/view.hpp"
 #include "tenzir/view3.hpp"
 
+#include <arrow/array/builder_binary.h>
 #include <arrow/array/builder_primitive.h>
 #include <arrow/array/data.h>
 #include <arrow/array/util.h>
@@ -28,6 +30,22 @@
 namespace tenzir::plugins::contains {
 
 namespace {
+
+/// Returns a copy of `array` with each value replaced by its full Unicode case
+/// folding, preserving nulls. Used for case-insensitive comparison.
+auto fold_case(const arrow::StringArray& array)
+  -> std::shared_ptr<arrow::StringArray> {
+  auto b = arrow::StringBuilder{tenzir::arrow_memory_pool()};
+  check(b.Reserve(array.length()));
+  for (auto i = int64_t{0}; i < array.length(); ++i) {
+    if (array.IsNull(i)) {
+      check(b.AppendNull());
+      continue;
+    }
+    check(b.Append(detail::utf8_fold_case(array.Value(i))));
+  }
+  return std::static_pointer_cast<arrow::StringArray>(finish(b));
+}
 
 auto comparable(const type& x, const type& y) -> bool {
   return match(std::tie(x, y), []<typename X, typename Y>(const X&, const Y&) {
@@ -66,9 +84,26 @@ auto equals(data_view3 l, const data& r, bool exact) -> bool {
 }
 
 auto contains(const series& input, const type& what_type, const data& what,
-              bool exact, std::vector<bool>& b) -> void {
+              bool exact, bool ignore_case, std::vector<bool>& b) -> void {
   TENZIR_ASSERT(std::cmp_equal(input.length(), b.size()));
   if (comparable(input.type, what_type)) {
+    // For case-insensitive string comparison we lower the column once and
+    // compare against the already-lowered needle. `what` is lowered by the
+    // caller when `ignore_case` is set.
+    if (ignore_case) {
+      if (auto ss = input.as<string_type>(); ss and is<std::string>(what)) {
+        const auto& needle = as<std::string>(what);
+        auto lowered = fold_case(*ss->array);
+        for (auto i = int64_t{0}; i < lowered->length(); ++i) {
+          if (lowered->IsNull(i)) {
+            continue;
+          }
+          auto v = lowered->Value(i);
+          b[i] = b[i] or (exact ? v == needle : v.contains(needle));
+        }
+        return;
+      }
+    }
     for (const auto& [i, val] : detail::enumerate(input.values())) {
       b[i] = b[i] or equals(val, what, exact);
     }
@@ -76,7 +111,7 @@ auto contains(const series& input, const type& what_type, const data& what,
   }
   if (const auto rs = input.as<record_type>()) {
     for (const auto& field : rs->fields()) {
-      contains(field.data, what_type, what, exact, b);
+      contains(field.data, what_type, what, exact, ignore_case, b);
     }
     return;
   }
@@ -84,7 +119,7 @@ auto contains(const series& input, const type& what_type, const data& what,
     auto b_ = std::vector<bool>{};
     b_.resize(ls->array->values()->length());
     contains({ls->type.value_type(), ls->array->values()}, what_type, what,
-             exact, b_);
+             exact, ignore_case, b_);
     auto curr = b_.begin();
     for (auto i = int64_t{}; i < ls->length(); ++i) {
       auto begin = curr;
@@ -108,10 +143,12 @@ class plugin final : public function_plugin {
     auto input = ast::expression{};
     auto target = located<data>{};
     auto exact = false;
+    auto ignore_case = false;
     TRY(argument_parser2::function(name())
           .positional("input", input, "any")
           .positional("target", target)
           .named_optional("exact", exact)
+          .named_optional("ignore_case", ignore_case)
           .parse(inv, ctx));
     if (is<record>(target.inner) or is<list>(target.inner)) {
       diagnostic::error("`target` cannot be a list or a record")
@@ -119,21 +156,24 @@ class plugin final : public function_plugin {
         .emit(ctx);
       return failure::promise();
     }
-    return function_use::make([in = std::move(input),
-                               what = std::move(target.inner),
-                               exact](evaluator eval, session) -> multi_series {
-      const auto what_type = type::infer(what).value();
-      auto b = arrow::BooleanBuilder{tenzir::arrow_memory_pool()};
-      check(b.Reserve(eval.length()));
-      auto result = std::vector<bool>{};
-      for (const auto& s : eval(in)) {
-        result.resize(detail::narrow<size_t>(s.length()));
-        contains(s, what_type, what, exact, result);
-        check(b.AppendValues(result));
-        result.clear();
-      }
-      return series{bool_type{}, finish(b)};
-    });
+    if (ignore_case and is<std::string>(target.inner)) {
+      target.inner = detail::utf8_fold_case(as<std::string>(target.inner));
+    }
+    return function_use::make(
+      [in = std::move(input), what = std::move(target.inner), exact,
+       ignore_case](evaluator eval, session) -> multi_series {
+        const auto what_type = type::infer(what).value();
+        auto b = arrow::BooleanBuilder{tenzir::arrow_memory_pool()};
+        check(b.Reserve(eval.length()));
+        auto result = std::vector<bool>{};
+        for (const auto& s : eval(in)) {
+          result.resize(detail::narrow<size_t>(s.length()));
+          contains(s, what_type, what, exact, ignore_case, result);
+          check(b.AppendValues(result));
+          result.clear();
+        }
+        return series{bool_type{}, finish(b)};
+      });
   }
 };
 

--- a/libtenzir/builtins/functions/string.cpp
+++ b/libtenzir/builtins/functions/string.cpp
@@ -7,12 +7,15 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include <tenzir/arrow_utils.hpp>
+#include <tenzir/detail/string.hpp>
 #include <tenzir/plugin/register.hpp>
 #include <tenzir/to_string.hpp>
 #include <tenzir/tql2/eval.hpp>
 #include <tenzir/tql2/plugin.hpp>
 
 #include <arrow/array/array_binary.h>
+#include <arrow/array/builder_binary.h>
+#include <arrow/array/builder_nested.h>
 #include <arrow/compute/api.h>
 #include <arrow/util/utf8.h>
 #include <re2/re2.h>
@@ -27,6 +30,22 @@ namespace {
 
 constexpr auto max_string_size
   = static_cast<size_t>(std::numeric_limits<int32_t>::max());
+
+/// Returns a copy of `array` with each value replaced by its full Unicode case
+/// folding, preserving nulls. Used for case-insensitive comparison.
+auto fold_case(const arrow::StringArray& array)
+  -> std::shared_ptr<arrow::StringArray> {
+  auto b = arrow::StringBuilder{tenzir::arrow_memory_pool()};
+  check(b.Reserve(array.length()));
+  for (auto i = int64_t{0}; i < array.length(); ++i) {
+    if (array.IsNull(i)) {
+      check(b.AppendNull());
+      continue;
+    }
+    check(b.Append(detail::utf8_fold_case(array.Value(i))));
+  }
+  return finish(b);
+}
 
 class starts_or_ends_with : public virtual function_plugin {
 public:
@@ -45,13 +64,15 @@ public:
     -> failure_or<function_ptr> override {
     auto subject_expr = ast::expression{};
     auto arg_expr = ast::expression{};
+    auto ignore_case = false;
     TRY(argument_parser2::function(name())
           .positional("x", subject_expr, "string")
           .positional("prefix", arg_expr, "string")
+          .named_optional("ignore_case", ignore_case)
           .parse(inv, ctx));
     // TODO: This shows the need for some abstraction.
     return function_use::make([subject_expr = std::move(subject_expr),
-                               arg_expr = std::move(arg_expr),
+                               arg_expr = std::move(arg_expr), ignore_case,
                                this](evaluator eval, session ctx) -> series {
       TENZIR_UNUSED(ctx);
       auto b = arrow::BooleanBuilder{tenzir::arrow_memory_pool()};
@@ -62,16 +83,26 @@ public:
         auto f = detail::overload{
           [&](const arrow::StringArray& subject,
               const arrow::StringArray& arg) {
-            for (auto i = int64_t{0}; i < subject.length(); ++i) {
-              if (subject.IsNull(i) or arg.IsNull(i)) {
+            auto subject_lc = std::shared_ptr<arrow::StringArray>{};
+            auto arg_lc = std::shared_ptr<arrow::StringArray>{};
+            const auto* s = &subject;
+            const auto* a = &arg;
+            if (ignore_case) {
+              subject_lc = fold_case(subject);
+              arg_lc = fold_case(arg);
+              s = subject_lc.get();
+              a = arg_lc.get();
+            }
+            for (auto i = int64_t{0}; i < s->length(); ++i) {
+              if (s->IsNull(i) or a->IsNull(i)) {
                 check(b.AppendNull());
                 continue;
               }
               auto result = bool{};
               if (starts_with_) {
-                result = subject.Value(i).starts_with(arg.Value(i));
+                result = s->Value(i).starts_with(a->Value(i));
               } else {
-                result = subject.Value(i).ends_with(arg.Value(i));
+                result = s->Value(i).ends_with(a->Value(i));
               }
               check(b.Append(result));
             }
@@ -578,12 +609,16 @@ public:
     auto pattern = located<std::string>{};
     auto replacement = std::string{};
     auto max_replacements = std::optional<located<int64_t>>{};
-    TRY(argument_parser2::function(name())
-          .positional("x", subject_expr, "string")
-          .positional("pattern", pattern)
-          .positional("replacement", replacement)
-          .named("max", max_replacements)
-          .parse(inv, ctx));
+    auto ignore_case = false;
+    auto parser = argument_parser2::function(name());
+    parser.positional("x", subject_expr, "string")
+      .positional("pattern", pattern)
+      .positional("replacement", replacement)
+      .named("max", max_replacements);
+    if (not regex_) {
+      parser.named_optional("ignore_case", ignore_case);
+    }
+    TRY(parser.parse(inv, ctx));
     if (max_replacements) {
       if (max_replacements->inner < 0) {
         diagnostic::error("`max` must be at least 0, but got {}",
@@ -592,47 +627,77 @@ public:
           .emit(ctx);
       }
     }
-    return function_use::make([this, subject_expr = std::move(subject_expr),
-                               pattern = std::move(pattern),
-                               replacement = std::move(replacement),
-                               max_replacements](evaluator eval, session ctx) {
-      auto result_type = string_type{};
-      auto result_arrow_type
-        = std::shared_ptr<arrow::DataType>{result_type.to_arrow_type()};
-      return map_series(eval(subject_expr), [&](series subject) {
-        auto f = detail::overload{
-          [&](const arrow::StringArray& array) {
-            auto max = max_replacements ? max_replacements->inner : -1;
-            auto options = arrow::compute::ReplaceSubstringOptions(
-              pattern.inner, replacement, max);
-            auto result = arrow::compute::CallFunction(
-              regex_ ? "replace_substring_regex" : "replace_substring", {array},
-              &options);
-            if (not result.ok()) {
-              diagnostic::warning("{}",
-                                  result.status().ToStringWithoutContextLines())
-                .severity(result.status().IsInvalid() ? severity::error
-                                                      : severity::warning)
-                .primary(pattern.source)
+    return function_use::make(
+      [this, subject_expr = std::move(subject_expr),
+       pattern = std::move(pattern), replacement = std::move(replacement),
+       max_replacements, ignore_case](evaluator eval, session ctx) {
+        auto result_type = string_type{};
+        auto result_arrow_type
+          = std::shared_ptr<arrow::DataType>{result_type.to_arrow_type()};
+        return map_series(eval(subject_expr), [&](series subject) {
+          auto f = detail::overload{
+            [&](const arrow::StringArray& array) {
+              auto max = max_replacements ? max_replacements->inner : -1;
+              // Arrow's literal `replace_substring` has no case-insensitive
+              // mode, so we match with full Unicode case folding ourselves and
+              // rebuild the result from the original bytes.
+              if (ignore_case and not regex_ and not pattern.inner.empty()) {
+                auto fp = detail::utf8_fold_case(pattern.inner);
+                auto b = arrow::StringBuilder{tenzir::arrow_memory_pool()};
+                check(b.Reserve(array.length()));
+                for (auto i = int64_t{0}; i < array.length(); ++i) {
+                  if (array.IsNull(i)) {
+                    check(b.AppendNull());
+                    continue;
+                  }
+                  auto v = array.Value(i);
+                  auto out = std::string{};
+                  auto pos = size_t{0};
+                  auto count = int64_t{0};
+                  for (auto [s, e] : detail::utf8_fold_case_find(v, fp)) {
+                    if (max >= 0 and count >= max) {
+                      break;
+                    }
+                    out.append(v.substr(pos, s - pos));
+                    out.append(replacement);
+                    pos = e;
+                    ++count;
+                  }
+                  out.append(v.substr(pos));
+                  check(b.Append(out));
+                }
+                return series{result_type, finish(b)};
+              }
+              auto options = arrow::compute::ReplaceSubstringOptions(
+                pattern.inner, replacement, max);
+              auto result = arrow::compute::CallFunction(
+                regex_ ? "replace_substring_regex" : "replace_substring",
+                {array}, &options);
+              if (not result.ok()) {
+                diagnostic::warning(
+                  "{}", result.status().ToStringWithoutContextLines())
+                  .severity(result.status().IsInvalid() ? severity::error
+                                                        : severity::warning)
+                  .primary(pattern.source)
+                  .emit(ctx);
+                return series::null(result_type, subject.length());
+              }
+              return series{result_type, result.MoveValueUnsafe().make_array()};
+            },
+            [&](const arrow::NullArray& array) {
+              return series::null(result_type, array.length());
+            },
+            [&](const auto&) {
+              diagnostic::warning("`{}` expected `string`, but got `{}`",
+                                  name(), subject.type.kind())
+                .primary(subject_expr)
                 .emit(ctx);
               return series::null(result_type, subject.length());
-            }
-            return series{result_type, result.MoveValueUnsafe().make_array()};
-          },
-          [&](const arrow::NullArray& array) {
-            return series::null(result_type, array.length());
-          },
-          [&](const auto&) {
-            diagnostic::warning("`{}` expected `string`, but got `{}`", name(),
-                                subject.type.kind())
-              .primary(subject_expr)
-              .emit(ctx);
-            return series::null(result_type, subject.length());
-          },
-        };
-        return match(*subject.array, f);
+            },
+          };
+          return match(*subject.array, f);
+        });
       });
-    });
   }
 
 private:
@@ -690,12 +755,16 @@ public:
     auto pattern = located<std::string>{};
     auto reverse = std::optional<location>{};
     auto max_splits = std::optional<located<int64_t>>{};
-    TRY(argument_parser2::function(name())
-          .positional("x", subject_expr, "string")
-          .positional("pattern", pattern)
-          .named("max", max_splits)
-          .named("reverse", reverse)
-          .parse(inv, ctx));
+    auto ignore_case = false;
+    auto parser = argument_parser2::function(name());
+    parser.positional("x", subject_expr, "string")
+      .positional("pattern", pattern)
+      .named("max", max_splits)
+      .named("reverse", reverse);
+    if (not regex_) {
+      parser.named_optional("ignore_case", ignore_case);
+    }
+    TRY(parser.parse(inv, ctx));
     if (max_splits) {
       if (max_splits->inner < 0) {
         diagnostic::error("`max` must be at least 0, but got {}",
@@ -706,12 +775,52 @@ public:
     }
     return function_use::make([this, subject_expr = std::move(subject_expr),
                                pattern = std::move(pattern), max_splits,
-                               reverse](evaluator eval, session ctx) {
+                               reverse,
+                               ignore_case](evaluator eval, session ctx) {
       static const auto result_type = type{list_type{string_type{}}};
       static const auto result_arrow_type = result_type.to_arrow_type();
       return map_series(eval(subject_expr), [&](series subject) {
         auto f = detail::overload{
           [&](const arrow::StringArray& array) {
+            // Arrow's literal `split_pattern` has no case-insensitive mode, so
+            // we match the delimiter with full Unicode case folding ourselves
+            // and split the original bytes.
+            if (ignore_case and not regex_ and not pattern.inner.empty()) {
+              auto fp = detail::utf8_fold_case(pattern.inner);
+              auto max = max_splits ? max_splits->inner : -1;
+              auto value_builder = std::make_shared<arrow::StringBuilder>(
+                tenzir::arrow_memory_pool());
+              auto b = arrow::ListBuilder{tenzir::arrow_memory_pool(),
+                                          value_builder};
+              for (auto i = int64_t{0}; i < array.length(); ++i) {
+                if (array.IsNull(i)) {
+                  check(b.AppendNull());
+                  continue;
+                }
+                check(b.Append());
+                auto v = array.Value(i);
+                auto ranges = detail::utf8_fold_case_find(v, fp);
+                // `max` bounds the number of splits; `reverse` keeps the
+                // rightmost ones. The output order stays left to right.
+                auto first = size_t{0};
+                auto last = ranges.size();
+                if (max >= 0 and ranges.size() > static_cast<size_t>(max)) {
+                  if (reverse.has_value()) {
+                    first = ranges.size() - static_cast<size_t>(max);
+                  } else {
+                    last = static_cast<size_t>(max);
+                  }
+                }
+                auto pos = size_t{0};
+                for (auto k = first; k < last; ++k) {
+                  auto [s, e] = ranges[k];
+                  check(value_builder->Append(v.substr(pos, s - pos)));
+                  pos = e;
+                }
+                check(value_builder->Append(v.substr(pos)));
+              }
+              return series{result_type, finish(b)};
+            }
             auto options = arrow::compute::SplitPatternOptions();
             options.pattern = pattern.inner;
             options.max_splits = max_splits ? max_splits->inner : -1;
@@ -851,6 +960,98 @@ public:
   }
 };
 
+class equals : public virtual function_plugin {
+public:
+  auto name() const -> std::string override {
+    return "equals";
+  }
+
+  auto is_deterministic() const -> bool override {
+    return true;
+  }
+
+  auto make_function(function_invocation inv, session ctx) const
+    -> failure_or<function_ptr> override {
+    auto left_expr = ast::expression{};
+    auto right_expr = ast::expression{};
+    auto ignore_case = false;
+    TRY(argument_parser2::function(name())
+          .positional("x", left_expr, "string")
+          .positional("y", right_expr, "string")
+          .named_optional("ignore_case", ignore_case)
+          .parse(inv, ctx));
+    return function_use::make(
+      [left_expr = std::move(left_expr), right_expr = std::move(right_expr),
+       ignore_case](evaluator eval, session ctx) -> series {
+        auto b = arrow::BooleanBuilder{tenzir::arrow_memory_pool()};
+        check(b.Reserve(eval.length()));
+        auto warned = false;
+        for (auto [left, right] :
+             split_multi_series(eval(left_expr), eval(right_expr))) {
+          TENZIR_ASSERT(left.length() == right.length());
+          // Three-valued equality consistent with the `==` operator: two nulls
+          // compare equal, a null and a non-null compare unequal.
+          auto append_null_aware = [&](const arrow::Array& l,
+                                       const arrow::Array& r, auto&& equal_at) {
+            for (auto i = int64_t{0}; i < l.length(); ++i) {
+              auto ln = l.IsNull(i);
+              auto rn = r.IsNull(i);
+              if (ln or rn) {
+                check(b.Append(ln and rn));
+                continue;
+              }
+              check(b.Append(equal_at(i)));
+            }
+          };
+          auto f = detail::overload{
+            [&](const arrow::StringArray& l, const arrow::StringArray& r) {
+              auto l_lc = std::shared_ptr<arrow::StringArray>{};
+              auto r_lc = std::shared_ptr<arrow::StringArray>{};
+              const auto* lp = &l;
+              const auto* rp = &r;
+              if (ignore_case) {
+                l_lc = fold_case(l);
+                r_lc = fold_case(r);
+                lp = l_lc.get();
+                rp = r_lc.get();
+              }
+              append_null_aware(l, r, [&](int64_t i) {
+                return lp->Value(i) == rp->Value(i);
+              });
+            },
+            [&](const arrow::NullArray&, const arrow::NullArray&) {
+              check(b.AppendValues(left.length(), true));
+            },
+            [&](const arrow::StringArray& l, const arrow::NullArray&) {
+              for (auto i = int64_t{0}; i < l.length(); ++i) {
+                check(b.Append(l.IsNull(i)));
+              }
+            },
+            [&](const arrow::NullArray&, const arrow::StringArray& r) {
+              for (auto i = int64_t{0}; i < r.length(); ++i) {
+                check(b.Append(r.IsNull(i)));
+              }
+            },
+            [&](const auto&, const auto&) {
+              if (not warned) {
+                warned = true;
+                diagnostic::warning("`equals` expected `string`, but got `{}` "
+                                    "and `{}`",
+                                    left.type.kind(), right.type.kind())
+                  .primary(left_expr)
+                  .primary(right_expr)
+                  .emit(ctx);
+              }
+              check(b.AppendNulls(left.length()));
+            },
+          };
+          match(std::tie(*left.array, *right.array), f);
+        }
+        return series{bool_type{}, finish(b)};
+      });
+  }
+};
+
 } // namespace
 
 } // namespace tenzir::plugins::string
@@ -902,3 +1103,4 @@ TENZIR_REGISTER_PLUGIN(string_fn<true>);
 TENZIR_REGISTER_PLUGIN(split_fn{true});
 TENZIR_REGISTER_PLUGIN(split_fn{false});
 TENZIR_REGISTER_PLUGIN(join);
+TENZIR_REGISTER_PLUGIN(equals);

--- a/libtenzir/include/tenzir/detail/string.hpp
+++ b/libtenzir/include/tenzir/detail/string.hpp
@@ -51,6 +51,26 @@ constexpr inline std::string_view ascii_whitespace = " \t\r\n\f\v";
   return ascii_isalpha(c) or ascii_isdigit(c);
 }
 
+/// Returns the full Unicode case folding of `input`.
+///
+/// Unlike lowercasing, full case folding maps characters so that
+/// case-insensitive comparison works across scripts, e.g. the German "ß"
+/// folds to "ss", so "STRASSE" and "straße" fold to the same string. Use this
+/// for case-insensitive string comparison rather than `ascii_tolower`.
+[[nodiscard]] auto utf8_fold_case(std::string_view input) -> std::string;
+
+/// Finds all non-overlapping, left-to-right occurrences of `folded_pattern`
+/// within `input` using full Unicode case folding, and returns their byte
+/// ranges `[start, end)` in `input`.
+///
+/// `folded_pattern` must already be case-folded (see `utf8_fold_case`). Matches
+/// are aligned to code point boundaries in `input`, so a pattern of `"s"` does
+/// not match half of a `"ß"` (which folds to `"ss"`). An empty pattern yields
+/// no matches.
+[[nodiscard]] auto
+utf8_fold_case_find(std::string_view input, std::string_view folded_pattern)
+  -> std::vector<std::pair<size_t, size_t>>;
+
 /// Returns a copy of `input` with ASCII bytes folded to lowercase.
 [[nodiscard]] inline auto ascii_tolower(std::string_view input) -> std::string {
   auto result = std::string{input};

--- a/libtenzir/src/detail/string.cpp
+++ b/libtenzir/src/detail/string.cpp
@@ -10,15 +10,105 @@
 
 #include "tenzir/detail/assert.hpp"
 #include "tenzir/detail/escapers.hpp"
+#include "tenzir/detail/narrow.hpp"
+
+#include <unicode/ucasemap.h>
+#include <unicode/utypes.h>
 
 #include <algorithm>
 #include <cstring>
 #include <simdjson.h>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 namespace tenzir {
 namespace detail {
+
+auto utf8_fold_case(std::string_view input) -> std::string {
+  if (input.empty()) {
+    return {};
+  }
+  auto status = U_ZERO_ERROR;
+  auto* csm = ucasemap_open("", 0, &status);
+  if (U_FAILURE(status)) {
+    return std::string{input};
+  }
+  const auto src_length = narrow_cast<int32_t>(input.size());
+  auto result = std::string{};
+  // Full case folding can grow the string (e.g. "ß" -> "ss"), so size up front
+  // and retry once if the initial buffer is too small.
+  result.resize(input.size());
+  auto dest_length = ucasemap_utf8FoldCase(csm, result.data(),
+                                           narrow_cast<int32_t>(result.size()),
+                                           input.data(), src_length, &status);
+  if (status == U_BUFFER_OVERFLOW_ERROR) {
+    status = U_ZERO_ERROR;
+    result.resize(narrow_cast<size_t>(dest_length));
+    dest_length = ucasemap_utf8FoldCase(csm, result.data(),
+                                        narrow_cast<int32_t>(result.size()),
+                                        input.data(), src_length, &status);
+  }
+  ucasemap_close(csm);
+  if (U_FAILURE(status)) {
+    return std::string{input};
+  }
+  result.resize(narrow_cast<size_t>(dest_length));
+  return result;
+}
+
+auto utf8_fold_case_find(std::string_view input,
+                         std::string_view folded_pattern)
+  -> std::vector<std::pair<size_t, size_t>> {
+  auto result = std::vector<std::pair<size_t, size_t>>{};
+  if (folded_pattern.empty() or input.empty()) {
+    return result;
+  }
+  // Decompose `input` into its code points, recording each one's byte range and
+  // its full case folding. Folding per code point matches folding the whole
+  // string for Unicode's default full case folding, while letting us map match
+  // boundaries back to the original byte offsets.
+  struct code_point {
+    size_t start;
+    size_t end;
+    std::string folded;
+  };
+  auto cps = std::vector<code_point>{};
+  for (size_t i = 0; i < input.size();) {
+    auto j = i + 1;
+    while (j < input.size()
+           and (static_cast<unsigned char>(input[j]) & 0xC0) == 0x80) {
+      ++j;
+    }
+    cps.push_back({i, j, utf8_fold_case(input.substr(i, j - i))});
+    i = j;
+  }
+  for (size_t i = 0; i < cps.size();) {
+    auto acc = std::string{};
+    auto matched_end = std::string_view::npos;
+    auto next = i;
+    for (auto j = i; j < cps.size(); ++j) {
+      acc += cps[j].folded;
+      if (acc.size() > folded_pattern.size()
+          or folded_pattern.compare(0, acc.size(), acc) != 0) {
+        // The accumulated folding overshoots or diverges from the pattern.
+        break;
+      }
+      if (acc.size() == folded_pattern.size()) {
+        matched_end = cps[j].end;
+        next = j + 1;
+        break;
+      }
+    }
+    if (matched_end != std::string_view::npos) {
+      result.emplace_back(cps[i].start, matched_end);
+      i = next;
+    } else {
+      ++i;
+    }
+  }
+  return result;
+}
 
 auto quoting_escaping_policy::basic_unescape_operation(
   std::string_view::iterator begin, std::string_view::iterator end,

--- a/nix/dependencies.nix
+++ b/nix/dependencies.nix
@@ -23,6 +23,7 @@
   nlohmann_json,
   crc32c,
   grpc,
+  icu,
   spdlog,
   simdjson,
   robin-map,
@@ -115,6 +116,7 @@ in
     libevent
     snappy
     google-cloud-cpp-tenzir
+    icu
     nlohmann_json
     crc32c
     grpc

--- a/scripts/debian/install-dev-dependencies.sh
+++ b/scripts/debian/install-dev-dependencies.sh
@@ -34,6 +34,7 @@ apt-get -y --no-install-recommends install \
   libgoogle-glog-dev \
   libgrpc-dev \
   libgrpc++-dev \
+  libicu-dev \
   libmaxminddb-dev \
   libmimalloc-dev \
   libnats-dev \

--- a/scripts/macOS/install-dev-dependencies.sh
+++ b/scripts/macOS/install-dev-dependencies.sh
@@ -23,6 +23,7 @@ brew install --overwrite \
   glog \
   gnu-sed \
   grpc \
+  icu4c \
   libevent \
   libmaxminddb \
   libpcap \

--- a/test/tests/functions/contains_ignore_case.tql
+++ b/test/tests/functions/contains_ignore_case.tql
@@ -1,0 +1,7 @@
+from {rec: {host: "HOST-A"}, tags: ["Foo", "BAR"], scalar: "Hello World"}
+contains_record = contains(rec, "host-a", ignore_case=true)
+contains_list = contains(tags, "bar", ignore_case=true)
+contains_substring = contains(scalar, "WORLD", ignore_case=true)
+contains_exact = contains(tags, "ba", exact=true, ignore_case=true)
+contains_exact_full = contains(tags, "bar", exact=true, ignore_case=true)
+contains_default = contains(scalar, "WORLD")

--- a/test/tests/functions/contains_ignore_case.txt
+++ b/test/tests/functions/contains_ignore_case.txt
@@ -1,0 +1,16 @@
+{
+  rec: {
+    host: "HOST-A",
+  },
+  tags: [
+    "Foo",
+    "BAR",
+  ],
+  scalar: "Hello World",
+  contains_record: true,
+  contains_list: true,
+  contains_substring: true,
+  contains_exact: false,
+  contains_exact_full: true,
+  contains_default: false,
+}

--- a/test/tests/functions/string/equals_case_folding.tql
+++ b/test/tests/functions/string/equals_case_folding.tql
@@ -1,0 +1,9 @@
+// Full Unicode case folding: German "ß" folds to "ss", so "STRASSE" and
+// "straße" must compare equal under `ignore_case`.
+from {
+  equals_ci: equals("STRASSE", "straße", ignore_case=true),
+  contains_ci: contains("STRASSE", "straße", ignore_case=true),
+  starts_with_ci: "STRASSE".starts_with("straße", ignore_case=true),
+  replace_ci: "Fußstraße".replace("STRASSE", "weg", ignore_case=true),
+  split_ci: "Fußstraße".split("STRASSE", ignore_case=true),
+}

--- a/test/tests/functions/string/equals_case_folding.txt
+++ b/test/tests/functions/string/equals_case_folding.txt
@@ -1,0 +1,10 @@
+{
+  equals_ci: true,
+  contains_ci: true,
+  starts_with_ci: true,
+  replace_ci: "Fußweg",
+  split_ci: [
+    "Fuß",
+    "",
+  ],
+}

--- a/test/tests/functions/string/equals_null.tql
+++ b/test/tests/functions/string/equals_null.tql
@@ -1,0 +1,6 @@
+from {a: "AB", b: null},
+  {a: null, b: null},
+  {a: "ab", b: "AB"},
+  {a: "ab", b: "ab"}
+equals_ci = equals(a, b, ignore_case=true)
+equals_cs = equals(a, b)

--- a/test/tests/functions/string/equals_null.txt
+++ b/test/tests/functions/string/equals_null.txt
@@ -1,0 +1,24 @@
+{
+  a: "AB",
+  b: null,
+  equals_ci: false,
+  equals_cs: false,
+}
+{
+  a: null,
+  b: null,
+  equals_ci: true,
+  equals_cs: true,
+}
+{
+  a: "ab",
+  b: "AB",
+  equals_ci: true,
+  equals_cs: false,
+}
+{
+  a: "ab",
+  b: "ab",
+  equals_ci: true,
+  equals_cs: true,
+}

--- a/test/tests/functions/string/ignore_case.tql
+++ b/test/tests/functions/string/ignore_case.tql
@@ -1,0 +1,15 @@
+from {
+  msg: "Connection ERROR on HOST-01",
+  method: "Get",
+  user: "Aljaž",
+  path: "/API/v1/Users",
+}
+starts_with = method.starts_with("get", ignore_case=true)
+starts_with_default = method.starts_with("get")
+ends_with = path.ends_with("USERS", ignore_case=true)
+equals = equals(method, "GET", ignore_case=true)
+equals_default = equals(method, "GET")
+equals_utf8 = equals(user, "ALJAŽ", ignore_case=true)
+replace = msg.replace("error", "<R>", ignore_case=true)
+replace_max = "aAaA".replace("a", "x", max=2, ignore_case=true)
+split = path.split("api", ignore_case=true)

--- a/test/tests/functions/string/ignore_case.txt
+++ b/test/tests/functions/string/ignore_case.txt
@@ -1,0 +1,18 @@
+{
+  msg: "Connection ERROR on HOST-01",
+  method: "Get",
+  user: "Aljaž",
+  path: "/API/v1/Users",
+  starts_with: true,
+  starts_with_default: false,
+  ends_with: true,
+  equals: true,
+  equals_default: false,
+  equals_utf8: true,
+  replace: "Connection <R> on HOST-01",
+  replace_max: "xxaA",
+  split: [
+    "/",
+    "/v1/Users",
+  ],
+}


### PR DESCRIPTION
## 🔍 Problem

- String matching in TQL is case-sensitive by default.
- Users currently need `to_lower(...)` workarounds that do not compose well.
- Binary operators cannot take named arguments, so string equality also needed a
  function-level API.

## 🛠️ Solution

- Add `ignore_case=false` to `starts_with`, `ends_with`, `contains`,
  `replace`, and `split`.
- Add a new `equals(x, y, ignore_case=false)` function.
- Use full Unicode case folding for case-insensitive string matching,
  including literal `replace` and `split`.
- Add integration coverage for ASCII and Unicode cases, including
  `STRASSE` vs `straße`.

## 💬 Review

- The main logic lives in the new Unicode case-folding helpers and the
  literal `replace` / `split` matching path.
- `replace_regex` and `split_regex` are intentionally unchanged in this PR.

<sub>
📚 Docs PR: tenzir/docs#409<br>
✅ Closes TNZ-696
</sub>
