### PR TITLE
Drain live export sources on shutdown

### DIFF
--- a/libtenzir/builtins/operators/export.cpp
+++ b/libtenzir/builtins/operators/export.cpp
@@ -249,6 +249,10 @@ public:
     }
     auto expected = std::move(result).as<caf::expected<table_slice>>();
     if (not expected) {
+      if (stopping_) {
+        done_ = true;
+        co_return;
+      }
       diagnostic::error(expected.error()).note("from export-bridge").emit(ctx);
       done_ = true;
       co_return;
@@ -327,6 +331,17 @@ public:
     return done_ ? OperatorState::done : OperatorState::normal;
   }
 
+  auto stop(OpCtx& ctx) -> Task<void> override {
+    TENZIR_UNUSED(ctx);
+    stopping_ = true;
+    if (bridge_) {
+      caf::anon_send_exit(bridge_, caf::exit_reason::user_shutdown);
+    } else {
+      done_ = true;
+    }
+    co_return;
+  }
+
   auto snapshot(Serde& serde) -> void override {
     serde("done", done_);
   }
@@ -347,6 +362,7 @@ private:
   detail::heterogeneous_string_hashset warned_unsupported_prometheus_schemas_;
   MetricsCounter read_events_counter_;
   metric_handler export_metrics_ = {};
+  bool stopping_ = false;
   bool done_ = false;
 };
 

--- a/libtenzir/builtins/operators/export.cpp
+++ b/libtenzir/builtins/operators/export.cpp
@@ -333,6 +333,17 @@ public:
 
   auto stop(OpCtx& ctx) -> Task<void> override {
     TENZIR_UNUSED(ctx);
+    // Only force the bridge down for a pure live wait. The bridge has no
+    // separate "stop accepting new live events" protocol, so when retro is
+    // also enabled we cannot tell whether the retro backlog has drained
+    // yet. Tearing down here would drop queued slices and in-flight
+    // partition reads. Pure retro exports also drain naturally via the
+    // bridge's empty-slice sentinel, so the only case that genuinely needs
+    // forced teardown is `live=true retro=false`, where the bridge would
+    // otherwise wait indefinitely.
+    if (not args_.live or args_.retro) {
+      co_return;
+    }
     stopping_ = true;
     if (bridge_) {
       caf::anon_send_exit(bridge_, caf::exit_reason::user_shutdown);


### PR DESCRIPTION
## 🔍 Problem

- Live export-backed sources (`diagnostics live=true`, `metrics live=true`, `export live=true`) keep waiting on the export bridge after graceful shutdown starts.
- That leaves hidden platform pipelines alive until the pipeline-manager watchdog steps in and force-kills them.

## 🛠️ Solution

- Add a `stop()` override on the export source operator that tears down the bridge for **pure live** waits (`live=true retro=false`), where the bridge would otherwise wait indefinitely.
- Keep `stop()` a no-op for retro-only and live+retro modes so the bridge can drain its backlog naturally via the empty-slice sentinel.
- Bump `contrib/tenzir-plugins` to pick up the matching `pipeline::activity` and `from_microsoft_graph` shutdown fixes.

## 💬 Review

- `libtenzir/builtins/operators/export.cpp` is the functional change here.
- Live+retro exports still rely on the watchdog on shutdown — the bridge has no protocol to "stop accepting new live events while still draining retro", so we accept the existing watchdog fallback rather than silently dropping retro data.
- Depends on tenzir/tenzir-plugins#571 for the submodule bump.

<sub>
📎 Related: tenzir/tenzir-plugins#571<br>
🔁 Supersedes: tenzir/tenzir#6375
</sub>
