### PR TITLE
Fix stopping of `export`, `every`, and `serve` pipelines

### DIFF
--- a/changelog/unreleased/reliable-completion-of-serve-pipelines.md
+++ b/changelog/unreleased/reliable-completion-of-serve-pipelines.md
@@ -1,0 +1,17 @@
+---
+title: Shutdown hangs and reports unresponsive pipelines
+type: bugfix
+authors:
+  - aljazerzen
+prs:
+  - 6428
+created: 2026-07-07T12:45:14.848087Z
+---
+
+Some internal pipelines and pipelines that use `every` operator, might not
+shutdown correctly when the pipeline is stopped. This can stall the node
+shutdown procedure and flood the logs with "logic error" messages.
+
+Additionally, error diagnostics from pipelines that fail while stopping are no
+longer lost. They now show up in the pipeline's diagnostics instead of a
+generic `pipeline failed` message.

--- a/libtenzir/builtins/operators/every.cpp
+++ b/libtenzir/builtins/operators/every.cpp
@@ -6,6 +6,7 @@
 // SPDX-FileCopyrightText: (c) 2024 The Tenzir Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+#include <tenzir/async/executor.hpp>
 #include <tenzir/async/semaphore.hpp>
 #include <tenzir/async/task.hpp>
 #include <tenzir/ir.hpp>
@@ -15,13 +16,15 @@
 #include <tenzir/plugin.hpp>
 #include <tenzir/try.hpp>
 
+#include <folly/CancellationToken.h>
+#include <folly/coro/CurrentExecutor.h>
+#include <folly/coro/Error.h>
 #include <folly/coro/Sleep.h>
