### PR TITLE
Report pipeline stopping state to platform

### DIFF
--- a/libtenzir/include/tenzir/platform_features.hpp
+++ b/libtenzir/include/tenzir/platform_features.hpp
@@ -1,0 +1,33 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <string>
+#include <unordered_set>
+
+namespace tenzir {
+
+/// Stores the feature set advertised by the platform when it connects.
+///
+/// The platform negotiates its supported features during the WebSocket
+/// handshake (see the `platform` plugin). Other plugins, such as the
+/// pipeline manager, need to know which features the platform understands so
+/// they can adjust the data they send to it. Because these plugins do not
+/// share state with the platform plugin, we keep the negotiated feature set in
+/// this process-global, thread-safe store.
+///
+/// Replaces the currently stored feature set with @p features. Passing an
+/// empty set (e.g. on disconnect) clears all features.
+auto set_platform_features(std::unordered_set<std::string> features) -> void;
+
+/// Returns whether the platform advertised the given feature on its most
+/// recent connection. Returns `false` if no platform is connected.
+auto platform_supports_feature(std::string_view feature) -> bool;
+
+} // namespace tenzir

--- a/libtenzir/src/platform_features.cpp
+++ b/libtenzir/src/platform_features.cpp
@@ -1,0 +1,33 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "tenzir/platform_features.hpp"
+
+#include <mutex>
+#include <shared_mutex>
+
+namespace tenzir {
+
+namespace {
+
+std::shared_mutex g_platform_features_mutex;
+std::unordered_set<std::string> g_platform_features;
+
+} // namespace
+
+auto set_platform_features(std::unordered_set<std::string> features) -> void {
+  auto lock = std::unique_lock{g_platform_features_mutex};
+  g_platform_features = std::move(features);
+}
+
+auto platform_supports_feature(std::string_view feature) -> bool {
+  auto lock = std::shared_lock{g_platform_features_mutex};
+  return g_platform_features.contains(std::string{feature});
+}
+
+} // namespace tenzir


### PR DESCRIPTION
## 🔍 Problem

The pipeline manager needs to conditionally report pipeline `stopping` state to the platform depending on whether the platform supports it. Without a shared way to communicate platform capabilities, plugins had no way to check what the connected platform understands.

## 🛠️ Solution

- Adds `platform_features.hpp` / `platform_features.cpp` with two thread-safe process-global functions:
  - `set_platform_features(features)` — called by the platform plugin on connect/disconnect.
  - `platform_supports_feature(feature)` — queried by other plugins (e.g. pipeline manager) at runtime.
- Backed by a `std::shared_mutex` for lock-free concurrent reads.

## 💬 Review

The guard is intentionally process-global (not actor-local) because the platform plugin and the pipeline manager plugin live in separate CAF actors with no shared state. The shared mutex keeps reads cheap under concurrent pipeline updates.

<sub>
📎 Related: tenzir/tenzir-plugins#575
<br/>
Related to TNZ-759
Related to https://github.com/tenzir/platform-internal/pull/236
</sub>