### PR TITLE
Make Nix builds pure for cache substitution

### DIFF
--- a/.github/workflows/nix-build-job.yaml
+++ b/.github/workflows/nix-build-job.yaml
@@ -75,7 +75,7 @@ jobs:
         with:
           name: tenzir
           authToken: "${{ secrets.CACHIX_TENZIR_API_TOKEN }}"
-          pushFilter: "(tenzir-ee|tenzir-plugins-source)"
+          pushFilter: "(tenzir-ee|tenzir-plugins-source|tenzir-plugins\\.tar\\.gz)"
       - name: Prepare ccache directory
         run: |
           sudo mkdir -p /tmp/tenzir-ccache

--- a/.github/workflows/nix-build-job.yaml
+++ b/.github/workflows/nix-build-job.yaml
@@ -17,13 +17,6 @@ on:
       build-version:
         type: string
         required: true
-      version-suffix:
-        type: string
-        required: false
-        default: ""
-      version-build-metadata:
-        type: string
-        required: true
       run-tests:
         type: boolean
         required: false
@@ -224,8 +217,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.TENZIR_BOT_GITHUB_TOKEN }}
-          TENZIR_VERSION_SUFFIX: ${{ inputs.version-suffix }}
-          TENZIR_VERSION_BUILD_METADATA: ${{ inputs.version-build-metadata }}
         run: |
           release_flag=""
           if [[ "${{ github.event_name }}" == "release" ]]; then
@@ -241,8 +232,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.TENZIR_BOT_GITHUB_TOKEN }}
-          TENZIR_VERSION_SUFFIX: ${{ inputs.version-suffix }}
-          TENZIR_VERSION_BUILD_METADATA: ${{ inputs.version-build-metadata }}
         run: |
           release_flag=""
           if [[ "${{ github.event_name }}" == "release" ]]; then
@@ -356,8 +345,6 @@ jobs:
           GHCR_TOKEN: ${{ secrets.TENZIR_BOT_GITHUB_TOKEN }}
           DOCKERHUB_USER: ${{ vars.DOCKERHUB_USER }}
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-          TENZIR_VERSION_SUFFIX: ${{ inputs.version-suffix }}
-          TENZIR_VERSION_BUILD_METADATA: ${{ inputs.version-build-metadata }}
         run: |
           # Determine push arguments based on event type
           release_flag=""

--- a/.github/workflows/nix-build.py
+++ b/.github/workflows/nix-build.py
@@ -436,11 +436,6 @@ def cmd_build(args: argparse.Namespace) -> int:
     # Update the tenzir-plugins submodule source info.
     _ = run(["nix/update-plugins.sh"])
 
-    version_env = [
-        name
-        for name in ["TENZIR_VERSION_SUFFIX", "TENZIR_VERSION_BUILD_METADATA"]
-        if os.environ.get(name)
-    ]
     cmd = [
         "nix",
         "--option",
@@ -450,8 +445,6 @@ def cmd_build(args: argparse.Namespace) -> int:
         "--print-build-logs",
         "build",
     ]
-    if version_env:
-        cmd += ["--impure"]
     cmd += [
         f".#{args.attribute}^package",
         "--no-link",
@@ -1114,11 +1107,6 @@ def cmd_push(args: argparse.Namespace) -> int:
         notice("No registries or tags specified, skipping image push")
         return 0
 
-    version_env = [
-        name
-        for name in ["TENZIR_VERSION_SUFFIX", "TENZIR_VERSION_BUILD_METADATA"]
-        if os.environ.get(name)
-    ]
     tag_suffix = "-slim" if "-static" in args.attribute else ""
     arch_suffix = f"-{args.arch}" if args.arch else ""
 
@@ -1142,7 +1130,6 @@ def cmd_push(args: argparse.Namespace) -> int:
                         "--accept-flake-config",
                         "run",
                     ]
