### PR TITLE
Update documentation links

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ Please make sure to follow our pull request conventions:
    is consumable by everyone, not just developers who know the context of the
    change you've made.
 2. Ensure that all user-facing changes have changelog entries according to our
-   guidelines: https://docs.tenzir.com/next/contribute/changelog
+   guidelines: https://tenzir.com/docs/next/contribute/changelog
 3. Provide instructions for the reviewer.
 4. Remove this comment so it doesn't show up in the merge commit.
 -->

--- a/.github/workflows/marketplace-release.yaml
+++ b/.github/workflows/marketplace-release.yaml
@@ -130,7 +130,7 @@ jobs:
                 "DetailsDocument": {
                   "Version": {
                     "VersionTitle": "Tenzir Node $RELEASE_TAG",
-                    "ReleaseNotes": "See https://docs.tenzir.com/changelog/node/ for release notes."
+                    "ReleaseNotes": "See https://tenzir.com/changelog for release notes."
                   },
                   "DeliveryOptions": [
                     {
@@ -142,7 +142,7 @@ jobs:
                           ],
                           "CompatibleServices": ["ECS"],
                           "Description": "Deploy this container to efficiently collect, shape, and route security data at scale within your AWS environment. Tenzir Node is the core building block for creating powerful and cost-effective security data pipelines.",
-                          "UsageInstructions": "Follow our detailed AWS instructions at https://docs.tenzir.com/guides/node-setup/deploy-a-node/#aws to deploy your Tenzir Node.\n\n**CloudFormation Deployment**: Deploy a single Tenzir Node into ECS: https://console.aws.amazon.com/cloudformation/home?region=eu-west-1#/stacks/new?templateURL=https://tenzir-marketplace-resources.s3.eu-west-1.amazonaws.com/tenzir-node-single-${RELEASE_TAG}.yaml"
+                          "UsageInstructions": "Follow our detailed AWS instructions at https://tenzir.com/docs/guides/node-setup/deploy-a-node/#aws to deploy your Tenzir Node.\n\n**CloudFormation Deployment**: Deploy a single Tenzir Node into ECS: https://console.aws.amazon.com/cloudformation/home?region=eu-west-1#/stacks/new?templateURL=https://tenzir-marketplace-resources.s3.eu-west-1.amazonaws.com/tenzir-node-single-${RELEASE_TAG}.yaml"
                         }
                       }
                     }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ building modular pipelines that process structured event data.
 - `.github/` - GitHub configuration and CI/CD workflows
 - `changelog/` - Changelog entries and release metadata
   - Managed with the `tenzir-ship` framework
-  - Reference: https://docs.tenzir.com/reference/ship-framework.md
+  - Reference: https://tenzir.com/docs/reference/ship-framework.md
 - `cmake/` - CMake build system modules and utilities
   - Various CMake modules for dependencies
   - TenzirConfig.cmake.in - CMake configuration template

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<a href="https://docs.tenzir.com">
+<a href="https://tenzir.com/docs">
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="./assets/tenzir-white.svg">
   <source media="(prefers-color-scheme: light)" srcset="./assets/tenzir-black.svg">
@@ -26,7 +26,7 @@ execute detections and run analytics in-stream.
 
 ## Get Started
 
