### PR TITLE
Use portable markdown in v5.20.0 changelog entry

### DIFF
--- a/changelog/releases/v5.20.0/entries/letter-module-router.md
+++ b/changelog/releases/v5.20.0/entries/letter-module-router.md
@@ -12,13 +12,11 @@ metrics collection affects every single allocation, it is currently disabled
 by default. To enable collection of these statistics, you can set an
 environment variable `TENZIR_ALLOC_STATS=true`.
 
-:::info[Changed metric layout]
-This change also changes the structure of `tenzir.metrics.memory`. The
-system-wide stats `total_bytes`, `free_bytes` and `used_bytes` are now grouped
-under a `system` key to differentiate them from the `process` memory usage and
-per-component memory usage added in this release. These process metrics were
-previously only found in `metrics.process`.
-:::
+**Changed metric layout:** This change also changes the structure of
+`tenzir.metrics.memory`. The system-wide stats `total_bytes`, `free_bytes` and
+`used_bytes` are now grouped under a `system` key to differentiate them from the
+`process` memory usage and per-component memory usage added in this release.
+These process metrics were previously only found in `metrics.process`.
 
 We also switched the default memory allocator used on all
 platforms to [mimalloc](https://github.com/microsoft/mimalloc), which may


### PR DESCRIPTION
## Summary

Replace the Starlight-specific `:::info[...]` aside directive with plain markdown using a bold prefix. This allows the changelog entry to render correctly in non-Starlight markdown consumers like the tenzir/news feed.

## Changes

- Convert `:::info[Changed metric layout]` aside block to plain markdown paragraph with bold label prefix
- Content preserved exactly; line wrapping maintained at ~80 columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)