### PR TITLE
Make pipeline manager reply to stop/update immediately

### DIFF
--- a/changelog/unreleased/pipeline-stop-immediate.md
+++ b/changelog/unreleased/pipeline-stop-immediate.md
@@ -1,0 +1,14 @@
+---
+title: Pipelines acknowledge stop requests while draining
+type: bugfix
+authors:
+  - aljazerzen
+created: 2026-06-29T08:15:20.200606Z
+---
+
+Fixes a problem where stopping or updating a running pipeline would render a
+node unresponsive and report `pipeline manager request ... timed out` error
+messages. The pipeline manager now acknowledges the request immediately,
+remembers that the pipeline is still draining, and finishes stopping (and, for
+definition updates, restarting) in the background once the executor has
+exited.


### PR DESCRIPTION
## 🔍 Problem

After upgrading a node to 6.3.0, graceful pipeline shutdown made the
pipeline manager hold a request open until the executor fully drained.
Pipelines that take minutes to drain caused repeated
`pipeline manager request ... timed out` errors, and the Pipelines UI
rendered blank.

## 🛠️ Solution

Bumps `tenzir-plugins` (tenzir/tenzir-plugins#574) so the pipeline manager:

- Acknowledges stop and definition-update requests immediately, tracking a
  draining pipeline via a new `stopping` state and settling it once the
  executor is down.
- Models the post-shutdown follow-up as a `post_shutdown` enum instead of a
  one-shot `on_stopped` callback, fixing a stale-callback bug where a clean
  drain could mislabel a later run.
- Reports executor-start failures to the originating request right away
  instead of waiting for the force-killed executor to exit.

## 💬 Review

- The behavioral fix and changelog are here; the implementation lives in
  the companion plugins PR.
- `stopping` is reported to clients as `stopped` for now; making the
  platform aware of a distinct draining state (and of buffered-data volume)
  remains follow-up work on TNZ-750.

<sub>
📎 Plugins PR: tenzir/tenzir-plugins#574<br>
🎫 References TNZ-750
🎫 Resolves TNZ-758
</sub>
