### PR TITLE
Support whitespace in `from_file` paths

### DIFF
--- a/changelog/unreleased/from-file-support-for-paths-with-spaces.md
+++ b/changelog/unreleased/from-file-support-for-paths-with-spaces.md
@@ -1,0 +1,15 @@
+---
+title: from_file support for paths with spaces
+type: bugfix
+authors:
+  - IyeOnline
+  - claude
+prs:
+  - 6394
+created: 2026-06-29T13:51:32.692597Z
+---
+
+The `from_file` operator now reads files whose path contains a space or other
+characters that require URI encoding. Previously, a space anywhere in the path
+(for example in a parent directory name) caused the pipeline to fail with a
+`failed to parse path as URI` error.

--- a/libtenzir/builtins/operators/from_file.cpp
+++ b/libtenzir/builtins/operators/from_file.cpp
@@ -45,12 +45,24 @@ protected:
       expanded = "./" + expanded;
     }
     expanded = std::filesystem::weakly_canonical(expanded);
+    // `UriFromAbsolutePath` percent-encodes characters that are illegal in a
+    // URI (e.g. a space in a parent directory name), which a manual `file://`
+    // prefix would not. `Uri::path()` decodes them again in `make_filesystem`.
+    auto uri_string = arrow::util::UriFromAbsolutePath(expanded);
+    if (not uri_string.ok()) {
+      diagnostic::error("failed to construct file URI")
+        .primary(args_.url)
+        .note(uri_string.status().ToStringWithoutContextLines())
+        .emit(ctx);
+      co_return failure::promise();
+    }
     auto uri = arrow::util::Uri{};
-    auto status = uri.Parse(fmt::format("file://{}", expanded));
+    auto status = uri.Parse(*uri_string);
     if (not status.ok()) {
       diagnostic::error("failed to parse path as URI")
         .primary(args_.url)
         .note(status.ToStringWithoutContextLines())
+        .note("full URI: `{}`", *uri_string)
         .emit(ctx);
       co_return failure::promise();
     }


### PR DESCRIPTION
`from_file` would previously raise an error when the concrete URI contained characters not allowed in an URI; this included characters in the parent directories of relative paths.

The fix is to simply URI escape the fully expanded "URI".