### PR TITLE
Retitle historical releases

### DIFF
--- a/changelog/releases/v1.0.0/manifest.yaml
+++ b/changelog/releases/v1.0.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2022-01-27
-title: "VAST v1.0.0"
+title: "Projection and selection plugins"

--- a/changelog/releases/v1.1.0/manifest.yaml
+++ b/changelog/releases/v1.1.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2022-03-03
-title: "VAST v1.1.0"
+title: "New query language and aggregations"

--- a/changelog/releases/v1.1.1/manifest.yaml
+++ b/changelog/releases/v1.1.1/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2022-03-25
-title: "VAST v1.1.1"
+title: "Backported bug fixes"

--- a/changelog/releases/v1.1.2/manifest.yaml
+++ b/changelog/releases/v1.1.2/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2022-03-29
-title: "VAST v1.1.2"
+title: "Exporter timeout race fix"

--- a/changelog/releases/v2.0.0/manifest.yaml
+++ b/changelog/releases/v2.0.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2022-05-16
-title: "VAST v2.0.0"
+title: "Dedicated partitions and transform compaction"

--- a/changelog/releases/v2.1.0/manifest.yaml
+++ b/changelog/releases/v2.1.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2022-07-07
-title: "VAST v2.1.0"
+title: "Parquet stores and rebuild command"

--- a/changelog/releases/v2.2.0/manifest.yaml
+++ b/changelog/releases/v2.2.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2022-08-05
-title: "VAST v2.2.0"
+title: "Summarize and pipeline operators"

--- a/changelog/releases/v2.3.0/manifest.yaml
+++ b/changelog/releases/v2.3.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2022-09-01
-title: "VAST v2.3.0"
+title: "Cloud matchers and reliable rebuilds"

--- a/changelog/releases/v2.3.1/manifest.yaml
+++ b/changelog/releases/v2.3.1/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2022-10-14
-title: "VAST v2.3.1"
+title: "Corrupted partition recovery"

--- a/changelog/releases/v2.4.0/manifest.yaml
+++ b/changelog/releases/v2.4.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2022-12-09
-title: "VAST v2.4.0"
+title: "Feather stores and Cloud MISP"

--- a/changelog/releases/v2.4.1/manifest.yaml
+++ b/changelog/releases/v2.4.1/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2022-12-19
-title: "VAST v2.4.1"
+title: "Incremental Feather reads"

--- a/changelog/releases/v2.4.2/manifest.yaml
+++ b/changelog/releases/v2.4.2/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2023-03-31
-title: "VAST v2.4.2"
+title: "Safer rebuilds alongside queries"

--- a/changelog/releases/v3.0.0/manifest.yaml
+++ b/changelog/releases/v3.0.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2023-03-14
-title: "VAST v3.0.0"
+title: "Pipeline language and web API overhaul"

--- a/changelog/releases/v3.0.1/manifest.yaml
+++ b/changelog/releases/v3.0.1/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2023-03-16
-title: "VAST v3.0.1"
+title: "Rebuild and legacy partition fixes"

--- a/changelog/releases/v3.0.2/manifest.yaml
+++ b/changelog/releases/v3.0.2/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2023-03-21
-title: "VAST v3.0.2"
+title: "Rebuild metrics fix"

--- a/changelog/releases/v3.0.3/manifest.yaml
+++ b/changelog/releases/v3.0.3/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2023-03-31
-title: "VAST v3.0.3"
+title: "Safer rebuilds and Boost support"

--- a/changelog/releases/v3.0.4/manifest.yaml
+++ b/changelog/releases/v3.0.4/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2023-04-18
-title: "VAST v3.0.4"
+title: "Rebuild partition selection fix"

--- a/changelog/releases/v3.1.0/manifest.yaml
+++ b/changelog/releases/v3.1.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2023-05-12
-title: "VAST v3.1.0"
+title: "Distributed pipeline executor"

--- a/changelog/releases/v4.0.0/manifest.yaml
+++ b/changelog/releases/v4.0.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2023-08-07
-title: "Tenzir Node v4.0.0"
+title: "Tenzir rebrand and pipeline UX"

--- a/changelog/releases/v4.0.1/manifest.yaml
+++ b/changelog/releases/v4.0.1/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2023-08-09
-title: "Tenzir Node v4.0.1"
+title: "Schema replacement in pipelines"

