### PR TITLE
Add missing PR number to operator metric names changelog

### DIFF
--- a/changelog/unreleased/operator-metric-names.md
+++ b/changelog/unreleased/operator-metric-names.md
@@ -3,6 +3,8 @@ title: Fix confusing operator names in metrics
 type: bugfix
 authors:
   - aljazerzen
+prs:
+  - 6402
 created: 2026-07-01T00:00:00.000000Z
 ---
 


### PR DESCRIPTION
## 🔍 Problem

The changelog entry added in tenzir/tenzir#6402 (`operator-metric-names.md`) was
merged without a `prs:` field, so it won't link to its pull request in the
generated changelog.

## 🛠️ Solution

- Add `prs: [6402]` to the changelog entry.

## 💬 Review

Metadata-only fix; no code changes.

<sub>
📎 Follow-up to tenzir/tenzir#6402
</sub>