### PR TITLE
Add platform endpoint token support

### DIFF
--- a/changelog/unreleased/platform-control-endpoints-in-tokens.md
+++ b/changelog/unreleased/platform-control-endpoints-in-tokens.md
@@ -1,0 +1,20 @@
+---
+title: Platform control endpoints in tokens
+type: feature
+authors:
+  - tobim
+  - codex
+created: 2026-06-25T13:38:07.719373Z
+---
+
+Tenzir nodes can now connect to the Tenzir Platform with a `tenzir.token` value
+that carries the platform control endpoint:
+
+```yaml
+tenzir:
+  token: tnz_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_<encoded-endpoint>
+```
+
+The same format works through the `TENZIR_TOKEN` environment variable. Set
+`tenzir.platform-control-endpoint` or `TENZIR_PLATFORM_CONTROL_ENDPOINT` only
+when you want to override the endpoint embedded in the token.

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -288,9 +288,10 @@ tenzir:
   # Zstd compression level applied to the Feather store backend.
   # zstd-compression-level: <default>
 
-  # The URL of the control endpoint when connecting to a self-hosted
-  # instance of the Tenzir Platform.
-  platform-control-endpoint: wss://ws.tenzir.app/production
+  # Override the control endpoint when connecting to a self-hosted instance of
+  # the Tenzir Platform. This takes precedence over endpoints embedded in
+  # platform tokens.
+  #platform-control-endpoint: wss://ws.tenzir.app/production
 
   # Whether to undermine the security of the TLS connection to the
   # Tenzir Platform by disabling certificate validation.

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -6,6 +6,8 @@
 tenzir:
   # The token that is offered when connecting to the Tenzir Platform.
   # It is used to identify the node and assign it to the correct workspace.
+  # Platform tokens may include the control endpoint. In that case,
+  # `platform-control-endpoint` is only needed to override the token value.
   # This setting is ignored in the open-source edition of Tenzir, which does
   # not contain the platform plugin.
   token: tnz_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX


### PR DESCRIPTION
## 🔍 Problem

Platform tokens could not carry the control endpoint, so nodes targeting a non-default Tenzir Platform endpoint needed a separate configuration value even when the token issuer already knew the endpoint.

## 🛠️ Solution

- Update `contrib/tenzir-plugins` to the parser change that accepts endpoint-bearing platform tokens.
- Document the override behavior in `tenzir.yaml.example`.
- Add an unreleased changelog entry for the new token format.

## 💬 Review

The main repo change is mostly integration surface: verify the submodule pointer, configuration wording, and changelog description match the plugin PR behavior.

<sub>
📎 Related: tenzir/tenzir-plugins#573
</sub>
