### PR TITLE
Add missing metrics

### DIFF
--- a/changelog/unreleased/operator-io-metrics.md
+++ b/changelog/unreleased/operator-io-metrics.md
@@ -1,0 +1,11 @@
+---
+title: Add ingress/egress metrics to more operators
+type: feature
+authors:
+  - IyeOnline
+created: 2026-07-01T00:00:00.000000Z
+---
+
+The `to_sentinelone_data_lake`, `to_azure_log_analytics`, `to_snowflake`,
+`from_sentinelone_data_lake`, `serve`, `serve_http`, and `serve_tcp` operators
+now report bytes and events metrics.

--- a/libtenzir/builtins/operators/serve.cpp
+++ b/libtenzir/builtins/operators/serve.cpp
@@ -1300,6 +1300,14 @@ public:
 
   auto start(OpCtx& ctx) -> Task<void> override {
     co_await OperatorBase::start(ctx);
+    bytes_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "serve"},
+                         MetricsDirection::write, MetricsVisibility::internal_,
+                         MetricsUnit::bytes);
+    events_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "serve"},
+                         MetricsDirection::write, MetricsVisibility::internal_,
+                         MetricsUnit::events);
     serve_manager_ = ctx.actor_system().registry().get<serve_manager_actor>(
       "tenzir.serve-manager");
     lifetime_actor_
@@ -1329,13 +1337,18 @@ public:
       // buffering it for the client.
       co_return;
     }
+    auto const rows = input.rows();
+    auto const bytes = input.approx_bytes();
     auto result = co_await async_mail(atom::put_v, args_.id, std::move(input))
                     .request(serve_manager_);
     if (not result) {
       diagnostic::error(result.error())
         .note("failed to buffer events at serve-manager")
         .emit(ctx);
+      co_return;
     }
+    bytes_counter_.add(bytes);
+    events_counter_.add(rows);
   }
 
   auto stop(OpCtx& ctx) -> Task<void> override {
@@ -1364,6 +1377,8 @@ private:
   serve_manager_actor serve_manager_;
   caf::actor lifetime_actor_;
   bool stopped_ = false;
+  MetricsCounter bytes_counter_;
+  MetricsCounter events_counter_;
 };
 
 // -- serve operator ----------------------------------------------------------

--- a/libtenzir/builtins/operators/serve_http.cpp
+++ b/libtenzir/builtins/operators/serve_http.cpp
@@ -349,6 +349,14 @@ public:
     }
     server_ = Arc<http_server::ScopedServer>::from_non_null(
       std::move(server).unwrap());
+    bytes_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "serve_http"},
+                         MetricsDirection::write, MetricsVisibility::external_,
+                         MetricsUnit::bytes);
+    events_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "serve_http"},
+                         MetricsDirection::write, MetricsVisibility::external_,
+                         MetricsUnit::events);
     ctx.spawn_task([this]() -> Task<void> {
       co_await catch_cancellation(wait_forever());
       co_await force_stop();
@@ -369,10 +377,18 @@ public:
       co_return;
     }
     auto& pipeline = as<SubHandle<table_slice>>(*sub);
+    // Count events at ingress: the number of rows accepted for serving. Egress
+    // event attribution is not possible here because the printer subpipeline
+    // is opaque, its output chunks carry no row count, and a single event may
+    // even span multiple chunks. Bytes, in contrast, are counted at egress in
+    // `broadcast_payload()` where per-client writes are exactly known.
+    auto const rows = input.rows();
     auto result = co_await pipeline.push(std::move(input));
     if (result.is_err()) {
       co_await force_stop();
+      co_return;
     }
+    events_counter_.add(rows);
     co_return;
   }
 
@@ -543,13 +559,19 @@ private:
         if (client->closing()) {
           continue;
         }
