### PR TITLE
Preserve notifications across cancelled Notify::wait()

### DIFF
--- a/libtenzir/include/tenzir/async/notify.hpp
+++ b/libtenzir/include/tenzir/async/notify.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "tenzir/async/task.hpp"
+#include "tenzir/atomic.hpp"
 
 #include <folly/CancellationToken.h>
 #include <folly/coro/Baton.h>
@@ -17,20 +18,21 @@
 namespace tenzir {
 
 /// A multi-use notification primitive for coroutines.
+///
+/// Cancellation contract: A cancelled `wait()` never consumes a notification.
 class Notify {
 public:
   Notify() = default;
   ~Notify() = default;
   Notify(Notify const&) = delete;
   auto operator=(Notify const&) -> Notify& = delete;
-  Notify(Notify&& other) noexcept : baton_{other.baton_.ready()} {
+  Notify(Notify&& other) noexcept
+    : notified_{other.notified_.exchange(false, std::memory_order_relaxed)} {
   }
   auto operator=(Notify&& other) noexcept -> Notify& {
-    if (other.baton_.ready()) {
-      baton_.post();
-    } else {
-      baton_.reset();
-    }
+    notified_.store(other.notified_.exchange(false, std::memory_order_relaxed),
+                    std::memory_order_relaxed);
+    baton_.reset();
     return *this;
   }
 
@@ -38,27 +40,36 @@ public:
   ///
   /// Multiple calls to this function don't stack.
   void notify_one() {
+    notified_.store(true, std::memory_order_release);
     baton_.post();
   }
 
   /// Wait for a notification. Returns immediately if already notified.
+  ///
+  /// If the wait is cancelled, it throws without consuming a notification.
   auto wait() -> Task<void> {
     auto& token = co_await folly::coro::co_current_cancellation_token;
-    auto callback = folly::CancellationCallback{token, [&]() noexcept {
-                                                  baton_.post();
-                                                }};
-    co_await baton_;
-    if (token.isCancellationRequested()) {
-      co_yield folly::coro::co_stopped_may_throw;
+    // The loop is needed because a posted baton might get left behind in a
+    // previous iteration.
+    while (true) {
+      if (token.isCancellationRequested()) {
+        co_yield folly::coro::co_stopped_may_throw;
+      }
+      if (notified_.exchange(false, std::memory_order_acquire)) {
+        co_return;
+      }
+      // Block until `notify_one()` posts the baton, or the cancellation
+      // callback posts it to unblock us
+      auto callback = folly::CancellationCallback{token, [this]() noexcept {
+                                                    baton_.post();
+                                                  }};
+      co_await baton_;
+      baton_.reset();
     }
-    // This races with other calls to `notify_one()`. However, that is okay, as
-    // we only guarantee that the notification is eventually consumed. We can
-    // thus pretend that we waited a bit longer here, the second notification
-    // arrived (which gets ignored), and only then we consume the first one.
-    baton_.reset();
   }
 
 private:
+  Atomic<bool> notified_ = false;
   folly::coro::Baton baton_;
 };
 

--- a/libtenzir/include/tenzir/async/notify.hpp
+++ b/libtenzir/include/tenzir/async/notify.hpp
@@ -8,36 +8,54 @@
 
 #pragma once
 
+#include "tenzir/arc.hpp"
 #include "tenzir/async/task.hpp"
-#include "tenzir/atomic.hpp"
+#include "tenzir/detail/assert.hpp"
+#include "tenzir/option.hpp"
 
 #include <folly/CancellationToken.h>
 #include <folly/coro/Baton.h>
 #include <folly/coro/CurrentExecutor.h>
 
+#include <deque>
+#include <mutex>
+#include <utility>
+
 namespace tenzir {
 
 /// A multi-use notification primitive for coroutines.
 ///
-/// Cancellation contract: A cancelled `wait()` never consumes a notification.
+/// Wakeup contract: Each notification wakes exactly one `wait()`, in FIFO
+/// order. Notifications don't stack: at most one is stored while no waiter is
+/// suspended. When a state change must be observed by all waiters (for
+/// example, a closed flag), each woken waiter has to cascade by calling
+/// `notify_one()` before returning.
 ///
-/// Wakeup contract: Each notification wakes exactly one `wait()`, even if
-/// multiple waiters are suspended. When a state change must be observed by
-/// all waiters (for example, a closed flag), each woken waiter has to cascade
-/// by calling `notify_one()` before returning.
+/// Cancellation contract: A cancelled `wait()` never consumes a notification.
+/// If a notification was already assigned to a waiter that got cancelled, the
+/// waiter hands it to the next waiter before throwing, or stores it if there
+/// is none.
 class Notify {
 public:
   Notify() = default;
-  ~Notify() = default;
+
+  ~Notify() {
+    TENZIR_ASSERT(waiters_.empty());
+  }
+
   Notify(Notify const&) = delete;
   auto operator=(Notify const&) -> Notify& = delete;
+
+  /// Moving is only allowed while no `wait()` is in flight.
   Notify(Notify&& other) noexcept
-    : notified_{other.notified_.exchange(false, std::memory_order_relaxed)} {
+    : notified_{std::exchange(other.notified_, false)} {
+    TENZIR_ASSERT(other.waiters_.empty());
   }
+
   auto operator=(Notify&& other) noexcept -> Notify& {
-    notified_.store(other.notified_.exchange(false, std::memory_order_relaxed),
-                    std::memory_order_relaxed);
-    baton_.reset();
+    TENZIR_ASSERT(waiters_.empty());
+    TENZIR_ASSERT(other.waiters_.empty());
+    notified_ = std::exchange(other.notified_, false);
     return *this;
   }
 
@@ -45,8 +63,14 @@ public:
   ///
   /// Multiple calls to this function don't stack.
   void notify_one() {
-    notified_.store(true, std::memory_order_release);
-    baton_.post();
+    auto waiter = Option<Arc<Waiter>>{};
+    {
+      auto lock = std::scoped_lock{mutex_};
+      waiter = deliver_one();
+    }
+    if (waiter.is_some()) {
+      (*waiter)->baton.post();
+    }
   }
 
   /// Wait for a notification. Returns immediately if already notified.
@@ -54,28 +78,86 @@ public:
   /// If the wait is cancelled, it throws without consuming a notification.
   auto wait() -> Task<void> {
     auto& token = co_await folly::coro::co_current_cancellation_token;
-    // The loop is needed because a posted baton might get left behind in a
-    // previous iteration.
-    while (true) {
-      if (token.isCancellationRequested()) {
-        co_yield folly::coro::co_stopped_may_throw;
-      }
-      if (notified_.exchange(false, std::memory_order_acquire)) {
+    if (token.isCancellationRequested()) {
+      co_yield folly::coro::co_stopped_may_throw;
+    }
+    auto waiter = Arc<Waiter>{std::in_place};
+    {
+      auto lock = std::scoped_lock{mutex_};
+      if (notified_) {
+        notified_ = false;
         co_return;
       }
-      // Block until `notify_one()` posts the baton, or the cancellation
-      // callback posts it to unblock us
-      auto callback = folly::CancellationCallback{token, [this]() noexcept {
-                                                    baton_.post();
-                                                  }};
-      co_await baton_;
-      baton_.reset();
+      waiters_.push_back(waiter);
     }
+    {
+      // The callback holds its own reference so that a late `post()` cannot
+      // touch a destroyed waiter.
+      auto callback
+        = folly::CancellationCallback{token, [waiter]() mutable noexcept {
+                                        waiter->baton.post();
+                                      }};
+      co_await waiter->baton;
+      // The callback's destructor joins an in-flight invocation, so no other
+      // thread touches `waiter->baton` beyond this point.
+    }
+    // Read the cancellation state exactly once so that the decision below is
+    // consistent: either we consume the notification, or we hand it over.
+    auto cancelled = token.isCancellationRequested();
+    auto notified = false;
+    auto handoff = Option<Arc<Waiter>>{};
+    {
+      auto lock = std::scoped_lock{mutex_};
+      notified = waiter->notified;
+      if (not notified) {
+        // Our wakeup came from the cancellation callback. Deregister so that
+        // no notification gets assigned to us anymore.
+        auto count = std::erase_if(waiters_, [&](Arc<Waiter> const& other) {
+          return &*other == &*waiter;
+        });
+        TENZIR_ASSERT(count == 1);
+      } else if (cancelled) {
+        // A notification was assigned to us, but we are cancelled: pass it to
+        // the next waiter, or store it if there is none.
+        handoff = deliver_one();
+      }
+    }
+    if (handoff.is_some()) {
+      (*handoff)->baton.post();
+    }
+    if (cancelled) {
+      co_yield folly::coro::co_stopped_may_throw;
+    }
+    TENZIR_ASSERT(notified);
   }
 
 private:
-  Atomic<bool> notified_ = false;
-  folly::coro::Baton baton_;
+  struct Waiter {
+    folly::coro::Baton baton;
+    /// Whether a notification was assigned to this waiter. Guarded by the
+    /// owning `Notify`'s `mutex_`.
+    bool notified = false;
+  };
+
+  /// Assign a notification to the next waiter, or store it if there is none.
+  /// Must be called while holding `mutex_`. The returned waiter must be posted
+  /// after releasing the lock, as posting resumes the waiting coroutine.
+  auto deliver_one() -> Option<Arc<Waiter>> {
+    if (waiters_.empty()) {
+      notified_ = true;
+      return None{};
+    }
+    auto waiter = std::move(waiters_.front());
+    waiters_.pop_front();
+    waiter->notified = true;
+    return Option{std::move(waiter)};
+  }
+
+  std::mutex mutex_;
+  /// A stored notification that no waiter was assigned to yet.
+  bool notified_ = false;
+  /// Waiters in FIFO order.
+  std::deque<Arc<Waiter>> waiters_;
 };
 
 } // namespace tenzir

--- a/libtenzir/include/tenzir/async/notify.hpp
+++ b/libtenzir/include/tenzir/async/notify.hpp
@@ -20,6 +20,11 @@ namespace tenzir {
 /// A multi-use notification primitive for coroutines.
 ///
 /// Cancellation contract: A cancelled `wait()` never consumes a notification.
+///
+/// Wakeup contract: Each notification wakes exactly one `wait()`, even if
+/// multiple waiters are suspended. When a state change must be observed by
+/// all waiters (for example, a closed flag), each woken waiter has to cascade
+/// by calling `notify_one()` before returning.
 class Notify {
 public:
   Notify() = default;

--- a/libtenzir/src/tql2/exec.cpp
+++ b/libtenzir/src/tql2/exec.cpp
@@ -844,6 +844,9 @@ public:
     auto lock = co_await mutex_.lock();
     while (lock->queue.empty()) {
       if (sender_closed_.load(std::memory_order::acquire)) {
+        // Cascade to the next blocked receiver: `close_sender()` only posts a
+        // single notification, but every receiver must observe the closure.
+        notify_receive_.notify_one();
         co_return None{};
       }
       lock.unlock();

--- a/libtenzir/test/async/notify.cpp
+++ b/libtenzir/test/async/notify.cpp
@@ -1,0 +1,242 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "tenzir/async/notify.hpp"
+
+#include <folly/OperationCancelled.h>
+#include <folly/coro/BlockingWait.h>
+#include <folly/coro/Collect.h>
+
+#ifdef CHECK
+#  undef CHECK
+#endif
+#include "tenzir/test/test.hpp"
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <thread>
+
+namespace tenzir {
+
+TEST("notify before wait completes immediately") {
+  auto notify = Notify{};
+  notify.notify_one();
+  folly::coro::blockingWait(notify.wait());
+}
+
+TEST("notifications do not stack") {
+  auto notify = Notify{};
+  notify.notify_one();
+  notify.notify_one();
+  folly::coro::blockingWait([&]() -> Task<void> {
+    co_await notify.wait();
+    // The second notification was coalesced into the first, so another wait
+    // must block until a new notification arrives.
+    auto second_done = false;
+    co_await folly::coro::collectAll(
+      [&]() -> Task<void> {
+        co_await notify.wait();
+        second_done = true;
+      }(),
+      [&]() -> Task<void> {
+        check(not second_done);
+        notify.notify_one();
+        co_return;
+      }());
+    check(second_done);
+  }());
+}
+
+TEST("notify wakes exactly one of two waiters") {
+  auto notify = Notify{};
+  folly::coro::blockingWait([&]() -> Task<void> {
+    auto done = std::array{false, false};
+    co_await folly::coro::collectAll(
+      [&]() -> Task<void> {
+        co_await notify.wait();
+        done[0] = true;
+      }(),
+      [&]() -> Task<void> {
+        co_await notify.wait();
+        done[1] = true;
+      }(),
+      [&]() -> Task<void> {
+        notify.notify_one();
+        co_await folly::coro::co_reschedule_on_current_executor;
+        // Only one waiter may have consumed the notification.
+        check_ne(done[0], done[1]);
+        notify.notify_one();
+      }());
+    check(done[0]);
+    check(done[1]);
+  }());
+}
+
+TEST("wait with cancelled token does not consume a notification") {
+  auto notify = Notify{};
+  notify.notify_one();
+  auto cancel = folly::CancellationSource{};
+  cancel.requestCancellation();
+  auto cancelled = false;
+  folly::coro::blockingWait([&]() -> Task<void> {
+    try {
+      co_await folly::coro::co_withCancellation(cancel.getToken(),
+                                                notify.wait());
+    } catch (folly::OperationCancelled const&) {
+      cancelled = true;
+    }
+  }());
+  check(cancelled);
+  // The notification must still be there.
+  folly::coro::blockingWait(notify.wait());
+}
+
+TEST("cancelled waiter hands its notification to the next waiter") {
+  auto notify = Notify{};
+  auto cancel = folly::CancellationSource{};
+  folly::coro::blockingWait([&]() -> Task<void> {
+    auto first_cancelled = false;
+    auto second_done = false;
+    co_await folly::coro::collectAll(
+      // First waiter: suspends first (FIFO), so the notification gets
+      // assigned to it, but it observes cancellation on resumption.
+      [&]() -> Task<void> {
+        try {
+          co_await folly::coro::co_withCancellation(cancel.getToken(),
+                                                    notify.wait());
+        } catch (folly::OperationCancelled const&) {
+          first_cancelled = true;
+        }
+      }(),
+      [&]() -> Task<void> {
+        co_await notify.wait();
+        second_done = true;
+      }(),
+      [&]() -> Task<void> {
+        // Assign the notification to the first waiter and cancel it before
+        // its continuation runs. It must hand the notification over instead
+        // of dropping or consuming it.
+        notify.notify_one();
+        cancel.requestCancellation();
+        co_return;
+      }());
+    check(first_cancelled);
+    check(second_done);
+  }());
+}
+
+TEST("cancelled waiter with no successor stores the notification") {
+  auto notify = Notify{};
+  auto cancel = folly::CancellationSource{};
+  auto cancelled = false;
+  folly::coro::blockingWait([&]() -> Task<void> {
+    co_await folly::coro::collectAll(
+      [&]() -> Task<void> {
+        try {
+          co_await folly::coro::co_withCancellation(cancel.getToken(),
+                                                    notify.wait());
+        } catch (folly::OperationCancelled const&) {
+          cancelled = true;
+        }
+      }(),
+      [&]() -> Task<void> {
+        notify.notify_one();
+        cancel.requestCancellation();
+        co_return;
+      }());
+  }());
+  check(cancelled);
+  // The notification survived the cancelled waiter.
+  folly::coro::blockingWait(notify.wait());
+}
+
+TEST("cancellation without notification wakes only the cancelled waiter") {
+  auto notify = Notify{};
+  auto cancel = folly::CancellationSource{};
+  folly::coro::blockingWait([&]() -> Task<void> {
+    auto first_cancelled = false;
+    auto second_done = false;
+    co_await folly::coro::collectAll(
+      [&]() -> Task<void> {
+        try {
+          co_await folly::coro::co_withCancellation(cancel.getToken(),
+                                                    notify.wait());
+        } catch (folly::OperationCancelled const&) {
+          first_cancelled = true;
+        }
+      }(),
+      [&]() -> Task<void> {
+        co_await notify.wait();
+        second_done = true;
+      }(),
+      [&]() -> Task<void> {
+        cancel.requestCancellation();
+        co_await folly::coro::co_reschedule_on_current_executor;
+        check(first_cancelled);
+        // The second waiter must not have been woken spuriously.
+        check(not second_done);
+        notify.notify_one();
+      }());
+    check(second_done);
+  }());
+}
+
+TEST("wait can be cancelled from another thread") {
+  auto notify = Notify{};
+  auto cancel = folly::CancellationSource{};
+  auto started = std::promise<void>{};
+  auto started_future = started.get_future();
+  auto cancelled = std::atomic<bool>{false};
+  auto worker = std::thread{[&] {
+    try {
+      folly::coro::blockingWait(folly::coro::co_withCancellation(
+        cancel.getToken(), [&]() -> Task<void> {
+          started.set_value();
+          co_await notify.wait();
+        }()));
+    } catch (folly::OperationCancelled const&) {
+      cancelled.store(true, std::memory_order_release);
+    }
+  }};
+  check_eq(started_future.wait_for(std::chrono::seconds{1}),
+           std::future_status::ready);
+  cancel.requestCancellation();
+  worker.join();
+  check(cancelled.load(std::memory_order_acquire));
+}
+
+TEST("concurrent notifications are neither lost nor duplicated") {
+  auto notify = Notify{};
+  constexpr auto num_notifications = 10'000;
+  auto consumed = std::atomic<int>{0};
+  auto consumer = std::thread{[&] {
+    folly::coro::blockingWait([&]() -> Task<void> {
+      for (auto i = 0; i < num_notifications; ++i) {
+        co_await notify.wait();
+        consumed.fetch_add(1, std::memory_order_relaxed);
+      }
+    }());
+  }};
+  auto producer = std::thread{[&] {
+    for (auto i = 0; i < num_notifications; ++i) {
+      // Wait until the previous notification was consumed so that none of
+      // them coalesce and the count stays exact.
+      while (consumed.load(std::memory_order_relaxed) < i) {
+        std::this_thread::yield();
+      }
+      notify.notify_one();
+    }
+  }};
+  producer.join();
+  consumer.join();
+  check_eq(consumed.load(std::memory_order_relaxed), num_notifications);
+}
+
+} // namespace tenzir


### PR DESCRIPTION
## 🔍 Problem

`Notify::wait()` used a single shared `Baton` for real notifications, cancellation wakeups, and re-arming via `reset()`. This had multiple lost-wakeup and spurious-wakeup races:

- A cancelled wait could leave a phantom notification behind, making the next `wait()` return without a real `notify_one()`.
- A waiter's `reset()` could swallow a coalesced post from a racing `notify_one()`, leaving the notification stored but undelivered to already-suspended waiters.
- A waiter's `reset()` could swallow another waiter's cancellation-callback post, stranding a cancelled waiter forever.

## 🛠️ Solution

Replace the shared baton with a mutex-guarded FIFO queue of per-waiter batons:

- `notify_one()` assigns the notification to the front waiter, or stores it when no waiter is suspended. Notifications don't stack.
- A cancelled `wait()` never consumes a notification. If one was already assigned to it, the waiter hands it to the next waiter before throwing (or stores it if there is none).
- No `reset()` remains, so no post can be lost. Batons are single-use per wait.
- `OpChannel::receive()` now cascades the wakeup on the closed path, since `close_sender()` posts only one notification while the channel is MPMC.

## 💬 Review

- Posting a baton resumes the waiter's continuation, so all posts happen after releasing the mutex; the `Arc<Waiter>` keeps the state alive if the waiter's frame dies concurrently.
- The cancellation outcome is decided from a single read of `isCancellationRequested()` after the callback is joined, so consume-vs-handoff is consistent.
- `notify_one()` now takes an uncontended mutex instead of being lock-free; acceptable for current users (`OpChannel` already locks its own mutex per operation).
- Unit tests in `libtenzir/test/async/notify.cpp` cover both contracts, the handoff path, and a cross-thread stress test.