### PR TITLE
Drain live export sources on shutdown

### DIFF
--- a/libtenzir/builtins/operators/export.cpp
+++ b/libtenzir/builtins/operators/export.cpp
@@ -249,6 +249,10 @@ public:
     }
     auto expected = std::move(result).as<caf::expected<table_slice>>();
     if (not expected) {
+      if (stopping_) {
+        done_ = true;
+        co_return;
+      }
       diagnostic::error(expected.error()).note("from export-bridge").emit(ctx);
       done_ = true;
       co_return;
@@ -327,6 +331,17 @@ public:
     return done_ ? OperatorState::done : OperatorState::normal;
   }
 
+  auto stop(OpCtx& ctx) -> Task<void> override {
+    TENZIR_UNUSED(ctx);
+    stopping_ = true;
+    if (bridge_) {
+      caf::anon_send_exit(bridge_, caf::exit_reason::user_shutdown);
+    } else {
+      done_ = true;
+    }
+    co_return;
+  }
+
   auto snapshot(Serde& serde) -> void override {
     serde("done", done_);
   }
@@ -347,6 +362,7 @@ private:
   detail::heterogeneous_string_hashset warned_unsupported_prometheus_schemas_;
   MetricsCounter read_events_counter_;
   metric_handler export_metrics_ = {};
+  bool stopping_ = false;
   bool done_ = false;
 };
 

--- a/libtenzir/builtins/operators/export.cpp
+++ b/libtenzir/builtins/operators/export.cpp
@@ -333,6 +333,14 @@ public:
 
   auto stop(OpCtx& ctx) -> Task<void> override {
     TENZIR_UNUSED(ctx);
+    // Retro-only exports drain naturally: the bridge emits an empty slice
+    // once all matching partitions have been read, and `process_task()`
+    // turns that sentinel into `done_`. Only live waits need explicit
+    // teardown, otherwise we would silently drop queued slices and
+    // in-flight partition reads on shutdown.
+    if (not args_.live) {
+      co_return;
+    }
     stopping_ = true;
     if (bridge_) {
       caf::anon_send_exit(bridge_, caf::exit_reason::user_shutdown);


### PR DESCRIPTION
## 🔍 Problem

- Live export-backed sources such as `diagnostics live=true` keep waiting on
  the export bridge after graceful shutdown starts.
- That leaves hidden platform pipelines alive until the node watchdog steps in.

## 🛠️ Solution

- Stop the export bridge explicitly from `Export::stop()`.
- Treat bridge teardown during shutdown as a clean exit.
- Bump `contrib/tenzir-plugins` to pick up the matching
  `pipeline::activity` shutdown fix.

## 💬 Review

- `libtenzir/builtins/operators/export.cpp` is the functional change here.
- This PR depends on the plugin submodule update until
  tenzir/tenzir-plugins#571 lands.

<sub>
📎 Related: tenzir/tenzir-plugins#571
</sub>
