### PR TITLE
Unlock CI on Codex's verdict instead of the timeout

### DIFF
--- a/.github/workflows/codex-review-gate.yaml
+++ b/.github/workflows/codex-review-gate.yaml
@@ -1,8 +1,13 @@
 # Periodically sweeps open PRs and applies the `ci-ready` label to PRs where
 # the Codex review has no open issues, i.e., either Codex left a 👍 reaction
 # (its "no comments" verdict) or all review threads it opened are resolved.
-# The signal must apply to the current head: a review must reference the head
-# commit, and a reaction must postdate the time the head was pushed.
+# A review carries the head's commit id, so it pins to that head. A 👍 does
+# not, but Codex removes the 👍 when it begins a review and only re-adds it if
+# that head is clean. So a 👍 that postdates the push is a verdict on the
+# current head (proceed at once), while a 👍 that survived the push was never
+# removed, meaning Codex skipped re-reviewing it (proceed after a short head
+# start -- nothing is coming). While a review is in flight the 👍 is absent,
+# so neither fires and we wait for it to land or for the grace fail-safe.
 #
 # The label is only ever added, never removed: delaying the build is a CI
 # cost optimization, while merge safety comes from the `Tenzir CI` commit
@@ -52,7 +57,14 @@ jobs:
           gh label create "$LABEL" --force --color 2EA44F \
             --description "Unlocks the CI build; applied when the Codex review is clean"
 
