### PR TITLE
Backfill PR numbers and fix aside in v6.3.0 changelog

### DIFF
--- a/changelog/releases/v6.3.0/entries/case-insensitive-text-functions.md
+++ b/changelog/releases/v6.3.0/entries/case-insensitive-text-functions.md
@@ -3,6 +3,8 @@ title: Case-insensitive text functions
 type: feature
 authors:
   - aljazerzen
+prs:
+  - 6378
 created: 2026-06-22T00:00:00.000000Z
 ---
 

--- a/changelog/releases/v6.3.0/entries/correct-null-handling-in-bloom-filter-context-lookups.md
+++ b/changelog/releases/v6.3.0/entries/correct-null-handling-in-bloom-filter-context-lookups.md
@@ -4,6 +4,8 @@ type: bugfix
 authors:
   - IyeOnline
   - claude
+prs:
+  - 6252
 created: 2026-06-03T14:20:38.490452Z
 ---
 

--- a/changelog/releases/v6.3.0/entries/graceful-pipeline-shutdown-with-data-draining.md
+++ b/changelog/releases/v6.3.0/entries/graceful-pipeline-shutdown-with-data-draining.md
@@ -3,6 +3,8 @@ title: Graceful pipeline shutdown with data draining
 type: feature
 authors:
   - aljazerzen
+prs:
+  - 6215
 created: 2026-05-21T19:28:37.839505Z
 ---
 

--- a/changelog/releases/v6.3.0/entries/parse-kv-duplicate-keys.md
+++ b/changelog/releases/v6.3.0/entries/parse-kv-duplicate-keys.md
@@ -3,6 +3,8 @@ title: Fix duplicate key handling in `parse_kv` and `read_kv`
 type: bugfix
 authors:
   - lava
+prs:
+  - 6369
 created: 2026-06-18T00:00:00.000000Z
 ---
 

--- a/changelog/releases/v6.3.0/entries/proxy-configuration-for-outbound-operators.md
+++ b/changelog/releases/v6.3.0/entries/proxy-configuration-for-outbound-operators.md
@@ -3,6 +3,8 @@ title: Configure an HTTP proxy for outbound operators
 type: feature
 authors:
   - raxyte
+prs:
+  - 6222
 created: 2026-05-25T00:00:00.000000Z
 ---
 

--- a/changelog/releases/v6.3.0/entries/re-added-pipelinedetach-and-pipelineadd.md
+++ b/changelog/releases/v6.3.0/entries/re-added-pipelinedetach-and-pipelineadd.md
@@ -10,6 +10,4 @@ created: 2026-06-22T12:42:38.267884Z
 
 The `pipeline::detach` and `pipeline::add` operators are available again on the new executor.
 
-:::note
-Prefer the `tenzir-test` `suite` feature with `mode: parallel` for coordinating background pipelines in tests.
-:::
+> **Note:** Prefer the `tenzir-test` `suite` feature with `mode: parallel` for coordinating background pipelines in tests.

--- a/changelog/releases/v6.3.0/notes.md
+++ b/changelog/releases/v6.3.0/notes.md
@@ -51,7 +51,7 @@ String functions now accept an `ignore_case` argument for case-insensitive match
 
 The new `equals(x, y, ignore_case=false)` function performs string equality with optional case folding, covering the case-insensitive equivalent of the `==` operator.
 
-*By @aljazerzen.*
+*By @aljazerzen in #6378.*
 
 ### Configure an HTTP proxy for outbound operators
 
@@ -69,7 +69,7 @@ Caveat: the GCS default credential chain first probes the metadata server at `me
 
 The proxy URL lives plaintext in YAML; promotion to a `secret` is deferred.
 
-*By @raxyte.*
+*By @raxyte in #6222.*
 
 ### Graceful pipeline shutdown with data draining
 
@@ -77,7 +77,7 @@ Stopping a pipeline or shutting down the node now drains in-flight data before t
 
 A configurable grace period (`tenzir.shutdown-grace-period`, default 3 minutes) bounds how long the system waits. After the grace period expires, remaining pipelines are force-killed. Setting the grace period to `0s` (or any non-positive value) waits indefinitely, so pipelines are never force-killed and drain fully before the node quits.
 
-*By @aljazerzen.*
+*By @aljazerzen in #6215.*
 
 ### New `from_clickhouse` source operator
 
@@ -99,7 +99,7 @@ from_clickhouse sql="SELECT * FROM events WHERE severity >= 3 ORDER BY time DESC
 
 The `pipeline::detach` and `pipeline::add` operators are available again on the new executor.
 
-:::note Prefer the `tenzir-test` `suite` feature with `mode: parallel` for coordinating background pipelines in tests. :::
+> **Note:** Prefer the `tenzir-test` `suite` feature with `mode: parallel` for coordinating background pipelines in tests.
 
 *By @IyeOnline in #6364.*
 
@@ -125,7 +125,7 @@ Conditional expressions such as `x if y else z` are now significantly more effic
 
 The `bloom-filter` context no longer matches `null` values when the filter was populated with empty strings. Now null values no longer match the context.
 
-*By @IyeOnline and @claude.*
+*By @IyeOnline and @claude in #6252.*
 
 ### Crash fix for list.add with null-typed record fields
 
@@ -137,4 +137,4 @@ The `bloom-filter` context no longer matches `null` values when the filter was p
 
 `parse_kv` and `read_kv` now upgrade a field to a list of values when a key occurs more than once in a single event, as documented. Previously, a repeated key silently kept only its last value.
 
-*By @lava.*
+*By @lava in #6369.*


### PR DESCRIPTION
## 🔍 Problem

The last release (`v6.3.0`) shipped with broken changelog entries:

- Five entries lacked PR references, so the generated release notes had no `in #NNNN` links.
- The `re-added-pipelinedetach-and-pipelineadd` entry used a Starlight `:::note` aside, which collapsed into a single mangled line in `notes.md`.

The previous release (`v6.2.0`) was checked too — all its entries already carry PR numbers.

## 🛠️ Solution

- Backfill PR numbers (matched against merge commits in `git log`):
  - `case-insensitive-text-functions` → #6378
  - `correct-null-handling-in-bloom-filter-context-lookups` → #6252
  - `graceful-pipeline-shutdown-with-data-draining` → #6215
  - `parse-kv-duplicate-keys` → #6369
  - `proxy-configuration-for-outbound-operators` → #6222
- Replace the `:::note` aside with a GitHub-friendly `> **Note:**` blockquote.
- Regenerate `notes.md` via `tenzir-ship release create v6.3.0`; `tenzir-ship validate` passes.

## 💬 Review

- These are already-released, normally-immutable artifacts; editing is intentional per request to correct the published `v6.3.0` notes.
- Worth a sanity check that each backfilled PR number maps to the right entry.
