### PR TITLE
Prioritize `export` over background enrichment I/O

### DIFF
--- a/changelog/unreleased/export-stays-fast-alongside-busy-context-enrichment.md
+++ b/changelog/unreleased/export-stays-fast-alongside-busy-context-enrichment.md
@@ -1,0 +1,11 @@
+---
+title: Export stays fast alongside busy context enrichment
+type: bugfix
+authors:
+  - IyeOnline
+created: 2026-07-03T20:07:17.066853Z
+prs:
+  - 6420
+---
+
+The `export` operator no longer stalls when a busy `context` enrichment pipeline (such as one using `lookup`) is reading from disk at the same time. Both used to compete for the same disk access, and a busy enrichment pipeline could make `export` dramatically slower or effectively stuck. `export` now takes priority over background enrichment reads, so it stays responsive regardless of how much enrichment work is running concurrently.

--- a/libtenzir/builtins/operators/export.cpp
+++ b/libtenzir/builtins/operators/export.cpp
@@ -65,6 +65,7 @@ struct ExportArgs {
   bool retro = false;
   bool internal = false;
   uint64_t parallel = 3;
+  bool high_priority = true;
   /// The filter pushed down by `describer.optimize_filter`.
   ir::optimize_filter filter;
   /// Setting for a special filter added by the `diagnostics` or `metrics`
@@ -221,8 +222,9 @@ public:
     auto expr = legacy_clauses.size() == 1
                   ? std::move(legacy_clauses[0])
                   : expression{conjunction{std::move(legacy_clauses)}};
-    auto mode = export_mode{args_.live ? args_.retro : true, args_.live,
-                            args_.internal, args_.parallel};
+    auto mode
+      = export_mode{args_.live ? args_.retro : true, args_.live, args_.internal,
+                    args_.parallel, args_.high_priority};
     auto result
       = co_await async_mail(atom::spawn_v, std::move(expr), mode).request(*node);
     if (not result) {
@@ -482,10 +484,15 @@ public:
   }
 
   auto describe() const -> Description override {
-    auto d = Describer<ExportArgs, Export>{};
+    auto d = Describer<ExportArgs, Export>{ExportArgs{
+      .filter = {},
+      .special_filter = export_special_filter::none,
+      .metrics_name = {},
+    }};
     d.named("live", &ExportArgs::live);
     d.named("retro", &ExportArgs::retro);
     d.named("internal", &ExportArgs::internal);
+    d.named("_high_priority", &ExportArgs::high_priority);
     auto parallel = d.named_optional("parallel", &ExportArgs::parallel);
     d.validate([=](DescribeCtx& ctx) -> Empty {
       TRY(auto value, ctx.get(parallel));
@@ -528,7 +535,7 @@ public:
           data{internal},
         },
       },
-      export_mode{retro, live, internal, parallel ? parallel->inner : 3});
+      export_mode{retro, live, internal, parallel ? parallel->inner : 3, true});
   }
 
   auto make(operator_factory_invocation inv, session ctx) const
@@ -562,7 +569,7 @@ public:
           data{internal},
         },
       },
-      export_mode{retro, live, internal, parallel ? parallel->inner : 3});
+      export_mode{retro, live, internal, parallel ? parallel->inner : 3, true});
   }
 };
 
@@ -587,6 +594,7 @@ public:
     }};
     d.named("live", &ExportArgs::live);
     d.named("retro", &ExportArgs::retro);
+    d.named("_high_priority", &ExportArgs::high_priority);
     auto parallel = d.named_optional("parallel", &ExportArgs::parallel);
     d.validate([=](DescribeCtx& ctx) -> Empty {
       TRY(auto value, ctx.get(parallel));
@@ -661,7 +669,7 @@ public:
           },
         },
       },
-      export_mode{retro, live, internal, parallel ? parallel->inner : 3});
+      export_mode{retro, live, internal, parallel ? parallel->inner : 3, true});
   }
 };
 
@@ -687,6 +695,7 @@ public:
     auto name = d.positional("name", &ExportArgs::metrics_name);
     d.named("live", &ExportArgs::live);
     d.named("retro", &ExportArgs::retro);