--- a/changelog/releases/v4.1.0/manifest.yaml
+++ b/changelog/releases/v4.1.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2023-08-31
-title: "Tenzir Node v4.1.0"
+title: "Sigma, compression, and show commands"

--- a/changelog/releases/v4.10.0/manifest.yaml
+++ b/changelog/releases/v4.10.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-03-11
-title: "Tenzir Node v4.10.0"
+title: "Configurable pipelines"

--- a/changelog/releases/v4.10.1/manifest.yaml
+++ b/changelog/releases/v4.10.1/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-03-11
-title: "Tenzir Node v4.10.1"
+title: "Configured pipeline startup fix"

--- a/changelog/releases/v4.10.3/manifest.yaml
+++ b/changelog/releases/v4.10.3/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-03-12
-title: "Tenzir Node v4.10.3"
+title: "Lookup and platform reconnect fixes"

--- a/changelog/releases/v4.10.4/manifest.yaml
+++ b/changelog/releases/v4.10.4/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-03-13
-title: "Tenzir Node v4.10.4"
+title: "Context, Python, and Sigma fixes"

--- a/changelog/releases/v4.11.0/manifest.yaml
+++ b/changelog/releases/v4.11.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-03-22
-title: "Tenzir Node v4.11.0"
+title: "SQS connector and context controls"

--- a/changelog/releases/v4.11.2/manifest.yaml
+++ b/changelog/releases/v4.11.2/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-03-26
-title: "Tenzir Node v4.11.2"
+title: "Python setup failure fix"

--- a/changelog/releases/v4.12.0/manifest.yaml
+++ b/changelog/releases/v4.12.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-04-24
-title: "Tenzir Node v4.12.0"
+title: "Configurable contexts and BITZ format"

--- a/changelog/releases/v4.12.1/manifest.yaml
+++ b/changelog/releases/v4.12.1/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-04-26
-title: "Tenzir Node v4.12.1"
+title: "Unified edition builds"

--- a/changelog/releases/v4.12.2/manifest.yaml
+++ b/changelog/releases/v4.12.2/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-04-30
-title: "Tenzir Node v4.12.2"
+title: "Schema dumping and shutdown fixes"

--- a/changelog/releases/v4.13.0/manifest.yaml
+++ b/changelog/releases/v4.13.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-05-10
-title: "Tenzir Node v4.13.0"
+title: "LEEF parser and cron operator"

--- a/changelog/releases/v4.13.1/manifest.yaml
+++ b/changelog/releases/v4.13.1/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-05-14
-title: "Tenzir Node v4.13.1"
+title: "Slice and partition cleanup fixes"

--- a/changelog/releases/v4.14.0/manifest.yaml
+++ b/changelog/releases/v4.14.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-05-17
-title: "Tenzir Node v4.14.0"
+title: "Statistical aggregations and slice strides"

--- a/changelog/releases/v4.15.0/manifest.yaml
+++ b/changelog/releases/v4.15.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-05-31
-title: "Tenzir Node v4.15.0"
+title: "Managed pipelines and RPM packages"

--- a/changelog/releases/v4.15.1/manifest.yaml
+++ b/changelog/releases/v4.15.1/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-05-31
-title: "Tenzir Node v4.15.1"
+title: "Demo node entrypoint fix"

--- a/changelog/releases/v4.15.2/manifest.yaml
+++ b/changelog/releases/v4.15.2/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-05-31
-title: "Tenzir Node v4.15.2"
+title: "Pipeline state shutdown fix"

--- a/changelog/releases/v4.16.0/manifest.yaml
+++ b/changelog/releases/v4.16.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-06-05
-title: "Tenzir Node v4.16.0"
+title: "Percentiles and lookup deletion"

--- a/changelog/releases/v4.17.0/manifest.yaml
+++ b/changelog/releases/v4.17.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-06-21
-title: "Tenzir Node v4.17.0"
+title: "Azure Log Analytics and diagnostics"

--- a/changelog/releases/v4.17.1/manifest.yaml
+++ b/changelog/releases/v4.17.1/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-06-21
-title: "Tenzir Node v4.17.1"
+title: "Component dependency revert"

--- a/changelog/releases/v4.17.2/manifest.yaml
+++ b/changelog/releases/v4.17.2/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-06-24
-title: "Tenzir Node v4.17.2"
+title: "Diagnostics and metrics fixes"