-Check out [our documentation](https://docs.tenzir.com/) where your find
+Check out [our documentation](https://tenzir.com/docs/) where your find
 tutorials that walk your through the first steps, how-to guides to solve a
 specific problem, explanations of key concepts, and an in-depth reference of the
 nitty-gritty technical details.

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,3 +1,3 @@
 This directory contains an Ansible host role for Tenzir.
 
-You can view the documentation at https://docs.tenzir.com/guides/node-setup/deploy-a-node/ansible/.
+You can view the documentation at https://tenzir.com/docs/guides/node-setup/deploy-a-node/ansible/.

--- a/changelog/releases/v6.0.0/entries/from-http-is-now-a-pure-http-client.md
+++ b/changelog/releases/v6.0.0/entries/from-http-is-now-a-pure-http-client.md
@@ -33,5 +33,5 @@ from_http "https://api.example.com/status" {
 ```
 
 Additionally, the `url` and `headers` arguments are now resolved as
-[secrets](https://docs.tenzir.com/explanations/secrets), so you can pass
+[secrets](https://tenzir.com/docs/explanations/secrets), so you can pass
 secret names instead of hardcoding tokens or sensitive URLs.

--- a/changelog/releases/v6.0.0/manifest.yaml
+++ b/changelog/releases/v6.0.0/manifest.yaml
@@ -2,7 +2,7 @@ created: 2026-06-01
 title: Tenzir Node v6.0.0
 intro: >-
   Tenzir v6 ships with a rewritten execution engine that unlocks faster, more capable,
-  and more scalable pipelines. Refer to the migration guide at https://docs.tenzir.com/guides/tenzir-v6-migration
+  and more scalable pipelines. Refer to the migration guide at https://tenzir.com/docs/guides/tenzir-v6-migration
   before upgrading.
 source:
   mode: promote-prerelease

--- a/changelog/releases/v6.0.0/notes.md
+++ b/changelog/releases/v6.0.0/notes.md
@@ -1,4 +1,4 @@
-Tenzir v6 ships with a rewritten execution engine that unlocks faster, more capable, and more scalable pipelines. Refer to the migration guide at https://docs.tenzir.com/guides/tenzir-v6-migration before upgrading.
+Tenzir v6 ships with a rewritten execution engine that unlocks faster, more capable, and more scalable pipelines. Refer to the migration guide at https://tenzir.com/docs/guides/tenzir-v6-migration before upgrading.
 
 ## 💥 Breaking changes
 
@@ -52,7 +52,7 @@ from_http "https://api.example.com/status" {
 }
 ```
 
-Additionally, the `url` and `headers` arguments are now resolved as [secrets](https://docs.tenzir.com/explanations/secrets), so you can pass secret names instead of hardcoding tokens or sensitive URLs.
+Additionally, the `url` and `headers` arguments are now resolved as [secrets](https://tenzir.com/docs/explanations/secrets), so you can pass secret names instead of hardcoding tokens or sensitive URLs.
 
 *By @aljazerzen in #5953.*
 

--- a/libtenzir/builtins/connectors/directory.cpp
+++ b/libtenzir/builtins/connectors/directory.cpp
@@ -125,7 +125,7 @@ class plugin : public virtual saver_plugin<directory_saver> {
 public:
   auto parse_saver(parser_interface& p) const
     -> std::unique_ptr<plugin_saver> override {
-    auto parser = argument_parser{name(), "https://docs.tenzir.com/"
+    auto parser = argument_parser{name(), "https://tenzir.com/docs/"
                                           "connectors/directory"};
     auto args = saver_args{};
     parser.add(args.path, "<path>");

--- a/libtenzir/builtins/connectors/file.cpp
+++ b/libtenzir/builtins/connectors/file.cpp
@@ -462,7 +462,7 @@ public:
   auto parse_loader(parser_interface& p) const
     -> std::unique_ptr<plugin_loader> override {
     auto args = loader_args{};
-    auto parser = argument_parser{"file", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"file", "https://tenzir.com/docs/"
                                           "connectors/file"};
     parser.add(args.path, "<path>");
     parser.add("-f,--follow", args.follow);
@@ -498,7 +498,7 @@ public:
   auto parse_saver(parser_interface& p) const
     -> std::unique_ptr<plugin_saver> override {
     auto args = saver_args{};
-    auto parser = argument_parser{"file", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"file", "https://tenzir.com/docs/"
                                           "connectors/file"};
     parser.add(args.path, "<path>");
     parser.add("-a,--append", args.append);
@@ -728,7 +728,7 @@ public:
     -> std::unique_ptr<plugin_loader> override {
     auto args = file::loader_args{};
     args.path.inner = "-";
-    auto parser = argument_parser{"stdin", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"stdin", "https://tenzir.com/docs/"
                                            "connectors/stdin"};
     parser.add("-t,--timeout", args.timeout, "<duration>");
     parser.parse(p);
@@ -749,7 +749,7 @@ public:
     -> std::unique_ptr<plugin_saver> override {
     auto args = file::saver_args{};
     args.path.inner = "-";
-    auto parser = argument_parser{name(), "https://docs.tenzir.com/"
+    auto parser = argument_parser{name(), "https://tenzir.com/docs/"
                                           "connectors/stdout"};
     parser.parse(p);
     return std::make_unique<file::file_saver>(std::move(args));

--- a/libtenzir/builtins/formats/bitz.cpp
+++ b/libtenzir/builtins/formats/bitz.cpp
@@ -519,7 +519,7 @@ class plugin final : public virtual parser_plugin<bitz_parser>,
 
   auto parse_parser(parser_interface& p) const
     -> std::unique_ptr<plugin_parser> override {
-    auto parser = argument_parser{"bitz", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"bitz", "https://tenzir.com/docs/"
                                           "formats/bitz"};
     parser.parse(p);
     return std::make_unique<bitz_parser>();
@@ -527,7 +527,7 @@ class plugin final : public virtual parser_plugin<bitz_parser>,
 
   auto parse_printer(parser_interface& p) const
     -> std::unique_ptr<plugin_printer> override {
-    auto parser = argument_parser{"bitz", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"bitz", "https://tenzir.com/docs/"
                                           "formats/bitz"};
     parser.parse(p);
     return std::make_unique<bitz_printer>();

--- a/libtenzir/builtins/formats/cef.cpp
+++ b/libtenzir/builtins/formats/cef.cpp
@@ -509,7 +509,7 @@ private:
 class cef_plugin final : public virtual parser_plugin<cef_parser> {
   auto parse_parser(parser_interface& p) const
     -> std::unique_ptr<plugin_parser> override {
-    auto parser = argument_parser{"cef", "https://docs.tenzir.com/formats/cef"};
+    auto parser = argument_parser{"cef", "https://tenzir.com/docs/formats/cef"};
     auto msb_parser = multi_series_builder_argument_parser{};
     msb_parser.add_all_to_parser(parser);
     parser.parse(p);

--- a/libtenzir/builtins/formats/feather.cpp
+++ b/libtenzir/builtins/formats/feather.cpp
@@ -1167,7 +1167,7 @@ class plugin final : public virtual parser_plugin<feather_parser>,
 
   auto parse_parser(parser_interface& p) const
     -> std::unique_ptr<plugin_parser> override {
-    auto parser = argument_parser{"feather", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"feather", "https://tenzir.com/docs/"
                                              "formats/feather"};
     parser.parse(p);
     return std::make_unique<feather_parser>();
@@ -1176,7 +1176,7 @@ class plugin final : public virtual parser_plugin<feather_parser>,
   auto parse_printer(parser_interface& p) const
     -> std::unique_ptr<plugin_printer> override {
     auto options = feather_options{};
-    auto parser = argument_parser{"feather", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"feather", "https://tenzir.com/docs/"
                                              "formats/feather"};
     parser.add("--compression-level", options.compression_level, "<level>");
     parser.add("--compression-type", options.compression_type, "<type>");

--- a/libtenzir/builtins/formats/grok.cpp
+++ b/libtenzir/builtins/formats/grok.cpp
@@ -675,7 +675,7 @@ public:
   auto parse_parser(parser_interface& p) const
     -> std::unique_ptr<plugin_parser> override {
     auto parser
-      = argument_parser{"grok", "https://docs.tenzir.com/operators/grok"};
+      = argument_parser{"grok", "https://tenzir.com/docs/operators/grok"};
     auto pattern_definitions = std::optional<located<std::string>>{};
     auto raw_pattern = located<std::string>{};
     auto indexed_captures = false;

--- a/libtenzir/builtins/formats/json.cpp
+++ b/libtenzir/builtins/formats/json.cpp
@@ -1057,7 +1057,7 @@ public:
   auto parse_parser(parser_interface& p) const
     -> std::unique_ptr<plugin_parser> override {
     auto parser
-      = argument_parser{name(), "https://docs.tenzir.com/formats/json"};
+      = argument_parser{name(), "https://tenzir.com/docs/formats/json"};
     auto args = parser_args{"json"};
     multi_series_builder_argument_parser msb_parser{
       {.default_schema_name = "tenzir.json"},
@@ -1141,7 +1141,7 @@ public:
     -> std::unique_ptr<plugin_printer> override {
     auto args = printer_args{};
     auto parser
-      = argument_parser{name(), "https://docs.tenzir.com/formats/json"};
+      = argument_parser{name(), "https://tenzir.com/docs/formats/json"};
     // We try to follow 'jq' option naming.
     parser.add("-c,--compact-output", args.compact_output);
     parser.add("-C,--color-output", args.color_output);
@@ -1165,7 +1165,7 @@ public:
   auto parse_parser(parser_interface& p) const
     -> std::unique_ptr<plugin_parser> override {
     auto parser = argument_parser{
-      name(), fmt::format("https://docs.tenzir.com/formats/{}", name())};
+      name(), fmt::format("https://tenzir.com/docs/formats/{}", name())};
     auto msb_parser = multi_series_builder_argument_parser{
       multi_series_builder::settings_type{.default_schema_name = "gelf"},
       multi_series_builder::policy_default{},
@@ -1198,7 +1198,7 @@ public:
   auto parse_parser(parser_interface& p) const
     -> std::unique_ptr<plugin_parser> override {
     auto parser = argument_parser{
-      name(), fmt::format("https://docs.tenzir.com/formats/{}", name())};
+      name(), fmt::format("https://tenzir.com/docs/formats/{}", name())};
     auto args = parser_args{std::string{Name.str()}};
     auto msb_parser = multi_series_builder_argument_parser{
       multi_series_builder::settings_type{

--- a/libtenzir/builtins/formats/kv.cpp
+++ b/libtenzir/builtins/formats/kv.cpp
@@ -34,7 +34,7 @@ namespace tenzir::plugins::kv {
 
 namespace {
 
-constexpr auto docs = "https://docs.tenzir.com/formats/kv";
+constexpr auto docs = "https://tenzir.com/docs/formats/kv";
 
 class splitter {
 public:

--- a/libtenzir/builtins/formats/leef.cpp
+++ b/libtenzir/builtins/formats/leef.cpp
@@ -479,7 +479,7 @@ class leef_plugin final : public virtual parser_plugin<leef_parser> {
   auto parse_parser(parser_interface& p) const
     -> std::unique_ptr<plugin_parser> override {
     auto parser = argument_parser{
-      name(), fmt::format("https://docs.tenzir.com/formats/{}", name())};
+      name(), fmt::format("https://tenzir.com/docs/formats/{}", name())};
     auto msb_parser = multi_series_builder_argument_parser{};
     msb_parser.add_all_to_parser(parser);
     parser.parse(p);

--- a/libtenzir/builtins/formats/lines.cpp
+++ b/libtenzir/builtins/formats/lines.cpp
@@ -283,7 +283,7 @@ public:
   auto parse_parser(parser_interface& p) const
     -> std::unique_ptr<plugin_parser> override {
     auto parser = argument_parser{
-      name(), fmt::format("https://docs.tenzir.com/formats/{}", name())};
+      name(), fmt::format("https://tenzir.com/docs/formats/{}", name())};
     auto args = parser_args{};
     parser.add("-s,--skip-empty", args.skip_empty);
     parser.add("--null", args.null);
@@ -296,7 +296,7 @@ public:
     if (not p.at_end()) {
       diagnostic::error("'lines' printer doesn't accept any arguments")
         .primary(p.current_span())
-        .docs(fmt::format("https://docs.tenzir.com/formats/{}", name()))
+        .docs(fmt::format("https://tenzir.com/docs/formats/{}", name()))
         .throw_();
     }
     return std::make_unique<lines_printer>();

--- a/libtenzir/builtins/formats/pcap.cpp
+++ b/libtenzir/builtins/formats/pcap.cpp
@@ -1079,7 +1079,7 @@ public:
   auto parse_parser(parser_interface& p) const
     -> std::unique_ptr<plugin_parser> override {
     auto parser = argument_parser{
-      name(), fmt::format("https://docs.tenzir.com/formats/{}", name())};
+      name(), fmt::format("https://tenzir.com/docs/formats/{}", name())};
     auto args = parser_args{};
     parser.add("-e,--emit-file-headers", args.emit_file_headers);
     parser.parse(p);
@@ -1089,7 +1089,7 @@ public:
   auto parse_printer(parser_interface& p) const
     -> std::unique_ptr<plugin_printer> override {
     auto parser = argument_parser{
-      name(), fmt::format("https://docs.tenzir.com/formats/{}", name())};
+      name(), fmt::format("https://tenzir.com/docs/formats/{}", name())};
     auto args = printer_args{};
     parser.parse(p);
     return std::make_unique<pcap_printer>(std::move(args));

--- a/libtenzir/builtins/formats/syslog.cpp
+++ b/libtenzir/builtins/formats/syslog.cpp
@@ -584,7 +584,7 @@ public:
   auto parse_parser(parser_interface& p) const
     -> std::unique_ptr<plugin_parser> override {
     auto parser = argument_parser{
-      name(), fmt::format("https://docs.tenzir.com/formats/{}", name())};
+      name(), fmt::format("https://tenzir.com/docs/formats/{}", name())};
     auto msb_parser = multi_series_builder_argument_parser{};
     msb_parser.add_all_to_parser(parser);
     parser.parse(p);

--- a/libtenzir/builtins/formats/xsv.cpp
+++ b/libtenzir/builtins/formats/xsv.cpp
@@ -73,7 +73,7 @@ struct xsv_printer_options {
 
   static auto try_parse_printer_options(parser_interface& p)
     -> xsv_printer_options {
-    auto parser = argument_parser{"xsv", "https://docs.tenzir.com/formats/xsv"};
+    auto parser = argument_parser{"xsv", "https://tenzir.com/docs/formats/xsv"};
     auto field_sep_str = located<std::string>{};
     auto list_sep_str = located<std::string>{};
     auto null_value = located<std::string>{};
@@ -1317,7 +1317,7 @@ public:
     // const auto is_parser = true;
     // auto options = xsv_options::try_parse(p, "xsv", is_parser);
     auto parser = argument_parser{
-      name(), fmt::format("https://docs.tenzir.com/formats/{}", name())};
+      name(), fmt::format("https://tenzir.com/docs/formats/{}", name())};
     auto opt_parser = xsv_common_parser_options_parser{name()};
     opt_parser.add_to_parser(parser);
     parser.parse(p);
@@ -1348,7 +1348,7 @@ public:
   auto parse_parser(parser_interface& p) const
     -> std::unique_ptr<plugin_parser> override {
     auto parser = argument_parser{
-      name(), fmt::format("https://docs.tenzir.com/formats/{}", name())};
+      name(), fmt::format("https://tenzir.com/docs/formats/{}", name())};
     auto opt_parser = xsv_common_parser_options_parser{
       name(),
       std::string{Sep},

--- a/libtenzir/builtins/formats/yaml.cpp
+++ b/libtenzir/builtins/formats/yaml.cpp
@@ -335,7 +335,7 @@ class yaml_plugin final : public virtual parser_plugin<yaml_parser>,
 
   auto parse_parser(parser_interface& p) const
     -> std::unique_ptr<plugin_parser> override {
-    auto parser = argument_parser{"yaml", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"yaml", "https://tenzir.com/docs/"
                                           "formats/yaml"};
     auto msb_parser = multi_series_builder_argument_parser{};
     msb_parser.add_all_to_parser(parser);
@@ -353,7 +353,7 @@ class yaml_plugin final : public virtual parser_plugin<yaml_parser>,
 
   auto parse_printer(parser_interface& p) const
     -> std::unique_ptr<plugin_printer> override {
-    auto parser = argument_parser{"yaml", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"yaml", "https://tenzir.com/docs/"
                                           "formats/yaml"};
     parser.parse(p);
     return std::make_unique<yaml_printer>();

--- a/libtenzir/builtins/operators/api.cpp
+++ b/libtenzir/builtins/operators/api.cpp
@@ -227,7 +227,7 @@ public:
     auto endpoint = std::string{};
     auto request_body = std::optional<std::string>{};
     auto parser
-      = argument_parser{"api", "https://docs.tenzir.com/operators/api"};
+      = argument_parser{"api", "https://tenzir.com/docs/operators/api"};
     parser.add(endpoint, "<command>");
     parser.add(request_body, "<request-body>");
     parser.parse(p);
@@ -252,7 +252,7 @@ public:
   }
 
   auto describe() const -> Description override {
-    auto d = Describer<ApiArgs, Api>{"https://docs.tenzir.com/operators/api"};
+    auto d = Describer<ApiArgs, Api>{"https://tenzir.com/docs/operators/api"};
     d.positional("endpoint", &ApiArgs::endpoint);
     d.positional("request_body", &ApiArgs::request_body);
     return d.without_optimize();

--- a/libtenzir/builtins/operators/batch.cpp
+++ b/libtenzir/builtins/operators/batch.cpp
@@ -267,7 +267,7 @@ public:
   }
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
-    auto parser = argument_parser{"batch", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"batch", "https://tenzir.com/docs/"
                                            "operators/batch"};
     auto limit = std::optional<located<uint64_t>>{};
     auto timeout = std::optional<located<duration>>{};

--- a/libtenzir/builtins/operators/buffer.cpp
+++ b/libtenzir/builtins/operators/buffer.cpp
@@ -558,7 +558,7 @@ public:
   }
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
-    auto parser = argument_parser{"buffer", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"buffer", "https://tenzir.com/docs/"
                                             "operators/buffer"};
     auto capacity = located<uint64_t>{};
     auto policy_str = std::optional<located<std::string>>{};

--- a/libtenzir/builtins/operators/cache.cpp
+++ b/libtenzir/builtins/operators/cache.cpp
@@ -1485,7 +1485,7 @@ public:
   }
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
-    auto parser = argument_parser{"cache", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"cache", "https://tenzir.com/docs/"
                                            "operators/cache"};
     auto id = located<std::string>{};
     auto mode = std::optional<located<std::string>>{};

--- a/libtenzir/builtins/operators/compress_decompress.cpp
+++ b/libtenzir/builtins/operators/compress_decompress.cpp
@@ -429,7 +429,7 @@ public:
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
     auto parser = argument_parser{"compress",
-                                  "https://docs.tenzir.com/operators/compress"};
+                                  "https://tenzir.com/docs/operators/compress"};
     auto args = operator_args{};
     parser.add(args.type, "<type>");
     parser.add("--level", args.level, "<level>");
@@ -526,7 +526,7 @@ public:
   }
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
-    auto parser = argument_parser{"decompress", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"decompress", "https://tenzir.com/docs/"
                                                 "operators/decompress"};
     auto args = operator_args{};
     parser.add(args.type, "<type>");

--- a/libtenzir/builtins/operators/decapsulate.cpp
+++ b/libtenzir/builtins/operators/decapsulate.cpp
@@ -440,7 +440,7 @@ public:
   }
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
-    auto parser = argument_parser{name(), fmt::format("https://docs.tenzir.com/"
+    auto parser = argument_parser{name(), fmt::format("https://tenzir.com/docs/"
                                                       "operators/{}",
                                                       name())};
     parser.parse(p);

--- a/libtenzir/builtins/operators/delay.cpp
+++ b/libtenzir/builtins/operators/delay.cpp
@@ -320,7 +320,7 @@ public:
     auto speed = std::optional<located<double>>{};
     auto start = std::optional<time>{};
     auto field = located<std::string>{};
-    auto parser = argument_parser{"delay", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"delay", "https://tenzir.com/docs/"
                                            "operators/delay"};
     parser.add("--speed", speed, "<factor>");
     parser.add("--start", start, "<time>");

--- a/libtenzir/builtins/operators/discard.cpp
+++ b/libtenzir/builtins/operators/discard.cpp
@@ -112,7 +112,7 @@ public:
   }
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
-    auto parser = argument_parser{"discard", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"discard", "https://tenzir.com/docs/"
                                              "operators/discard"};
     parser.parse(p);
     return std::make_unique<discard_operator>();

--- a/libtenzir/builtins/operators/export.cpp
+++ b/libtenzir/builtins/operators/export.cpp
@@ -500,7 +500,7 @@ public:
   }
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
-    auto parser = argument_parser{"export", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"export", "https://tenzir.com/docs/"
                                             "operators/export"};
     auto retro = false;
     auto live = false;
@@ -601,7 +601,7 @@ public:
   }
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
-    auto parser = argument_parser{"diagnostics", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"diagnostics", "https://tenzir.com/docs/"
                                                  "operators/diagnostics"};
     auto live = false;
     auto retro = false;
@@ -713,7 +713,7 @@ public:
   }
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
-    auto parser = argument_parser{"metrics", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"metrics", "https://tenzir.com/docs/"
                                              "operators/metrics"};
     auto name = std::optional<std::string>{};
     auto live = false;

--- a/libtenzir/builtins/operators/fields.cpp
+++ b/libtenzir/builtins/operators/fields.cpp
@@ -141,7 +141,7 @@ public:
   }
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
-    auto parser = argument_parser{"fields", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"fields", "https://tenzir.com/docs/"
                                             "operators/fields"};
     parser.parse(p);
     return std::make_unique<fields_operator>();

--- a/libtenzir/builtins/operators/files.cpp
+++ b/libtenzir/builtins/operators/files.cpp
@@ -476,7 +476,7 @@ public:
   }
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
-    auto parser = argument_parser{"files", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"files", "https://tenzir.com/docs/"
                                            "operators/files"};
     auto args = files_args{};
     parser.add(args.path, "<path>");

--- a/libtenzir/builtins/operators/flatten.cpp
+++ b/libtenzir/builtins/operators/flatten.cpp
@@ -112,7 +112,7 @@ public:
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
     auto parser
-      = argument_parser{"flatten", "https://docs.tenzir.com/operators/flatten"};
+      = argument_parser{"flatten", "https://tenzir.com/docs/operators/flatten"};
     auto sep = std::optional<located<std::string>>{};
     parser.add(sep, "<separator>");
     parser.parse(p);

--- a/libtenzir/builtins/operators/from_load_read.cpp
+++ b/libtenzir/builtins/operators/from_load_read.cpp
@@ -166,13 +166,13 @@ throw_loader_not_found(located<std::string_view> x, bool use_uri_schemes) {
     diagnostic::error("loader for `{}` scheme could not be found", x.inner)
       .primary(x.source)
       .hint("must be one of {}", fmt::join(available, ", "))
-      .docs("https://docs.tenzir.com/connectors")
+      .docs("https://tenzir.com/docs/connectors")
       .throw_();
   }
   diagnostic::error("loader `{}` could not be found", x.inner)
     .primary(x.source)
     .hint("must be one of {}", fmt::join(available, ", "))
-    .docs("https://docs.tenzir.com/connectors")
+    .docs("https://tenzir.com/docs/connectors")
     .throw_();
 }
 
@@ -184,7 +184,7 @@ throw_loader_not_found(located<std::string_view> x, bool use_uri_schemes) {
   diagnostic::error("parser `{}` could not be found", x.inner)
     .primary(x.source)
     .hint("must be one of {}", fmt::join(available, ", "))
-    .docs("https://docs.tenzir.com/formats")
+    .docs("https://tenzir.com/docs/formats")
     .throw_();
 }
 
@@ -217,7 +217,7 @@ public:
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
     auto usage = "from <loader> <args>... [read <parser> <args>...]";
-    auto docs = "https://docs.tenzir.com/operators/from";
+    auto docs = "https://tenzir.com/docs/operators/from";
     if (const auto peek_tcp = p.peek_shell_arg();
         peek_tcp
         and (peek_tcp->inner == "tcp"
@@ -277,7 +277,7 @@ public:
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
     auto usage = "load <loader> <args>...";
-    auto docs = "https://docs.tenzir.com/operators/load";
+    auto docs = "https://tenzir.com/docs/operators/load";
     auto [loader, _] = get_loader(p, usage, docs);
     TENZIR_DIAG_ASSERT(loader);
     return std::make_unique<load_operator>(std::move(loader));
@@ -292,7 +292,7 @@ public:
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
     auto usage = "read <parser> <args>...";
-    auto docs = "https://docs.tenzir.com/operators/read";
+    auto docs = "https://tenzir.com/docs/operators/read";
     auto name = p.accept_shell_arg();
     if (not name) {
       diagnostic::error("expected parser name")

--- a/libtenzir/builtins/operators/from_to_2.cpp
+++ b/libtenzir/builtins/operators/from_to_2.cpp
@@ -206,7 +206,7 @@ class from_plugin2 final : public virtual operator_factory_plugin,
                            public virtual operator_compiler_plugin {
 public:
   constexpr static auto docs
-    = "https://docs.tenzir.com/reference/operators/from";
+    = "https://tenzir.com/docs/reference/operators/from";
   auto name() const -> std::string override {
     return "tql2.from";
   }
@@ -281,7 +281,7 @@ public:
 
 class to_plugin2 final : public virtual operator_factory_plugin {
 public:
-  constexpr static auto docs = "https://docs.tenzir.com/reference/operators/to";
+  constexpr static auto docs = "https://tenzir.com/docs/reference/operators/to";
   auto name() const -> std::string override {
     return "tql2.to";
   }

--- a/libtenzir/builtins/operators/import.cpp
+++ b/libtenzir/builtins/operators/import.cpp
@@ -297,7 +297,7 @@ public:
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
     auto parser = argument_parser{
       "import",
-      "https://docs.tenzir.com/operators/import",
+      "https://tenzir.com/docs/operators/import",
     };
     parser.parse(p);
     return std::make_unique<import_operator>();

--- a/libtenzir/builtins/operators/measure.cpp
+++ b/libtenzir/builtins/operators/measure.cpp
@@ -236,7 +236,7 @@ public:
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
     bool real_time = false;
     bool cumulative = false;
-    auto parser = argument_parser{"measure", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"measure", "https://tenzir.com/docs/"
                                              "operators/measure"};
     parser.add("--real-time", real_time);
     parser.add("--cumulative", cumulative);

--- a/libtenzir/builtins/operators/openapi.cpp
+++ b/libtenzir/builtins/operators/openapi.cpp
@@ -187,7 +187,7 @@ public:
   }
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
-    auto parser = argument_parser{"openapi", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"openapi", "https://tenzir.com/docs/"
                                              "operators/openapi"};
     parser.parse(p);
     return std::make_unique<openapi_operator>();

--- a/libtenzir/builtins/operators/parse.cpp
+++ b/libtenzir/builtins/operators/parse.cpp
@@ -58,7 +58,7 @@ public:
       std::move(d)
         .modify()
         .usage("parse <input> <parser> <args>...")
-        .docs("https://docs.tenzir.com/operators/parse")
+        .docs("https://tenzir.com/docs/operators/parse")
         .throw_();
     }
     TENZIR_ASSERT(parser);

--- a/libtenzir/builtins/operators/partitions.cpp
+++ b/libtenzir/builtins/operators/partitions.cpp
@@ -253,7 +253,7 @@ public:
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
     auto parser = argument_parser{
       "partitions",
-      "https://docs.tenzir.com/operators/partitions",
+      "https://tenzir.com/docs/operators/partitions",
     };
     auto expr = std::optional<located<tenzir::expression>>{};
     auto experimental_include_ranges = std::optional<location>{};

--- a/libtenzir/builtins/operators/pass.cpp
+++ b/libtenzir/builtins/operators/pass.cpp
@@ -75,7 +75,7 @@ public:
   }
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
-    argument_parser{"pass", "https://docs.tenzir.com/operators/pass"}.parse(p);
+    argument_parser{"pass", "https://tenzir.com/docs/operators/pass"}.parse(p);
     return std::make_unique<pass_operator>();
   }
 

--- a/libtenzir/builtins/operators/plugins.cpp
+++ b/libtenzir/builtins/operators/plugins.cpp
@@ -147,7 +147,7 @@ public:
   }
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
-    auto parser = argument_parser{"plugins", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"plugins", "https://tenzir.com/docs/"
                                              "operators/plugins"};
     parser.parse(p);
     return std::make_unique<plugins_operator>();

--- a/libtenzir/builtins/operators/print.cpp
+++ b/libtenzir/builtins/operators/print.cpp
@@ -80,7 +80,7 @@ public:
       std::move(d)
         .modify()
         .usage("print <input> <printer> <args>...")
-        .docs("https://docs.tenzir.com/operators/print")
+        .docs("https://tenzir.com/docs/operators/print")
         .throw_();
     }
   }

--- a/libtenzir/builtins/operators/processes.cpp
+++ b/libtenzir/builtins/operators/processes.cpp
@@ -116,7 +116,7 @@ public:
   }
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
-    auto parser = argument_parser{"processes", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"processes", "https://tenzir.com/docs/"
                                                "operators/processes"};
     parser.parse(p);
     return std::make_unique<processes_operator>();

--- a/libtenzir/builtins/operators/repeat.cpp
+++ b/libtenzir/builtins/operators/repeat.cpp
@@ -240,7 +240,7 @@ public:
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
     auto repetitions = std::optional<uint64_t>{};
-    auto parser = argument_parser{"repeat", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"repeat", "https://tenzir.com/docs/"
                                             "operators/repeat"};
     parser.add(repetitions, "<count>");
     parser.parse(p);

--- a/libtenzir/builtins/operators/sample.cpp
+++ b/libtenzir/builtins/operators/sample.cpp
@@ -281,7 +281,7 @@ public:
     auto str = std::optional<located<std::string>>{};
     auto args = operator_args{};
     auto parser
-      = argument_parser{"sample", "https://docs.tenzir.com/operators/sample"};
+      = argument_parser{"sample", "https://tenzir.com/docs/operators/sample"};
     parser.add("--period", args.period, "<period>");
     parser.add("--mode", str, "<string>");
     parser.add("--min-events", args.min_events, "<uint>");

--- a/libtenzir/builtins/operators/schemas.cpp
+++ b/libtenzir/builtins/operators/schemas.cpp
@@ -141,7 +141,7 @@ public:
   }
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
-    auto parser = argument_parser{"schemas", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"schemas", "https://tenzir.com/docs/"
                                              "operators/schemas"};
     parser.parse(p);
     return std::make_unique<schemas_operator>();

--- a/libtenzir/builtins/operators/set_attributes.cpp
+++ b/libtenzir/builtins/operators/set_attributes.cpp
@@ -82,7 +82,7 @@ public:
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
     configuration attributes{};
-    auto docs = fmt::format("https://docs.tenzir.com/operators/{}", name());
+    auto docs = fmt::format("https://tenzir.com/docs/operators/{}", name());
     while (not p.at_end()) {
       auto key = p.accept_shell_arg();
       if (not key) {

--- a/libtenzir/builtins/operators/set_select.cpp
+++ b/libtenzir/builtins/operators/set_select.cpp
@@ -58,7 +58,7 @@ public:
   auto make(operator_factory_invocation inv, session ctx) const
     -> failure_or<operator_ptr> override {
     auto usage = "set <path>=<expr>...";
-    auto docs = "https://docs.tenzir.com/reference/operators/set";
+    auto docs = "https://tenzir.com/docs/reference/operators/set";
     auto assignments = std::vector<ast::assignment>{};
     for (auto& arg : inv.args) {
       arg.match(
@@ -81,7 +81,7 @@ public:
   auto compile(ast::invocation inv, compile_ctx ctx) const
     -> failure_or<ir::CompileResult> override {
     auto usage = "set <path>=<expr>...";
-    auto docs = "https://docs.tenzir.com/reference/operators/set";
+    auto docs = "https://tenzir.com/docs/reference/operators/set";
     auto assignments = std::vector<ast::assignment>{};
     for (auto& arg : inv.args) {
       auto* assignment = try_as<ast::assignment>(arg);

--- a/libtenzir/builtins/operators/show.cpp
+++ b/libtenzir/builtins/operators/show.cpp
@@ -93,7 +93,7 @@ public:
   }
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
-    auto parser = argument_parser{"show", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"show", "https://tenzir.com/docs/"
                                           "operators/show"};
     auto aspect = std::optional<located<std::string>>{};
     parser.add(aspect, "<aspect>");

--- a/libtenzir/builtins/operators/sigma.cpp
+++ b/libtenzir/builtins/operators/sigma.cpp
@@ -879,7 +879,7 @@ public:
   }
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
-    auto parser = argument_parser{"sigma", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"sigma", "https://tenzir.com/docs/"
                                            "reference/operators"};
     auto refresh_interval = duration{std::chrono::seconds{5}};
     auto refresh_interval_arg = std::optional<located<std::string>>{};

--- a/libtenzir/builtins/operators/sockets.cpp
+++ b/libtenzir/builtins/operators/sockets.cpp
@@ -114,7 +114,7 @@ public:
   }
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
-    auto parser = argument_parser{"sockets", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"sockets", "https://tenzir.com/docs/"
                                              "operators/sockets"};
     parser.parse(p);
     return std::make_unique<sockets_operator>();

--- a/libtenzir/builtins/operators/summarize.cpp
+++ b/libtenzir/builtins/operators/summarize.cpp
@@ -570,7 +570,7 @@ auto build_config(std::vector<ast::expression> exprs, session ctx)
       diagnostic::error("function does not support aggregations")
         .primary(call.fn)
         .hint("if you want to group by this, use assignment before")
-        .docs("https://docs.tenzir.com/operators/summarize")
+        .docs("https://tenzir.com/docs/operators/summarize")
         .emit(ctx);
       failed = true;
       return;

--- a/libtenzir/builtins/operators/taste.cpp
+++ b/libtenzir/builtins/operators/taste.cpp
@@ -104,7 +104,7 @@ public:
   }
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
-    auto parser = argument_parser{"taste", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"taste", "https://tenzir.com/docs/"
                                            "operators/taste"};
     auto count = std::optional<uint64_t>{};
     parser.add(count, "<limit>");

--- a/libtenzir/builtins/operators/tcp-listen.cpp
+++ b/libtenzir/builtins/operators/tcp-listen.cpp
@@ -620,7 +620,7 @@ public:
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
     // tcp_listen <endpoint> [<args...>] read [<op_args...>]
     auto parser
-      = argument_parser{"tcp-listen", "https://docs.tenzir.com/connectors/tcp"};
+      = argument_parser{"tcp-listen", "https://tenzir.com/docs/connectors/tcp"};
     auto q = until_keyword_parser{"read", p};
     auto args = tcp_listen_args{};
     auto endpoint = located<std::string>{};

--- a/libtenzir/builtins/operators/time.cpp
+++ b/libtenzir/builtins/operators/time.cpp
@@ -35,7 +35,7 @@ namespace tenzir::plugins::time {
 
 namespace {
 
-constexpr auto docs = "https://docs.tenzir.com/formats/time";
+constexpr auto docs = "https://tenzir.com/docs/formats/time";
 
 #if TENZIR_HAS_DATE_H
 auto find_tz_by_name(std::string_view tz_name, diagnostic_handler& diag)

--- a/libtenzir/builtins/operators/to_write_save.cpp
+++ b/libtenzir/builtins/operators/to_write_save.cpp
@@ -36,7 +36,7 @@ namespace {
   diagnostic::error("printer `{}` could not be found", x.inner)
     .primary(x.source)
     .hint("must be one of {}", fmt::join(available, ", "))
-    .docs("https://docs.tenzir.com/formats")
+    .docs("https://tenzir.com/docs/formats")
     .throw_();
 }
 
@@ -56,13 +56,13 @@ throw_saver_not_found(located<std::string_view> x, bool use_uri_schemes) {
     diagnostic::error("saver for `{}` scheme could not be found", x.inner)
       .primary(x.source)
       .hint("must be one of {}", fmt::join(available, ", "))
-      .docs("https://docs.tenzir.com/connectors")
+      .docs("https://tenzir.com/docs/connectors")
       .throw_();
   }
   diagnostic::error("saver `{}` could not be found", x.inner)
     .primary(x.source)
     .hint("must be one of {}", fmt::join(available, ", "))
-    .docs("https://docs.tenzir.com/connectors")
+    .docs("https://tenzir.com/docs/connectors")
     .throw_();
 }
 
@@ -179,7 +179,7 @@ public:
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
     auto usage = "write <printer> <args>...";
-    auto docs = "https://docs.tenzir.com/operators/write";
+    auto docs = "https://tenzir.com/docs/operators/write";
     auto name = p.accept_shell_arg();
     if (not name) {
       diagnostic::error("expected printer name")
@@ -293,7 +293,7 @@ public:
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
     auto usage = "save <saver> <args>...";
-    auto docs = "https://docs.tenzir.com/operators/save";
+    auto docs = "https://tenzir.com/docs/operators/save";
     auto [saver, _] = get_saver(p, usage, docs);
     TENZIR_DIAG_ASSERT(saver);
     return std::make_unique<save_operator>(std::move(saver));
@@ -392,7 +392,7 @@ public:
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
     auto usage = "to <saver> <args>... [write <printer> <args>...]";
-    auto docs = "https://docs.tenzir.com/operators/to";
+    auto docs = "https://tenzir.com/docs/operators/to";
     auto q = until_keyword_parser{"write", p};
     auto [saver, saver_path] = get_saver(q, usage, docs);
     TENZIR_DIAG_ASSERT(saver);

--- a/libtenzir/builtins/operators/unflatten.cpp
+++ b/libtenzir/builtins/operators/unflatten.cpp
@@ -64,7 +64,7 @@ public:
   }
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
-    auto parser = argument_parser{"unflatten", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"unflatten", "https://tenzir.com/docs/"
                                                "operators/unflatten"};
     auto sep = std::optional<located<std::string>>{};
     parser.add(sep, "<separator>");

--- a/libtenzir/builtins/operators/unique.cpp
+++ b/libtenzir/builtins/operators/unique.cpp
@@ -29,7 +29,7 @@ public:
   }
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
-    auto parser = argument_parser{"unique", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"unique", "https://tenzir.com/docs/"
                                             "operators/unique"};
     parser.parse(p);
     auto result

--- a/libtenzir/builtins/operators/unroll.cpp
+++ b/libtenzir/builtins/operators/unroll.cpp
@@ -529,7 +529,7 @@ public:
   }
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
-    auto parser = argument_parser{"unroll", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"unroll", "https://tenzir.com/docs/"
                                             "operators/unroll"};
     auto field = located<std::string>{};
     parser.add(field, "<field>");

--- a/libtenzir/builtins/operators/version.cpp
+++ b/libtenzir/builtins/operators/version.cpp
@@ -248,7 +248,7 @@ public:
   }
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
-    auto parser = argument_parser{"version", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"version", "https://tenzir.com/docs/"
                                              "operators/version"};
     parser.parse(p);
     return std::make_unique<version_operator>();

--- a/libtenzir/builtins/operators/where_map.cpp
+++ b/libtenzir/builtins/operators/where_map.cpp
@@ -129,7 +129,7 @@ public:
   }
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
-    auto parser = argument_parser{"where", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"where", "https://tenzir.com/docs/"
                                            "operators/where"};
     auto expr = located<tenzir::expression>{};
     parser.add(expr, "<expr>");

--- a/libtenzir/builtins/operators/yield.cpp
+++ b/libtenzir/builtins/operators/yield.cpp
@@ -34,7 +34,7 @@ public:
   yield_operator() = default;
 
   explicit yield_operator(parser_interface& p) {
-    auto parser = argument_parser{"yield", "https://docs.tenzir.com/"
+    auto parser = argument_parser{"yield", "https://tenzir.com/docs/"
                                            "operators/yield"};
     auto extractor = located<std::string>{};
     // TODO: This assumes that the given extractor can be parsed as a shell-like

--- a/libtenzir/src/argument_parser2.cpp
+++ b/libtenzir/src/argument_parser2.cpp
@@ -504,7 +504,7 @@ auto argument_parser2::docs() const -> std::string {
     TENZIR_UNREACHABLE();
   });
   boost::replace_all(name, "::", "/");
-  return fmt::format("https://docs.tenzir.com/reference/{}/{}", category, name);
+  return fmt::format("https://tenzir.com/docs/reference/{}/{}", category, name);
 }
 
 template <class T>

--- a/libtenzir/src/from_file_base.cpp
+++ b/libtenzir/src/from_file_base.cpp
@@ -532,7 +532,7 @@ auto from_file_state::make_pipeline(std::string_view path)
   TRY(auto compression_and_format,
       get_compression_and_format<true>(
         located<std::string_view>{path, args_.url.source}, nullptr,
-        "https://docs.tenzir.com/reference/operators/from_file", parse_dh));
+        "https://tenzir.com/docs/reference/operators/from_file", parse_dh));
   const auto& format = compression_and_format.format.get();
   const auto* compression = compression_and_format.compression;
   auto provider = session_provider::make(parse_dh);

--- a/libtenzir/src/ir.cpp
+++ b/libtenzir/src/ir.cpp
@@ -717,7 +717,7 @@ auto ast::pipeline::compile(compile_ctx ctx) && -> failure_or<ir::pipeline> {
                 "This operator is not available in Tenzir Node v6")
                 .primary(x.op)
                 .hint("{}", get_porting_hint(x.op))
-                .hint("see https://docs.tenzir.com/guides/tenzir-v6-migration")
+                .hint("see https://tenzir.com/docs/guides/tenzir-v6-migration")
                 .emit(ctx);
               return failure::promise();
 #endif

--- a/libtenzir/src/operator_plugin.cpp
+++ b/libtenzir/src/operator_plugin.cpp
@@ -777,7 +777,7 @@ auto OperatorPlugin::describe_shared() const
            pos = docs_path.find("::")) {
         docs_path.replace(pos, 2, "/");
       }
-      desc->docs = "https://docs.tenzir.com/reference/operators/" + docs_path;
+      desc->docs = "https://tenzir.com/docs/reference/operators/" + docs_path;
     }
     cached_desc_ = std::move(desc);
   });

--- a/libtenzir/src/pipeline_executor.cpp
+++ b/libtenzir/src/pipeline_executor.cpp
@@ -249,7 +249,7 @@ auto pipeline_executor_state::start() -> caf::result<void> {
     }
     abort_start(
       diagnostic::error("expected pipeline to end with a sink{}", suffix)
-        .docs("https://docs.tenzir.com/reference/operators")
+        .docs("https://tenzir.com/docs/reference/operators")
         .done());
     return start_rp;
   }

--- a/libtenzir/src/tql/parser.cpp
+++ b/libtenzir/src/tql/parser.cpp
@@ -381,7 +381,7 @@ private:
     if (not plugin) {
       diagnostic::error("no such operator: `{}`", ident.name)
         .primary(ident.source)
-        .docs("https://docs.tenzir.com/operators")
+        .docs("https://tenzir.com/docs/operators")
         .throw_();
     }
     try {

--- a/libtenzir/src/tql2/exec.cpp
+++ b/libtenzir/src/tql2/exec.cpp
@@ -304,7 +304,7 @@ public:
     // this, but putting everything here was easy to do. We should reconsider
     // this strategy when introducing a second operator that can modify the
     // constant environment.
-    const auto* docs = "https://docs.tenzir.com/tql2/operators/load_balance";
+    const auto* docs = "https://tenzir.com/docs/tql2/operators/load_balance";
     const auto* usage = "load_balance over:list { … }";
     auto emit = [&](diagnostic_builder d) {
       if (d.inner().severity == severity::error) {

--- a/libtenzir/src/tql2/resolve.cpp
+++ b/libtenzir/src/tql2/resolve.cpp
@@ -129,7 +129,7 @@ public:
         builder = std::move(builder).hint("did you mean `{}`?", *suggestion);
       }
       builder = std::move(builder).docs(
-        "https://docs.tenzir.com/reference/{}",
+        "https://tenzir.com/docs/reference/{}",
         target_ns == entity_ns::op ? "operators" : "functions");
       std::move(builder).emit(diag_);
     };

--- a/plugins/from_velociraptor/src/plugin.cpp
+++ b/plugins/from_velociraptor/src/plugin.cpp
@@ -334,7 +334,7 @@ public:
 
   auto parse_operator(parser_interface& p) const -> operator_ptr override {
     auto args = operator_args{};
-    auto parser = argument_parser{name(), "https://docs.tenzir.com/operators/"
+    auto parser = argument_parser{name(), "https://tenzir.com/docs/operators/"
                                           "velociraptor"};
     auto org_id = std::optional<located<std::string>>{};
     auto request_name = std::optional<located<std::string>>{};

--- a/python/tenzir/pyproject.toml
+++ b/python/tenzir/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://tenzir.com"
-Documentation = "https://docs.tenzir.com/reference/python-api"
+Documentation = "https://tenzir.com/docs/reference/python-api"
 Repository = "https://github.com/tenzir/tenzir"
 
 [project.scripts]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -163,7 +163,7 @@ else
     echo "  1. Use Docker"
     echo "  2. Build from source"
     echo
-    echo "Visit ${bold}https://docs.tenzir.com${normal} for further instructions."
+    echo "Visit ${bold}https://tenzir.com/docs${normal} for further instructions."
     exit 1
   fi
 fi
@@ -343,6 +343,6 @@ if [ -z "${open_source}" ]; then
   echo "  - Explore your node and manage pipelines at" \
     "${bold}https://app.tenzir.com${normal}"
 fi
-echo "  - Follow the guides at ${bold}https://docs.tenzir.com${normal}"
+echo "  - Follow the guides at ${bold}https://tenzir.com/docs${normal}"
 echo "  - Swing by our friendly Discord at" \
   "${bold}https://discord.tenzir.com${normal}"

--- a/scripts/macOS/installer/readme.html
+++ b/scripts/macOS/installer/readme.html
@@ -49,7 +49,7 @@
 
   <h2>Documentation</h2>
   <p>
-    Visit <a href="https://docs.tenzir.com">docs.tenzir.com</a> for
+    Visit <a href="https://tenzir.com/docs">tenzir.com/docs</a> for
     comprehensive documentation, tutorials, and guides.
   </p>
 

--- a/scripts/macOS/installer/welcome.html
+++ b/scripts/macOS/installer/welcome.html
@@ -37,7 +37,7 @@
   </p>
   <p>
     For more information, visit <a href="https://tenzir.com">tenzir.com</a> or
-    read the <a href="https://docs.tenzir.com">documentation</a>.
+    read the <a href="https://tenzir.com/docs">documentation</a>.
   </p>
 </body>
 </html>

--- a/tenzir/tenzir.1.md
+++ b/tenzir/tenzir.1.md
@@ -23,7 +23,7 @@ executable serves both as client and server.
 # USAGE
 
 The usage examples in this manpage only scratch the surface. Please consult the
-official documentation at https://docs.tenzir.com for a comprehensive user guide.
+official documentation at https://tenzir.com/docs for a comprehensive user guide.
 
 You get short usage instructions for every `tenzir` command by adding the `help`
 sub-command or providing the option `--help` (which has the shorthand `-h`):
@@ -63,7 +63,7 @@ tenzir export json '6.6.6.6 || (dst_port < 1024 && proto == "UDP")'
 
 ## Next steps
 
-To learn more about using Tenzir, continue over at https://docs.tenzir.com.
+To learn more about using Tenzir, continue over at https://tenzir.com/docs.
 
 # ISSUES
 

--- a/test/tests/functions/community_id/missing_dst_ip.txt
+++ b/test/tests/functions/community_id/missing_dst_ip.txt
@@ -5,4 +5,4 @@ error: required argument `dst_ip` was not provided
   |        ^^^^^^^^^^^^ 
   |
   = usage: community_id(src_ip=ip, dst_ip=ip, proto=string, [src_port=int, dst_port=int, seed=int])
-  = docs: https://docs.tenzir.com/reference/functions/community_id
+  = docs: https://tenzir.com/docs/reference/functions/community_id

--- a/test/tests/functions/community_id/missing_proto.txt
+++ b/test/tests/functions/community_id/missing_proto.txt
@@ -5,4 +5,4 @@ error: required argument `proto` was not provided
   |        ^^^^^^^^^^^^ 
   |
   = usage: community_id(src_ip=ip, dst_ip=ip, proto=string, [src_port=int, dst_port=int, seed=int])
-  = docs: https://docs.tenzir.com/reference/functions/community_id
+  = docs: https://tenzir.com/docs/reference/functions/community_id

--- a/test/tests/functions/community_id/missing_src_ip.txt
+++ b/test/tests/functions/community_id/missing_src_ip.txt
@@ -5,4 +5,4 @@ error: required argument `src_ip` was not provided
   |        ^^^^^^^^^^^^ 
   |
   = usage: community_id(src_ip=ip, dst_ip=ip, proto=string, [src_port=int, dst_port=int, seed=int])
-  = docs: https://docs.tenzir.com/reference/functions/community_id
+  = docs: https://tenzir.com/docs/reference/functions/community_id

--- a/test/tests/functions/list_map/non_lambda_argument.txt
+++ b/test/tests/functions/list_map/non_lambda_argument.txt
@@ -5,4 +5,4 @@ error: expected a lambda
    |           ^^^^ 
    |
    = usage: map(list:list, function:any -> any)
-   = docs: https://docs.tenzir.com/reference/functions/map
+   = docs: https://tenzir.com/docs/reference/functions/map

--- a/test/tests/functions/list_where/non_lambda_argument.txt
+++ b/test/tests/functions/list_where/non_lambda_argument.txt
@@ -5,4 +5,4 @@ error: expected a lambda
   |             ^^^^ 
   |
   = usage: where(list:list, predicate:any => bool)
-  = docs: https://docs.tenzir.com/reference/functions/where
+  = docs: https://tenzir.com/docs/reference/functions/where

--- a/test/tests/language/expr/dollar_var_as_argument_name.txt
+++ b/test/tests/language/expr/dollar_var_as_argument_name.txt
@@ -5,4 +5,4 @@ error: invalid argument name
   |      ^^^^ 
   |
   = usage: head [count:int]
-  = docs: https://docs.tenzir.com/reference/operators/head
+  = docs: https://tenzir.com/docs/reference/operators/head

--- a/test/tests/language/expr/ufcs_error.txt
+++ b/test/tests/language/expr/ufcs_error.txt
@@ -5,7 +5,7 @@ error: expected additional positional argument `prefix`
   |            ^^^^^^^^^^^ 
   |
   = usage: starts_with(x:string, prefix:string, [ignore_case=bool])
-  = docs: https://docs.tenzir.com/reference/functions/starts_with
+  = docs: https://tenzir.com/docs/reference/functions/starts_with
 
 error: expected additional positional argument `prefix`
  --> tests/language/expr/ufcs_error.tql:7:6
@@ -14,4 +14,4 @@ error: expected additional positional argument `prefix`
   |      ^^^^^^^^^^^ 
   |
   = usage: starts_with(x:string, prefix:string, [ignore_case=bool])
-  = docs: https://docs.tenzir.com/reference/functions/starts_with
+  = docs: https://tenzir.com/docs/reference/functions/starts_with

--- a/test/tests/operators/accept_http/error_missing_parser.txt
+++ b/test/tests/operators/accept_http/error_missing_parser.txt
@@ -5,4 +5,4 @@ error: required subpipeline was not provided
   | ^^^^^^^^^^^ 
   |
   = usage: accept_http endpoint:string, [responses=record, max_request_size=int, max_connections=int, tls=record]
-  = docs: https://docs.tenzir.com/reference/operators/accept_http
+  = docs: https://tenzir.com/docs/reference/operators/accept_http

--- a/test/tests/operators/discard/after_sink.txt
+++ b/test/tests/operators/discard/after_sink.txt
@@ -4,4 +4,4 @@ error: operator does not accept void
 5 | discard | discard
   | ^^^^^^^ 
   |
-  = docs: https://docs.tenzir.com/reference/operators/discard
+  = docs: https://tenzir.com/docs/reference/operators/discard

--- a/test/tests/operators/each/substitution_error.txt
+++ b/test/tests/operators/each/substitution_error.txt
@@ -4,4 +4,4 @@ error: expected positive integer, got `-1`
 7 |   head $this.limit
   |        ^^^^^^^^^^^ 
   |
-  = docs: https://docs.tenzir.com/reference/operators/head
+  = docs: https://tenzir.com/docs/reference/operators/head

--- a/test/tests/operators/every/missing_duration.txt
+++ b/test/tests/operators/every/missing_duration.txt
@@ -5,4 +5,4 @@ error: expected exactly 1 positional argument
   | ^^^^^ 
   |
   = usage: every interval:duration
-  = docs: https://docs.tenzir.com/reference/operators/every
+  = docs: https://tenzir.com/docs/reference/operators/every

--- a/test/tests/operators/from_ftp/validation/error_missing_parser_pipeline.txt
+++ b/test/tests/operators/from_ftp/validation/error_missing_parser_pipeline.txt
@@ -5,4 +5,4 @@ error: required subpipeline was not provided
   | ^^^^^^^^ 
   |
   = usage: from_ftp url:string, [tls=record]
-  = docs: https://docs.tenzir.com/reference/operators/from_ftp
+  = docs: https://tenzir.com/docs/reference/operators/from_ftp

--- a/test/tests/operators/from_http/error_metadata_fields_arg.txt
+++ b/test/tests/operators/from_http/error_metadata_fields_arg.txt
@@ -5,4 +5,4 @@ error: named argument `metadata_fields` does not exist
   |                                  ^^^^^^^^^^^^^^^ 
   |
   = usage: from_http url:string, [method=string, body=any, headers=record, tls=record, timeout=duration, error_field=field, metadata_field=any, paginate=any, paginate_delay=duration, connection_timeout=duration, max_retry_count=int, retry_delay=duration, encode=string, server=bool]
-  = docs: https://docs.tenzir.com/reference/operators/from_http
+  = docs: https://tenzir.com/docs/reference/operators/from_http

--- a/test/tests/operators/parallel/error_bytes_input.txt
+++ b/test/tests/operators/parallel/error_bytes_input.txt
@@ -4,4 +4,4 @@ error: operator does not accept bytes
 7 | parallel { pass }
   | ^^^^^^^^ 
   |
-  = docs: https://docs.tenzir.com/reference/operators/parallel
+  = docs: https://tenzir.com/docs/reference/operators/parallel

--- a/test/tests/operators/to_ftp/validation/error_missing_printer_pipeline.txt
+++ b/test/tests/operators/to_ftp/validation/error_missing_printer_pipeline.txt
@@ -5,4 +5,4 @@ error: required subpipeline was not provided
   | ^^^^^^ 
   |
   = usage: to_ftp url:string, [tls=record]
-  = docs: https://docs.tenzir.com/reference/operators/to_ftp
+  = docs: https://tenzir.com/docs/reference/operators/to_ftp

--- a/test/tests/operators/window/error_missing_on.txt
+++ b/test/tests/operators/window/error_missing_on.txt
@@ -5,4 +5,4 @@ error: required argument `on` was not provided
   | ^^^^^^ 
   |
   = usage: window size=duration, on=time, [every=duration, tolerance=duration, idle_timeout=duration]
-  = docs: https://docs.tenzir.com/reference/operators/window
+  = docs: https://tenzir.com/docs/reference/operators/window

--- a/test/tests/operators/window/error_missing_size.txt
+++ b/test/tests/operators/window/error_missing_size.txt
@@ -5,4 +5,4 @@ error: required argument `size` was not provided
   | ^^^^^^ 
   |
   = usage: window size=duration, on=time, [every=duration, tolerance=duration, idle_timeout=duration]
-  = docs: https://docs.tenzir.com/reference/operators/window
+  = docs: https://tenzir.com/docs/reference/operators/window


### PR DESCRIPTION
## 🔍 Problem

- Product and repository links still pointed at the old `docs.tenzir.com` host after the documentation moved under `tenzir.com`.
- Operator help and diagnostics exposed the old URL to users.

## 🛠️ Solution

- Replace `docs.tenzir.com` links with their new `tenzir.com` destinations, including `tenzir.com/docs` for documentation and `tenzir.com/changelog` for changelog pages.
- Bump `contrib/tenzir-plugins` to the companion URL fix.

## 💬 Review

- Mechanical URL rewrite; focus on URL shape and the submodule pointer.
- No companion docs PR: this updates links to the docs site, not docs content.

<sub>
📎 Related: tenzir/tenzir-plugins#577
</sub>