-          # Heads pushed before this without a Codex verdict unlock the build.
+          # Codex removes the 👍 when it starts a review, so a 👍 still present
+          # this long after a push means Codex skipped the re-review (it never
+          # engaged); trust its standing verdict instead of waiting the grace.
+          # The head start gives Codex time to remove the 👍 if it is going to
+          # review, so this is not read while a review is merely pending.
+          headstart_cutoff=$(date -u -d '5 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
+          # Fail-safe for a Codex that engaged but stalled, or never weighs in
+          # at all (down/out of tokens): heads pushed before this unlock anyway.
           grace_cutoff=$(date -u -d '30 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
 
           process_pr() {
@@ -60,7 +72,7 @@ jobs:
             # so fallible commands abort explicitly via `|| return`.
             local pr=$1
             local head_sha pushed thumb reviewed unresolved verdict clean
-            local has_label
+            local has_label decision
             # The label is sticky, so labeled PRs need no further checks.
             has_label=$(gh api "repos/$GH_REPO/issues/$pr" \
               --jq "[.labels[].name] | any(. == \"$LABEL\")") || return
@@ -122,30 +134,51 @@ jobs:
                      | select((.comments.nodes[0].author.login // "")
                               | startswith("chatgpt-codex-connector"))]
                     | length') || return
-            # Codex's verdict applies to the current head if it reviewed that
-            # commit or its 👍 reaction postdates the last push. ISO-8601
-            # timestamps compare lexicographically.
+            # Does Codex's verdict apply to the current head? A review carries
+            # the head's commit id, so it does. A 👍 has no commit binding,
+            # but Codex removes it when it begins a review and re-adds it only
+            # if the head is clean, so a 👍 that postdates the push is a fresh
+            # verdict on this head.
             verdict=false
-            if [[ "$reviewed" -gt 0 ]] \
-               || [[ -n "$thumb" && "$thumb" > "$pushed" ]]; then
+            if [[ "$reviewed" -gt 0 || ( -n "$thumb" && "$thumb" > "$pushed" ) ]]; then
               verdict=true
             fi
             clean=false
+            decision=wait
             if [[ "$verdict" == true && "$unresolved" -eq 0 ]]; then
               clean=true
-            elif [[ "$verdict" == false && "$pushed" < "$grace_cutoff" ]]; then
-              # Fail-safe: no verdict within the grace period means Codex is
-              # down or out of tokens, so unlock the build. Unresolved
-              # threads from earlier heads still block the merge.
+              decision=head-verdict
+            elif [[ -n "$thumb" && "$unresolved" -eq 0 \
+                    && "$pushed" < "$headstart_cutoff" ]]; then
+              # A 👍 still present a head start after the push was never
+              # removed, so Codex skipped re-reviewing this commit. While a
+              # review is actually in flight the 👍 is absent and this branch
+              # cannot fire, so trusting it does not race Codex -- it only
+              # avoids waiting out the full grace for a review that is not
+              # coming. (A clean re-review re-adds a 👍 that postdates the push
+              # and is caught above; new issues open threads, caught here.)
               clean=true
-              echo "PR #$pr: no Codex verdict within grace period"
+              decision=skip-headstart
+            elif [[ "$verdict" == false && "$pushed" < "$grace_cutoff" ]]; then
+              # Fail-safe: the 👍 is absent (Codex mid-review or stalled) or
+              # never existed (Codex down). After the grace, unlock anyway so a
+              # slow or stuck Codex cannot hold up CI; unresolved threads from
+              # earlier heads still block the merge.
+              clean=true
+              decision=grace
             fi
+            # Audit: one structured line per decision. The `skip-headstart`
+            # path rests on Codex removing the 👍 when it reviews; cross-check
+            # it after the fact against whether Codex later posted a review for
+            # this head (a review landing just after means it was in flight,
+            # not skipped, and the head start was too short).
+            echo "PR #$pr: decision=$decision clean=$clean head=${head_sha:0:9}" \
+              "pushed=$pushed thumb=${thumb:-none} reviewed=$reviewed" \
+              "unresolved=$unresolved headstart=$headstart_cutoff"
             if [[ "$clean" == true ]]; then
               gh api -X POST "repos/$GH_REPO/issues/$pr/labels" \
                 -f "labels[]=$LABEL" --silent || return
               echo "PR #$pr: added $LABEL"
-            else
-              echo "PR #$pr: not clean"
             fi
           }
 

--- a/.github/workflows/codex-review-gate.yaml
+++ b/.github/workflows/codex-review-gate.yaml
@@ -14,7 +14,9 @@
 # status and required conversation resolution. Applying the label manually
 # unlocks the build without waiting for Codex. As a fail-safe, a PR whose
 # head has no Codex verdict 30 minutes after the push is treated as clean,
-# so that an unavailable Codex does not hold up CI.
+# so that an unavailable Codex does not hold up CI. Draft PRs are skipped
+# outright, since Codex does not review them and there is thus no verdict to
+# wait for; marking a PR ready, or labeling it by hand, opts it back in.
 #
 # This needs to be a cron sweep because GitHub emits no webhook events for
 # reactions. The label is applied with a GitHub App token so that it can
@@ -72,7 +74,7 @@ jobs:
             # so fallible commands abort explicitly via `|| return`.
             local pr=$1
             local head_sha pushed thumb reviewed unresolved verdict clean
-            local has_label decision
+            local has_label decision is_draft
             # The label is sticky, so labeled PRs need no further checks.
             has_label=$(gh api "repos/$GH_REPO/issues/$pr" \
               --jq "[.labels[].name] | any(. == \"$LABEL\")") || return
@@ -82,6 +84,18 @@ jobs:
             fi
             head_sha=$(gh api "repos/$GH_REPO/pulls/$pr" --jq .head.sha) \
               || return
+            # Codex does not review drafts, so a draft has no verdict to wait
+            # for; the grace fail-safe below would otherwise mistake that for
+            # an unavailable Codex and unlock it. Skip drafts: marking the PR
+            # ready routes it through the normal flow, and the label can still
+            # be applied by hand to force a draft build. This also stops a
+            # grace-labelled draft from later being marked ready and building
+            # on its sticky label without any Codex review.
+            is_draft=$(gh api "repos/$GH_REPO/pulls/$pr" --jq .draft) || return
+            if [[ "$is_draft" == true ]]; then
+              echo "PR #$pr: draft, not eligible for auto-unlock"
+              return
+            fi
             # The head commit's committer timestamp can predate the time it
             # was pushed to the PR, e.g., for pre-existing local commits, so
             # prefer the creation time of the earliest workflow run for the


### PR DESCRIPTION
## 🔍 Problem

- The Codex review gate keyed the "no comments" verdict on a 👍 reaction postdating the push. A reaction has no commit binding, so this only held for a head's *first* review; any re-pushed PR fell through to the 30-minute grace fail-safe — which is what the gate hit in most real cases (e.g. #6383, #6365).
- Codex does not review **draft** PRs, so a draft never has a verdict. The same grace fail-safe then treated that like an unavailable Codex and unlocked the build anyway. Worse, because the label is sticky, a grace-labelled draft that is later marked ready builds on that label **without any Codex review at all** (currently all 12 open drafts carry `ci-ready`).

## 🛠️ Solution

Codex removes the 👍 when it begins a review and re-adds it only if the head is clean. Resolve the verdict against that lifecycle:

- **👍 postdates the push** → fresh verdict on the head → unlock now.
- **👍 still present 5 min after the push** → never removed → Codex skipped the re-review → unlock. While a review is in flight the 👍 is absent, so this branch can't fire mid-review and never races Codex.
- **otherwise** (👍 absent: mid-review/stalled, or never existed: Codex down) → the 30-minute grace fail-safe still applies.

Plus:

- **Skip draft PRs** in the sweep — they are never auto-labelled. Marking a PR ready routes it through the normal flow; the label can still be applied by hand to force a draft build.
- A structured **audit line** per decision (tier + raw signals) to verify the head-start assumption in production.

## 💬 Review

- Load-bearing assumption: Codex removes the 👍 within the 5-minute head start when it actually reviews (incl. auto on-push reviews). The audit line exists to confirm this — grep `decision=skip-headstart` against whether Codex later posted a review for that head.
- Head start (5 min) and grace (30 min) are the two tunables; the sweep cadence is `*/5`.
- Draft skip preserves the manual opt-in (apply `ci-ready` by hand). It does **not** retroactively unlabel the drafts already carrying `ci-ready`, nor block a PR converted back to draft after labeling — a hard block (`github.event.pull_request.draft == false` on the build's configure job) would cover those too, at the cost of the manual opt-in. Left out unless we want it.