--- a/changelog/releases/v4.17.3/manifest.yaml
+++ b/changelog/releases/v4.17.3/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-06-25
-title: "Tenzir Node v4.17.3"
+title: "Configured context deletion fix"

--- a/changelog/releases/v4.17.4/manifest.yaml
+++ b/changelog/releases/v4.17.4/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-06-27
-title: "Tenzir Node v4.17.4"
+title: "Configured pipeline crash fixes"

--- a/changelog/releases/v4.18.0/manifest.yaml
+++ b/changelog/releases/v4.18.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-07-11
-title: "Tenzir Node v4.18.0"
+title: "API metrics and export revamp"

--- a/changelog/releases/v4.18.1/manifest.yaml
+++ b/changelog/releases/v4.18.1/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-07-12
-title: "Tenzir Node v4.18.1"
+title: "Node-to-node connection controls"

--- a/changelog/releases/v4.18.2/manifest.yaml
+++ b/changelog/releases/v4.18.2/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-07-15
-title: "Tenzir Node v4.18.2"
+title: "Export bridge shutdown fix"

--- a/changelog/releases/v4.18.3/manifest.yaml
+++ b/changelog/releases/v4.18.3/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-07-16
-title: "Tenzir Node v4.18.3"
+title: "Live export memory fix"

--- a/changelog/releases/v4.18.4/manifest.yaml
+++ b/changelog/releases/v4.18.4/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-07-17
-title: "Tenzir Node v4.18.4"
+title: "Hidden subscriber backpressure fix"

--- a/changelog/releases/v4.18.5/manifest.yaml
+++ b/changelog/releases/v4.18.5/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-07-19
-title: "Tenzir Node v4.18.5"
+title: "New unflatten implementation"

--- a/changelog/releases/v4.19.0/manifest.yaml
+++ b/changelog/releases/v4.19.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-07-26
-title: "Tenzir Node v4.19.0"
+title: "Package manager and buffer operator"

--- a/changelog/releases/v4.19.1/manifest.yaml
+++ b/changelog/releases/v4.19.1/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-08-02
-title: "Tenzir Node v4.19.1"
+title: "AMQP heartbeat fix"

--- a/changelog/releases/v4.19.2/manifest.yaml
+++ b/changelog/releases/v4.19.2/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-08-06
-title: "Tenzir Node v4.19.2"
+title: "Throttle operator and demand controls"

--- a/changelog/releases/v4.19.3/manifest.yaml
+++ b/changelog/releases/v4.19.3/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-08-06
-title: "Tenzir Node v4.19.3"
+title: "Packaged pipeline state fix"

--- a/changelog/releases/v4.19.4/manifest.yaml
+++ b/changelog/releases/v4.19.4/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-08-08
-title: "Tenzir Node v4.19.4"
+title: "Packages plugin packaging fix"

--- a/changelog/releases/v4.19.5/manifest.yaml
+++ b/changelog/releases/v4.19.5/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-08-13
-title: "Tenzir Node v4.19.5"
+title: "Serve CPU usage fix"

--- a/changelog/releases/v4.19.6/manifest.yaml
+++ b/changelog/releases/v4.19.6/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-08-15
-title: "Tenzir Node v4.19.6"
+title: "Assert operator and shell fixes"

--- a/changelog/releases/v4.2.0/manifest.yaml
+++ b/changelog/releases/v4.2.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2023-09-19
-title: "Tenzir Node v4.2.0"
+title: "Cloud connectors and network sources"

--- a/changelog/releases/v4.20.0/manifest.yaml
+++ b/changelog/releases/v4.20.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-08-30
-title: "Tenzir Node v4.20.0"
+title: "Cache operator and unstoppable pipelines"

--- a/changelog/releases/v4.20.1/manifest.yaml
+++ b/changelog/releases/v4.20.1/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-09-02
-title: "Tenzir Node v4.20.1"
+title: "Pipeline launch cache fix"

--- a/changelog/releases/v4.20.2/manifest.yaml
+++ b/changelog/releases/v4.20.2/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-09-06
-title: "Tenzir Node v4.20.2"
+title: "OCSF schemas and connector fixes"

--- a/changelog/releases/v4.20.3/manifest.yaml
+++ b/changelog/releases/v4.20.3/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-09-09
-title: "Tenzir Node v4.20.3"
+title: "Serve retry and latency fixes"

--- a/changelog/releases/v4.21.0/manifest.yaml
+++ b/changelog/releases/v4.21.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-10-04
-title: "Tenzir Node v4.21.0"
+title: "Precise parsing and Azure Blob Storage"

