### PR TITLE
Fix integration test reference

### DIFF
--- a/test/tests/functions/record/map_keys_non_lambda.txt
+++ b/test/tests/functions/record/map_keys_non_lambda.txt
@@ -5,4 +5,4 @@ error: expected a lambda
    |                            ^^^^ 
    |
    = usage: map_keys(x:record, function:string => string)
-   = docs: https://docs.tenzir.com/reference/functions/map_keys
+   = docs: https://tenzir.com/docs/reference/functions/map_keys


### PR DESCRIPTION
The integration test reference got merged before re-generating the
references, thus a the new `map_keys` tests added after its merge-base
are now incorrect.
