### PR TITLE
Drop partition columns from filesystem sink payloads

### DIFF
--- a/changelog/unreleased/hive-partitioned-filesystem-sinks.md
+++ b/changelog/unreleased/hive-partitioned-filesystem-sinks.md
@@ -1,0 +1,15 @@
+---
+title: Hive-partitioned filesystem sinks drop partition columns
+type: breaking
+authors:
+  - raxyte
+prs:
+  - 6400
+created: 2026-07-01T11:39:43.520966Z
+---
+
+Filesystem sink operators that use `partition_by` now omit the partition fields
+from the written payload. This is a breaking change for pipelines that expected
+those fields inside each written file. The values remain encoded in the
+hive-style directory components, such as `region=us/`, so readers that recover
+partition columns from the path no longer see duplicate fields.

--- a/libtenzir/src/arrow_fs.cpp
+++ b/libtenzir/src/arrow_fs.cpp
@@ -21,6 +21,7 @@
 #include "tenzir/substitute_ctx.hpp"
 #include "tenzir/table_slice.hpp"
 #include "tenzir/tql2/eval.hpp"
+#include "tenzir/tql2/set.hpp"
 #include "tenzir/view3.hpp"
 
 #include <arrow/array/array_primitive.h>
@@ -748,7 +749,8 @@ auto ToArrowFsOperator::process(table_slice input, OpCtx& ctx) -> Task<void> {
         .emit(ctx.dh());
       co_return;
     }
-    auto slice = filter(input, arrow::BooleanArray{rows, bitmap});
+    auto without_partitions = drop(input, fields, ctx, false);
+    auto slice = filter(without_partitions, arrow::BooleanArray{rows, bitmap});
     auto const slice_rows = slice.rows();
     // `push` runs without the guard. If it suspends on a full input
     // channel and we still hold the guard, `process_sub` on the draining

--- a/test/tests/operators/to_file/partition/02_verify_partition_dirs.py
+++ b/test/tests/operators/to_file/partition/02_verify_partition_dirs.py
@@ -23,6 +23,9 @@ def main() -> None:
                 for line in fh:
                     line = line.strip()
                     if line:
+                        event = json.loads(line)
+                        assert "id" in event, event
+                        assert "region" not in event, event
                         count += 1
         totals[d.name] = count
 

--- a/test/tests/operators/to_file/partition/04_verify_multi_field.py
+++ b/test/tests/operators/to_file/partition/04_verify_multi_field.py
@@ -1,6 +1,7 @@
 # runner: python
 """Verify multi-field hive partitioning creates correct directory structure."""
 
+import json
 import os
 from pathlib import Path
 
@@ -19,7 +20,15 @@ def main() -> None:
             count = 0
             for f in tier_dir.glob("*.json"):
                 with open(f) as fh:
-                    count += sum(1 for line in fh if line.strip())
+                    for line in fh:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        event = json.loads(line)
+                        assert "id" in event, event
+                        assert "region" not in event, event
+                        assert "tier" not in event, event
+                        count += 1
             partitions.append(
                 f"{region_dir.name}/{tier_dir.name}: files={n_files} rows={count}"
             )


### PR DESCRIPTION
Route rows by partition keys before dropping the partition fields, so Arrow filesystem sinks write hive-style datasets without duplicating path columns in the payload.