### PR TITLE
Retarget docs dispatches to tenzir/content

### DIFF
--- a/.github/workflows/sync-docs-configuration.yaml
+++ b/.github/workflows/sync-docs-configuration.yaml
@@ -19,12 +19,12 @@ jobs:
         with:
           app-id: ${{ vars.TENZIR_GITHUB_APP_ID }}
           private-key: ${{ secrets.TENZIR_GITHUB_APP_PRIVATE_KEY }}
-          repositories: docs
+          repositories: content
 
       - name: Trigger docs sync workflow
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh workflow run sync-node-configuration.yaml \
-            --repo tenzir/docs \
+          gh workflow run sync-node-configuration.yml \
+            --repo tenzir/content \
             --field source_ref="${{ github.sha }}"

--- a/.github/workflows/tenzir.yaml
+++ b/.github/workflows/tenzir.yaml
@@ -755,14 +755,14 @@ jobs:
         with:
           app-id: ${{ vars.TENZIR_GITHUB_APP_ID }}
           private-key: ${{ secrets.TENZIR_GITHUB_APP_PRIVATE_KEY }}
-          repositories: docs
+          repositories: content
 
       - name: Trigger docs OpenAPI regeneration
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh workflow run generate-openapi-node.yaml \
-            --repo tenzir/docs \
+          gh workflow run update-node-openapi.yml \
+            --repo tenzir/content \
             --field tenzir_docker_tag="${{ github.sha }}"
 
   regression-tests:


### PR DESCRIPTION
## 🔍 Problem

tenzir/docs retires tonight. Two workflows here still dispatch into it and would fail (or silently rot) after archival:

- `sync-docs-configuration.yaml`: triggers the `tenzir.yaml.example` sync on every change to that file on main.
- `tenzir.yaml` job `sync-openapi-to-docs`: triggers node OpenAPI spec regeneration on every push to main.

## 🛠️ Solution

Point both dispatches at the equivalent workflows in tenzir/content (`sync-node-configuration.yml`, `update-node-openapi.yml`), which take the same inputs (`source_ref`, `tenzir_docker_tag`). App token scope changes from `docs` to `content`.

## 💬 Review

- Merge tenzir/content#68 first — it adds the receiving `sync-node-configuration.yml`. The OpenAPI target already exists on main there.
- Requires the tenzir GitHub App to be installed on tenzir/content (it is — the same App creds already drive that repo's OpenAPI refresh workflows).

<sub>
📎 Related: tenzir/content#68
</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)