### PR TITLE
Fix catalog lookup after schema erase

### DIFF
--- a/changelog/unreleased/catalog-lookups-after-schema-removal.md
+++ b/changelog/unreleased/catalog-lookups-after-schema-removal.md
@@ -1,0 +1,12 @@
+---
+title: Catalog lookups after schema removal
+type: bugfix
+authors:
+  - tobim
+  - codex
+prs:
+  - 6411
+created: 2026-07-03T09:34:36.758056Z
+---
+
+Tenzir nodes no longer terminate with an internal error when catalog maintenance removes the last partition for a schema while lookups continue. Queries now treat the removed schema as absent.

--- a/libtenzir/src/catalog.cpp
+++ b/libtenzir/src/catalog.cpp
@@ -351,11 +351,12 @@ auto catalog_state::merge(std::vector<partition_synopsis_pair> partitions)
 }
 
 void catalog_state::erase(const uuid& partition) {
-  for (auto& [type, uuid_synopsis_map] : synopses_per_type) {
-    const auto num_erased = uuid_synopsis_map.erase(partition);
+  for (auto it = synopses_per_type.begin(); it != synopses_per_type.end();
+       ++it) {
+    const auto num_erased = it->second.erase(partition);
     if (num_erased > 0) {
-      if (uuid_synopsis_map.empty()) {
-        synopses_per_type.erase(type);
+      if (it->second.empty()) {
+        synopses_per_type.erase(it);
       }
       return;
     }
@@ -421,7 +422,9 @@ auto catalog_state::lookup_impl(const expression& expr,
   -> catalog_lookup_result::candidate_info {
   TENZIR_ASSERT(not is<caf::none_t>(expr));
   auto synopsis_map_per_type_it = synopses_per_type.find(schema);
-  TENZIR_ASSERT(synopsis_map_per_type_it != synopses_per_type.end());
+  if (synopsis_map_per_type_it == synopses_per_type.end()) {
+    return {};
+  }
   const auto& partition_synopses = synopsis_map_per_type_it->second;
   // The partition UUIDs must be sorted, otherwise the invariants of the
   // inplace union and intersection algorithms are violated, leading to


### PR DESCRIPTION
## 🔍 Problem

- `tenzir-node` could terminate after catalog partition erasure removed the last partition for a schema.
- A later catalog lookup for that schema hit an internal assertion instead of treating the schema as absent.

## 🛠️ Solution

- Erase empty schema buckets through the active map iterator.
- Return no lookup candidates when a schema bucket is no longer present.

## 💬 Review

- The fix is intentionally narrow and does not change query semantics for existing schema buckets.