### PR TITLE
Add missing PR number to the read_bitz fix

### DIFF
--- a/changelog/unreleased/bitz-streams-from-neo-pipelines.md
+++ b/changelog/unreleased/bitz-streams-from-neo-pipelines.md
@@ -4,6 +4,8 @@ type: bugfix
 authors:
   - tobim
   - codex
+prs:
+  - 6397
 created: 2026-06-30T13:14:37.340644Z
 ---
 


### PR DESCRIPTION
https://github.com/tenzir/tenzir/pull/6397 added a changelog entry without a PR reference. This adds the missing piece.