+    d.named("_high_priority", &ExportArgs::high_priority);
     auto shape
       = d.named_optional("shape", &ExportArgs::shape, "raw|prometheus");
     auto parallel = d.named_optional("parallel", &ExportArgs::parallel);
@@ -795,7 +804,7 @@ public:
           },
         },
       },
-      export_mode{retro, live, internal, parallel ? parallel->inner : 3});
+      export_mode{retro, live, internal, parallel ? parallel->inner : 3, true});
   }
 };
 

--- a/libtenzir/include/tenzir/actors.hpp
+++ b/libtenzir/include/tenzir/actors.hpp
@@ -362,11 +362,17 @@ struct export_mode {
   bool live = false;
   bool internal = false;
   uint64_t parallel = 3;
+  bool high_priority = false;
 
   export_mode() = default;
 
-  export_mode(bool retro_, bool live_, bool internal_, uint64_t parallel_)
-    : retro{retro_}, live{live_}, internal{internal_}, parallel{parallel_} {
+  export_mode(bool retro_, bool live_, bool internal_, uint64_t parallel_,
+              bool high_priority_ = false)
+    : retro{retro_},
+      live{live_},
+      internal{internal_},
+      parallel{parallel_},
+      high_priority{high_priority_} {
     TENZIR_ASSERT(live or retro);
   }
 
@@ -374,7 +380,8 @@ struct export_mode {
     return f.object(x).fields(f.field("retro", x.retro),
                               f.field("live", x.live),
                               f.field("internal", x.internal),
-                              f.field("parallel", x.parallel));
+                              f.field("parallel", x.parallel),
+                              f.field("high_priority", x.high_priority));
   }
 };
 

--- a/libtenzir/include/tenzir/passive_partition.hpp
+++ b/libtenzir/include/tenzir/passive_partition.hpp
@@ -20,6 +20,7 @@
 #include "tenzir/type.hpp"
 #include "tenzir/uuid.hpp"
 
+#include <caf/message_priority.hpp>
 #include <caf/typed_event_based_actor.hpp>
 
 #include <filesystem>
@@ -85,6 +86,9 @@ struct passive_partition_state {
   /// Actor handle of the filesystem.
   filesystem_actor filesystem = {};
 
+  /// The priority for requests to the filesystem actor.
+  caf::message_priority priority = caf::message_priority::normal;
+
   /// The store to retrieve the data from.
   store_actor store = {};
 
@@ -122,8 +126,10 @@ struct partition_chunk {
 /// @param id The UUID of this partition.
 /// @param filesystem The actor handle of the filesystem actor.
 /// @param path The path where the partition flatbuffer can be found.
+/// @param priority The priority for requests to the filesystem actor.
 partition_actor::behavior_type passive_partition(
   partition_actor::stateful_pointer<passive_partition_state> self, uuid id,
-  filesystem_actor filesystem, const std::filesystem::path& path);
+  filesystem_actor filesystem, const std::filesystem::path& path,
+  caf::message_priority priority);
 
 } // namespace tenzir

--- a/libtenzir/include/tenzir/plugin/store.hpp
+++ b/libtenzir/include/tenzir/plugin/store.hpp
@@ -13,6 +13,7 @@
 #include "tenzir/uuid.hpp"
 
 #include <caf/expected.hpp>
+#include <caf/message_priority.hpp>
 
 #include <cstddef>
 #include <memory>
@@ -56,10 +57,11 @@ public:
   /// partition that uses this partition as a store backend.
   /// @param fs The actor handle of a filesystem.
   /// @param header The store header as found in the partition flatbuffer.
+  /// @param priority The priority for requests to the filesystem actor.
   /// @returns A new store actor.
   [[nodiscard]] virtual auto
-  make_store(filesystem_actor fs, std::span<const std::byte> header) const
-    -> caf::expected<store_actor>
+  make_store(filesystem_actor fs, std::span<const std::byte> header,
+             caf::message_priority priority) const -> caf::expected<store_actor>
     = 0;
 };
 
@@ -83,7 +85,8 @@ private:
     -> caf::expected<builder_and_header> final;
 
   [[nodiscard]] auto