-        join.add([client, chunk, content_type]() mutable -> Task<bool> {
-          co_return co_await folly::coro::co_withExecutor(
+        join.add([this, client, chunk, content_type]() mutable -> Task<bool> {
+          auto const ok = co_await folly::coro::co_withExecutor(
             client->evb(),
             folly::coro::co_invoke(
               [client, chunk, content_type]() mutable -> Task<bool> {
                 co_return co_await client->write_payload(chunk, content_type);
               }));
+          if (ok) {
+            // Count bytes per successful client write so the egress metric
+            // reflects the actual fan-out to each connected client.
+            bytes_counter_.add(chunk->size());
+          }
+          co_return ok;
         });
       }
       // wait for all; the slowest client determines progress.
@@ -621,6 +643,8 @@ private:
   Option<Arc<http_server::ScopedServer>> server_;
   Arc<Semaphore> active_connections_;
   std::vector<Arc<Client>> clients_;
+  MetricsCounter bytes_counter_;
+  MetricsCounter events_counter_;
   // --- state ---
   Lifecycle lifecycle_ = Lifecycle::running;
 };

--- a/libtenzir/builtins/operators/serve_tcp.cpp
+++ b/libtenzir/builtins/operators/serve_tcp.cpp
@@ -190,6 +190,14 @@ public:
     server_ = std::make_unique<folly::coro::ServerSocket>(
       std::move(socket), address_, listen_backlog);
     tcp_metrics_ = make_metric_handler(ctx, tcp_metrics_type());
+    bytes_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "serve_tcp"},
+                         MetricsDirection::write, MetricsVisibility::external_,
+                         MetricsUnit::bytes);
+    events_counter_
+      = ctx.make_counter(MetricsLabel{"operator", "serve_tcp"},
+                         MetricsDirection::write, MetricsVisibility::external_,
+                         MetricsUnit::events);
     accept_loop_started_ = true;
     ctx.spawn_task([this, &ctx]() -> Task<void> {
       auto notify_finished = detail::scope_guard{[this, &ctx]() noexcept {
@@ -271,10 +279,18 @@ public:
       co_return;
     }
     auto& pipeline = as<SubHandle<table_slice>>(*sub);
+    // Count events at ingress: the number of rows accepted for serving. Egress
+    // event attribution is not possible here because the printer subpipeline
+    // is opaque, its output chunks carry no row count, and a single event may
+    // even span multiple chunks. Bytes, in contrast, are counted at egress in
+    // `broadcast_payload()` where per-client writes are exactly known.
+    auto const rows = input.rows();
     auto result = co_await pipeline.push(std::move(input));
     if (result.is_err()) {
       co_await request_stop();
+      co_return;
     }
+    events_counter_.add(rows);
   }
 
   auto process_sub(SubKeyView, chunk_ptr chunk, OpCtx&) -> Task<void> override {
@@ -407,6 +423,9 @@ private:
     for (size_t i = 0; i < clients_.size();) {
       auto ok = co_await write_to_client(clients_[i], data);
       if (ok) {
+        // Count bytes per successful client write so the egress metric reflects
+        // the actual fan-out: each connected client is counted separately.
+        bytes_counter_.add(data.size());
         ++i;
         continue;
       }
@@ -496,6 +515,8 @@ private:
   Box<folly::CancellationSource> accept_cancel_{std::in_place};
   std::vector<Client> clients_;
   metric_handler tcp_metrics_ = {};
+  MetricsCounter bytes_counter_;
+  MetricsCounter events_counter_;
   bool accept_loop_started_ = false;
   Lifecycle lifecycle_ = Lifecycle::running;
 };


### PR DESCRIPTION
Add bytes and events metrics to operators that were missing them.

- `serve`, `serve_http`, `serve_tcp` — write metrics (events at printer input, bytes at printer output; `serve` uses `approx_bytes`).
- Plugin operators (`to_sentinelone_data_lake`, `to_azure_log_analytics`, `to_snowflake`, `from_sentinelone_data_lake`) via tenzir/tenzir-plugins#576.

🤖 Generated with [Claude Code](https://claude.com/claude-code)