-                    + (["--impure"] if version_env else [])
                     + [
                         f".#{args.attribute}.asImage.{repo}.copyTo",
                         "--",

--- a/.github/workflows/nix-build.py
+++ b/.github/workflows/nix-build.py
@@ -435,6 +435,21 @@ def cmd_build(args: argparse.Namespace) -> int:
     """Build the Nix package and output the package directory."""
     # Update the tenzir-plugins submodule source info.
     _ = run(["nix/update-plugins.sh"])
+    diff_result = run(
+        [
+            "git",
+            "diff",
+            "--exit-code",
+            "--",
+            "nix/tenzir/plugins/source.json",
+            "nix/tenzir/plugins/names.nix",
+        ],
+        check=False,
+    )
+    if diff_result.returncode != 0:
+        print(diff_result.stdout)
+        error("nix/update-plugins.sh changed generated plugin source files")
+        return diff_result.returncode
 
     cmd = [
         "nix",

--- a/.github/workflows/tenzir.yaml
+++ b/.github/workflows/tenzir.yaml
@@ -804,8 +804,6 @@ jobs:
       arch: aarch64
       attribute: tenzir-static
       build-version: ${{ needs.configure.outputs.build-version }}
-      version-suffix: ${{ needs.configure.outputs.tenzir-version-suffix }}
-      version-build-metadata: ${{ needs.configure.outputs.tenzir-version-build-metadata }}
     secrets: inherit
 
   tenzir-static-x86_64-linux:
@@ -819,8 +817,6 @@ jobs:
       arch: x86_64
       attribute: tenzir-static
       build-version: ${{ needs.configure.outputs.build-version }}
-      version-suffix: ${{ needs.configure.outputs.tenzir-version-suffix }}
-      version-build-metadata: ${{ needs.configure.outputs.tenzir-version-build-metadata }}
     secrets: inherit
 
   tenzir-static-arm64-darwin:
@@ -834,8 +830,6 @@ jobs:
       arch: arm64
       attribute: tenzir-static
       build-version: ${{ needs.configure.outputs.build-version }}
-      version-suffix: ${{ needs.configure.outputs.tenzir-version-suffix }}
-      version-build-metadata: ${{ needs.configure.outputs.tenzir-version-build-metadata }}
       notarize_macos: ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}
     secrets: inherit
 

--- a/.github/workflows/tenzir.yaml
+++ b/.github/workflows/tenzir.yaml
@@ -1119,7 +1119,7 @@ jobs:
         with:
           name: tenzir
           authToken: "${{ secrets.CACHIX_TENZIR_API_TOKEN }}"
-          pushFilter: "(tenzir-ee|tenzir-plugins-source)"
+          pushFilter: "(tenzir-ee|tenzir-plugins-source|tenzir-plugins\\.tar\\.gz)"
       - name: Install workspace dependencies
         working-directory: python
         run: |
@@ -1186,7 +1186,7 @@ jobs:
         with:
           name: tenzir
           authToken: "${{ secrets.CACHIX_TENZIR_API_TOKEN }}"
-          pushFilter: "(tenzir-ee|tenzir-plugins-source)"
+          pushFilter: "(tenzir-ee|tenzir-plugins-source|tenzir-plugins\\.tar\\.gz)"
       - name: Download signed tarball (macOS)
         if: runner.os == 'macOS'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/flake.nix
+++ b/flake.nix
@@ -68,22 +68,13 @@
         tenzirPythonPkgs = pkgs.callPackage ./python {
           inherit (inputs) uv2nix pyproject-nix pyproject-build-systems;
         };
-        tenzirVersionSuffix = builtins.getEnv "TENZIR_VERSION_SUFFIX";
-        tenzirVersionBuildMetadataFromEnv = builtins.getEnv "TENZIR_VERSION_BUILD_METADATA";
-        tenzirVersionBuildMetadata =
-          if tenzirVersionBuildMetadataFromEnv != "" then
-            tenzirVersionBuildMetadataFromEnv
-          else if self ? rev then
-            "g${builtins.substring 0 10 self.rev}"
-          else
-            null;
         package = pkgs.callPackages ./nix/package.nix {
           nix2container = inputs.nix2container.packages.${system};
-          inherit tenzirPythonPkgs tenzirVersionSuffix tenzirVersionBuildMetadata;
+          inherit tenzirPythonPkgs;
         };
         package-clang = pkgs.callPackages ./nix/package.nix {
           nix2container = inputs.nix2container.packages.${system};
-          inherit tenzirPythonPkgs tenzirVersionSuffix tenzirVersionBuildMetadata;
+          inherit tenzirPythonPkgs;
           forceClang = true;
         };
         treefmtEval = inputs.treefmt-nix.lib.evalModule pkgs ./nix/treefmt.nix;

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -3,8 +3,6 @@
   lib,
   pkgs,
   tenzirPythonPkgs,
-  tenzirVersionSuffix ? "",
-  tenzirVersionBuildMetadata ? null,
   forceClang ? false,
 }:
 rec {
@@ -102,8 +100,6 @@ rec {
         inherit
           tenzir-source
           tenzirPythonPkgs
-          tenzirVersionSuffix
-          tenzirVersionBuildMetadata
           toImageFn
           ;
         stdenv = tenzirCcacheStdenv;

--- a/nix/tenzir/default.nix
+++ b/nix/tenzir/default.nix
@@ -19,8 +19,6 @@ let
       extraPlugins ? [ ],
       symlinkJoin,
       extraCmakeFlags ? [ ],
-      tenzirVersionSuffix ? "",
-      tenzirVersionBuildMetadata ? null,
       python3,
       uv,
       uv-bin,
@@ -254,18 +252,7 @@ let
           ++ extraCmakeFlags;
 
           preConfigure = ''
-            ${
-              if tenzirVersionBuildMetadata == null then
-                ''
-                  version_build_metadata="N$(basename $out | cut -d'-' -f 1)"
-                ''
-              else
-                ''
-                  version_build_metadata=${lib.escapeShellArg tenzirVersionBuildMetadata}
-                ''
-            }
-            version_suffix=${lib.escapeShellArg tenzirVersionSuffix}
-            cmakeFlagsArray+=("-DTENZIR_VERSION_SUFFIX=$version_suffix")
+            version_build_metadata="N$(basename $out | cut -d'-' -f 1)"
             cmakeFlagsArray+=("-DTENZIR_VERSION_BUILD_METADATA=$version_build_metadata")
           '';
 

--- a/nix/tenzir/default.nix
+++ b/nix/tenzir/default.nix
@@ -60,6 +60,8 @@ let
         "plugins/yara"
       ];
 
+      tenzirPluginNames = import ./plugins/names.nix;
+
       pythonDeps = import ../python-dependencies.nix;
       py3 =
         let
@@ -72,9 +74,7 @@ let
           ]
         );
 
