### PR TITLE
Use operator names for metrics instead of C++ type names

### DIFF
--- a/changelog/unreleased/operator-metric-names.md
+++ b/changelog/unreleased/operator-metric-names.md
@@ -1,0 +1,11 @@
+---
+title: Fix confusing operator names in metrics
+type: bugfix
+authors:
+  - aljazerzen
+created: 2026-07-01T00:00:00.000000Z
+---
+
+Operator metrics and profiling no longer report demangled C++ type names such
+as `Discard<tenzir::table_slice>`. Instead, they use the operator's name as it
+appears in TQL, for example `discard`.

--- a/libtenzir/builtins/operators/cache.cpp
+++ b/libtenzir/builtins/operators/cache.cpp
@@ -1391,15 +1391,15 @@ public:
     args.write_timeout = write_timeout_value_;
     if (*mode_value_ == "write") {
       TENZIR_ASSERT(input.is<table_slice>());
-      return WriteCacheSink{std::move(args)};
+      return WriteCacheSink{std::move(args)}.with_name("cache");
     }
     if (*mode_value_ == "read") {
       TENZIR_ASSERT(input.is<void>());
-      return ReadCacheSource{std::move(args)};
+      return ReadCacheSource{std::move(args)}.with_name("cache");
     }
     TENZIR_ASSERT(*mode_value_ == "readwrite");
     TENZIR_ASSERT(input.is<table_slice>());
-    return CacheReadwrite{std::move(args)};
+    return CacheReadwrite{std::move(args)}.with_name("cache");
   }
 
   auto main_location() const -> location override {

--- a/libtenzir/builtins/operators/from_to_2.cpp
+++ b/libtenzir/builtins/operators/from_to_2.cpp
@@ -180,7 +180,7 @@ public:
 
   auto spawn(element_type_tag input) && -> Option<AnyOperator> override {
     TENZIR_ASSERT(input.is<void>());
-    return From{std::move(events_)};
+    return From{std::move(events_)}.with_name("from");
   }
 
   auto infer_type(element_type_tag input, diagnostic_handler& dh) const

--- a/libtenzir/builtins/operators/summarize.cpp
+++ b/libtenzir/builtins/operators/summarize.cpp
@@ -996,7 +996,7 @@ public:
 
   auto spawn(element_type_tag input) && -> Option<AnyOperator> override {
     TENZIR_ASSERT(input.is<table_slice>());
-    return Summarize{std::move(cfg_)};
+    return Summarize{std::move(cfg_)}.with_name("summarize");
   }
 
   auto infer_type(element_type_tag input, diagnostic_handler& dh) const

--- a/libtenzir/builtins/operators/version.cpp
+++ b/libtenzir/builtins/operators/version.cpp
@@ -212,7 +212,7 @@ public:
   }
   auto spawn(element_type_tag input) && -> Option<AnyOperator> override {
     TENZIR_ASSERT(input.is<void>());
-    return Version{};
+    return Version{}.with_name("version");
   }
 
   auto infer_type(element_type_tag input, diagnostic_handler& dh) const

--- a/libtenzir/builtins/operators/where_map.cpp
+++ b/libtenzir/builtins/operators/where_map.cpp
@@ -878,7 +878,7 @@ public:
 
   auto spawn(element_type_tag input) && -> Option<AnyOperator> override {
     TENZIR_ASSERT(input.is<table_slice>());
-    return Where{std::move(predicate_)};
+    return Where{std::move(predicate_)}.with_name("where");
   }
 
   auto infer_type(element_type_tag input, diagnostic_handler& dh) const

--- a/libtenzir/include/tenzir/async.hpp
+++ b/libtenzir/include/tenzir/async.hpp
@@ -455,8 +455,25 @@ public:
     co_return;
   }
 
+  /// The user-facing name of this operator, used for metrics and profiling.
+  auto name() const -> std::string_view {
+    return name_;
+  }
+
+  /// Sets the user-facing name of this operator and returns it, so that it can
+  /// be chained at construction, e.g. `IfSink{...}.with_name("if")`. Called by
+  /// the spawning machinery with `Description::name`.
+  template <class Self>
+  auto with_name(this Self&& self, std::string name) -> Self {
+    self.name_ = std::move(name);
+    return std::forward<Self>(self);
+  }
+
 protected:
   ~OperatorBase() = default;
+
+private:
+  std::string name_;
 };
 
 template <class Input, class Output>

--- a/libtenzir/src/async/executor.cpp
+++ b/libtenzir/src/async/executor.cpp
@@ -16,6 +16,7 @@
 #include "tenzir/async/select_set.hpp"
 #include "tenzir/async_secret_resolution.hpp"
 #include "tenzir/co_match.hpp"
+#include "tenzir/detail/assert.hpp"
 #include "tenzir/ir.hpp"
 #include "tenzir/option.hpp"
 #include "tenzir/pipeline.hpp"
@@ -25,7 +26,6 @@
 #include <folly/OperationCancelled.h>
 #include <folly/coro/BoundedQueue.h>
 
-#include <chrono>
 #include <mutex>
 
 // TODO: Why does this not report line numbers correctly?
@@ -38,12 +38,6 @@ namespace tenzir {
 
 // Forward declaration to avoid including registry.hpp.
 auto global_registry() -> std::shared_ptr<const registry>;
-
-namespace {
-
-auto demangle_op_type(std::type_info const& type) -> std::string;
-
-} // namespace
 
 /// Transforms a `Push<OperatorMsg<T>>` into a `Push<T>`.
 template <class T>
@@ -112,11 +106,14 @@ public:
   }
 };
 
