### PR TITLE
Add missing PR numbers to changelog entries

### DIFF
--- a/changelog/unreleased/bitz-streams-from-neo-pipelines.md
+++ b/changelog/unreleased/bitz-streams-from-neo-pipelines.md
@@ -4,6 +4,8 @@ type: bugfix
 authors:
   - tobim
   - codex
+prs:
+  - 6397
 created: 2026-06-30T13:14:37.340644Z
 ---
 

--- a/changelog/unreleased/pipeline-stop-immediate.md
+++ b/changelog/unreleased/pipeline-stop-immediate.md
@@ -3,6 +3,8 @@ title: Pipelines acknowledge stop requests while draining
 type: bugfix
 authors:
   - aljazerzen
+prs:
+  - 6392
 created: 2026-06-29T08:15:20.200606Z
 ---
 


### PR DESCRIPTION
## 🔍 Problem

- Two unreleased changelog entries were missing the `prs:` field, so they weren't linked to their originating pull requests:
  - `pipeline-stop-immediate.md`
  - `bitz-streams-from-neo-pipelines.md`

## 🛠️ Solution

- Add `prs: [6392]` to `pipeline-stop-immediate.md` (tenzir/tenzir#6392).
- Add `prs: [6397]` to `bitz-streams-from-neo-pipelines.md` (tenzir/tenzir#6397).

## 💬 Review

- Trivial metadata fix; no behavior change.