-      allPluginSrcs = builtins.mapAttrs (
-        name: type: if type == "directory" then "${tenzir-plugins-source}/${name}" else null
-      ) (lib.filterAttrs (_: type: type == "directory") (builtins.readDir tenzir-plugins-source));
+      allPluginSrcs = lib.genAttrs tenzirPluginNames (name: "${tenzir-plugins-source}/${name}");
 
       withTenzirPluginsStatic =
         { prevLayer }:

--- a/nix/tenzir/default.nix
+++ b/nix/tenzir/default.nix
@@ -253,6 +253,7 @@ let
 
           preConfigure = ''
             version_build_metadata="N$(basename $out | cut -d'-' -f 1)"
+            cmakeFlagsArray+=("-DTENZIR_VERSION_SUFFIX=$version_build_metadata")
             cmakeFlagsArray+=("-DTENZIR_VERSION_BUILD_METADATA=$version_build_metadata")
           '';
 

--- a/nix/tenzir/plugins/names.nix
+++ b/nix/tenzir/plugins/names.nix
@@ -1,0 +1,18 @@
+[
+  "compaction"
+  "context"
+  "from_microsoft_sql"
+  "from_sentinelone_data_lake"
+  "microsoft_graph"
+  "packages"
+  "pipeline-manager"
+  "platform"
+  "snowflake"
+  "to_amazon_security_lake"
+  "to_azure_log_analytics"
+  "to_google_cloud_logging"
+  "to_google_secops"
+  "to_sentinelone_data_lake"
+  "to_splunk"
+  "vast"
+]

--- a/nix/update-plugins.sh
+++ b/nix/update-plugins.sh
@@ -46,13 +46,22 @@ EOF
 echo "Updating contrib/tenzir-plugins"
 tenzir_plugins_rev="$(get-submodule-rev "${toplevel}/contrib/tenzir-plugins")"
 
-nix --extra-experimental-features nix-command store prefetch-file \
+prefetch_json="$(nix --extra-experimental-features nix-command store prefetch-file \
   --name "${name}" \
   --json \
   --netrc-file "$NETRC_DIR/netrc" \
-  "${url_base}/${tenzir_plugins_rev}.tar.gz" |
-  jq \
-    --arg url "${url_base}/${tenzir_plugins_rev}.tar.gz" \
-    --arg name "${name}" \
-    '.name = $name | .url = $url | del(.storePath)' \
-    >"${dir}/tenzir/plugins/source.json"
+  "${url_base}/${tenzir_plugins_rev}.tar.gz")"
+jq \
+  --arg url "${url_base}/${tenzir_plugins_rev}.tar.gz" \
+  --arg name "${name}" \
+  '.name = $name | .url = $url | del(.storePath)' \
+  <<<"${prefetch_json}" \
+  >"${dir}/tenzir/plugins/source.json"
+
+{
+  echo "["
+  tar -tf "$(jq -r .storePath <<<"${prefetch_json}")" |
+    sed -n 's#^[^/]*/\([^/]*\)/CMakeLists\.txt$#  "\1"#p' |
+    sort
+  echo "]"
+} >"${dir}/tenzir/plugins/names.nix"


### PR DESCRIPTION
## 🔍 Problem

- CI passed version metadata into Nix through environment variables, which made the build impure.
- Evaluating plugin-enabled packages forced realization of the fetched `tenzir-plugins` source just to enumerate plugin directories.
- Both make cache substitution less useful for `nix build github:tenzir/tenzir/<branch>` and similar pure builds.

## 🛠️ Solution

- Stamp Nix package identity from the output path hash instead of CI-provided version environment variables.
- Keep packaged plugin names in a generated Nix file, refreshed by `nix/update-plugins.sh` together with `source.json`.
- Avoid reading the fetched plugin source during Nix evaluation.

## 💬 Review

- verify that `nix --accept-flake-config build github:tenzir/tenzir/topic/purify-nix-builds` substitutes from cachix instead of building locally.
- Please also check the generated plugin-name list flow in `nix/update-plugins.sh`.