--- a/changelog/releases/v4.21.1/manifest.yaml
+++ b/changelog/releases/v4.21.1/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-10-11
-title: "Tenzir Node v4.21.1"
+title: "Grok precision and sample operator"

--- a/changelog/releases/v4.22.0/manifest.yaml
+++ b/changelog/releases/v4.22.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-10-18
-title: "Tenzir Node v4.22.0"
+title: "Google Cloud Pub/Sub connectors"

--- a/changelog/releases/v4.22.1/manifest.yaml
+++ b/changelog/releases/v4.22.1/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-10-23
-title: "Tenzir Node v4.22.1"
+title: "TQL2 aggregations and serve fixes"

--- a/changelog/releases/v4.22.2/manifest.yaml
+++ b/changelog/releases/v4.22.2/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-10-28
-title: "Tenzir Node v4.22.2"
+title: "Value counts and sort functions"

--- a/changelog/releases/v4.23.0/manifest.yaml
+++ b/changelog/releases/v4.23.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-11-07
-title: "Tenzir Node v4.23.0"
+title: "Universal functions and Splunk sink"

--- a/changelog/releases/v4.23.1/manifest.yaml
+++ b/changelog/releases/v4.23.1/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-11-21
-title: "Tenzir Node v4.23.1"
+title: "Docker and TQL2 bug fixes"

--- a/changelog/releases/v4.24.0/manifest.yaml
+++ b/changelog/releases/v4.24.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-12-03
-title: "Tenzir Node v4.24.0"
+title: "TQL2 contexts and I/O operators"

--- a/changelog/releases/v4.24.1/manifest.yaml
+++ b/changelog/releases/v4.24.1/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-12-12
-title: "Tenzir Node v4.24.1"
+title: "Aggregation and startup fixes"

--- a/changelog/releases/v4.25.0/manifest.yaml
+++ b/changelog/releases/v4.25.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2025-01-09
-title: "Tenzir Node v4.25.0"
+title: "Search sinks and TQL2-only mode"

--- a/changelog/releases/v4.26.0/manifest.yaml
+++ b/changelog/releases/v4.26.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2025-01-22
-title: "Tenzir Node v4.26.0"
+title: "TQL printer and CAF metrics"

--- a/changelog/releases/v4.27.0/manifest.yaml
+++ b/changelog/releases/v4.27.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2025-01-30
-title: "Tenzir Node v4.27.0"
+title: "Chart operators and retention settings"

--- a/changelog/releases/v4.28.0/manifest.yaml
+++ b/changelog/releases/v4.28.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2025-02-10
-title: "Tenzir Node v4.28.0"
+title: "Parsing functions and standard streams"

--- a/changelog/releases/v4.28.2/manifest.yaml
+++ b/changelog/releases/v4.28.2/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2025-02-13
-title: "Tenzir Node v4.28.2"
+title: "Chart fill and AMQP fixes"

--- a/changelog/releases/v4.29.0/manifest.yaml
+++ b/changelog/releases/v4.29.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2025-02-25
-title: "Tenzir Node v4.29.0"
+title: "Duration and print functions"

--- a/changelog/releases/v4.29.1/manifest.yaml
+++ b/changelog/releases/v4.29.1/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2025-03-03
-title: "Tenzir Node v4.29.1"
+title: "Pipeline IDs and UDO fixes"

--- a/changelog/releases/v4.29.2/manifest.yaml
+++ b/changelog/releases/v4.29.2/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2025-03-11
-title: "Tenzir Node v4.29.2"
+title: "Load TCP diagnostics and cache fixes"

--- a/changelog/releases/v4.3.0/manifest.yaml
+++ b/changelog/releases/v4.3.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2023-10-10
-title: "Tenzir Node v4.3.0"
+title: "YAML support and pipeline labels"

--- a/changelog/releases/v4.30.0/manifest.yaml
+++ b/changelog/releases/v4.30.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2025-03-18
-title: "Tenzir Node v4.30.0"
+title: "ClickHouse sink and pipeline metrics"

--- a/changelog/releases/v4.30.1/manifest.yaml
+++ b/changelog/releases/v4.30.1/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2025-03-20
-title: "Tenzir Node v4.30.1"
+title: "Importer rebatching"

