### PR TITLE
Require PR metadata for changelog entries

### DIFF
--- a/.github/workflows/changelog-validate.yaml
+++ b/.github/workflows/changelog-validate.yaml
@@ -1,0 +1,33 @@
+name: Validate Changelog
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+    paths:
+      - "changelog/**"
+      - ".github/workflows/changelog-validate.yaml"
+      - "lefthook.yml"
+  merge_group:
+    types:
+      - checks_requested
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: changelog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d # v7.1.0
+        with:
+          version: "0.9.2"
+
+      - name: Validate changelog
+        run: uvx tenzir-ship validate

--- a/changelog/config.yaml
+++ b/changelog/config.yaml
@@ -4,3 +4,4 @@ description: >-
   The security data pipeline engine that collects security telemetry, normalizes
   events to OCSF, and offers an open data lake for storage.
 repository: tenzir/tenzir
+require_pr: true

--- a/changelog/unreleased/operator-io-metrics.md
+++ b/changelog/unreleased/operator-io-metrics.md
@@ -3,6 +3,8 @@ title: Add ingress/egress metrics to more operators
 type: feature
 authors:
   - IyeOnline
+prs:
+  - 6401
 created: 2026-07-01T00:00:00.000000Z
 ---
 

--- a/changelog/unreleased/serve-export-graceful-shutdown.md
+++ b/changelog/unreleased/serve-export-graceful-shutdown.md
@@ -3,6 +3,8 @@ title: Serve and live export shut down promptly
 type: bugfix
 authors:
   - aljazerzen
+prs:
+  - 6403
 created: 2026-07-01T00:00:00.000000Z
 ---
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -10,7 +10,7 @@ pre-push:
     changelog:
       files: &branch_files 'git diff --name-only --diff-filter=ACMR "$(git merge-base origin/main HEAD)" HEAD'
       glob: "changelog/**"
-      run: uvx tenzir-ship validate
+      run: uvx tenzir-ship validate --lenient
     ruff-format:
       env:
         RUFF_VERSION: &ruff_version "0.15.12"


### PR DESCRIPTION
## 🔍 Problem

- Changelog entries can still land without PR metadata in this repository.
- Local pre-push validation needs to tolerate missing PR numbers before the first push creates a pull request.

## 🛠️ Solution

- Enable `require_pr: true` for the changelog project.
- Keep CI changelog validation strict.
- Run Lefthook changelog validation with `--lenient` for local pre-push checks.

## 💬 Review

- Release-process-only change; no product changelog entry.

<sub>
📎 Related: tenzir/ship#34
</sub>
