### PR TITLE
Make serve and live export shut down promptly

### DIFF
--- a/changelog/unreleased/serve-export-graceful-shutdown.md
+++ b/changelog/unreleased/serve-export-graceful-shutdown.md
@@ -1,0 +1,17 @@
+---
+title: Serve and live export shut down promptly
+type: bugfix
+authors:
+  - aljazerzen
+created: 2026-07-01T00:00:00.000000Z
+---
+
+Stopping a pipeline that ends in `serve` no longer waits for the entire buffer
+to drain, which previously made graceful shutdown slow or made it hang
+indefinitely when a large backlog was buffered with no client draining it. The
+buffered data is now dropped and pending requests are released so the operator
+exits immediately.
+
+Live exports with `retro=true` no longer ignore graceful shutdown. Previously
+the pipeline could enter an indefinite live-wait after the retrospective
+backlog drained and never terminate.

--- a/libtenzir/builtins/operators/export.cpp
+++ b/libtenzir/builtins/operators/export.cpp
@@ -333,15 +333,14 @@ public:
 
   auto stop(OpCtx& ctx) -> Task<void> override {
     TENZIR_UNUSED(ctx);
-    // Only force the bridge down for a pure live wait. The bridge has no
-    // separate "stop accepting new live events" protocol, so when retro is
-    // also enabled we cannot tell whether the retro backlog has drained
-    // yet. Tearing down here would drop queued slices and in-flight
-    // partition reads. Pure retro exports also drain naturally via the
-    // bridge's empty-slice sentinel, so the only case that genuinely needs
-    // forced teardown is `live=true retro=false`, where the bridge would
-    // otherwise wait indefinitely.
-    if (not args_.live or args_.retro) {
+    // Pure retro exports drain naturally via the bridge's empty-slice
+    // sentinel, so they don't need forced teardown.
+    // For any live export (`live=true`, with or without `retro`) the bridge
+    // enters an indefinite live-wait after the retro backlog is consumed and
+    // will never send the sentinel on its own. Kill it so the pipeline can
+    // terminate. In-flight retro reads that haven't been pushed downstream
+    // yet may be dropped, which is acceptable under stop() semantics.
+    if (not args_.live) {
       co_return;
     }
     stopping_ = true;

--- a/libtenzir/builtins/operators/serve.cpp
+++ b/libtenzir/builtins/operators/serve.cpp
@@ -442,10 +442,10 @@ using serve_manager_actor = typed_actor_fwd<
   auto(atom::start, std::string serve_id, uint64_t buffer_size,
        caf::actor watched)
     ->caf::result<void>,
-  // Deregister a serve operator, waiting until it completed.
-  auto(atom::stop, std::string serve_id)->caf::result<void>,
   // Drop all buffered data and complete immediately, without waiting for the
   // data to be drained to the client.
+  auto(atom::stop, std::string serve_id)->caf::result<void>,
+  // Deregister a serve operator, waiting until it completed.
   auto(atom::shutdown, std::string serve_id)->caf::result<void>,
   // Put additional slices into the buffer for the given access token.
   auto(atom::put, std::string serve_id, table_slice)->caf::result<void>,
@@ -647,7 +647,7 @@ struct serve_manager_state {
     return {};
   }
 
-  auto stop(std::string serve_id) -> caf::result<void> {
+  auto finalize(std::string serve_id) -> caf::result<void> {
     const auto found
       = std::find_if(ops.begin(), ops.end(), [&](const auto& op) {
           return op.serve_id == serve_id;
@@ -668,7 +668,7 @@ struct serve_manager_state {
     return found->stop_rp;
   }
 
-  auto drop(std::string serve_id) -> caf::result<void> {
+  auto stop(std::string serve_id) -> caf::result<void> {
     const auto found
       = std::find_if(ops.begin(), ops.end(), [&](const auto& op) {
           return op.serve_id == serve_id;
@@ -864,10 +864,10 @@ auto serve_manager(
                                  std::move(watched));
     },
     [self](atom::stop, std::string& serve_id) -> caf::result<void> {
-      return self->state().stop(std::move(serve_id));
+      return self->state().finalize(std::move(serve_id));
     },
     [self](atom::shutdown, std::string& serve_id) -> caf::result<void> {
-      return self->state().drop(std::move(serve_id));
+      return self->state().stop(std::move(serve_id));
     },
     [self](atom::put, std::string& serve_id,
            table_slice& slice) -> caf::result<void> {
@@ -1398,7 +1398,8 @@ public:
     // serve-manager.
     stopped_ = true;
     auto result
-      = co_await async_mail(atom::shutdown_v, args_.id).request(serve_manager_);
+      = co_await async_mail(atom::stop_v, args_.id).request(serve_manager_);
+    co_return;
     if (not result) {
       diagnostic::error(result.error())
         .note("failed to stop serve-manager")
@@ -1408,7 +1409,7 @@ public:
 
   auto finalize(OpCtx& ctx) -> Task<FinalizeBehavior> override {
     auto result
-      = co_await async_mail(atom::stop_v, args_.id).request(serve_manager_);
+      = co_await async_mail(atom::shutdown_v, args_.id).request(serve_manager_);
     if (not result) {
       diagnostic::error(result.error())
         .note("failed to deregister at serve-manager")
@@ -1483,7 +1484,7 @@ public:
     //  Wait until all events were fetched.
     ctrl.set_waiting(true);
     ctrl.self()
-      .mail(atom::stop_v, serve_id_)
+      .mail(atom::shutdown_v, serve_id_)
       .request(serve_manager, caf::infinite)
       .then(
         [&]() {

--- a/libtenzir/builtins/operators/serve.cpp
+++ b/libtenzir/builtins/operators/serve.cpp
@@ -864,10 +864,10 @@ auto serve_manager(
                                  std::move(watched));
     },
     [self](atom::stop, std::string& serve_id) -> caf::result<void> {
-      return self->state().finalize(std::move(serve_id));
+      return self->state().stop(std::move(serve_id));
     },
     [self](atom::shutdown, std::string& serve_id) -> caf::result<void> {
-      return self->state().stop(std::move(serve_id));
+      return self->state().finalize(std::move(serve_id));
     },
     [self](atom::put, std::string& serve_id,
            table_slice& slice) -> caf::result<void> {
@@ -1399,12 +1399,12 @@ public:
     stopped_ = true;
     auto result
       = co_await async_mail(atom::stop_v, args_.id).request(serve_manager_);
-    co_return;
     if (not result) {
       diagnostic::error(result.error())
         .note("failed to stop serve-manager")
         .emit(ctx);
     }
+    co_return;
   }
 
   auto finalize(OpCtx& ctx) -> Task<FinalizeBehavior> override {

--- a/libtenzir/builtins/operators/serve.cpp
+++ b/libtenzir/builtins/operators/serve.cpp
@@ -47,6 +47,7 @@
 // multiple times. We should revisit this in the future.
 
 #include "tenzir/async.hpp"
+#include "tenzir/async/channel.hpp"
 #include "tenzir/async/mail.hpp"
 #include "tenzir/detail/fanout_counter.hpp"
 
@@ -1366,6 +1367,16 @@ public:
             },
           };
         });
+    // The `put` request to the serve-manager applies backpressure by
+    // withholding its response until the client has drained the buffer. We must
+    // not block the operator's main loop on such a request, because otherwise a
+    // graceful shutdown (which is delivered as a control message on that same
+    // loop) could not interrupt it. Instead, we run each `put` in a background
+    // task and report completion through this channel, applying backpressure
+    // via `state()` by admitting only one in-flight `put` at a time.
+    auto [tx, rx] = channel<std::monostate>(1);
+    put_done_tx_ = std::make_shared<Sender<std::monostate>>(std::move(tx));
+    put_done_rx_ = std::make_shared<Receiver<std::monostate>>(std::move(rx));
     auto result = co_await async_mail(atom::start_v, args_.id,
                                       args_.buffer_size, lifetime_actor_)
                     .request(serve_manager_);
@@ -1383,19 +1394,56 @@ public:
       // buffering it for the client.
       co_return;
     }
-    auto result = co_await async_mail(atom::put_v, args_.id, std::move(input))
-                    .request(serve_manager_);
-    if (not result) {
-      diagnostic::error(result.error())
-        .note("failed to buffer events at serve-manager")
-        .emit(ctx);
+    // Forward the slice in a background task so that the main loop stays
+    // responsive to control messages while the serve-manager throttles us.
+    put_in_flight_ = true;
+    ctx.spawn_task([serve_manager = serve_manager_, id = args_.id,
+                    slice = std::move(input), tx = put_done_tx_,
+                    dh = &ctx.dh()]() mutable -> Task<void> {
+      auto result = co_await async_mail(atom::put_v, id, std::move(slice))
+                      .request(serve_manager);
+      if (not result) {
+        diagnostic::error(result.error())
+          .note("failed to buffer events at serve-manager")
+          .emit(*dh);
+      }
+      co_await tx->send(std::monostate{});
+    });
+    co_return;
+  }
+
+  auto await_task(diagnostic_handler& dh) const -> Task<Any> override {
+    TENZIR_UNUSED(dh);
+    // Wait for the completion of an in-flight `put`. When there is none, this
+    // blocks until the next one completes.
+    auto msg = co_await put_done_rx_->recv();
+    if (not msg) {
+      co_await wait_forever();
     }
+    co_return {};
+  }
+
+  auto process_task(Any result, OpCtx& ctx) -> Task<void> override {
+    TENZIR_UNUSED(result, ctx);
+    put_in_flight_ = false;
+    co_return;
+  }
+
+  auto state() -> OperatorState override {
+    // While a `put` is in flight, we do not admit further input. Once we are
+    // stopping, we accept and drop input so the pipeline can drain to
+    // end-of-input quickly.
+    if (stopped_) {
+      return OperatorState::normal;
+    }
+    return put_in_flight_ ? OperatorState::blocked : OperatorState::normal;
   }
 
   auto stop(OpCtx& ctx) -> Task<void> override {
-    // On graceful shutdown we stop buffering input for the client. Any input
-    // accepted after this point is dropped instead of being forwarded to the
-    // serve-manager.
+    // On graceful shutdown we do not wait for the buffered data to be drained
+    // to the client. Instead, we tell the serve-manager to drop all data and
+    // release any pending `put` request so that the operator can shut down
+    // immediately.
     stopped_ = true;
     auto result
       = co_await async_mail(atom::stop_v, args_.id).request(serve_manager_);
@@ -1408,6 +1456,10 @@ public:
   }
 
   auto finalize(OpCtx& ctx) -> Task<FinalizeBehavior> override {
+    if (stopped_) {
+      // We already dropped all data during `stop()`.
+      co_return FinalizeBehavior::done;
+    }
     auto result
       = co_await async_mail(atom::shutdown_v, args_.id).request(serve_manager_);
     if (not result) {
@@ -1422,6 +1474,9 @@ private:
   ServeArgs args_;
   serve_manager_actor serve_manager_;
   caf::actor lifetime_actor_;
+  std::shared_ptr<Sender<std::monostate>> put_done_tx_;
+  std::shared_ptr<Receiver<std::monostate>> put_done_rx_;
+  bool put_in_flight_ = false;
   bool stopped_ = false;
 };
 

--- a/libtenzir/builtins/operators/serve.cpp
+++ b/libtenzir/builtins/operators/serve.cpp
@@ -444,6 +444,9 @@ using serve_manager_actor = typed_actor_fwd<
     ->caf::result<void>,
   // Deregister a serve operator, waiting until it completed.
   auto(atom::stop, std::string serve_id)->caf::result<void>,
+  // Drop all buffered data and complete immediately, without waiting for the
+  // data to be drained to the client.
+  auto(atom::shutdown, std::string serve_id)->caf::result<void>,
   // Put additional slices into the buffer for the given access token.
   auto(atom::put, std::string serve_id, table_slice)->caf::result<void>,
   // Get slices from the buffer for the given access token, returning the next
@@ -665,6 +668,48 @@ struct serve_manager_state {
     return found->stop_rp;
   }
 
+  auto drop(std::string serve_id) -> caf::result<void> {
+    const auto found
+      = std::find_if(ops.begin(), ops.end(), [&](const auto& op) {
+          return op.serve_id == serve_id;
+        });
+    if (found == ops.end()) {
+      return caf::make_error(ec::invalid_argument,
+                             fmt::format("{} received request to drop for "
+                                         "unknown serve id {}",
+                                         *self, escape_operator_arg(serve_id)));
+    }
+    TENZIR_DEBUG("{} drops all buffered data for serve id {}", *self,
+                 escape_operator_arg(serve_id));
+    // Drop all buffered data and mark the operator as done so that subsequent
+    // requests observe a terminal state instead of waiting for a drain that
+    // will never happen.
+    found->buffer.clear();
+    found->done = true;
+    found->requested = 0;
+    found->delayed_attempt.dispose();
+    // Release the pipeline if we throttled it, so that the pending `put`
+    // request in the operator completes and the operator can shut down.
+    if (found->put_rp.pending()) {
+      found->put_rp.deliver();
+    }
+    // Complete any in-flight get requests with a terminal response. We keep the
+    // last continuation token acceptable so that a client polling with the
+    // previously advertised token still observes a completed response instead
+    // of an error.
+    found->last_continuation_token
+      = std::exchange(found->continuation_token, {});
+    for (auto&& get_rp : std::exchange(found->get_rps, {})) {
+      get_rp.deliver(
+        std::make_tuple(std::string{}, std::vector<table_slice>{}));
+    }
+    // Unblock a pending stop request, if any.
+    if (found->stop_rp.pending()) {
+      found->stop_rp.deliver();
+    }
+    return {};
+  }
+
   auto put(std::string serve_id, table_slice slice) -> caf::result<void> {
     const auto found
       = std::find_if(ops.begin(), ops.end(), [&](const auto& op) {
@@ -726,6 +771,12 @@ struct serve_manager_state {
         split(found->last_results, request.max_events).first);
     }
     if (found->continuation_token != request.continuation_token) {
+      // If the operator already reached a terminal state, e.g., because it was
+      // dropped on graceful shutdown, we report completion instead of an error
+      // for a client that polls with the previously advertised token.
+      if (found->done) {
+        return std::make_tuple(std::string{}, std::vector<table_slice>{});
+      }
       return caf::make_error(
         ec::invalid_argument,
         fmt::format("{} got request for events with unknown continuation token "
@@ -814,6 +865,9 @@ auto serve_manager(
     },
     [self](atom::stop, std::string& serve_id) -> caf::result<void> {
       return self->state().stop(std::move(serve_id));
+    },
+    [self](atom::shutdown, std::string& serve_id) -> caf::result<void> {
+      return self->state().drop(std::move(serve_id));
     },
     [self](atom::put, std::string& serve_id,
            table_slice& slice) -> caf::result<void> {
@@ -1342,9 +1396,14 @@ public:
     // On graceful shutdown we stop buffering input for the client. Any input
     // accepted after this point is dropped instead of being forwarded to the
     // serve-manager.
-    TENZIR_UNUSED(ctx);
     stopped_ = true;
-    co_return;
+    auto result
+      = co_await async_mail(atom::shutdown_v, args_.id).request(serve_manager_);
+    if (not result) {
+      diagnostic::error(result.error())
+        .note("failed to stop serve-manager")
+        .emit(ctx);
+    }
   }
 
   auto finalize(OpCtx& ctx) -> Task<FinalizeBehavior> override {
@@ -1354,7 +1413,6 @@ public:
       diagnostic::error(result.error())
         .note("failed to deregister at serve-manager")
         .emit(ctx);
-      co_return FinalizeBehavior::done;
     }
     co_return FinalizeBehavior::done;
   }

--- a/libtenzir/builtins/operators/serve.cpp
+++ b/libtenzir/builtins/operators/serve.cpp
@@ -47,7 +47,6 @@
 // multiple times. We should revisit this in the future.
 
 #include "tenzir/async.hpp"
-#include "tenzir/async/channel.hpp"
 #include "tenzir/async/mail.hpp"
 #include "tenzir/detail/fanout_counter.hpp"
 
@@ -1367,16 +1366,6 @@ public:
             },
           };
         });
-    // The `put` request to the serve-manager applies backpressure by
-    // withholding its response until the client has drained the buffer. We must
-    // not block the operator's main loop on such a request, because otherwise a
-    // graceful shutdown (which is delivered as a control message on that same
-    // loop) could not interrupt it. Instead, we run each `put` in a background
-    // task and report completion through this channel, applying backpressure
-    // via `state()` by admitting only one in-flight `put` at a time.
-    auto [tx, rx] = channel<std::monostate>(1);
-    put_done_tx_ = std::make_shared<Sender<std::monostate>>(std::move(tx));
-    put_done_rx_ = std::make_shared<Receiver<std::monostate>>(std::move(rx));
     auto result = co_await async_mail(atom::start_v, args_.id,
                                       args_.buffer_size, lifetime_actor_)
                     .request(serve_manager_);
@@ -1394,56 +1383,19 @@ public:
       // buffering it for the client.
       co_return;
     }
-    // Forward the slice in a background task so that the main loop stays
-    // responsive to control messages while the serve-manager throttles us.
-    put_in_flight_ = true;
-    ctx.spawn_task([serve_manager = serve_manager_, id = args_.id,
-                    slice = std::move(input), tx = put_done_tx_,
-                    dh = &ctx.dh()]() mutable -> Task<void> {
-      auto result = co_await async_mail(atom::put_v, id, std::move(slice))
-                      .request(serve_manager);
-      if (not result) {
-        diagnostic::error(result.error())
-          .note("failed to buffer events at serve-manager")
-          .emit(*dh);
-      }
-      co_await tx->send(std::monostate{});
-    });
-    co_return;
-  }
-
-  auto await_task(diagnostic_handler& dh) const -> Task<Any> override {
-    TENZIR_UNUSED(dh);
-    // Wait for the completion of an in-flight `put`. When there is none, this
-    // blocks until the next one completes.
-    auto msg = co_await put_done_rx_->recv();
-    if (not msg) {
-      co_await wait_forever();
+    auto result = co_await async_mail(atom::put_v, args_.id, std::move(input))
+                    .request(serve_manager_);
+    if (not result) {
+      diagnostic::error(result.error())
+        .note("failed to buffer events at serve-manager")
+        .emit(ctx);
     }
-    co_return {};
-  }
-
-  auto process_task(Any result, OpCtx& ctx) -> Task<void> override {
-    TENZIR_UNUSED(result, ctx);
-    put_in_flight_ = false;
-    co_return;
-  }
-
-  auto state() -> OperatorState override {
-    // While a `put` is in flight, we do not admit further input. Once we are
-    // stopping, we accept and drop input so the pipeline can drain to
-    // end-of-input quickly.
-    if (stopped_) {
-      return OperatorState::normal;
-    }
-    return put_in_flight_ ? OperatorState::blocked : OperatorState::normal;
   }
 
   auto stop(OpCtx& ctx) -> Task<void> override {
-    // On graceful shutdown we do not wait for the buffered data to be drained
-    // to the client. Instead, we tell the serve-manager to drop all data and
-    // release any pending `put` request so that the operator can shut down
-    // immediately.
+    // On graceful shutdown we stop buffering input for the client. Any input
+    // accepted after this point is dropped instead of being forwarded to the
+    // serve-manager.
     stopped_ = true;
     auto result
       = co_await async_mail(atom::stop_v, args_.id).request(serve_manager_);
@@ -1456,10 +1408,6 @@ public:
   }
 
   auto finalize(OpCtx& ctx) -> Task<FinalizeBehavior> override {
-    if (stopped_) {
-      // We already dropped all data during `stop()`.
-      co_return FinalizeBehavior::done;
-    }
     auto result
       = co_await async_mail(atom::shutdown_v, args_.id).request(serve_manager_);
     if (not result) {
@@ -1474,9 +1422,6 @@ private:
   ServeArgs args_;
   serve_manager_actor serve_manager_;
   caf::actor lifetime_actor_;
-  std::shared_ptr<Sender<std::monostate>> put_done_tx_;
-  std::shared_ptr<Receiver<std::monostate>> put_done_rx_;
-  bool put_in_flight_ = false;
   bool stopped_ = false;
 };
 


### PR DESCRIPTION
## 🔍 Problem

Graceful shutdown could stall for pipelines that buffer data on stop:

- The internal `serve` operator streamed its entire buffer to the platform on
  shutdown. With a large backlog and no client draining it, shutdown was slow
  or hung indefinitely.
- Live `export` with `retro=true` returned early from `stop()` without killing
  the bridge. After the retro backlog drained, the bridge entered an indefinite
  live-wait and the pipeline never terminated.

## 🛠️ Solution

- serve-manager gains a drop path (`atom::shutdown`) that clears the buffer,
  marks the operator done, and releases pending put/get/stop promises. A client
  polling with the last advertised continuation token after a drop now sees a
  completed response instead of an error.
- Widen `export`'s teardown to cover all live exports regardless of `retro`.
  In-flight retro reads may be dropped, which is acceptable under `stop()`.

## 💬 Review

- Follow-up to the merged tenzir/tenzir#6393.
- The final commit reverts an experimental `process()` cancellation approach in
  favor of the drop path; review the net diff rather than intermediate commits.

<sub>
✅ Closes TNZ-762
</sub>