+#include <folly/coro/WithCancellation.h>
 
 namespace tenzir::plugins::every_cron {
 
 namespace {
-
-using std::chrono::steady_clock;
 
 struct EveryArgs {
   duration interval = {};
@@ -40,16 +43,40 @@ struct EveryImpl {
   }
 
   auto await_task_impl() const -> Task<Any> {
-    // Start the timer once the subpipeline was actually started. This makes it
-    // so that it runs for the specified interval. The time it takes for it to
-    // close before starting the new pipelines is added on top of that. We could
-    // also do it differently and aim for the total time to match the specified
-    // interval. But if the subpipeline is slow to shut down (e.g., `to_http`
-    // sending requests), then we run into trouble when the interval is short.
-    // Hence we're going with the former, safer alternative for now.
-    auto permit = co_await sleep_permits_.acquire();
-    co_await sleep_for(args_.interval);
-    co_return permit;
+    // Run the interval timer under a token that also fires when we request a
+    // stop on `stop_source_`, so a stop can interrupt us even while we are
+    // still waiting for the permit. Acquiring the permit outside the
+    // cancellation scope would park this task on the semaphore, out of reach
+    // of the stop token, whenever the permit is still held (e.g., a previous
+    // interval fired but its subpipeline has not finished yet), so a
+    // concurrent stop could not wake us and shutdown would hang.
+    //
+    // The permit is acquired only once the previous subpipeline released it,
+    // so the interval timer starts after the subpipeline was actually
+    // started. The time it takes to close before starting the new pipelines
+    // is added on top of that. We could also aim for the total time to match
+    // the specified interval, but if the subpipeline is slow to shut down
+    // (e.g., `to_http` sending requests), then we run into trouble when the
+    // interval is short. Hence we're going with the former, safer alternative.
+    auto outer = co_await folly::coro::co_current_cancellation_token;
+    auto result
+      = co_await folly::coro::co_awaitTry(folly::coro::co_withCancellation(
+        folly::cancellation_token_merge(outer, stop_source_.getToken()),
+        folly::coro::co_invoke(
+          [this, interval = args_.interval]() mutable -> Task<SemaphorePermit> {
+            auto permit = co_await sleep_permits_.acquire();
+            co_await sleep_for(interval);
+            co_return std::move(permit);
+          })));
+    if (result.hasValue()) {
+      co_return std::move(result).value();
+    }
+    // The wait was cancelled by the whole pipeline shutting down; propagate.
+    if (outer.isCancellationRequested()) {
+      co_yield folly::coro::co_stopped_may_throw;
+    }
+    co_await wait_forever();
+    TENZIR_UNREACHABLE();
   }
 
   auto process_task_impl(Any result, OpCtx& ctx) -> Task<void> {
@@ -77,6 +104,8 @@ struct EveryImpl {
   // TODO: Clean this up with the upcoming subpipelines PR.
   auto finalize_impl() -> FinalizeBehavior {
     stop_spawning_ = true;
+    // Cancel a pending `await_task` so it stops instead of arming a new timer.
+    stop_source_.requestCancellation();
     return FinalizeBehavior::done;
   }
 
@@ -84,6 +113,7 @@ struct EveryImpl {
     requires(std::same_as<Input, void>)
   {
     stop_spawning_ = true;
+    stop_source_.requestCancellation();
   }
 
   auto state_impl() -> OperatorState {
@@ -146,6 +176,7 @@ struct EveryImpl {
   int64_t next_sub_id_ = 0;
   bool sub_finished_ = false;
   bool stop_spawning_ = false;
+  folly::CancellationSource stop_source_;
 };
 
 template <class Input, class Output>

--- a/libtenzir/builtins/operators/serve.cpp
+++ b/libtenzir/builtins/operators/serve.cpp
@@ -48,6 +48,7 @@
 
 #include "tenzir/async.hpp"
 #include "tenzir/async/mail.hpp"
+#include "tenzir/box.hpp"
 #include "tenzir/detail/fanout_counter.hpp"
 
 #include <tenzir/actors.hpp>
@@ -76,6 +77,7 @@
 #include <caf/send.hpp>
 #include <caf/stateful_actor.hpp>
 #include <caf/typed_event_based_actor.hpp>
+#include <folly/coro/BoundedQueue.h>
 
 #include <sstream>
 
@@ -444,9 +446,10 @@ using serve_manager_actor = typed_actor_fwd<
     ->caf::result<void>,
   // Drop all buffered data and complete immediately, without waiting for the
   // data to be drained to the client.
-  auto(atom::stop, std::string serve_id)->caf::result<void>,
+  auto(atom::stop, std::string serve_id, caf::actor source)->caf::result<void>,
   // Deregister a serve operator, waiting until it completed.
-  auto(atom::shutdown, std::string serve_id)->caf::result<void>,
+  auto(atom::shutdown, std::string serve_id, caf::actor source)
+    ->caf::result<void>,
   // Put additional slices into the buffer for the given access token.
   auto(atom::put, std::string serve_id, table_slice)->caf::result<void>,
   // Get slices from the buffer for the given access token, returning the next
@@ -536,15 +539,27 @@ struct managed_serve_operator {
     TENZIR_DEBUG("clearing continuation token");
     last_continuation_token = std::exchange(continuation_token, {});
     last_results = results;
-    if (stop_rp.pending() and buffer.empty()) {
+    // Emit the terminal response (null continuation token) once the source is
+    // gone and the buffer is drained. `stop_rp.pending()` covers the case
+    // where a client drains the buffer before finalization; `done` covers the
+    // case where finalization already happened without a waiter and a late
+    // client drains the retained buffer afterwards.
+    if ((stop_rp.pending() or done) and buffer.empty()) {
       TENZIR_ASSERT(not put_rp.pending());
       TENZIR_DEBUG("serve for id {} is done", escape_operator_arg(serve_id));
-      continuation_token.clear();
+      // Mark the operator done so that a client re-polling with the empty
+      // continuation token before the lifetime actor's DOWN is processed
+      // observes a completed state instead of queuing a request that hangs.
+      // Note: `continuation_token` was already cleared by the `std::exchange`
+      // above.
+      done = true;
       for (auto&& get_rp : std::exchange(get_rps, {})) {
         TENZIR_ASSERT(get_rp.pending());
         get_rp.deliver(std::make_tuple(std::string{}, results));
       }
-      stop_rp.deliver();
+      if (stop_rp.pending()) {
+        stop_rp.deliver();
+      }
       return true;
     }
     // If we throttled the serve operator, then we can continue its operation
@@ -581,7 +596,12 @@ struct serve_manager_state {
     const auto found = std::ranges::find_if(ops, [&](const auto& op) {
       return op.source == source;
     });
-    TENZIR_ASSERT(found != ops.end());
+    if (found == ops.end()) {
+      // The entry may already be gone, e.g., because it was removed on an
+      // earlier error path.
+      TENZIR_DEBUG("{} received DOWN for an unknown serve operator", *self);
+      return;
+    }
     if (not found->continuation_token.empty()) {
       TENZIR_DEBUG("{} received premature DOWN for serve id {} with "
                    "continuation "
@@ -620,13 +640,16 @@ struct serve_manager_state {
       return op.serve_id == serve_id;
     });
     if (found != ops.end()) {
-      if (not found->done) {
-        return caf::make_error(
-          ec::invalid_argument,
-          fmt::format("{} received duplicate serve id {}", *self,
-                      escape_operator_arg(found->serve_id)));
-      }
-      ops.erase(found);
+      // Reject any serve id that is still registered, even one that is `done`
+      // but lingering for the retention window. Replacing a live entry would
+      // let a stale `stop`/`shutdown` from the previous operator resolve
+      // against the new entry, so we require serve ids to be unique among
+      // registered operators. A serve id may be reused only once its entry
+      // has been fully removed.
+      return caf::make_error(ec::invalid_argument,
+                             fmt::format("{} received duplicate serve id {}",
+                                         *self,
+                                         escape_operator_arg(found->serve_id)));
     }
     if (not watched) {
       return caf::make_error(ec::invalid_argument,
@@ -647,16 +670,20 @@ struct serve_manager_state {
     return {};
   }
 
-  auto finalize(std::string serve_id) -> caf::result<void> {
+  auto finalize(std::string serve_id, caf::actor source) -> caf::result<void> {
+    const auto source_addr = source ? source->address() : caf::actor_addr{};
     const auto found
       = std::find_if(ops.begin(), ops.end(), [&](const auto& op) {
-          return op.serve_id == serve_id;
+          return op.serve_id == serve_id
+                 and (not source_addr or op.source == source_addr);
         });
     if (found == ops.end()) {
-      return caf::make_error(ec::invalid_argument,
-                             fmt::format("{} received request to despawn for "
-                                         "unknown serve id {}",
-                                         *self, escape_operator_arg(serve_id)));
+      // The entry was already removed, e.g., because the operator's DOWN was
+      // processed first. Treat the request as a no-op so the operator can
+      // finish instead of surfacing a spurious error.
+      TENZIR_DEBUG("{} ignores despawn request for unknown serve id {}", *self,
+                   escape_operator_arg(serve_id));
+      return {};
     }
     if (found->stop_rp.pending()) {
       return caf::make_error(ec::logic_error,
@@ -665,19 +692,45 @@ struct serve_manager_state {
                                          *self, escape_operator_arg(serve_id)));
     }
     found->stop_rp = self->make_response_promise<void>();
+    if (not found->get_rps.empty()) {
+      // A client is already waiting: deliver the results to it. This pages
+      // through the buffer across successive requests and delivers the stop
+      // promise once the buffer is fully drained.
+      const auto delivered = found->try_deliver_results(false);
+      TENZIR_ASSERT(delivered);
+      return found->stop_rp;
+    }
+    // No client is waiting. Complete finalization immediately instead of
+    // blocking until a client polls, which may never happen (e.g., a pipeline
+    // ending in `serve` whose client already disconnected, or a hidden
+    // pipeline during shutdown). We mark the entry done and, if rows remain,
+    // retain them as the final page so that a poll within the retention window
+    // can still fetch them.
+    TENZIR_ASSERT(not found->put_rp.pending());
+    found->delayed_attempt.dispose();
+    found->requested = 0;
+    // Mark the entry done and resolve immediately. The buffer is kept intact:
+    // `get()` pages through it across successive polls even though the source
+    // is gone, and reports completion only once it is fully drained. The
+    // entry survives for the retention window (see `handle_down_msg`).
+    found->done = true;
+    found->stop_rp.deliver();
     return found->stop_rp;
   }
 
-  auto stop(std::string serve_id) -> caf::result<void> {
+  auto stop(std::string serve_id, caf::actor source) -> caf::result<void> {
+    const auto source_addr = source ? source->address() : caf::actor_addr{};
     const auto found
       = std::find_if(ops.begin(), ops.end(), [&](const auto& op) {
-          return op.serve_id == serve_id;
+          return op.serve_id == serve_id
+                 and (not source_addr or op.source == source_addr);
         });
     if (found == ops.end()) {
-      return caf::make_error(ec::invalid_argument,
-                             fmt::format("{} received request to drop for "
-                                         "unknown serve id {}",
-                                         *self, escape_operator_arg(serve_id)));
+      // The entry was already removed, e.g., because the operator's DOWN was
+      // processed first. Treat the request as a no-op.
+      TENZIR_DEBUG("{} ignores drop request for unknown serve id {}", *self,
+                   escape_operator_arg(serve_id));
+      return {};
     }
     TENZIR_DEBUG("{} drops all buffered data for serve id {}", *self,
                  escape_operator_arg(serve_id));
@@ -783,14 +836,16 @@ struct serve_manager_state {
                     "{} for serve id {}",
                     *self, request.continuation_token, request.serve_id));
     }
-    if (found->done) {
+    if (found->done and found->buffer.empty()) {
       return std::make_tuple(std::string{}, std::vector<table_slice>{});
     }
     auto rp = self->make_response_promise<serve_response>();
     found->get_rps.push_back(rp);
     found->requested = request.max_events;
     found->min_events = request.min_events;
-    const auto delivered = found->try_deliver_results(false);
+    // Once the source is gone, no more data will arrive, so deliver whatever
+    // remains buffered immediately rather than waiting for `min_events`.
+    const auto delivered = found->try_deliver_results(found->done);
     if (delivered) {
       return rp;
     }
@@ -863,11 +918,13 @@ auto serve_manager(
       return self->state().start(std::move(serve_id), buffer_size,
                                  std::move(watched));
     },
-    [self](atom::stop, std::string& serve_id) -> caf::result<void> {
-      return self->state().stop(std::move(serve_id));
+    [self](atom::stop, std::string& serve_id,
+           caf::actor& source) -> caf::result<void> {
+      return self->state().stop(std::move(serve_id), std::move(source));
     },
-    [self](atom::shutdown, std::string& serve_id) -> caf::result<void> {
-      return self->state().finalize(std::move(serve_id));
+    [self](atom::shutdown, std::string& serve_id,
+           caf::actor& source) -> caf::result<void> {
+      return self->state().finalize(std::move(serve_id), std::move(source));
     },
     [self](atom::put, std::string& serve_id,
            table_slice& slice) -> caf::result<void> {
@@ -1352,6 +1409,11 @@ public:
   explicit ServeImpl(ServeArgs args) : args_{std::move(args)} {
   }
 
+  ServeImpl(ServeImpl&&) = default;
+  auto operator=(ServeImpl&&) -> ServeImpl& = default;
+  ServeImpl(const ServeImpl&) = delete;
+  auto operator=(const ServeImpl&) -> ServeImpl& = delete;
+
   auto start(OpCtx& ctx) -> Task<void> override {
     co_await OperatorBase::start(ctx);
     bytes_counter_
@@ -1365,12 +1427,17 @@ public:
     serve_manager_ = ctx.actor_system().registry().get<serve_manager_actor>(
       "tenzir.serve-manager");
     lifetime_actor_
-      = ctx.actor_system().spawn<caf::hidden>([](caf::event_based_actor*) {
+      = ctx.actor_system().spawn<caf::hidden>([](caf::event_based_actor* self) {
           return caf::behavior{
-            []() {
-              // Dummy handler because CAF immediately kills actors who return
-              // an empty behavior.
-              return;
+            [self](atom::done) {
+              // Quit cleanly so the serve-manager's down handler takes the
+              // retention path instead of treating this as a failure.
+              self->quit();
+            },
+            [self](caf::error& reason) {
+              // Quit with the given failure reason so the serve-manager
+              // expires the serve id and reports the failure to clients.
+              self->quit(std::move(reason));
             },
           };
         });
@@ -1393,16 +1460,59 @@ public:
     }
     auto const rows = input.rows();
     auto const bytes = input.approx_bytes();
-    auto result = co_await async_mail(atom::put_v, args_.id, std::move(input))
-                    .request(serve_manager_);
-    if (not result) {
-      diagnostic::error(result.error())
+    // Send the `put` without blocking the operator's main loop on the
+    // serve-manager's response. When the manager throttles us it keeps the
+    // response pending until a client drains the buffer. Awaiting that here
+    // would stall the main loop and, critically, prevent a concurrent
+    // graceful-stop signal from being delivered -- yet that signal is the only
+    // way the serve-manager learns to drop its buffer and release the pending
+    // `put`. That circular wait made stopped pipelines with a full buffer and
+    // no draining client hang forever.
+    //
+    // Instead we report `blocked` from `state()` until the `put` resolves,
+    // which applies the same one-slice-at-a-time backpressure as before
+    // without stalling control-message processing. While blocked, the executor
+    // withholds further input and the end-of-input signal, so at most one
+    // `put` is ever in flight and `finalize()` cannot run before it completes.
+    blocked_ = true;
+    ctx.spawn_task([this, id = args_.id, input = std::move(input), rows,
+                    bytes]() mutable -> Task<void> {
+      auto result = co_await async_mail(atom::put_v, id, std::move(input))
+                      .request(serve_manager_);
+      co_await put_queue_->enqueue(PutDone{std::move(result), rows, bytes});
+    });
+    co_return;
+  }
+
+  auto await_task(diagnostic_handler& dh) const -> Task<Any> override {
+    TENZIR_UNUSED(dh);
+    co_return co_await put_queue_->dequeue();
+  }
+
+  auto process_task(Any result, OpCtx& ctx) -> Task<void> override {
+    auto* done = result.try_as<PutDone>();
+    if (not done) {
+      co_return;
+    }
+    // The in-flight `put` completed; unblock so the executor resumes feeding
+    // input (or delivers the end-of-input signal it withheld while blocked).
+    blocked_ = false;
+    if (not done->result) {
+      diagnostic::error(done->result.error())
         .note("failed to buffer events at serve-manager")
         .emit(ctx);
       co_return;
     }
-    bytes_counter_.add(bytes);
-    events_counter_.add(rows);
+    bytes_counter_.add(done->bytes);
+    events_counter_.add(done->rows);
+    co_return;
+  }
+
+  auto state() -> OperatorState override {
+    // Apply backpressure without blocking the main loop: while a `put` is in
+    // flight we do not want more input, but control messages (graceful stop)
+    // must still be processed.
+    return blocked_ ? OperatorState::blocked : OperatorState::normal;
   }
 
   auto stop(OpCtx& ctx) -> Task<void> override {
@@ -1410,8 +1520,8 @@ public:
     // accepted after this point is dropped instead of being forwarded to the
     // serve-manager.
     stopped_ = true;
-    auto result
-      = co_await async_mail(atom::stop_v, args_.id).request(serve_manager_);
+    auto result = co_await async_mail(atom::stop_v, args_.id, lifetime_actor_)
+                    .request(serve_manager_);
     if (not result) {
       diagnostic::error(result.error())
         .note("failed to stop serve-manager")
@@ -1422,7 +1532,15 @@ public:
 
   auto finalize(OpCtx& ctx) -> Task<FinalizeBehavior> override {
     auto result
-      = co_await async_mail(atom::shutdown_v, args_.id).request(serve_manager_);
+      = co_await async_mail(atom::shutdown_v, args_.id, lifetime_actor_)
+          .request(serve_manager_);
+    // Terminate the lifetime actor cleanly. The serve-manager then keeps the
+    // final result set available for the retention time so that a client can
+    // still fetch it. Letting the actor die from its handle being dropped
+    // would surface as an `unreachable` error at the serve-manager, which
+    // deletes the serve id immediately and breaks late client requests.
+    caf::anon_mail(atom::done_v).send(lifetime_actor_);
+    lifetime_actor_ = nullptr;
     if (not result) {
       diagnostic::error(result.error())
         .note("failed to deregister at serve-manager")
@@ -1431,11 +1549,38 @@ public:
     co_return FinalizeBehavior::done;
   }
 
+  ~ServeImpl() override {
+    if (lifetime_actor_) {
+      // We did not reach `finalize`, e.g., because the pipeline was
+      // force-killed. Signal a failure to the serve-manager so it expires the
+      // serve id right away. Use a diagnostic error rather than
+      // `user_shutdown`: the `/serve` endpoint maps `user_shutdown` to a
+      // successful completion, which would hide that the pipeline was aborted
+      // before all results were delivered.
+      caf::anon_mail(diagnostic::error("serve pipeline was aborted before all "
+                                       "results were delivered")
+                       .to_error())
+        .send(lifetime_actor_);
+    }
+  }
+
 private:
+  /// The result of an in-flight `put`, handed from the background task that
+  /// awaits the serve-manager response back to the operator's main loop via
+  /// `await_task()` / `process_task()`.
+  struct PutDone {
+    caf::expected<void> result;
+    uint64_t rows = {};
+    uint64_t bytes = {};
+  };
+
   ServeArgs args_;
   serve_manager_actor serve_manager_;
   caf::actor lifetime_actor_;
   bool stopped_ = false;
+  /// Whether a `put` is currently in flight; drives `state()` backpressure.
+  bool blocked_ = false;
+  mutable Box<folly::coro::BoundedQueue<PutDone>> put_queue_{std::in_place, 1};
   MetricsCounter bytes_counter_;
   MetricsCounter events_counter_;
 };
@@ -1499,7 +1644,8 @@ public:
     //  Wait until all events were fetched.
     ctrl.set_waiting(true);
     ctrl.self()
-      .mail(atom::shutdown_v, serve_id_)
+      .mail(atom::shutdown_v, serve_id_,
+            caf::actor_cast<caf::actor>(&ctrl.self()))
       .request(serve_manager, caf::infinite)
       .then(
         [&]() {

--- a/libtenzir/include/tenzir/async/executor.hpp
+++ b/libtenzir/include/tenzir/async/executor.hpp
@@ -34,19 +34,6 @@ auto map_awaitable(SemiAwaitable&& awaitable, F&& f) -> Task<
   co_return std::invoke(f, co_await std::forward<SemiAwaitable>(awaitable));
 }
 
-// TODO: This might not be cancellation safe?
-template <class... SemiAwaitable>
-auto select_into_variant(SemiAwaitable&&... awaitable)
-  -> Task<variant<folly::coro::semi_await_result_t<SemiAwaitable>...>> {
-  using result_t = variant<folly::coro::semi_await_result_t<SemiAwaitable>...>;
-  auto [_, result] = co_await folly::coro::collectAny(
-    map_awaitable(std::forward<SemiAwaitable>(awaitable), []<class T>(T&& x) {
-      return result_t{std::forward<T>(x)};
-    })...);
-  TENZIR_ASSERT(result.hasValue());
-  co_return std::move(*result);
-}
-
 /// A sequence of operators with the given input and output.
 template <class Input, class Output>
 class OperatorChain {

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -1,5 +1,5 @@
 {
-  "hash": "sha256-bGdq1vRQa9IJHv8Szea/DiZHSR4O2dFKvBfvaVL+MqM=",
+  "hash": "sha256-X8iMAefdfZYxFkJ8JZcpZSqpS1+eAPEPdiHTVTPhs5Y=",
   "name": "tenzir-plugins.tar.gz",
-  "url": "https://github.com/tenzir/tenzir-plugins/archive/1830d514cea92eb15e1547633aa84f8e4624e14c.tar.gz"
+  "url": "https://github.com/tenzir/tenzir-plugins/archive/98ce0eae1da2b9b8fb29ed9746c0052f1fc9f01b.tar.gz"
 }

--- a/test/tests/node/pipeline_manager/neo_launch_update.py
+++ b/test/tests/node/pipeline_manager/neo_launch_update.py
@@ -9,13 +9,14 @@ import shlex
 import shutil
 import socket
 import subprocess
+import threading
 import time
 import urllib.error
 import urllib.request
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 API_PREFIX = "/api/v0"
 
@@ -232,6 +233,51 @@ def _check_sink_id_escaping(base_url: str) -> None:
             _delete_pipeline(base_url, created_id)
 
 
+def _wait_for_pipeline_state(
+    base_url: str,
+    pipeline_id: str,
+    expected_state: str,
+    *,
+    timeout: float = 10,
+) -> dict[str, Any]:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        # Query the pipeline directly instead of using /pipeline/list, as the
+        # latter omits hidden pipelines.
+        status, body = _post_api(base_url, "/pipeline/update", {"id": pipeline_id})
+        assert status == 200, body
+        pipeline = body.get("pipeline")
+        assert isinstance(pipeline, dict), body
+        if pipeline.get("state") == expected_state:
+            return pipeline
+        time.sleep(0.1)
+    raise AssertionError(
+        f"pipeline {pipeline_id} did not reach state {expected_state!r} within {timeout}s"
+    )
+
+
+def _wait_for_pipeline_stopped_or_deleted(
+    base_url: str,
+    pipeline_id: str,
+    *,
+    timeout: float = 10,
+) -> None:
+    # Hidden pipelines are automatically deleted once they stop, so a
+    # successful stop manifests either as the `stopped` state or as the
+    # pipeline no longer existing.
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        status, body = _post_api(base_url, "/pipeline/update", {"id": pipeline_id})
+        pipeline = body.get("pipeline")
+        if status != 200 or not isinstance(pipeline, dict):
+            # The pipeline no longer exists.
+            return
+        if pipeline.get("state") == "stopped":
+            return
+        time.sleep(0.1)
+    raise AssertionError(f"pipeline {pipeline_id} did not stop within {timeout}s")
+
+
 def _check_update_parse_compatibility(base_url: str) -> None:
     legacy_definition = "from {x: 1} | discard"
     legacy_updated_definition = "from {x: 2} | discard"
@@ -275,11 +321,174 @@ def _check_update_parse_compatibility(base_url: str) -> None:
             _delete_pipeline(base_url, created_id)
 
 
+class _ServeResult(NamedTuple):
+    status: int
+    body: dict[str, Any]
+
+
+@contextmanager
+def _background_serve_request(
+    base_url: str, serve_id: str
+) -> Iterator[tuple[threading.Event, list[_ServeResult], list[BaseException]]]:
+    """Poll `/serve` on a background thread.
+
+    Yields `(done_event, results, errors)`. After the context exits, exactly
+    one of `results` or `errors` will be populated (once `done_event` is set).
+    """
+    done = threading.Event()
+    results: list[_ServeResult] = []
+    errors: list[BaseException] = []
+
+    def worker() -> None:
+        try:
+            status, response = _post_api(
+                base_url,
+                "/serve",
+                {
+                    "serve_id": serve_id,
+                    "timeout": "10s",
+                    "min_events": 1,
+                    "max_events": 1,
+                    "schema": "never",
+                },
+            )
+            results.append(_ServeResult(status, response))
+        except BaseException as exc:  # pragma: no cover - surfaced below
+            errors.append(exc)
+        finally:
+            done.set()
+
+    thread = threading.Thread(target=worker, daemon=True)
+    thread.start()
+    try:
+        yield done, results, errors
+    finally:
+        thread.join(timeout=0)
+
+
+def _assert_serve_completed_after_stop(
+    base_url: str,
+    created_id: str,
+    serve_id: str,
+    done: threading.Event,
+    results: list[_ServeResult],
+    errors: list[BaseException],
+) -> dict[str, Any]:
+    """Stop `created_id` and assert the background `/serve` completes cleanly."""
+    time.sleep(0.5)
+    assert not done.is_set(), "serve returned before pipeline stop"
+    status, body = _post_api(
+        base_url,
+        "/pipeline/update",
+        {"id": created_id, "action": "stop"},
+    )
+    assert status == 200, body
+    assert done.wait(5), "serve did not terminate promptly after stop"
+    assert not errors, errors
+    assert len(results) == 1, results
+    result = results[0]
+    assert result.status == 200, result
+    assert isinstance(result.body, dict), result
+    assert result.body.get("state") == "completed", result.body
+    _wait_for_pipeline_stopped_or_deleted(base_url, created_id)
+    return result.body
+
+
+def _check_every_stop_terminates_serve(base_url: str) -> None:
+    created_id = ""
+    try:
+        status, body = _post_api(
+            base_url,
+            "/pipeline/launch",
+            {
+                "definition": (
+                    "//neo\n"
+                    "every 500ms {\n"
+                    "  pipeline::list\n"
+                    "  where not hidden\n"
+                    "  sort id\n"
+                    "  summarize pipelines = this.collect()\n"
+                    # Discard all events so that the long-polling /serve
+                    # request below stays blocked until the pipeline stops.
+                    "  where false\n"
+                    "}\n"
+                ),
+                "name": "neo-every-stop",
+                "hidden": True,
+                "serve_id": "neo-every-stop",
+                "ttl": "60s",
+                "autostart": {"created": True},
+            },
+        )
+        assert status == 200, body
+        created_id = str(body.get("id", ""))
+        assert created_id, body
+        _wait_for_pipeline_state(base_url, created_id, "running")
+        with _background_serve_request(base_url, "neo-every-stop") as (
+            done,
+            results,
+            errors,
+        ):
+            _assert_serve_completed_after_stop(
+                base_url, created_id, "neo-every-stop", done, results, errors
+            )
+        print("every-stop-terminates-serve: ok")
+    finally:
+        if created_id:
+            _delete_pipeline(base_url, created_id)
+
+
+def _check_hidden_diagnostics_stop_terminates_serve(base_url: str) -> None:
+    created_id = ""
+    try:
+        status, body = _post_api(
+            base_url,
+            "/pipeline/launch",
+            {
+                "definition": (
+                    "//neo\n"
+                    'diagnostics live=true, retro=true | where pipeline_id == "'
+                    '00000000-0000-0000-0000-000000000000"'
+                ),
+                "name": "neo-hidden-diagnostics-stop",
+                "hidden": True,
+                "serve_id": "neo-hidden-diagnostics-stop",
+                "ttl": "60s",
+                "autostart": {"created": True},
+            },
+        )
+        assert status == 200, body
+        created_id = str(body.get("id", ""))
+        assert created_id, body
+        _wait_for_pipeline_state(base_url, created_id, "running")
+        with _background_serve_request(base_url, "neo-hidden-diagnostics-stop") as (
+            done,
+            results,
+            errors,
+        ):
+            response = _assert_serve_completed_after_stop(
+                base_url,
+                created_id,
+                "neo-hidden-diagnostics-stop",
+                done,
+                results,
+                errors,
+            )
+        events = response.get("events")
+        assert isinstance(events, list) and not events, response
+        print("hidden-diagnostics-stop-terminates-serve: ok")
+    finally:
+        if created_id:
+            _delete_pipeline(base_url, created_id)
+
+
 def main() -> None:
     with _running_web_server() as base_url:
         _check_launch_compile_diagnostics(base_url)
         _check_sink_id_escaping(base_url)
         _check_update_parse_compatibility(base_url)
+        _check_every_stop_terminates_serve(base_url)
+        _check_hidden_diagnostics_stop_terminates_serve(base_url)
 
 
 if __name__ == "__main__":

--- a/test/tests/node/pipeline_manager/neo_launch_update.py
+++ b/test/tests/node/pipeline_manager/neo_launch_update.py
@@ -482,6 +482,49 @@ def _check_hidden_diagnostics_stop_terminates_serve(base_url: str) -> None:
             _delete_pipeline(base_url, created_id)
 
 
+def _check_full_buffer_stop_terminates_serve(base_url: str) -> None:
+    # Regression test: a pipeline ending in `serve` whose buffer is full (the
+    # operator is throttled inside its `put`) and that has no client draining
+    # it must still stop promptly. Previously the operator blocked its own main
+    # loop awaiting the throttling `put`, so the graceful-stop signal was never
+    # delivered, the serve-manager never dropped its buffer, and the pipeline
+    # hung until the shutdown watchdog force-killed it.
+    created_id = ""
+    try:
+        status, body = _post_api(
+            base_url,
+            "/pipeline/launch",
+            {
+                # Produce far more than the default serve buffer (1024 events)
+                # so the operator gets throttled with no client draining it.
+                "definition": ("//neo\nfrom {x: 1}\nrepeat 100000\n"),
+                "name": "neo-full-buffer-stop",
+                "hidden": True,
+                "serve_id": "neo-full-buffer-stop",
+                "ttl": "60s",
+                "autostart": {"created": True},
+            },
+        )
+        assert status == 200, body
+        created_id = str(body.get("id", ""))
+        assert created_id, body
+        _wait_for_pipeline_state(base_url, created_id, "running")
+        # Give the pipeline a moment to fill the serve buffer and throttle,
+        # without ever polling `/serve`.
+        time.sleep(1.0)
+        status, body = _post_api(
+            base_url,
+            "/pipeline/update",
+            {"id": created_id, "action": "stop"},
+        )
+        assert status == 200, body
+        _wait_for_pipeline_stopped_or_deleted(base_url, created_id, timeout=10)
+        print("full-buffer-stop-terminates-serve: ok")
+    finally:
+        if created_id:
+            _delete_pipeline(base_url, created_id)
+
+
 def main() -> None:
     with _running_web_server() as base_url:
         _check_launch_compile_diagnostics(base_url)
@@ -489,6 +532,7 @@ def main() -> None:
         _check_update_parse_compatibility(base_url)
         _check_every_stop_terminates_serve(base_url)
         _check_hidden_diagnostics_stop_terminates_serve(base_url)
+        _check_full_buffer_stop_terminates_serve(base_url)
 
 
 if __name__ == "__main__":

--- a/test/tests/node/pipeline_manager/neo_launch_update.txt
+++ b/test/tests/node/pipeline_manager/neo_launch_update.txt
@@ -1,3 +1,5 @@
 neo-launch-compile-diagnostics: ok
 neo-launch-sink-id-escaping: ok
 update-accepts-legacy-and-neo-definitions: ok
+every-stop-terminates-serve: ok
+hidden-diagnostics-stop-terminates-serve: ok

--- a/test/tests/node/pipeline_manager/neo_launch_update.txt
+++ b/test/tests/node/pipeline_manager/neo_launch_update.txt
@@ -3,3 +3,4 @@ neo-launch-sink-id-escaping: ok
 update-accepts-legacy-and-neo-definitions: ok
 every-stop-terminates-serve: ok
 hidden-diagnostics-stop-terminates-serve: ok
+full-buffer-stop-terminates-serve: ok


### PR DESCRIPTION
## 🔍 Problem

Stopping pipelines that use `export`/`metrics`, `every`, or `serve` was broken in several ways:

- Pipelines ending in `serve` never finished draining when no client was polling: the serve-manager only resolved the operator's stop request from within a client `GET`. During node shutdown, hidden serve pipelines hung until the grace-period watchdog force-killed them.
- After a serve pipeline completed, its lifetime actor died uncleanly (`unreachable`), so the serve-manager expired the serve id immediately. Clients polling afterwards got `expired serve id ... !! unreachable` instead of the final response — this crippled the platform, which relaunched pipelines in a loop.
- `every` pipelines crashed with `assertion 'result.hasValue()' failed` whenever a downstream operator (e.g. `head`, `serve`) closed the pipeline, because `select_into_variant` asserted on the winning `Try` instead of propagating the stored exception (e.g. `folly::OperationCancelled`).
- Error diagnostics of pipelines failing while stopping were silently dropped, leaving only a generic `pipeline failed` message (see companion PR).

## 🛠️ Solution

- The serve-manager resolves stop requests immediately when its buffer is empty, marks the entry as done, and preserves the continuation token so a late client poll receives the final, empty result set.
- The `serve` operator terminates its lifetime actor cleanly on finalize, so completed serve ids remain fetchable for the retention time; force-killed pipelines still expire promptly.
- `select_into_variant` rethrows the winning task's exception instead of asserting, so cancellation and errors propagate as usual.
- Bump `tenzir-plugins` for the pipeline-manager side: diagnostics forwarding during stop/shutdown and the launch endpoint's `serve` argument fix.

## 💬 Review

- Rebased onto `main`; the original `export` stopping fix was dropped as it is subsumed by #6403, and the serve fixes were rebased on top of #6403's `stop`/`finalize` split of the serve-manager protocol.

- `every` still loses in-flight events in some close scenarios (`tests/operators/every/*`, `serve_tcp/plain_write_ndjson`); tracked as follow-up work on the `every` rework.
- The serve-manager keeps waiting for a client when the buffer is non-empty at stop; only the empty-buffer case completes eagerly.

<sub>
📎 Companion PR: tenzir/tenzir-plugins#580
</sub>
