### PR TITLE
Fix all compiler warnings

### DIFF
--- a/libtenzir/src/async/curl.cpp
+++ b/libtenzir/src/async/curl.cpp
@@ -77,6 +77,26 @@ auto curl_perform_failure(curl::multi::code code) -> CurlPerformResult {
                             .response_code = response_code(easy)};
 }
 
+/// A wake-up deferred by a state transition: built while holding the lock and
+/// run by the caller after releasing it. An empty `Wakeup` means the state did
+/// not change and there is nothing to do.
+class [[nodiscard]] Wakeup {
+public:
+  Wakeup() = default;
+  explicit Wakeup(std::function<void()> action) : action_{std::move(action)} {
+  }
+
+  /// Runs the deferred wake-up, if any. Safe to call when empty.
+  auto run() -> void {
+    if (action_) {
+      action_();
+    }
+  }
+
+private:
+  std::function<void()> action_;
+};
+
 class UploadStream {
 public:
   explicit UploadStream(size_t capacity) : capacity_{capacity} {
@@ -108,15 +128,15 @@ public:
   }
 
   auto close() -> void {
-    wakeup(transition_to_closed());
+    transition_to_closed().run();
   }
 
   auto abort() -> void {
-    wakeup(transition_to_aborted());
+    transition_to_aborted().run();
   }
 
   auto terminate() -> void {
-    wakeup(transition_to_terminated());
+    transition_to_terminated().run();
   }
 
   auto wait_until_ready() -> Task<bool> {
@@ -192,11 +212,6 @@ private:
     aborted_terminated,
   };
 
-  struct Transition {
-    bool changed = false;
-    std::function<void()> resume;
-  };
-
   auto is_aborted_state() const -> bool {
     return state_ == State::aborted or state_ == State::aborted_terminated;
   }
@@ -209,42 +224,41 @@ private:
     return resume_callback_;
   }
 