--- a/changelog/releases/v4.30.2/manifest.yaml
+++ b/changelog/releases/v4.30.2/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2025-03-22
-title: "Tenzir Node v4.30.2"
+title: "Fluent Bit shutdown fix"

--- a/changelog/releases/v4.30.3/manifest.yaml
+++ b/changelog/releases/v4.30.3/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2025-03-25
-title: "Tenzir Node v4.30.3"
+title: "Fluent Bit and Azure fixes"

--- a/changelog/releases/v4.31.0/manifest.yaml
+++ b/changelog/releases/v4.31.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2025-03-31
-title: "Tenzir Node v4.31.0"
+title: "Conditional expressions and OpenSearch source"

--- a/changelog/releases/v4.31.2/manifest.yaml
+++ b/changelog/releases/v4.31.2/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2025-04-01
-title: "Tenzir Node v4.31.2"
+title: "Hive compression and builder limits"

--- a/changelog/releases/v4.32.0/manifest.yaml
+++ b/changelog/releases/v4.32.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2025-04-04
-title: "Tenzir Node v4.32.0"
+title: "Google SecOps sink"

--- a/changelog/releases/v4.32.1/manifest.yaml
+++ b/changelog/releases/v4.32.1/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2025-04-08
-title: "Tenzir Node v4.32.1"
+title: "Google SecOps request sizing"

--- a/changelog/releases/v4.4.0/manifest.yaml
+++ b/changelog/releases/v4.4.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2023-11-06
-title: "Tenzir Node v4.4.0"
+title: "AMQP, YARA, and Velociraptor"

--- a/changelog/releases/v4.5.0/manifest.yaml
+++ b/changelog/releases/v4.5.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2023-11-16
-title: "Tenzir Node v4.5.0"
+title: "API source and operator controls"

--- a/changelog/releases/v4.6.0/manifest.yaml
+++ b/changelog/releases/v4.6.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2023-12-01
-title: "Tenzir Node v4.6.0"
+title: "Unified I/O and Python operator"

--- a/changelog/releases/v4.6.3/manifest.yaml
+++ b/changelog/releases/v4.6.3/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2023-12-04
-title: "Tenzir Node v4.6.3"
+title: "Debian migration fix"

--- a/changelog/releases/v4.6.4/manifest.yaml
+++ b/changelog/releases/v4.6.4/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2023-12-07
-title: "Tenzir Node v4.6.4"
+title: "Syslog and YAML fixes"

--- a/changelog/releases/v4.7.0/manifest.yaml
+++ b/changelog/releases/v4.7.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2023-12-19
-title: "Tenzir Node v4.7.0"
+title: "GeoIP context and grok parser"

--- a/changelog/releases/v4.7.1/manifest.yaml
+++ b/changelog/releases/v4.7.1/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2023-12-20
-title: "Tenzir Node v4.7.1"
+title: "Pipeline push behavior fix"

--- a/changelog/releases/v4.8.0/manifest.yaml
+++ b/changelog/releases/v4.8.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-01-22
-title: "Tenzir Node v4.8.0"
+title: "Diagnostics, lookup, and GELF support"

--- a/changelog/releases/v4.8.1/manifest.yaml
+++ b/changelog/releases/v4.8.1/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-01-23
-title: "Tenzir Node v4.8.1"
+title: "AMQP static binary fix"

--- a/changelog/releases/v4.8.2/manifest.yaml
+++ b/changelog/releases/v4.8.2/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-01-24
-title: "Tenzir Node v4.8.2"
+title: "Unflatten and idle scheduling fixes"

--- a/changelog/releases/v4.9.0/manifest.yaml
+++ b/changelog/releases/v4.9.0/manifest.yaml
@@ -1,2 +1,2 @@
 created: 2024-02-21
-title: "Tenzir Node v4.9.0"
+title: "Context management and Bloom filters"

--- a/changelog/releases/v5.22.2/manifest.yaml
+++ b/changelog/releases/v5.22.2/manifest.yaml
@@ -1,5 +1,5 @@
 created: 2025-12-21
-title: Tenzir Node v5.22.2
+title: "Parser performance and duplicate keys"
 intro: >-
   This release fixes a performance regression when parsing lists with mixed-type elements,
   where batch processing was inadvertently broken. It also resolves an assertion failure

--- a/changelog/releases/v5.23.0/manifest.yaml
+++ b/changelog/releases/v5.23.0/manifest.yaml
@@ -1,5 +1,5 @@
 created: 2025-12-23