-  make_store(filesystem_actor fs, std::span<const std::byte> header) const
+  make_store(filesystem_actor fs, std::span<const std::byte> header,
+             caf::message_priority priority) const
     -> caf::expected<store_actor> final;
 };
 

--- a/libtenzir/include/tenzir/store.hpp
+++ b/libtenzir/include/tenzir/store.hpp
@@ -16,6 +16,7 @@
 #include "tenzir/table_slice.hpp"
 #include "tenzir/uuid.hpp"
 
+#include <caf/message_priority.hpp>
 #include <caf/typed_event_based_actor.hpp>
 
 #include <variant>
@@ -131,11 +132,13 @@ struct default_passive_store_state {
 /// @param filesystem A handle to the filesystem actor.
 /// @param path The path to load the store from.
 /// @param store_type The unique store identifier of the used store plugin.
+/// @param priority The priority for requests to the filesystem actor.
 default_passive_store_actor::behavior_type default_passive_store(
   default_passive_store_actor::stateful_pointer<default_passive_store_state>
     self,
   std::unique_ptr<passive_store> store, filesystem_actor filesystem,
-  std::filesystem::path path, std::string store_type);
+  std::filesystem::path path, std::string store_type,
+  caf::message_priority priority);
 
 /// The state of the default active store actor implementation.
 struct default_active_store_state {

--- a/libtenzir/src/export_bridge.cpp
+++ b/libtenzir/src/export_bridge.cpp
@@ -247,26 +247,40 @@ auto make_bridge(export_bridge_actor::stateful_pointer<bridge_state> self,
   TENZIR_ASSERT(importer);
   self->state().importer_address = importer->address();
   self->state().unpersisted_events.emplace();
-  self
-    ->mail(atom::get_v, caf::actor_cast<receiver_actor<table_slice>>(self),
-           self->state().mode.internal,
-           /*live=*/self->state().mode.live,
-           /*recent=*/self->state().mode.retro)
-    .request(importer, caf::infinite)
-    .await(
-      [self, mode](std::vector<table_slice>& unpersisted_events) {
+  auto on_subscribed
+    = [self, mode](std::vector<table_slice>& unpersisted_events) {
         TENZIR_DEBUG("{} subscribed to importer", *self);
         if (mode.retro) {
           TENZIR_ASSERT(self->state().unpersisted_events);
           TENZIR_ASSERT(self->state().unpersisted_events->empty());
           *self->state().unpersisted_events = std::move(unpersisted_events);
         }
-      },
-      [self](const caf::error& err) {
-        self->quit(diagnostic::error(err)
-                     .note("{} failed to subscribe to importer", *self)
-                     .to_error());
-      });
+      };
+  auto on_subscribe_error = [self](const caf::error& err) {
+    self->quit(diagnostic::error(err)
+                 .note("{} failed to subscribe to importer", *self)
+                 .to_error());
+  };
+  auto subscribe = [&](auto mailer) {
+    std::move(mailer)
+      .request(importer, caf::infinite)
+      .await(std::move(on_subscribed), std::move(on_subscribe_error));
+  };
+  if (self->state().mode.high_priority) {
+    subscribe(self
+                ->mail(atom::get_v,
+                       caf::actor_cast<receiver_actor<table_slice>>(self),
+                       self->state().mode.internal,
+                       /*live=*/self->state().mode.live,
+                       /*recent=*/self->state().mode.retro)
+                .urgent());
+  } else {
+    subscribe(self->mail(atom::get_v,
+                         caf::actor_cast<receiver_actor<table_slice>>(self),
+                         self->state().mode.internal,
+                         /*live=*/self->state().mode.live,
+                         /*recent=*/self->state().mode.retro));
+  }
   // If we're retro, then we can query the catalog immediately.
   if (mode.retro) {
     const auto catalog
@@ -278,58 +292,62 @@ auto make_bridge(export_bridge_actor::stateful_pointer<bridge_state> self,
     TENZIR_DEBUG("export operator starts catalog lookup with id {} and "
                  "expression {}",
                  query_context.id, self->state().expr);
-    self->mail(atom::candidates_v, query_context)
-      .request(catalog, caf::infinite)
-      .then(
-        [self, query_context](catalog_lookup_result& result) {
-          self->state().checked_candidates = true;
-          auto max_import_time = time::min();
-          for (auto& [type, info] : result.candidate_infos) {
-            if (info.partition_infos.empty()) {
-              continue;
-            }
-            const auto* bound_expr = self->state().bind_expr(type, info.exp);
-            if (not bound_expr) {
-              // failing to bind is not an error.
-              continue;
-            }
-            auto ctx = query_context;
-            ctx.expr = *bound_expr;
-            for (auto& partition_info : info.partition_infos) {
-              max_import_time
-                = std::max(max_import_time, partition_info.max_import_time);
-              self->state().queued_partitions.emplace(std::move(partition_info),
-                                                      ctx);
-            }
-            while (self->state().open_partitions
-                   < self->state().mode.parallel) {
-              ++self->state().open_partitions;
-              detail::weak_run_delayed(self, duration::zero(), [self] {
-                self->state().pop_partition();
-              });
-            }
-          }
-          TENZIR_ASSERT(self->state().unpersisted_events);
-          for (auto& slice : *self->state().unpersisted_events) {
-            if (slice.import_time() > max_import_time) {
-              self->state().add_events(std::move(slice),
-                                       event_source::unpersisted,
-                                       caf::typed_response_promise<void>{});
-            }
-          }
-          self->state().unpersisted_events.reset();
-          // In case we get zero partitions back from the catalog we need to
-          // already signal that we're done here.
-          if (self->state().buffer_rp.pending() and self->state().is_done()) {
-            self->state().buffer_rp.deliver(table_slice{});
-          }
-        },
-        [self](const caf::error& err) {
-          self->quit(
-            diagnostic::error(err)
-              .note("{} failed to retrieve candidates from catalog", *self)
-              .to_error());
-        });
+    auto on_candidates = [self, query_context](catalog_lookup_result& result) {
+      self->state().checked_candidates = true;
+      auto max_import_time = time::min();
+      for (auto& [type, info] : result.candidate_infos) {
+        if (info.partition_infos.empty()) {
+          continue;
+        }
+        const auto* bound_expr = self->state().bind_expr(type, info.exp);
+        if (not bound_expr) {
+          // failing to bind is not an error.
+          continue;
+        }
+        auto ctx = query_context;
+        ctx.expr = *bound_expr;
+        for (auto& partition_info : info.partition_infos) {
+          max_import_time
+            = std::max(max_import_time, partition_info.max_import_time);
+          self->state().queued_partitions.emplace(std::move(partition_info),
+                                                  ctx);
+        }
+        while (self->state().open_partitions < self->state().mode.parallel) {
+          ++self->state().open_partitions;
+          detail::weak_run_delayed(self, duration::zero(), [self] {
+            self->state().pop_partition();
+          });
+        }
+      }
+      TENZIR_ASSERT(self->state().unpersisted_events);
+      for (auto& slice : *self->state().unpersisted_events) {
+        if (slice.import_time() > max_import_time) {
+          self->state().add_events(std::move(slice), event_source::unpersisted,
+                                   caf::typed_response_promise<void>{});
+        }
+      }
+      self->state().unpersisted_events.reset();
+      // In case we get zero partitions back from the catalog we need to
+      // already signal that we're done here.
+      if (self->state().buffer_rp.pending() and self->state().is_done()) {
+        self->state().buffer_rp.deliver(table_slice{});
+      }
+    };
+    auto on_candidates_error = [self](const caf::error& err) {
+      self->quit(diagnostic::error(err)
+                   .note("{} failed to retrieve candidates from catalog", *self)
+                   .to_error());
+    };
+    auto lookup = [&](auto mailer) {
+      std::move(mailer)
+        .request(catalog, caf::infinite)
+        .then(std::move(on_candidates), std::move(on_candidates_error));
+    };
+    if (self->state().mode.high_priority) {
+      lookup(self->mail(atom::candidates_v, query_context).urgent());
+    } else {
+      lookup(self->mail(atom::candidates_v, query_context));
+    }
   }
   return {
     [self](table_slice& slice) -> caf::result<void> {

--- a/libtenzir/src/export_bridge.cpp
+++ b/libtenzir/src/export_bridge.cpp
@@ -114,9 +114,11 @@ struct bridge_state {
     // TODO: We may want to monitor the spawned partitions to be able to return
     // better diagnostics. As-is, we only get a caf::sec::request_receiver_down
     // if they quit, but not their actual error message.
-    const auto partition = self->spawn(
-      passive_partition, info.uuid, filesystem,
-      std::filesystem::path{fmt::format("index/{:l}", info.uuid)});
+    const auto partition
+      = self->spawn(passive_partition, info.uuid, filesystem,
+                    std::filesystem::path{fmt::format("index/{:l}", info.uuid)},
+                    mode.high_priority ? caf::message_priority::high
+                                       : caf::message_priority::normal);
     self->mail(atom::query_v, std::move(ctx))
       .request(partition, caf::infinite)
       .then(

--- a/libtenzir/src/index.cpp
+++ b/libtenzir/src/index.cpp
@@ -315,7 +315,8 @@ partition_actor partition_factory::operator()(const uuid& id) const {
   const auto path = state_.partition_path(id);
   TENZIR_TRACE("{} loads partition {} for path {}", *state_.self, id, path);
   materializations_++;
-  return state_.self->spawn(passive_partition, id, filesystem_, path);
+  return state_.self->spawn(passive_partition, id, filesystem_, path,
+                            caf::message_priority::normal);
 }
 
 size_t partition_factory::materializations() const {
@@ -436,8 +437,8 @@ caf::error index_state::load_from_disk() {
             // result in incorrect index statistics. This depends on whether the
             // statistics where already updated on-disk before Tenzir crashed or
             // not, which is hard to figure out here.
-            auto partition
-              = self->spawn(passive_partition, uuid, filesystem, path);
+            auto partition = self->spawn(passive_partition, uuid, filesystem,
+                                         path, caf::message_priority::normal);
             self->mail(atom::erase_v)
               .request(partition, caf::infinite)
               .then(

--- a/libtenzir/src/partition_transformer.cpp
+++ b/libtenzir/src/partition_transformer.cpp
@@ -353,7 +353,8 @@ private:
                                 "'{}' for partition {}",
                                 partition_state.store_id, partition.uuid);
     }
-    auto store = plugin->make_store(filesystem_, partition_state.store_header);
+    auto store = plugin->make_store(filesystem_, partition_state.store_header,
+                                    caf::message_priority::normal);
     if (not store) {
       co_return std::move(store.error());
     }

--- a/libtenzir/src/passive_partition.cpp
+++ b/libtenzir/src/passive_partition.cpp
@@ -234,73 +234,81 @@ passive_partition_state::initialize_from_chunk(const tenzir::chunk_ptr& chunk) {
 
 partition_actor::behavior_type passive_partition(
   partition_actor::stateful_pointer<passive_partition_state> self, uuid id,
-  filesystem_actor filesystem, const std::filesystem::path& path) {
+  filesystem_actor filesystem, const std::filesystem::path& path,
+  caf::message_priority priority) {
   auto id_string = fmt::to_string(id);
   self->state().self = self;
   self->state().path = path;
   self->state().filesystem = std::move(filesystem);
+  self->state().priority = priority;
   TENZIR_TRACEPOINT(passive_partition_spawned, id_string.c_str());
   // We send a "read" to the fs actor and upon receiving the result deserialize
   // the flatbuffer and switch to the "normal" partition behavior for responding
   // to queries.
-  self->mail(atom::mmap_v, path)
-    .request(self->state().filesystem, caf::infinite)
-    .then(
-      [=](chunk_ptr chunk) {
-        TENZIR_TRACE("{} {}", *self, TENZIR_ARG(chunk));
-        TENZIR_TRACEPOINT(passive_partition_loaded, id_string.c_str());
-        TENZIR_ASSERT(not self->state().partition_chunk);
-        if (auto err = self->state().initialize_from_chunk(chunk);
-            err.valid()) {
-          TENZIR_ERROR("{} failed to initialize passive partition from file "
-                       "{}: "
-                       "{}",
-                       *self, path, err);
-          self->quit();
-          return;
-        }
-        if (self->state().id != id) {
-          TENZIR_ERROR("unexpected ID for passive partition: expected {}, got "
-                       "{}",
-                       id, self->state().id);
-          self->quit();
-          return;
-        }
-        const auto* plugin
-          = plugins::find<store_actor_plugin>(self->state().store_id);
-        if (not plugin) {
-          auto error = caf::make_error(ec::format_error,
-                                       "encountered unhandled store backend");
-          TENZIR_ERROR("{} encountered unknown store backend '{}'", *self,
-                       self->state().store_id);
-          self->quit(std::move(error));
-          return;
-        }
-        auto store = plugin->make_store(self->state().filesystem,
-                                        self->state().store_header);
-        if (not store) {
-          TENZIR_ERROR("{} failed to spawn store: {}", *self, store.error());
-          self->quit(caf::make_error(ec::system_error, "failed to spawn "
-                                                       "store"));
-          return;
-        }
-        self->state().store = *store;
-        self->monitor(self->state().store, [=](caf::error err) {
-          TENZIR_ERROR("{} shuts down after DOWN from {} store: {}", *self,
-                       self->state().store_id, err);
-          self->quit(std::move(err));
-        });
-        // Delegate all deferred evaluations now that we have the partition chunk.
-        delegate_deferred_requests(self->state());
-      },
-      [=](caf::error err) {
-        // This error is nicely printed at the export operator as a warning. No
-        // need to print it as an error here already.
-        TENZIR_WARN("{} failed to load partition: {}", *self, err);
-        deliver_error_to_deferred_requests(self->state(), err);
-        // Quit the partition.
-        self->quit(std::move(err));
-      });
+  auto on_chunk = [=](chunk_ptr chunk) {
+    TENZIR_TRACE("{} {}", *self, TENZIR_ARG(chunk));
+    TENZIR_TRACEPOINT(passive_partition_loaded, id_string.c_str());
+    TENZIR_ASSERT(not self->state().partition_chunk);
+    if (auto err = self->state().initialize_from_chunk(chunk); err.valid()) {
+      TENZIR_ERROR("{} failed to initialize passive partition from file "
+                   "{}: "
+                   "{}",
+                   *self, path, err);
+      self->quit();
+      return;
+    }
+    if (self->state().id != id) {
+      TENZIR_ERROR("unexpected ID for passive partition: expected {}, got "
+                   "{}",
+                   id, self->state().id);
+      self->quit();
+      return;
+    }
+    const auto* plugin
+      = plugins::find<store_actor_plugin>(self->state().store_id);
+    if (not plugin) {
+      auto error = caf::make_error(ec::format_error,
+                                   "encountered unhandled store backend");
+      TENZIR_ERROR("{} encountered unknown store backend '{}'", *self,
+                   self->state().store_id);
+      self->quit(std::move(error));
+      return;
+    }
+    auto store = plugin->make_store(self->state().filesystem,
+                                    self->state().store_header, priority);
+    if (not store) {
+      TENZIR_ERROR("{} failed to spawn store: {}", *self, store.error());
+      self->quit(caf::make_error(ec::system_error, "failed to spawn "
+                                                   "store"));
+      return;
+    }
+    self->state().store = *store;
+    self->monitor(self->state().store, [=](caf::error err) {
+      TENZIR_ERROR("{} shuts down after DOWN from {} store: {}", *self,
+                   self->state().store_id, err);
+      self->quit(std::move(err));
+    });
+    // Delegate all deferred evaluations now that we have the partition chunk.
+    delegate_deferred_requests(self->state());
+  };
+  auto on_error = [=](caf::error err) {
+    // This error is nicely printed at the export operator as a warning. No
+    // need to print it as an error here already.
+    TENZIR_WARN("{} failed to load partition: {}", *self, err);
+    deliver_error_to_deferred_requests(self->state(), err);
+    // Quit the partition.
+    self->quit(std::move(err));
+  };
+  if (priority == caf::message_priority::high) {
+    self->mail(atom::mmap_v, path)
+      .urgent()
+      .request(self->state().filesystem, caf::infinite)
+      .then(std::move(on_chunk), std::move(on_error));
+  } else {
+    self->mail(atom::mmap_v, path)
+      .request(self->state().filesystem, caf::infinite)
+      .then(std::move(on_chunk), std::move(on_error));
+  }
   return {
     [self](atom::query,
            tenzir::query_context query_context) -> caf::result<uint64_t> {

--- a/libtenzir/src/plugin.cpp
+++ b/libtenzir/src/plugin.cpp
@@ -535,7 +535,8 @@ auto store_plugin::make_store_builder(filesystem_actor fs,
 }
 
 auto store_plugin::make_store(filesystem_actor fs,
-                              std::span<const std::byte> header) const
+                              std::span<const std::byte> header,
+                              caf::message_priority priority) const
   -> caf::expected<store_actor> {
   auto store = make_passive_store();
   if (not store) {
@@ -552,8 +553,10 @@ auto store_plugin::make_store(filesystem_actor fs,
   std::error_code err{};
   const auto abs_dir = std::filesystem::absolute(db_dir, err);
   auto path = abs_dir / "archive" / fmt::format("{}.{}", id, name());
-  return fs->home_system().spawn<caf::lazy_init>(
-    default_passive_store, std::move(*store), fs, std::move(path), name());
+  return fs->home_system().spawn<caf::lazy_init>(default_passive_store,
+                                                 std::move(*store), fs,
+                                                 std::move(path), name(),
+                                                 priority);
 }
 
 // -- aspect plugin ------------------------------------------------------------

--- a/libtenzir/src/store.cpp
+++ b/libtenzir/src/store.cpp
@@ -156,7 +156,8 @@ default_passive_store_actor::behavior_type default_passive_store(
   default_passive_store_actor::stateful_pointer<default_passive_store_state>
     self,
   std::unique_ptr<passive_store> store, filesystem_actor filesystem,
-  std::filesystem::path path, std::string store_type) {
+  std::filesystem::path path, std::string store_type,
+  caf::message_priority priority) {
   // Configure our actor state.
   self->state().self = self;
   self->state().filesystem = std::move(filesystem);
@@ -164,18 +165,25 @@ default_passive_store_actor::behavior_type default_passive_store(
   self->state().path = std::move(path);
   self->state().store_type = std::move(store_type);
   // Load data from disk.
-  self->mail(atom::mmap_v, self->state().path)
-    .request(self->state().filesystem, caf::infinite)
-    .await(
-      [self](chunk_ptr& chunk) {
-        auto load_error = self->state().store->load(std::move(chunk));
-        if (load_error.valid()) {
-          self->quit(std::move(load_error));
-        }
-      },
-      [self](caf::error& error) {
-        self->quit(std::move(error));
-      });
+  auto on_chunk = [self](chunk_ptr& chunk) {
+    auto load_error = self->state().store->load(std::move(chunk));
+    if (load_error.valid()) {
+      self->quit(std::move(load_error));
+    }
+  };
+  auto on_error = [self](caf::error& error) {
+    self->quit(std::move(error));
+  };
+  if (priority == caf::message_priority::high) {
+    self->mail(atom::mmap_v, self->state().path)
+      .urgent()
+      .request(self->state().filesystem, caf::infinite)
+      .await(std::move(on_chunk), std::move(on_error));
+  } else {
+    self->mail(atom::mmap_v, self->state().path)
+      .request(self->state().filesystem, caf::infinite)
+      .await(std::move(on_chunk), std::move(on_error));
+  }
   return {
     [self](atom::query,
            const query_context& query_context) -> caf::result<uint64_t> {


### PR DESCRIPTION
## Summary
- The node has a single, node-wide filesystem actor that serializes all disk I/O. Busy `context` enrichment pipelines (e.g. using `lookup`) flood it with retro-scan reads, starving concurrent `export` operations.
- `export` (and internally `diagnostics`/`metrics`, which share its implementation) now sends its partition-load requests to the filesystem actor with high priority by default, so it no longer waits behind background enrichment reads.

<sub>
📎 Companion: tenzir/tenzir-plugins#579
</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)