-  auto transition_to_closed() -> Transition {
+  auto make_wakeup(std::function<void()> resume) -> Wakeup {
+    return Wakeup{[this, resume = std::move(resume)] {
+      data_ready_.notify_one();
+      space_available_.notify_one();
+      if (resume) {
+        resume();
+      }
+    }};
+  }
+
+  auto transition_to_closed() -> Wakeup {
     auto lock = std::lock_guard{mutex_};
     if (state_ != State::open) {
       return {};
     }
     state_ = State::closed;
-    return {.changed = true, .resume = take_resume_callback()};
+    return make_wakeup(take_resume_callback());
   }
 
-  auto transition_to_aborted() -> Transition {
+  auto transition_to_aborted() -> Wakeup {
     auto lock = std::lock_guard{mutex_};
     if (is_aborted_state() or state_ == State::terminated) {
       return {};
     }
     state_ = State::aborted;
-    return {.changed = true, .resume = take_resume_callback()};
+    return make_wakeup(take_resume_callback());
   }
 
-  auto transition_to_terminated() -> Transition {
+  auto transition_to_terminated() -> Wakeup {
     auto lock = std::lock_guard{mutex_};
     if (state_ == State::terminated or state_ == State::aborted_terminated) {
       return {};
     }
     state_ = is_aborted_state() ? State::aborted_terminated : State::terminated;
-    return {.changed = true, .resume = take_resume_callback()};
-  }
-
-  auto wakeup(Transition transition) -> void {
-    if (not transition.changed) {
-      return;
-    }
-    data_ready_.notify_one();
-    space_available_.notify_one();
-    if (transition.resume) {
-      transition.resume();
-    }
+    return make_wakeup(take_resume_callback());
   }
 
   mutable std::mutex mutex_;
@@ -292,20 +306,11 @@ public:
   }
 
   auto abort() -> void {
-    auto transition = transition_to_aborted();
-    if (not transition.changed) {
-      return;
-    }
-    data_available_.notify_one();
-    if (transition.resume) {
-      transition.resume();
-    }
+    transition_to_aborted().run();
   }
 
   auto close() -> void {
-    if (transition_to_closed().changed) {
-      data_available_.notify_one();
-    }
+    transition_to_closed().run();
   }
 
   auto is_aborted() const -> bool {
@@ -339,11 +344,6 @@ private:
     aborted,
   };
 
-  struct Transition {
-    bool changed = false;
-    std::function<void()> resume;
-  };
-
   auto take_resume_callback() -> std::function<void()> {
     if (not paused_) {
       return {};
@@ -352,23 +352,30 @@ private:
     return resume_callback_;
   }
 
-  auto transition_to_closed() -> Transition {
+  auto transition_to_closed() -> Wakeup {
     auto lock = std::lock_guard{mutex_};
     if (state_ != State::open) {
       return {};
     }
     state_ = State::closed;
-    return {.changed = true};
+    return Wakeup{[this] {
+      data_available_.notify_one();
+    }};
   }
 
-  auto transition_to_aborted() -> Transition {
+  auto transition_to_aborted() -> Wakeup {
     auto lock = std::lock_guard{mutex_};
     if (state_ == State::aborted) {
       return {};
     }
     state_ = State::aborted;
     buffered_.clear();
-    return {.changed = true, .resume = take_resume_callback()};
+    return Wakeup{[this, resume = take_resume_callback()] {
+      data_available_.notify_one();
+      if (resume) {
+        resume();
+      }
+    }};
   }
 
   mutable std::mutex mutex_;

--- a/libtenzir/src/tql2/parser.cpp
+++ b/libtenzir/src/tql2/parser.cpp
@@ -532,7 +532,7 @@ public:
       if (auto bin_op = peek_binary_op()) {
         auto new_prec = precedence(*bin_op);
         if (new_prec >= min_prec) {
-          advance();
+          (void)advance();
           consume_trivia_with_newlines();
           auto right = parse_expression(new_prec + 1, stop_at_if);
           expr = binary_expr{

--- a/plugins/amazon-cloudwatch/include/cloudwatch/operators.hpp
+++ b/plugins/amazon-cloudwatch/include/cloudwatch/operators.hpp
@@ -14,6 +14,7 @@
 #include <tenzir/async/semaphore.hpp>
 #include <tenzir/fwd.hpp>
 #include <tenzir/pipeline_metrics.hpp>
+#include <tenzir/result.hpp>
 #include <tenzir/tql2/ast.hpp>
 
 #include <folly/CancellationToken.h>
@@ -81,12 +82,16 @@ struct CloudWatchEvent {
   Option<std::string> event_id;
 };
 
+/// A page of events read from CloudWatch Logs.
 struct SourcePage {
   std::vector<CloudWatchEvent> events;
   std::string next_token;
-  std::string error;
+  /// Whether this is the final page; no further reads should follow.
   bool done = false;
 };
+
+/// The outcome of a source read: either a page of events or a failure message.
+using SourceResult = Result<SourcePage, std::string>;
 
 enum class ToCloudWatchDiagnosticSeverity {
   warning,
@@ -99,6 +104,17 @@ enum class ToCloudWatchDiagnosticPrimary {
 };
 
 struct ToCloudWatchDiagnostic {
+  ToCloudWatchDiagnostic() = default;
+  ToCloudWatchDiagnostic(ToCloudWatchDiagnosticSeverity severity,
+                         ToCloudWatchDiagnosticPrimary primary,
+                         std::string message,
+                         std::vector<std::string> notes = {})
+    : severity{severity},
+      primary{primary},
+      message{std::move(message)},
+      notes{std::move(notes)} {
+  }
+
   ToCloudWatchDiagnosticSeverity severity
     = ToCloudWatchDiagnosticSeverity::warning;
   ToCloudWatchDiagnosticPrimary primary
@@ -138,7 +154,7 @@ private:
   FromMode mode_ = FromMode::live;
   std::shared_ptr<amazon::SignedHttpClient> client_;
   folly::CancellationSource live_cancel_;
-  mutable Option<Arc<folly::coro::BoundedQueue<SourcePage, false, true>>>
+  mutable Option<Arc<folly::coro::BoundedQueue<SourceResult, false, true>>>
     live_queue_;
   std::string next_token_;
   uint64_t emitted_ = 0;

--- a/plugins/amazon-cloudwatch/src/operators.cpp
+++ b/plugins/amazon-cloudwatch/src/operators.cpp
@@ -434,18 +434,18 @@ auto cloudwatch_warning(ToCloudWatchDiagnosticPrimary primary,
                         std::vector<std::string> notes = {})
   -> ToCloudWatchDiagnostic {
   return {
-    .severity = ToCloudWatchDiagnosticSeverity::warning,
-    .primary = primary,
-    .message = std::move(message),
-    .notes = std::move(notes),
+    ToCloudWatchDiagnosticSeverity::warning,
+    primary,
+    std::move(message),
+    std::move(notes),
   };
 }
 
 auto cloudwatch_error(std::string message) -> ToCloudWatchDiagnostic {
   return {
-    .severity = ToCloudWatchDiagnosticSeverity::error,
-    .primary = ToCloudWatchDiagnosticPrimary::operator_,
-    .message = std::move(message),
+    ToCloudWatchDiagnosticSeverity::error,
+    ToCloudWatchDiagnosticPrimary::operator_,
+    std::move(message),
   };
 }
 
@@ -608,15 +608,12 @@ auto accepted_http_metrics(ToMethod method, std::string const& body,
 auto parse_filter_log_events_response(std::string const& body,
                                       std::string const& log_group,
                                       std::string const& previous_token)
-  -> SourcePage {
+  -> SourceResult {
   auto parser = simdjson::dom::parser{};
   auto doc = parser.parse(body);
   if (doc.error()) {
-    return SourcePage{.error
-                      = fmt::format("failed to parse CloudWatch Logs "
-                                    "response: {}",
-                                    simdjson::error_message(doc.error())),
-                      .done = true};
+    return Err{fmt::format("failed to parse CloudWatch Logs response: {}",
+                           simdjson::error_message(doc.error()))};
   }
   auto page = SourcePage{};
   page.next_token = string_from_json(doc.value(), "nextToken");
@@ -645,15 +642,12 @@ auto parse_get_log_events_response(std::string const& body,
                                    std::string const& log_group,
                                    std::string const& log_stream,
                                    std::string const& previous_token,
-                                   bool from_start) -> SourcePage {
+                                   bool from_start) -> SourceResult {
   auto parser = simdjson::dom::parser{};
   auto doc = parser.parse(body);
   if (doc.error()) {
-    return SourcePage{.error
-                      = fmt::format("failed to parse CloudWatch Logs "
-                                    "response: {}",
-                                    simdjson::error_message(doc.error())),
-                      .done = true};
+    return Err{fmt::format("failed to parse CloudWatch Logs response: {}",
+                           simdjson::error_message(doc.error()))};
   }
   auto page = SourcePage{};
   page.next_token = string_from_json(
@@ -938,7 +932,7 @@ auto FromCloudWatch::start(OpCtx& ctx) -> Task<void> {
                        MetricsDirection::read, MetricsVisibility::external_,
                        MetricsUnit::events);
   if (mode_ == FromMode::live) {
-    auto queue = Arc<folly::coro::BoundedQueue<SourcePage, false, true>>{
+    auto queue = Arc<folly::coro::BoundedQueue<SourceResult, false, true>>{
       std::in_place,
       live_tail_queue_capacity,
     };
@@ -998,7 +992,7 @@ auto FromCloudWatch::start(OpCtx& ctx) -> Task<void> {
                 };
                 request.GetEventStreamDecoder().Pump(bytes);
                 for (auto& page : pending_pages) {
-                  co_await queue->enqueue(std::move(page));
+                  co_await queue->enqueue(SourceResult{std::move(page)});
                 }
                 pending_pages.clear();
                 if (session_expired) {
@@ -1006,10 +1000,8 @@ auto FromCloudWatch::start(OpCtx& ctx) -> Task<void> {
                 }
                 if (not pending_error.empty()) {
                   stream_error = true;
-                  co_await queue->enqueue(SourcePage{
-                    .error = std::exchange(pending_error, {}),
-                    .done = true,
-                  });
+                  co_await queue->enqueue(
+                    SourceResult{Err{std::exchange(pending_error, {})}});
                   co_return true;
                 }
                 co_return false;
@@ -1038,10 +1030,8 @@ auto FromCloudWatch::start(OpCtx& ctx) -> Task<void> {
                 }
               }
               if (not terminal_error.empty()) {
-                co_await queue->enqueue(SourcePage{
-                  .error = std::move(terminal_error),
-                  .done = true,
-                });
+                co_await queue->enqueue(
+                  SourceResult{Err{std::move(terminal_error)}});
                 co_return;
               }
               if (stream_error) {
@@ -1074,8 +1064,7 @@ auto FromCloudWatch::await_task(diagnostic_handler& dh) const -> Task<Any> {
     }
     auto response = co_await client_->api_call("FilterLogEvents", request);
     if (response.is_err()) {
-      co_return SourcePage{.error = std::move(response).unwrap_err(),
-                           .done = true};
+      co_return SourceResult{Err{std::move(response).unwrap_err()}};
     }
     auto http_response = std::move(response).unwrap();
     co_return parse_filter_log_events_response(
@@ -1088,8 +1077,7 @@ auto FromCloudWatch::await_task(diagnostic_handler& dh) const -> Task<Any> {
   }
   auto response = co_await client_->api_call("GetLogEvents", request);
   if (response.is_err()) {
-    co_return SourcePage{.error = std::move(response).unwrap_err(),
-                         .done = true};
+    co_return SourceResult{Err{std::move(response).unwrap_err()}};
   }
   auto http_response = std::move(response).unwrap();
   co_return parse_get_log_events_response(http_response.body,
@@ -1100,14 +1088,15 @@ auto FromCloudWatch::await_task(diagnostic_handler& dh) const -> Task<Any> {
 
 auto FromCloudWatch::process_task(Any result, Push<table_slice>& push,
                                   OpCtx& ctx) -> Task<void> {
-  auto page = std::move(result).as<SourcePage>();
-  if (not page.error.empty()) {
-    diagnostic::error("{}", page.error)
+  auto outcome = std::move(result).as<SourceResult>();
+  if (outcome.is_err()) {
+    diagnostic::error("{}", outcome.unwrap_err())
       .primary(args_.operator_location)
       .emit(ctx);
     done_ = true;
     co_return;
   }
+  auto page = std::move(outcome).unwrap();
   next_token_ = std::move(page.next_token);
   done_ = page.done;
   if (args_.count) {
@@ -1143,7 +1132,9 @@ auto FromCloudWatch::stop(OpCtx& ctx) -> Task<void> {
   TENZIR_UNUSED(ctx);
   live_cancel_.requestCancellation();
   if (live_queue_) {
-    std::ignore = (*live_queue_)->try_enqueue(SourcePage{.done = true});
+    auto page = SourcePage{};
+    page.done = true;
+    std::ignore = (*live_queue_)->try_enqueue(SourceResult{std::move(page)});
   }
   done_ = true;
   co_return;

--- a/plugins/amazon-kinesis/include/operators.hpp
+++ b/plugins/amazon-kinesis/include/operators.hpp
@@ -28,6 +28,11 @@
 namespace tenzir::plugins::amazon_kinesis {
 
 struct KinesisApiError {
+  KinesisApiError() = default;
+  explicit KinesisApiError(std::string message, std::string code = {})
+    : message{std::move(message)}, code{std::move(code)} {
+  }
+
   std::string message;
   std::string code;
 };

--- a/plugins/amazon-kinesis/src/operators.cpp
+++ b/plugins/amazon-kinesis/src/operators.cpp
@@ -15,9 +15,11 @@
 #include <tenzir/detail/narrow.hpp>
 #include <tenzir/detail/string.hpp>
 #include <tenzir/multi_series_builder.hpp>
+#include <tenzir/result.hpp>
 #include <tenzir/tql2/entity_path.hpp>
 #include <tenzir/tql2/eval.hpp>
 #include <tenzir/uuid.hpp>
+#include <tenzir/variant.hpp>
 
 #include <arrow/array/array_binary.h>
 #include <aws/core/utils/Array.h>
@@ -67,23 +69,45 @@ struct ReadRecord {
   duration behind_latest = {};
 };
 
-struct ReadResult {
+/// A successful `GetRecords` response for a shard.
+struct ShardPage {
   std::vector<ReadRecord> records;
-  std::string shard_id;
   std::string next_iterator;
   std::string next_sequence_number;
   /// How far this response lags behind the tip of the shard; zero means the
   /// read is caught up with the stream.
   duration behind_latest = {};
   bool shard_closed = false;
-  bool iterator_expired = false;
-  bool throttled = false;
-  /// Whether the shard loop finished because it reached the tip in exit mode.
-  bool caught_up = false;
-  std::string error;
 };
 
+/// The shard iterator expired and must be recreated before reading again.
+struct IteratorExpired {};
+
+/// The read was throttled and should be retried after a backoff.
+struct Throttled {};
+
+/// The outcome of a single `read_from_shard` call.
+using ShardRead
+  = variant<ShardPage, IteratorExpired, Throttled, KinesisApiError>;
+
+/// A shard's progress reported from its loop to the operator's main task.
+struct ShardUpdate {
+  std::string shard_id;
+  std::vector<ReadRecord> records;
+  std::string next_sequence_number;
+  bool shard_closed = false;
+  /// Whether the shard loop finished because it reached the tip in exit mode.
+  bool caught_up = false;
+};
+
+/// What a shard loop hands to `process_task`: either progress or a failure.
+using ShardReport = Result<ShardUpdate, KinesisApiError>;
+
 struct ShardInfo {
+  ShardInfo() = default;
+  explicit ShardInfo(std::string id) : id{std::move(id)} {
+  }
+
   std::string id;
   std::vector<std::string> parents;
 };
@@ -105,15 +129,15 @@ auto kinesis_api_call(amazon::SignedHttpClient& client,
   auto response = co_await client.raw_post("/", std::move(body),
                                            std::move(headers), operation);
   if (response.is_err()) {
-    co_return Err{KinesisApiError{.message = std::move(response).unwrap_err()}};
+    co_return Err{KinesisApiError{std::move(response).unwrap_err()}};
   }
   auto http_response = std::move(response).unwrap();
   if (not http_response.is_status_success()) {
     co_return Err{KinesisApiError{
-      .message = fmt::format(
-        "{} returned HTTP {}: {}", operation, http_response.status_code,
-        amazon::extract_aws_error_message(http_response.body)),
-      .code = amazon::extract_aws_error_code(http_response.body),
+      fmt::format("{} returned HTTP {}: {}", operation,
+                  http_response.status_code,
+                  amazon::extract_aws_error_message(http_response.body)),
+      amazon::extract_aws_error_code(http_response.body),
     }};
   }
   co_return amazon::to_aws_json_result(std::move(http_response));
@@ -181,7 +205,7 @@ auto list_shards(amazon::SignedHttpClient& client, std::string_view stream,
     auto page
       = Aws::Kinesis::Model::ListShardsResult{std::move(aws_result).unwrap()};
     for (const auto& shard : page.GetShards()) {
-      auto info = ShardInfo{.id = amazon::from_aws_string(shard.GetShardId())};
+      auto info = ShardInfo{amazon::from_aws_string(shard.GetShardId())};
       if (shard.ParentShardIdHasBeenSet()) {
         info.parents.push_back(
           amazon::from_aws_string(shard.GetParentShardId()));
@@ -199,7 +223,7 @@ auto list_shards(amazon::SignedHttpClient& client, std::string_view stream,
 
 auto read_from_shard(amazon::SignedHttpClient& client, std::string_view stream,
                      std::string_view shard_id, std::string iterator, int limit)
-  -> Task<ReadResult> {
+  -> Task<ShardRead> {
   auto request = Aws::Kinesis::Model::GetRecordsRequest{};
   request.SetShardIterator(Aws::String{iterator.data(), iterator.size()});
   request.SetLimit(limit);
@@ -207,18 +231,16 @@ auto read_from_shard(amazon::SignedHttpClient& client, std::string_view stream,
   if (aws_result.is_err()) {
     auto error = std::move(aws_result).unwrap_err();
     if (is_error(error, "ExpiredIteratorException")) {
-      co_return {.shard_id = std::string{shard_id}, .iterator_expired = true};
+      co_return IteratorExpired{};
     }
     if (is_error(error, "ProvisionedThroughputExceededException")) {
-      co_return {.shard_id = std::string{shard_id}, .throttled = true};
+      co_return Throttled{};
     }
-    co_return {.shard_id = std::string{shard_id},
-               .error = std::move(error.message)};
+    co_return std::move(error);
   }
   auto result
     = Aws::Kinesis::Model::GetRecordsResult{std::move(aws_result).unwrap()};
-  auto output = ReadResult{};
-  output.shard_id = std::string{shard_id};
+  auto output = ShardPage{};
   output.next_iterator = amazon::from_aws_string(result.GetNextShardIterator());
   output.shard_closed = output.next_iterator.empty();
   output.behind_latest
@@ -497,8 +519,10 @@ auto FromAmazonKinesis::start(OpCtx& ctx) -> Task<void> {
     auto infos = std::move(shard_infos).unwrap();
     shards_.reserve(infos.size());
     for (auto& info : infos) {
-      shards_.push_back(ShardState{.id = std::move(info.id),
-                                   .parents = std::move(info.parents)});
+      auto shard = ShardState{};
+      shard.id = std::move(info.id);
+      shard.parents = std::move(info.parents);
+      shards_.push_back(std::move(shard));
     }
   }
   if (shards_.empty() and args_.exit) {
@@ -570,47 +594,53 @@ auto FromAmazonKinesis::shard_loop(ShardState shard) -> Task<void> {
     if (iterator.empty()) {
       auto created = co_await recreate_shard_iterator(shard);
       if (created.is_err()) {
-        auto result = ReadResult{};
-        result.shard_id = shard.id;
-        result.error = std::move(created).unwrap_err().message;
-        co_await results_->enqueue(Any{std::move(result)});
+        co_await results_->enqueue(
+          Any{ShardReport{Err{std::move(created).unwrap_err()}}});
         co_return;
       }
       iterator = std::move(created).unwrap();
       if (iterator.empty()) {
-        auto result = ReadResult{};
-        result.shard_id = shard.id;
-        result.shard_closed = true;
-        co_await results_->enqueue(Any{std::move(result)});
+        auto update = ShardUpdate{};
+        update.shard_id = shard.id;
+        update.shard_closed = true;
+        co_await results_->enqueue(Any{ShardReport{std::move(update)}});
         co_return;
       }
     }
-    auto result = co_await read_from_shard(
-      *client_, args_.stream.inner, shard.id, iterator, records_per_call_);
-    if (result.throttled) {
+    auto read = co_await read_from_shard(*client_, args_.stream.inner, shard.id,
+                                         iterator, records_per_call_);
+    if (try_as<Throttled>(read)) {
       co_await folly::coro::sleep(
         std::chrono::duration_cast<folly::HighResDuration>(throttle_backoff));
       continue;
     }
-    if (result.iterator_expired) {
+    if (try_as<IteratorExpired>(read)) {
       iterator.clear();
       continue;
     }
-    iterator = result.next_iterator;
-    if (not result.next_sequence_number.empty()) {
-      shard.next_sequence_number = result.next_sequence_number;
+    if (auto* error = try_as<KinesisApiError>(read)) {
+      co_await results_->enqueue(Any{ShardReport{Err{std::move(*error)}}});
+      co_return;
+    }
+    auto& page = as<ShardPage>(read);
+    iterator = page.next_iterator;
+    if (not page.next_sequence_number.empty()) {
+      shard.next_sequence_number = page.next_sequence_number;
     }
     // In exit mode, a shard is finished once it reaches the tip of the
     // stream; the loop ends and reports this completion as its final result.
     // An empty response alone is not enough: sparse streams can return empty
     // batches with records still ahead.
-    result.caught_up = args_.exit and result.behind_latest == duration::zero();
-    const auto failed = not result.error.empty();
-    const auto closed = result.shard_closed;
-    const auto finished = result.caught_up;
-    const auto idle = result.records.empty();
-    co_await results_->enqueue(Any{std::move(result)});
-    if (failed or closed or finished) {
+    auto update = ShardUpdate{};
+    update.shard_id = shard.id;
+    update.next_sequence_number = std::move(page.next_sequence_number);
+    update.shard_closed = page.shard_closed;
+    update.caught_up = args_.exit and page.behind_latest == duration::zero();
+    update.records = std::move(page.records);
+    const auto terminal = update.shard_closed or update.caught_up;
+    const auto idle = update.records.empty();
+    co_await results_->enqueue(Any{ShardReport{std::move(update)}});
+    if (terminal) {
       co_return;
     }
     if (idle) {
@@ -671,9 +701,11 @@ auto FromAmazonKinesis::discover_new_shards(OpCtx& ctx) -> Task<void> {
       if (latest and not descends_from_tracked) {
         continue;
       }
-      shards_.push_back(ShardState{.id = std::move(info.id),
-                                   .parents = std::move(info.parents),
-                                   .trim_horizon_start = true});
+      auto shard = ShardState{};
+      shard.id = std::move(info.id);
+      shard.parents = std::move(info.parents);
+      shard.trim_horizon_start = true;
+      shards_.push_back(std::move(shard));
       added = true;
     }
   }
@@ -686,12 +718,15 @@ auto FromAmazonKinesis::await_task(diagnostic_handler& dh) const -> Task<Any> {
 
 auto FromAmazonKinesis::process_task(Any result, Push<table_slice>& push,
                                      OpCtx& ctx) -> Task<void> {
-  auto batch = std::move(result).as<ReadResult>();
-  if (not batch.error.empty()) {
-    diagnostic::error("{}", batch.error).primary(args_.stream.source).emit(ctx);
+  auto report = std::move(result).as<ShardReport>();
+  if (report.is_err()) {
+    diagnostic::error("{}", report.unwrap_err().message)
+      .primary(args_.stream.source)
+      .emit(ctx);
     done_ = true;
     co_return;
   }
+  auto batch = std::move(report).unwrap();
   if (auto it = std::ranges::find(shards_, batch.shard_id, &ShardState::id);
       it != shards_.end()) {
     it->closed = batch.shard_closed;

--- a/plugins/amqp/builtins/from_amqp.cpp
+++ b/plugins/amqp/builtins/from_amqp.cpp
@@ -407,8 +407,9 @@ public:
   }
 
   auto describe() const -> Description override {
-    auto d = Describer<FromAmqpArgs, FromAmqp>{
-      FromAmqpArgs{.plugin_config = config_}};
+    auto args = FromAmqpArgs{};
+    args.plugin_config = config_;
+    auto d = Describer<FromAmqpArgs, FromAmqp>{std::move(args)};
     d.positional("url", &FromAmqpArgs::url);
     auto channel_arg = d.named("channel", &FromAmqpArgs::channel);
     d.named("exchange", &FromAmqpArgs::exchange);

--- a/plugins/amqp/builtins/to_amqp.cpp
+++ b/plugins/amqp/builtins/to_amqp.cpp
@@ -353,8 +353,9 @@ public:
   }
 
   auto describe() const -> Description override {
-    auto d
-      = Describer<ToAmqpArgs, ToAmqp>{ToAmqpArgs{.plugin_config = config_}};
+    auto args = ToAmqpArgs{};
+    args.plugin_config = config_;
+    auto d = Describer<ToAmqpArgs, ToAmqp>{std::move(args)};
     d.positional("url", &ToAmqpArgs::url);
     d.named_optional("message", &ToAmqpArgs::message, "blob|string");
     auto channel_arg = d.named("channel", &ToAmqpArgs::channel);


### PR DESCRIPTION
## 🔍 Problem

A clean build emitted **19 compiler warnings**. While fixing them, two
internal types modeled their state awkwardly enough to be worth tidying.

## 🛠️ Solution

### Warnings fixed (19 → 0)

| Warning | Count | Where |
|---|---|---|
| `-Wunused-result` (`[[nodiscard]]`) | 1 | TQL2 parser discarded `advance()`'s result |
| `-Wmissing-designated-field-initializers` | 18 | partial designated initializers across the AWS/AMQP plugins and `curl.cpp` |

Breakdown of the 18 missing-field-initializer warnings: `curl.cpp` (1),
amazon-cloudwatch (8), amazon-kinesis (7), amqp `from_amqp`/`to_amqp` (1 each).

Fixes follow three patterns:
- `(void)`-mark the intentional `nodiscard` discard.
- Add constructors to small value structs (`KinesisApiError`, `ShardInfo`,
  `ToCloudWatchDiagnostic`).
- Default-construct-then-assign where a constructor doesn't fit (arg
  prototypes, scattered field subsets).

### Cleanup

- **curl**: replaced the duplicated `{bool changed; std::function resume}`
  `Transition` struct (handled inconsistently across the two stream classes)
  with a single `[[nodiscard]] Wakeup` deferred-action type.
- **Kinesis / CloudWatch**: replaced the flag-and-sentinel result structs
  (`ReadResult`, `SourcePage`) — whose error state was detected via
  `not error.empty()` — with explicit sum types: `variant` where there are
  non-error alternatives (retry signals), `Result<T, E>` where the outcome is
  purely success-or-failure. Reusing `KinesisApiError` stops dropping the AWS
  error code.

## 💬 Review

- All changes are behavior-preserving; no user-facing impact, so no changelog
  entry.
- Worth a look: the Kinesis/CloudWatch outcome-state mapping (each old flag
  state mapped to a variant/Result arm) and the `Wakeup` post-lock semantics.
- These AWS plugins have no local tests; verified via a clean build with zero
  warnings.