-title: Tenzir Node v5.23.0
+title: "Node-level TLS configuration"
 intro: >-
   This release introduces centralized node-level TLS configuration, allowing you to
   configure TLS settings once in tenzir.yaml instead of passing options to each operator

--- a/changelog/releases/v5.23.1/manifest.yaml
+++ b/changelog/releases/v5.23.1/manifest.yaml
@@ -1,5 +1,5 @@
 created: 2026-01-02
-title: Tenzir Node v5.23.1
+title: "Heterogeneous evaluation fixes"
 intro: >-
   This release fixes internal errors in expression evaluation for heterogeneous data,
   resolves a crash in the  operator when using , and ensures the  connector shuts

--- a/changelog/releases/v5.24.0/manifest.yaml
+++ b/changelog/releases/v5.24.0/manifest.yaml
@@ -1,5 +1,5 @@
 created: 2026-01-16
-title: Tenzir Node v5.24.0
+title: "XML parsing and parallel pipelines"
 intro: >-
   This release adds XML parsing functions (`parse_xml` and `parse_winlog`) for analyzing
   XML-formatted logs including Windows Event Logs. It also introduces the `parallel`

--- a/changelog/releases/v5.25.0/manifest.yaml
+++ b/changelog/releases/v5.25.0/manifest.yaml
@@ -1,5 +1,5 @@
 created: 2026-01-27
-title: Tenzir Node v5.25.0
+title: "Periodic summarize and AWS IAM"
 intro: >-
   This release adds periodic emission to the summarize operator, enabling real-time
   streaming analytics with configurable intervals and accumulation modes. It also

--- a/changelog/releases/v5.25.1/manifest.yaml
+++ b/changelog/releases/v5.25.1/manifest.yaml
@@ -1,5 +1,5 @@
 created: 2026-01-30
-title: Tenzir Node v5.25.1
+title: "Kafka decompression and parser fixes"
 intro: >-
   This release includes several bug fixes for the JSON parser, `where`, `replace`,
   and `if` operators, along with Kafka decompression support and a new `raw_message`

--- a/changelog/releases/v5.25.2/manifest.yaml
+++ b/changelog/releases/v5.25.2/manifest.yaml
@@ -1,4 +1,4 @@
 created: 2026-02-09
-title: Tenzir Node v5.25.2
+title: "Sigma directory loading fix"
 intro: >-
   This release fixes the sigma operator to correctly load all rule files from a directory.

--- a/changelog/releases/v5.27.0/manifest.yaml
+++ b/changelog/releases/v5.27.0/manifest.yaml
@@ -1,5 +1,5 @@
 created: 2026-02-24
-title: Tenzir Node v5.27.0
+title: "Sort comparators and list slicing"
 intro: >-
   This release enhances the sort function with custom comparators and descending order
   support, and extends the slice function to work with lists.

--- a/changelog/releases/v5.27.1/manifest.yaml
+++ b/changelog/releases/v5.27.1/manifest.yaml
@@ -1,5 +1,5 @@
 created: 2026-02-25
-title: Tenzir Node v5.27.1
+title: "Platform client certificate fix"
 intro: >-
   This release fixes an issue where the platform plugin did not correctly use the
   configured certfile, keyfile, and cafile options for client certificate authentication.

--- a/changelog/releases/v5.27.2/manifest.yaml
+++ b/changelog/releases/v5.27.2/manifest.yaml
@@ -1,5 +1,5 @@
 created: 2026-02-27
-title: Tenzir Node v5.27.2
+title: "HMAC and slicing fixes"
 intro: >-
   This release adds the hmac function for computing Hash-based Message Authentication
   Codes over strings and blobs. It also fixes an assertion failure in array slicing

--- a/changelog/releases/v5.27.3/manifest.yaml
+++ b/changelog/releases/v5.27.3/manifest.yaml
@@ -1,5 +1,5 @@
 created: 2026-03-03
-title: Tenzir Node v5.27.3
+title: "JSON and CEF parser fixes"
 intro: >-
   This release fixes a crash that could occur when reading JSON data. It also improves
   CEF parsing to handle non-conforming unescaped equals characters.

--- a/changelog/releases/v5.28.0/manifest.yaml
+++ b/changelog/releases/v5.28.0/manifest.yaml
@@ -1,5 +1,5 @@
 created: 2026-03-06
