### PR TITLE
Raise pipeline shutdown grace period to 3 minutes

### DIFF
--- a/changelog/unreleased/graceful-pipeline-shutdown-with-data-draining.md
+++ b/changelog/unreleased/graceful-pipeline-shutdown-with-data-draining.md
@@ -12,5 +12,5 @@ graceful stop signal and can finish outstanding work before the pipeline
 shuts down.
 
 A configurable grace period (`tenzir.shutdown-grace-period`, default
-30 seconds) bounds how long the system waits. After the grace period
+3 minutes) bounds how long the system waits. After the grace period
 expires, remaining pipelines are force-killed.

--- a/changelog/unreleased/graceful-pipeline-shutdown-with-data-draining.md
+++ b/changelog/unreleased/graceful-pipeline-shutdown-with-data-draining.md
@@ -13,4 +13,6 @@ shuts down.
 
 A configurable grace period (`tenzir.shutdown-grace-period`, default
 3 minutes) bounds how long the system waits. After the grace period
-expires, remaining pipelines are force-killed.
+expires, remaining pipelines are force-killed. Setting the grace period
+to `0s` (or any non-positive value) waits indefinitely, so pipelines are
+never force-killed and drain fully before the node quits.

--- a/libtenzir/include/tenzir/defaults.hpp
+++ b/libtenzir/include/tenzir/defaults.hpp
@@ -251,17 +251,6 @@ inline constexpr std::chrono::milliseconds node_connection_timeout
 inline constexpr std::chrono::milliseconds scheduler_timeout
   = std::chrono::minutes{15};
 
-/// The period to wait until a shutdown sequence finishes cleanly. After the
-/// elapses, the shutdown procedure escalates into a "hard kill".
-/// @relates shutdown_kill_timeout
-inline constexpr std::chrono::milliseconds shutdown_grace_period
-  = std::chrono::minutes{3};
-
-/// Time to wait until receiving a DOWN from a killed actor.
-/// @relates shutdown_grace_period
-inline constexpr std::chrono::seconds shutdown_kill_timeout
-  = std::chrono::minutes{1};
-
 /// The allowed false positive rate for a synopsis.
 inline constexpr double fp_rate = 0.01;
 

--- a/libtenzir/include/tenzir/detail/signal_guard.hpp
+++ b/libtenzir/include/tenzir/detail/signal_guard.hpp
@@ -33,6 +33,10 @@ namespace tenzir::detail {
 /// is fired so the pipeline can drain. On a second signal (or after the
 /// grace period) the `cancel_source` is triggered to force-cancel.
 ///
+/// A non-positive grace period means the pipeline is allowed to drain
+/// indefinitely: it is never force-cancelled on a timeout, only by a
+/// second signal.
+///
 /// The destructor joins the thread and restores the original handlers.
 class SignalGuard {
 public:
@@ -96,10 +100,13 @@ private:
     fmt::print(stderr, "\rinitiating graceful shutdown... "
                        "(repeat to terminate immediately)\n");
     graceful_stop_->notify_one();
-    // Wait for second signal, grace-period timeout, or normal completion.
+    // Wait for second signal, grace-period timeout, or normal completion. A
+    // non-positive grace period waits indefinitely (timeout -1), so the
+    // pipeline is only force-cancelled by a second signal, never by a timeout.
     pfds[0].revents = 0;
     pfds[1].revents = 0;
-    rc = ::poll(pfds.data(), pfds.size(), grace_ms);
+    auto timeout = grace_ms > 0 ? grace_ms : -1;
+    rc = ::poll(pfds.data(), pfds.size(), timeout);
     if (rc > 0 and (pfds[1].revents & POLLIN)) {
       return; // Pipeline finished on its own.
     }

--- a/libtenzir/src/tql2/exec.cpp
+++ b/libtenzir/src/tql2/exec.cpp
@@ -2223,8 +2223,15 @@ auto run_plan_blocking(OperatorChain<void, void> chain, caf::actor_system& sys,
   auto diag_handler = ExecDiagHandler{dh, cancel_source};
   auto has_terminal = ::isatty(STDIN_FILENO) == 1;
   auto graceful_stop = Notify{};
-  auto signal_guard = detail::SignalGuard{graceful_stop, cancel_source,
-                                          std::chrono::seconds{3}};
+  // The grace period bounds how long a pipeline may drain after a graceful
+  // stop request before it is force-cancelled. A non-positive value disables
+  // the timeout, letting the pipeline drain indefinitely.
+  auto grace
+    = caf::get_or(caf::content(sys.config()), "tenzir.shutdown-grace-period",
+                  caf::timespan{std::chrono::seconds{3}});
+  auto signal_guard = detail::SignalGuard{
+    graceful_stop, cancel_source,
+    std::chrono::duration_cast<std::chrono::milliseconds>(grace)};
   auto task = folly::coro::co_invoke([&] -> Task<Option<failure_or<void>>> {
     co_return co_await catch_cancellation(folly::coro::co_withCancellation(
       cancel_source.getToken(),

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -24,6 +24,12 @@ tenzir:
   # without retries.
   connection-retry-delay: 3s
 
+  # How long pipelines may drain in-flight data on node shutdown before they
+  # are force-killed. Set to 0s (or any non-positive value) to wait
+  # indefinitely, in which case pipelines are never force-killed and the node
+  # quits only once they have drained on their own.
+  shutdown-grace-period: 3min
+
   # URL of an HTTP/HTTPS proxy used for outbound `http://` targets. The URL
   # must include an explicit port, and may carry Basic-auth userinfo
   # (`http://user:pw@proxy.example.com:3128`). If unset,


### PR DESCRIPTION
## 🔍 Problem

- Pipelines only had 30 seconds to drain in-flight data on node shutdown before being force-killed, so long-running drains often could not finish cleanly.
- There was no way to let pipelines drain without an upper time bound.
- `libtenzir` still carried `shutdown_grace_period`/`shutdown_kill_timeout` constants that are no longer referenced.

## 🛠️ Solution

- Bump the `tenzir-plugins` submodule to pick up the 3-minute default grace period, the late-completion handling for timed-out shutdown requests, and indefinite-drain support (tenzir/tenzir-plugins#572).
- The CLI executor now reads `tenzir.shutdown-grace-period` (default 3s) and treats a non-positive value as indefinite: the pipeline is only force-cancelled by a second signal, never by a timeout.
- Document `tenzir.shutdown-grace-period` (including the zero-means-indefinite semantics) in `tenzir.yaml.example`, which the docs site renders.
- Drop the dead shutdown constants from `libtenzir`'s defaults.

## 💬 Review

- `SignalGuard`: non-positive grace polls with timeout `-1` (indefinite).
- Submodule bump pulls in the node-side behavior; see the companion plugins PR.

<sub>
📎 Companion PR: tenzir/tenzir-plugins#572
</sub>