+namespace {
 auto make_identity_operator(element_type_tag input) -> AnyOperator {
   return match(input, []<class Input>(tag<Input>) -> AnyOperator {
-    return Box<Operator<Input, Input>>{IdentityOperator<Input>{}};
+    return Box<Operator<Input, Input>>{
+      IdentityOperator<Input>{}.with_name("pass")};
   });
 }
+}; // namespace
 
 /// An message transported from a subpipeline to the parent pipeline.
 ///
@@ -1016,8 +1013,8 @@ private:
   auto io_executor() -> folly::Executor::KeepAlive<folly::IOExecutor> override {
     if (not io_executor_) {
       auto& op = base_op();
-      io_executor_
-        = exec_ctx_.make_io_executor(id_, demangle_op_type(typeid(op)));
+      TENZIR_ASSERT(not op.name().empty());
+      io_executor_ = exec_ctx_.make_io_executor(id_, std::string{op.name()});
     }
     return io_executor_;
   }
@@ -1691,21 +1688,6 @@ auto run_operator(Box<Operator<Input, Output>> op,
   co_return;
 }
 
-/// Demangle a C++ type name and strip the namespace prefix.
-auto demangle_op_type(std::type_info const& type) -> std::string {
-  auto demangled = folly::demangle(type);
-  auto result = std::string{demangled};
-  // Strip namespace prefix, keeping only the class name.
-  // Only look before '<' to avoid matching '::' inside template arguments.
-  auto tpl = result.find('<');
-  auto prefix = tpl != std::string::npos ? result.substr(0, tpl) : result;
-  auto pos = prefix.rfind("::");
-  if (pos != std::string::npos) {
-    result = result.substr(pos + 2);
-  }
-  return result;
-}
-
 } // namespace
 
 class ChainRunner {
@@ -1766,8 +1748,9 @@ private:
           Option<Sender<FromControl>>{std::move(from_control_sender)},
           std::move(to_control_receiver),
         });
-        auto executor = exec_ctx_.make_executor(id_.op(index),
-                                                demangle_op_type(typeid(*op)));
+        TENZIR_ASSERT(not op->name().empty());
+        auto executor
+          = exec_ctx_.make_executor(id_.op(index), std::string{op->name()});
         auto task = run_operator(std::move(op), std::move(input),
                                  std::move(output_sender),
                                  std::move(from_control_receiver),

--- a/libtenzir/src/ir.cpp
+++ b/libtenzir/src/ir.cpp
@@ -251,7 +251,7 @@ auto ir::SetIr::substitute(substitute_ctx ctx, bool instantiate)
 
 auto ir::SetIr::spawn(element_type_tag input) && -> Option<AnyOperator> {
   TENZIR_ASSERT(input.is<table_slice>());
-  return Set{std::move(assignments_), order_};
+  return Set{std::move(assignments_), order_}.with_name("set");
 }
 
 namespace {
@@ -582,9 +582,9 @@ public:
     auto output = infer_type(input, dh);
     TENZIR_ASSERT(output and *output);
     if ((**output).is<void>()) {
-      return IfSink{std::move(args_)};
+      return IfSink{std::move(args_)}.with_name("if");
     }
-    return If{std::move(args_)};
+    return If{std::move(args_)}.with_name("if");
   }
 
   auto infer_type(element_type_tag input, diagnostic_handler& dh) const

--- a/libtenzir/src/ir_match.cpp
+++ b/libtenzir/src/ir_match.cpp
@@ -512,9 +512,9 @@ public:
     auto output = infer_type(input, dh);
     TENZIR_ASSERT(output and *output);
     if ((**output).is<void>()) {
-      return MatchSink{std::move(args_)};
+      return MatchSink{std::move(args_)}.with_name("match");
     }
-    return Match{std::move(args_)};
+    return Match{std::move(args_)}.with_name("match");
   }
 
   auto infer_type(element_type_tag input, diagnostic_handler& dh) const

--- a/libtenzir/src/operator_plugin.cpp
+++ b/libtenzir/src/operator_plugin.cpp
@@ -462,10 +462,16 @@ public:
     if (desc_->set_order) {
       (*desc_->set_order)(args, order_);
     }
-    if (spawner) {
-      return match(*spawner, [&](auto& spawner) -> AnyOperator {
-        return spawner(std::move(args));
+    auto with_name = [&](AnyOperator op) -> AnyOperator {
+      match(op, [&](auto& op) {
+        op->with_name(desc_->name);
       });
+      return op;
+    };
+    if (spawner) {
+      return with_name(match(*spawner, [&](auto& spawner) -> AnyOperator {
+        return spawner(std::move(args));
+      }));
     }
     for (auto& spawn : desc_->spawns) {
       auto result = match(
@@ -478,7 +484,7 @@ public:
           return std::nullopt;
         });
       if (result) {
-        return std::move(*result);
+        return with_name(std::move(*result));
       }
     }
     TENZIR_UNREACHABLE();


### PR DESCRIPTION
## 🔍 Problem

Operator metrics and profiling derived their label from the demangled C++ type
of the runtime operator, surfacing confusing names such as
`Discard<tenzir::table_slice>` that leak template arguments and don't match the
TQL surface.

## 🛠️ Solution

- Add a `name` to `OperatorBase`, populated from `Description::name` when
  spawning through `GenericIr`.
- Tag operators that construct their runtime instance directly (`set`, `if`,
  `match`, `from`, `where`, `summarize`, `cache`, and the injected identity
  operator) via a chainable `with_name` (C++23 deducing `this`).
- Drop the demangling fallback and assert that a name is always set.

## 💬 Review

- `with_name` uses deducing `this`: rvalue calls return by value for chaining
  at construction; lvalue calls mutate the boxed operator in place.
- Worth confirming the direct-spawn list is exhaustive; the assertions will
  fire fast in debug if any path was missed.