-title: Tenzir Node v5.28.0
+title: "Check Point syslog parsing"
 intro: >-
   This release adds support for parsing Check Point syslog structured-data dialects
   that deviate from RFC 5424, improving out-of-the-box interoperability with Check

--- a/changelog/releases/v5.29.1/manifest.yaml
+++ b/changelog/releases/v5.29.1/manifest.yaml
@@ -1,5 +1,5 @@
 created: 2026-03-16
-title: Tenzir Node v5.29.1
+title: "Detached operator scheduling fix"
 intro: >-
   This release fixes a scheduling issue introduced in v5.24.0 that could cause the
   node to become unresponsive when too many pipelines using detached operators were

--- a/changelog/releases/v5.29.3/manifest.yaml
+++ b/changelog/releases/v5.29.3/manifest.yaml
@@ -1,5 +1,5 @@
 created: 2026-03-20
-title: Tenzir Node v5.29.3
+title: "Maintenance release automation"
 intro: >-
   This patch release keeps the 5.29 line moving with a small maintenance update and
   validates the refreshed release automation. It ships as a clean follow-up release

--- a/changelog/releases/v5.34.0/manifest.yaml
+++ b/changelog/releases/v5.34.0/manifest.yaml
@@ -1,5 +1,5 @@
 created: 2026-04-27
-title: Tenzir Node v5.34.0
+title: "Internal maintenance"
 intro: >-
   This release contains internal changes only.
 source:

--- a/changelog/releases/v6.0.0/manifest.yaml
+++ b/changelog/releases/v6.0.0/manifest.yaml
@@ -1,5 +1,5 @@
 created: 2026-06-01
-title: Tenzir Node v6.0.0
+title: "Rewritten execution engine"
 intro: >-
   Tenzir v6 ships with a rewritten execution engine that unlocks faster, more capable,
   and more scalable pipelines. Refer to the migration guide at https://tenzir.com/docs/guides/tenzir-v6-migration

--- a/changelog/releases/v6.1.0/manifest.yaml
+++ b/changelog/releases/v6.1.0/manifest.yaml
@@ -1,5 +1,5 @@
 created: 2026-06-09
-title: Tenzir v6.1.0
+title: "Event-time windowing"
 intro: "This release introduces the `window` operator for event-time windowing, which\
   \ groups streaming events into configurable time windows driven by event timestamps\
   \ rather than wall-clock time. It also adds several new operators \u2014 `ai::prompt`\

--- a/changelog/releases/v6.3.0/manifest.yaml
+++ b/changelog/releases/v6.3.0/manifest.yaml
@@ -1,5 +1,5 @@
 created: 2026-06-24
-title: Tenzir v6.3.0
+title: "Graceful pipeline shutdown"
 intro: >-
   Tenzir now drains in-flight data before stopping pipelines or shutting down a node,
   so you no longer lose events on shutdown. This release also improves diagnostics

--- a/changelog/releases/v6.4.0/manifest.yaml
+++ b/changelog/releases/v6.4.0/manifest.yaml
@@ -1,5 +1,5 @@
 created: 2026-06-29
-title: Tenzir v6.4.0
+title: "Package constants and ClickHouse JSON"
 intro: >-
   Packages can now define reusable constants that any pipeline can reference, and
   the to_clickhouse operator supports native ClickHouse JSON columns. Nodes can also

--- a/changelog/releases/v6.5.0/manifest.yaml
+++ b/changelog/releases/v6.5.0/manifest.yaml
@@ -1,5 +1,5 @@
 created: 2026-07-03
-title: Tenzir v6.5.0
+title: "Reliability fixes and faster summarize"
 intro: >-
   This release resolves several node reliability issues and improves summarize throughput
   on interleaved-key inputs. It also adds the map_keys function and changes hive-partitioned


### PR DESCRIPTION
## 🔍 Problem

- Many historical changelog releases use only the product name and version as their title.
- Those titles make release listings hard to scan because they hide the release headline.
- The release workflow still allowed future releases to omit a human-readable title.

## 🛠️ Solution

- Replace version-only release manifest titles with concise headlines based on each release's entries or intro.
- Require release workflow callers to provide a short user-facing title and validate that it is not empty.
- Leave the release notes and changelog entries themselves unchanged.

## 💬 Review

- Focus on whether the selected headlines capture the main theme for older VAST and Tenzir Node releases.
- Check whether making release titles mandatory fits the release process.
