### PR TITLE
Drop the index's redundant partition bookkeeping

### DIFF
--- a/changelog/unreleased/index-drops-redundant-partition-bookkeeping.md
+++ b/changelog/unreleased/index-drops-redundant-partition-bookkeeping.md
@@ -4,6 +4,8 @@ type: bugfix
 authors:
   - tobim
   - claude
+prs:
+  - 6433
 created: 2026-07-10T00:00:00.000000Z
 ---
 

--- a/changelog/unreleased/index-drops-redundant-partition-bookkeeping.md
+++ b/changelog/unreleased/index-drops-redundant-partition-bookkeeping.md
@@ -1,0 +1,20 @@
+---
+title: Rebuild no longer trips over concurrently deleted partitions
+type: bugfix
+authors:
+  - tobim
+  - claude
+created: 2026-07-10T00:00:00.000000Z
+---
+
+The index no longer maintains its own set of persisted partitions alongside
+the catalog. This bookkeeping could drift from the catalog's view when
+partitions were deleted while a rebuild was in flight, causing repeated
+`index skips unknown partition` warnings and needless retries of partitions
+that no longer existed.
+
+Partition transforms now detect inputs that vanished from disk—for example
+because compaction or the disk monitor deleted them concurrently—skip them
+gracefully, and report them back, so rebuild drops them from the run instead
+of retrying them. As part of this cleanup the index also stops writing the
+vestigial `index.bin` state file, which no released version reads back.

--- a/changelog/unreleased/parallel-and-lazy-catalog-loading.md
+++ b/changelog/unreleased/parallel-and-lazy-catalog-loading.md
@@ -16,13 +16,18 @@ threads defaults to the hardware concurrency and can be tuned with
 storage (such as NFS), where loading is dominated by I/O latency that overlaps
 across requests.
 
-The new `tenzir.index.lazy-sketches` option makes the index skip deserializing
-Bloom-filter sketches when loading the catalog. Only string and IP fields use
-Bloom filters; the corresponding fields remain registered, so the catalog still
-considers them when answering queries (it may return more candidate partitions,
-but never fewer), trading sketch-based pruning of equality predicates on these
-high-cardinality fields for drastically lower resident memory and faster
-startup. Numeric and duration min/max synopses and time synopses are never
+The new `tenzir.index.lazy-sketches` option defers loading Bloom-filter
+sketches at startup and loads them on demand when a query needs them. Only
+string and IP fields use Bloom filters; deferring them drastically lowers
+resident memory and startup cost for nodes with very many partitions. When a
+predicate would benefit from a deferred sketch, the catalog loads it for the
+surviving candidate partitions and caches it, so equality pruning on these
+high-cardinality fields is preserved. The cache is bounded by
+`tenzir.index.sketch-cache-bytes` (default 1 GiB, least-recently-used
+eviction), keeping resident memory capped regardless of the number of
+partitions. Loading reads the partition's local `.mdx`; on remote stores the
+partition is conservatively treated as a candidate instead (never a false
+negative). Numeric and duration min/max synopses and time synopses are never
 deferred, so range pruning—for example on a timestamp field—is unaffected.
 
 The new `tenzir.index.skip-synopsis-verification` option skips the recursive

--- a/changelog/unreleased/parallel-and-lazy-catalog-loading.md
+++ b/changelog/unreleased/parallel-and-lazy-catalog-loading.md
@@ -20,12 +20,13 @@ The new `tenzir.index.lazy-sketches` option defers loading Bloom-filter
 sketches at startup and loads them on demand when a query needs them. Only
 string and IP fields use Bloom filters; deferring them drastically lowers
 resident memory and startup cost for nodes with very many partitions. When a
-predicate would benefit from a deferred sketch, the catalog loads it for the
-surviving candidate partitions and caches it, so equality pruning on these
-high-cardinality fields is preserved. The cache is bounded by
-`tenzir.index.sketch-cache-bytes` (default 1 GiB, least-recently-used
-eviction), keeping resident memory capped regardless of the number of
-partitions. Loading reads the partition's local `.mdx`; on remote stores the
+predicate would benefit from a deferred sketch, the catalog loads and checks
+the surviving candidate partitions one at a time, so equality pruning on these
+high-cardinality fields is preserved no matter how many partitions match —
+only a single sketch is resident at a time. Loaded sketches are kept in a
+memory-bounded LRU cache (`tenzir.index.sketch-cache-bytes`, default 1 GiB) to
+speed up later queries; the budget caps that warm set, not how much can be
+pruned. Loading reads the partition's local `.mdx`; on remote stores the
 partition is conservatively treated as a candidate instead (never a false
 negative). Numeric and duration min/max synopses and time synopses are never
 deferred, so range pruning—for example on a timestamp field—is unaffected.

--- a/changelog/unreleased/parallel-and-lazy-catalog-loading.md
+++ b/changelog/unreleased/parallel-and-lazy-catalog-loading.md
@@ -1,0 +1,26 @@
+---
+title: Faster, lower-memory catalog loading at startup
+type: feature
+authors:
+  - jachris
+  - claude
+created: 2026-06-18T10:35:07.122320Z
+---
+
+Nodes with a very large number of partitions now start up faster and with a
+smaller memory footprint.
+
+Partition synopses are now loaded from disk concurrently. The number of worker
+threads defaults to the hardware concurrency and can be tuned with
+`tenzir.index.load-concurrency`. This is especially effective on networked
+storage (such as NFS), where loading is dominated by I/O latency that overlaps
+across requests.
+
+The new `tenzir.index.lazy-sketch-threshold` option (in bytes, `0` disables it)
+makes the index skip deserializing large opaque synopses—most notably Bloom
+filters—when loading the catalog. The corresponding fields remain registered,
+so the catalog still considers them when answering queries (it may return more
+candidate partitions, but never fewer), trading sketch-based pruning of
+equality predicates on high-cardinality fields for drastically lower resident
+memory and faster startup. Min/max and time synopses are always loaded, so
+range pruning—for example on a timestamp field—is unaffected.

--- a/changelog/unreleased/parallel-and-lazy-catalog-loading.md
+++ b/changelog/unreleased/parallel-and-lazy-catalog-loading.md
@@ -4,6 +4,8 @@ type: feature
 authors:
   - jachris
   - claude
+prs:
+  - 6368
 created: 2026-06-18T10:35:07.122320Z
 ---
 

--- a/changelog/unreleased/parallel-and-lazy-catalog-loading.md
+++ b/changelog/unreleased/parallel-and-lazy-catalog-loading.md
@@ -24,3 +24,16 @@ candidate partitions, but never fewer), trading sketch-based pruning of
 equality predicates on high-cardinality fields for drastically lower resident
 memory and faster startup. Min/max and time synopses are always loaded, so
 range pruning—for example on a timestamp field—is unaffected.
+
+The new `tenzir.index.skip-synopsis-verification` option skips the recursive
+FlatBuffers verification of partition synopses when reading them at startup,
+verifying them once when they are written instead. Verification walks the
+entire buffer and faults in all of its pages—including sketch payloads that are
+never decoded—so skipping it is the dominant startup saving on networked
+storage. It trades robustness against on-disk corruption for speed and should
+only be enabled when the storage backend is trusted.
+
+Loading also avoids a `realpath` and several `stat` calls per partition by
+resolving the base directories once and reusing file sizes gathered during the
+initial directory scan, and it now reports progress periodically for large
+catalogs.

--- a/changelog/unreleased/parallel-and-lazy-catalog-loading.md
+++ b/changelog/unreleased/parallel-and-lazy-catalog-loading.md
@@ -16,10 +16,9 @@ threads defaults to the hardware concurrency and can be tuned with
 storage (such as NFS), where loading is dominated by I/O latency that overlaps
 across requests.
 
-The new `tenzir.index.lazy-sketch-threshold` option (in bytes, `0` disables it)
-makes the index skip deserializing Bloom-filter sketches larger than the
-threshold when loading the catalog. Only string and IP fields use Bloom
-filters; the corresponding fields remain registered, so the catalog still
+The new `tenzir.index.lazy-sketches` option makes the index skip deserializing
+Bloom-filter sketches when loading the catalog. Only string and IP fields use
+Bloom filters; the corresponding fields remain registered, so the catalog still
 considers them when answering queries (it may return more candidate partitions,
 but never fewer), trading sketch-based pruning of equality predicates on these
 high-cardinality fields for drastically lower resident memory and faster

--- a/changelog/unreleased/parallel-and-lazy-catalog-loading.md
+++ b/changelog/unreleased/parallel-and-lazy-catalog-loading.md
@@ -17,13 +17,14 @@ storage (such as NFS), where loading is dominated by I/O latency that overlaps
 across requests.
 
 The new `tenzir.index.lazy-sketch-threshold` option (in bytes, `0` disables it)
-makes the index skip deserializing large opaque synopses—most notably Bloom
-filters—when loading the catalog. The corresponding fields remain registered,
-so the catalog still considers them when answering queries (it may return more
-candidate partitions, but never fewer), trading sketch-based pruning of
-equality predicates on high-cardinality fields for drastically lower resident
-memory and faster startup. Min/max and time synopses are always loaded, so
-range pruning—for example on a timestamp field—is unaffected.
+makes the index skip deserializing Bloom-filter sketches larger than the
+threshold when loading the catalog. Only string and IP fields use Bloom
+filters; the corresponding fields remain registered, so the catalog still
+considers them when answering queries (it may return more candidate partitions,
+but never fewer), trading sketch-based pruning of equality predicates on these
+high-cardinality fields for drastically lower resident memory and faster
+startup. Numeric and duration min/max synopses and time synopses are never
+deferred, so range pruning—for example on a timestamp field—is unaffected.
 
 The new `tenzir.index.skip-synopsis-verification` option skips the recursive
 FlatBuffers verification of partition synopses when reading them at startup,

--- a/libtenzir/builtins/commands/rebuild.cpp
+++ b/libtenzir/builtins/commands/rebuild.cpp
@@ -661,7 +661,8 @@ struct rebuilder_state {
             return;
           }
           if (result.input_partitions.empty()
-              and result.output_partitions.empty()) {
+              and result.output_partitions.empty()
+              and result.skipped_partitions.empty()) {
             TENZIR_DEBUG("{} skipped {} partitions as they are already being "
                          "transformed by another actor",
                          *self, num_partitions);
@@ -672,11 +673,22 @@ struct rebuilder_state {
                         atom::rebuild_v);
             return;
           }
+          // Partitions that vanished before the transformer could load them
+          // were erased concurrently, e.g., by compaction or the disk
+          // monitor. Drop them from the run instead of retrying them.
+          if (not result.skipped_partitions.empty()) {
+            TENZIR_VERBOSE("{} drops {} partition(s) that no longer exist",
+                           *self, result.skipped_partitions.size());
+            run->statistics.num_total -= result.skipped_partitions.size();
+          }
           auto unconsumed_partitions = selected_partitions;
           std::erase_if(unconsumed_partitions, [&](const auto& partition) {
             return std::find(result.input_partitions.begin(),
                              result.input_partitions.end(), partition)
-                   != result.input_partitions.end();
+                     != result.input_partitions.end()
+                   or std::find(result.skipped_partitions.begin(),
+                                result.skipped_partitions.end(), partition)
+                        != result.skipped_partitions.end();
           });
           if (not result.input_complete or not unconsumed_partitions.empty()) {
             TENZIR_DEBUG("{} requeues {} partition(s) that were selected but "

--- a/libtenzir/include/tenzir/catalog.hpp
+++ b/libtenzir/include/tenzir/catalog.hpp
@@ -24,6 +24,7 @@
 #include <caf/typed_event_based_actor.hpp>
 
 #include <list>
+#include <unordered_set>
 #include <vector>
 
 namespace tenzir {
@@ -148,9 +149,14 @@ public:
   /// pruning. This is only sound because the evaluation has no cross-partition
   /// state: evaluating a set equals the union of evaluating each partition
   /// alone. Keep it that way.
-  auto lookup_impl(const expression& expr, const type& schema,
-                   const detail::flat_map<uuid, partition_synopsis_ptr>&
-                     partition_synopses) const
+  /// @param deferred_sketch_partitions Receives the ids of partitions kept only
+  /// because a Bloom-filter sketch was deferred and could prune them if loaded.
+  /// `lookup` uses this to restrict on-demand loading to exactly those
+  /// candidates instead of every surviving candidate in every schema.
+  auto lookup_impl(
+    const expression& expr, const type& schema,
+    const detail::flat_map<uuid, partition_synopsis_ptr>& partition_synopses,
+    std::unordered_set<uuid>& deferred_sketch_partitions) const
     -> catalog_lookup_result::candidate_info;
 
   /// Loads the deferred Bloom-filter sketches of the given partition into the
@@ -188,11 +194,6 @@ public:
   /// dropped so that ongoing ingest does not accumulate them in resident
   /// memory; they are loaded on demand from disk instead.
   bool lazy_sketches = false;
-
-  /// Set by `lookup_impl` when a predicate matched a partition only because a
-  /// Bloom-filter sketch was deferred (null) and could be loaded to prune it.
-  /// Drives whether `lookup` performs the on-demand load + re-evaluation.
-  mutable bool encountered_deferred_sketch = false;
 
   std::optional<detail::request_cache> cache;
 

--- a/libtenzir/include/tenzir/catalog.hpp
+++ b/libtenzir/include/tenzir/catalog.hpp
@@ -23,6 +23,7 @@
 #include <caf/settings.hpp>
 #include <caf/typed_event_based_actor.hpp>
 
+#include <list>
 #include <vector>
 
 namespace tenzir {
@@ -56,6 +57,49 @@ struct catalog_lookup_result {
   }
 };
 
+/// A memory-bounded LRU cache of fully-loaded partition synopses. It serves
+/// Bloom-filter pruning for partitions whose sketches were deferred at startup
+/// (see `tenzir.index.lazy-sketches`): the authoritative synopses keep their
+/// deferred (null) sketches, and the catalog loads them on demand into this
+/// cache when a query needs them. Entries are owned solely by the cache and
+/// never alias the resident synopses, so eviction is O(1) and cannot disturb
+/// resident state.
+class sketch_cache {
+public:
+  sketch_cache() = default;
+  explicit sketch_cache(size_t budget_bytes) : budget_{budget_bytes} {
+  }
+
+  /// Returns the cached synopsis for `id` without changing its recency, or
+  /// nullptr on a miss. Used on the read (lookup) path, which must stay const.
+  [[nodiscard]] auto peek(const uuid& id) const -> partition_synopsis_ptr;
+
+  /// Inserts a loaded synopsis and marks it most-recently-used, evicting
+  /// least-recently-used entries until the total is within budget.
+  void put(const uuid& id, partition_synopsis_ptr synopsis);
+
+  /// Removes `id` from the cache if present (used on erase/merge/replace).
+  void erase(const uuid& id);
+
+  [[nodiscard]] auto budget() const -> size_t {
+    return budget_;
+  }
+  [[nodiscard]] auto used() const -> size_t {
+    return used_;
+  }
+
+private:
+  struct entry {
+    partition_synopsis_ptr synopsis = {};
+    size_t bytes = 0;
+    std::list<uuid>::iterator pos = {};
+  };
+  size_t budget_ = 0;
+  size_t used_ = 0;
+  std::list<uuid> lru_ = {}; // front = most-recently-used
+  std::unordered_map<uuid, entry> entries_ = {};
+};
+
 /// The state of the CATALOG actor.
 struct catalog_state {
 public:
@@ -86,10 +130,16 @@ public:
   /// Retrieves the list of candidate partition IDs for a given expression.
   /// @param expr The expression to lookup.
   /// @returns A lookup result of candidate partitions categorized by type.
-  auto lookup(expression expr) const -> caf::expected<catalog_lookup_result>;
+  auto lookup(expression expr) -> caf::expected<catalog_lookup_result>;
 
   auto lookup_impl(const expression& expr, const type& schema) const
     -> catalog_lookup_result::candidate_info;
+
+  /// Loads the deferred Bloom-filter sketches of the given partition into the
+  /// sketch cache, if possible. Returns the number of bytes loaded, or 0 if
+  /// the partition was already cached, has no loadable sketches, or could not
+  /// be loaded (in which case the partition stays a conservative candidate).
+  auto ensure_sketches_loaded(const uuid& id, const type& schema) -> size_t;
 
   /// @returns A best-effort estimate of the amount of memory used for this
   /// catalog (in bytes).
@@ -111,6 +161,15 @@ public:
                      detail::flat_map<uuid, partition_synopsis_ptr>>
     synopses_per_type;
 
+  /// On-demand cache of partitions whose deferred Bloom-filter sketches have
+  /// been loaded for pruning. Bounded by `tenzir.index.sketch-cache-bytes`.
+  sketch_cache sketches;
+
+  /// Set by `lookup_impl` when a predicate matched a partition only because a
+  /// Bloom-filter sketch was deferred (null) and could be loaded to prune it.
+  /// Drives whether `lookup` performs the on-demand load + re-evaluation.
+  mutable bool encountered_deferred_sketch = false;
+
   std::optional<detail::request_cache> cache;
 
   tenzir::taxonomies taxonomies = {};
@@ -121,8 +180,10 @@ public:
 /// data. The CATALOG may return false positives but never false negatives.
 /// @param self The actor handle.
 /// @param filesystem Used to move/erase on-disk partition files during
-/// quarantine.
+/// @param sketch_cache_bytes Memory budget for on-demand loading of deferred
+/// Bloom-filter sketches; zero disables on-demand loading.
 auto catalog(catalog_actor::stateful_pointer<catalog_state> self,
-             filesystem_actor filesystem) -> catalog_actor::behavior_type;
+             filesystem_actor filesystem, size_t sketch_cache_bytes = 0)
+  -> catalog_actor::behavior_type;
 
 } // namespace tenzir

--- a/libtenzir/include/tenzir/catalog.hpp
+++ b/libtenzir/include/tenzir/catalog.hpp
@@ -64,6 +64,14 @@ struct catalog_lookup_result {
 /// cache when a query needs them. Entries are owned solely by the cache and
 /// never alias the resident synopses, so eviction is O(1) and cannot disturb
 /// resident state.
+///
+/// This is intentionally separate from `detail::lru_cache`, which bounds the
+/// *number* of items. Here the bound must be on *memory* (`sketch-cache-bytes`)
+/// because synopsis sizes vary by orders of magnitude, so a count bound would
+/// not cap resident memory — the very problem lazy sketches address. The loader
+/// is also fallible (a failed/remote load leaves the partition deferred) and
+/// reports the bytes actually cached, which the generic factory-on-miss
+/// interface does not express.
 class sketch_cache {
 public:
   sketch_cache() = default;

--- a/libtenzir/include/tenzir/catalog.hpp
+++ b/libtenzir/include/tenzir/catalog.hpp
@@ -167,6 +167,12 @@ public:
   /// been loaded for pruning. Bounded by `tenzir.index.sketch-cache-bytes`.
   sketch_cache sketches;
 
+  /// Whether Bloom-filter sketches are deferred (see `tenzir.index.lazy-
+  /// sketches`). When set, newly merged synopses also have their Bloom filters
+  /// dropped so that ongoing ingest does not accumulate them in resident
+  /// memory; they are loaded on demand from disk instead.
+  bool lazy_sketches = false;
+
   /// Set by `lookup_impl` when a predicate matched a partition only because a
   /// Bloom-filter sketch was deferred (null) and could be loaded to prune it.
   /// Drives whether `lookup` performs the on-demand load + re-evaluation.
@@ -184,8 +190,11 @@ public:
 /// @param filesystem Used to move/erase on-disk partition files during
 /// @param sketch_cache_bytes Memory budget for on-demand loading of deferred
 /// Bloom-filter sketches; zero disables on-demand loading.
+/// @param lazy_sketches Whether Bloom-filter sketches are deferred; when set,
+/// merged synopses also have their Bloom filters dropped to keep resident
+/// memory bounded during ongoing ingest.
 auto catalog(catalog_actor::stateful_pointer<catalog_state> self,
-             filesystem_actor filesystem, size_t sketch_cache_bytes = 0)
-  -> catalog_actor::behavior_type;
+             filesystem_actor filesystem, size_t sketch_cache_bytes = 0,
+             bool lazy_sketches = false) -> catalog_actor::behavior_type;
 
 } // namespace tenzir

--- a/libtenzir/include/tenzir/catalog.hpp
+++ b/libtenzir/include/tenzir/catalog.hpp
@@ -142,7 +142,15 @@ public:
   /// @returns A lookup result of candidate partitions categorized by type.
   auto lookup(expression expr) -> caf::expected<catalog_lookup_result>;
 
-  auto lookup_impl(const expression& expr, const type& schema) const
+  /// Evaluates `expr` against the given partition collection of `schema`.
+  /// The collection is a parameter (rather than always the full per-schema map)
+  /// so the same logic can evaluate a single partition during on-demand sketch
+  /// pruning. This is only sound because the evaluation has no cross-partition
+  /// state: evaluating a set equals the union of evaluating each partition
+  /// alone. Keep it that way.
+  auto lookup_impl(const expression& expr, const type& schema,
+                   const detail::flat_map<uuid, partition_synopsis_ptr>&
+                     partition_synopses) const
     -> catalog_lookup_result::candidate_info;
 
   /// Loads the deferred Bloom-filter sketches of the given partition into the

--- a/libtenzir/include/tenzir/catalog.hpp
+++ b/libtenzir/include/tenzir/catalog.hpp
@@ -75,8 +75,10 @@ public:
   [[nodiscard]] auto peek(const uuid& id) const -> partition_synopsis_ptr;
 
   /// Inserts a loaded synopsis and marks it most-recently-used, evicting
-  /// least-recently-used entries until the total is within budget.
-  void put(const uuid& id, partition_synopsis_ptr synopsis);
+  /// least-recently-used entries until the total is within budget. Returns the
+  /// number of bytes actually cached, which is zero if the entry alone exceeds
+  /// the budget (it is then not cached at all).
+  auto put(const uuid& id, partition_synopsis_ptr synopsis) -> size_t;
 
   /// Removes `id` from the cache if present (used on erase/merge/replace).
   void erase(const uuid& id);

--- a/libtenzir/include/tenzir/defaults.hpp
+++ b/libtenzir/include/tenzir/defaults.hpp
@@ -229,6 +229,11 @@ inline constexpr caf::timespan rebuild_interval = std::chrono::minutes{30};
 /// Maximum number of in-memory INDEX partitions.
 inline constexpr size_t max_in_mem_partitions = 1;
 
+/// Memory budget for the catalog's on-demand cache of deferred Bloom-filter
+/// sketches (see `tenzir.index.lazy-sketches`). Loaded sketches are evicted
+/// least-recently-used once the total exceeds this many bytes.
+inline constexpr size_t sketch_cache_bytes = 1'073'741'824; // 1 Gi
+
 /// Maximum number of concurrent INDEX queries.
 inline constexpr size_t num_query_supervisors = 10;
 

--- a/libtenzir/include/tenzir/index.hpp
+++ b/libtenzir/include/tenzir/index.hpp
@@ -65,7 +65,8 @@ auto inspect(Inspector& f, send_initial_dbstate& x) {
 //  TODO: Move into separate header.
 caf::error
 extract_partition_synopsis(const std::filesystem::path& partition_path,
-                           const std::filesystem::path& partition_synopsis_path);
+                           const std::filesystem::path& partition_synopsis_path,
+                           bool verify = false);
 
 /// Flatbuffer integration. Note that this is only one-way, restoring
 /// the index state needs additional runtime information.

--- a/libtenzir/include/tenzir/index.hpp
+++ b/libtenzir/include/tenzir/index.hpp
@@ -15,7 +15,6 @@
 #include "tenzir/catalog.hpp"
 #include "tenzir/detail/lru_cache.hpp"
 #include "tenzir/detail/stable_set.hpp"
-#include "tenzir/fbs/index.hpp"
 #include "tenzir/importer.hpp"
 #include "tenzir/plugin_fwd.hpp"
 #include "tenzir/query_context.hpp"
@@ -67,13 +66,6 @@ caf::error
 extract_partition_synopsis(const std::filesystem::path& partition_path,
                            const std::filesystem::path& partition_synopsis_path,
                            bool verify = false);
-
-/// Flatbuffer integration. Note that this is only one-way, restoring
-/// the index state needs additional runtime information.
-// TODO: Pull out the persisted part of the state into a separate struct
-// that can be packed and unpacked.
-caf::expected<flatbuffers::Offset<fbs::Index>>
-pack(flatbuffers::FlatBufferBuilder& builder, const index_state& state);
 
 /// The state of the active partition.
 struct active_partition_info {
@@ -137,9 +129,6 @@ struct index_state {
 
   // -- persistence ------------------------------------------------------------
 
-  [[nodiscard]] std::filesystem::path
-  index_filename(const std::filesystem::path& basename = {}) const;
-
   /// The path to a partition transform finalize marker.
   [[nodiscard]] std::filesystem::path marker_path(const uuid& id) const;
 
@@ -178,8 +167,6 @@ struct index_state {
   transformer_partition_synopsis_path_template() const;
 
   caf::error load_from_disk();
-
-  void flush_to_disk();
 
   // -- inbound path -----------------------------------------------------------
 
@@ -259,9 +246,6 @@ struct index_state {
   /// Uses the `partition_factory` to load new partitions as needed, and evicts
   /// old entries when the size exceeds `max_inmem_partitions`.
   detail::lru_cache<uuid, partition_actor, partition_factory> inmem_partitions;
-
-  /// The set of partitions that exist on disk.
-  std::unordered_set<uuid> persisted_partitions = {};
 
   /// The maximum number of events that a partition can hold.
   size_t partition_capacity = {};

--- a/libtenzir/include/tenzir/index_config.hpp
+++ b/libtenzir/include/tenzir/index_config.hpp
@@ -68,6 +68,16 @@ struct index_config {
   /// unaffected.
   size_t lazy_sketch_threshold = 0;
 
+  /// When set, partition synopses are not verified when read from disk at
+  /// startup, and are instead verified once when written. Verification
+  /// recursively walks the entire FlatBuffers buffer, faulting in all of its
+  /// pages; skipping it on read avoids reading sketch payloads that are never
+  /// decoded (see `lazy_sketch_threshold`) and is the dominant startup cost on
+  /// networked storage. This trades robustness against on-disk corruption for
+  /// faster startup, so it should only be enabled when the storage backend is
+  /// trusted.
+  bool skip_synopsis_verification = false;
+
   template <class Inspector>
   friend auto inspect(Inspector& f, index_config& x) {
     return detail::apply_all(f, x.rules, x.default_fp_rate);

--- a/libtenzir/include/tenzir/index_config.hpp
+++ b/libtenzir/include/tenzir/index_config.hpp
@@ -56,16 +56,16 @@ struct index_config {
   /// startup time by keeping more requests in flight.
   size_t load_concurrency = 0;
 
-  /// When non-zero, opaque partition synopses (most notably Bloom filters)
-  /// whose serialized payload exceeds this many bytes are not deserialized when
-  /// loading the catalog at startup. The corresponding fields are still
+  /// When non-zero, Bloom-filter sketches whose serialized payload exceeds this
+  /// many bytes are not deserialized when loading the catalog at startup. Only
+  /// string and IP fields use Bloom filters; the corresponding fields are still
   /// registered, but with no synopsis, so the catalog conservatively treats
   /// predicates on them as candidates (it may return false positives, never
   /// false negatives). This drastically lowers resident memory and startup cost
   /// for nodes with very many partitions, at the price of coarser pruning for
-  /// equality predicates on high-cardinality fields. Min/max and time synopses
-  /// are always loaded, so range pruning (e.g. on a timestamp field) is
-  /// unaffected.
+  /// equality predicates on these high-cardinality fields. Numeric and duration
+  /// min/max synopses and time synopses are never deferred, so range pruning
+  /// (e.g. on a timestamp field) is unaffected regardless of the threshold.
   size_t lazy_sketch_threshold = 0;
 
   /// When set, partition synopses are not verified when read from disk at

--- a/libtenzir/include/tenzir/index_config.hpp
+++ b/libtenzir/include/tenzir/index_config.hpp
@@ -49,6 +49,25 @@ struct index_config {
   std::vector<rule> rules = {};
   double default_fp_rate = defaults::fp_rate;
 
+  /// The number of worker threads used to load partition synopses from disk
+  /// when the index starts up. Zero selects a default derived from the hardware
+  /// concurrency. Loading is dominated by I/O latency (especially on networked
+  /// storage such as NFS), so values above the core count can further reduce
+  /// startup time by keeping more requests in flight.
+  size_t load_concurrency = 0;
+
+  /// When non-zero, opaque partition synopses (most notably Bloom filters)
+  /// whose serialized payload exceeds this many bytes are not deserialized when
+  /// loading the catalog at startup. The corresponding fields are still
+  /// registered, but with no synopsis, so the catalog conservatively treats
+  /// predicates on them as candidates (it may return false positives, never
+  /// false negatives). This drastically lowers resident memory and startup cost
+  /// for nodes with very many partitions, at the price of coarser pruning for
+  /// equality predicates on high-cardinality fields. Min/max and time synopses
+  /// are always loaded, so range pruning (e.g. on a timestamp field) is
+  /// unaffected.
+  size_t lazy_sketch_threshold = 0;
+
   template <class Inspector>
   friend auto inspect(Inspector& f, index_config& x) {
     return detail::apply_all(f, x.rules, x.default_fp_rate);

--- a/libtenzir/include/tenzir/index_config.hpp
+++ b/libtenzir/include/tenzir/index_config.hpp
@@ -56,23 +56,23 @@ struct index_config {
   /// startup time by keeping more requests in flight.
   size_t load_concurrency = 0;
 
-  /// When non-zero, Bloom-filter sketches whose serialized payload exceeds this
-  /// many bytes are not deserialized when loading the catalog at startup. Only
-  /// string and IP fields use Bloom filters; the corresponding fields are still
-  /// registered, but with no synopsis, so the catalog conservatively treats
-  /// predicates on them as candidates (it may return false positives, never
-  /// false negatives). This drastically lowers resident memory and startup cost
-  /// for nodes with very many partitions, at the price of coarser pruning for
-  /// equality predicates on these high-cardinality fields. Numeric and duration
-  /// min/max synopses and time synopses are never deferred, so range pruning
-  /// (e.g. on a timestamp field) is unaffected regardless of the threshold.
-  size_t lazy_sketch_threshold = 0;
+  /// When set, Bloom-filter sketches are not deserialized when loading the
+  /// catalog at startup. Only string and IP fields use Bloom filters; the
+  /// corresponding fields are still registered, but with no synopsis, so the
+  /// catalog conservatively treats predicates on them as candidates (it may
+  /// return false positives, never false negatives). This drastically lowers
+  /// resident memory and startup cost for nodes with very many partitions, at
+  /// the price of coarser pruning for equality predicates on these
+  /// high-cardinality fields. Numeric and duration min/max synopses and time
+  /// synopses are never deferred, so range pruning (e.g. on a timestamp field)
+  /// is unaffected.
+  bool lazy_sketches = false;
 
   /// When set, partition synopses are not verified when read from disk at
   /// startup, and are instead verified once when written. Verification
   /// recursively walks the entire FlatBuffers buffer, faulting in all of its
   /// pages; skipping it on read avoids reading sketch payloads that are never
-  /// decoded (see `lazy_sketch_threshold`) and is the dominant startup cost on
+  /// decoded (see `lazy_sketches`) and is the dominant startup cost on
   /// networked storage. This trades robustness against on-disk corruption for
   /// faster startup, so it should only be enabled when the storage backend is
   /// trusted.

--- a/libtenzir/include/tenzir/partition_synopsis.hpp
+++ b/libtenzir/include/tenzir/partition_synopsis.hpp
@@ -219,6 +219,10 @@ struct partition_synopsis_pair {
 struct partition_transformer_result {
   std::vector<partition_info> input_partitions;
   std::vector<partition_synopsis_pair> output_partitions;
+  /// Partitions that were selected as input but whose on-disk state no longer
+  /// existed when the transformer tried to load them. Their data is not part
+  /// of the output partitions, and callers must not retry them.
+  std::vector<partition_info> skipped_partitions;
   bool input_complete = true;
 
   template <class Inspector>
@@ -227,6 +231,7 @@ struct partition_transformer_result {
       .pretty_name("tenzir.partition-transformer-result")
       .fields(f.field("input-partitions", x.input_partitions),
               f.field("output-partitions", x.output_partitions),
+              f.field("skipped-partitions", x.skipped_partitions),
               f.field("input-complete", x.input_complete));
   }
 };
@@ -234,6 +239,10 @@ struct partition_transformer_result {
 struct partition_apply_result {
   std::vector<partition_info> input_partitions;
   std::vector<partition_info> output_partitions;
+  /// Partitions that were selected as input but whose on-disk state no longer
+  /// existed when the transformer tried to load them. Their data is not part
+  /// of the output partitions, and callers must not retry them.
+  std::vector<partition_info> skipped_partitions;
   bool input_complete = true;
 
   template <class Inspector>
@@ -242,6 +251,7 @@ struct partition_apply_result {
       .pretty_name("tenzir.partition-apply-result")
       .fields(f.field("input-partitions", x.input_partitions),
               f.field("output-partitions", x.output_partitions),
+              f.field("skipped-partitions", x.skipped_partitions),
               f.field("input-complete", x.input_complete));
   }
 };

--- a/libtenzir/include/tenzir/partition_synopsis.hpp
+++ b/libtenzir/include/tenzir/partition_synopsis.hpp
@@ -94,7 +94,7 @@ struct partition_synopsis final : public caf::ref_counted {
 
   FRIEND_ATTRIBUTE_NODISCARD friend caf::error
   unpack(const fbs::partition_synopsis::LegacyPartitionSynopsis&,
-         partition_synopsis&);
+         partition_synopsis&, size_t lazy_sketch_threshold);
 
   // Returns a raw pointer to a deep copy of this partition synopsis.
   // For use by the `caf::intrusive_cow_ptr`.
@@ -104,6 +104,20 @@ private:
   // Cached memory usage.
   mutable std::atomic<size_t> memusage_ = 0ull;
 };
+
+/// Unpacks a partition synopsis from its FlatBuffers representation.
+/// @param x The serialized partition synopsis.
+/// @param ps The synopsis to populate.
+/// @param lazy_sketch_threshold When non-zero, opaque per-field and per-type
+/// synopses (e.g. Bloom filters) whose serialized payload exceeds this many
+/// bytes are not deserialized. Such fields are still registered with a null
+/// synopsis so that the catalog conservatively treats predicates on them as
+/// candidates (never a false negative), trading sketch-based pruning for much
+/// lower resident memory and faster startup. Min/max, time, and bool synopses,
+/// which are small, are always loaded.
+[[nodiscard]] caf::error
+unpack(const fbs::partition_synopsis::LegacyPartitionSynopsis& x,
+       partition_synopsis& ps, size_t lazy_sketch_threshold = 0);
 
 /// Some quantitative information about a partition.
 struct partition_info {

--- a/libtenzir/include/tenzir/partition_synopsis.hpp
+++ b/libtenzir/include/tenzir/partition_synopsis.hpp
@@ -94,7 +94,7 @@ struct partition_synopsis final : public caf::ref_counted {
 
   FRIEND_ATTRIBUTE_NODISCARD friend caf::error
   unpack(const fbs::partition_synopsis::LegacyPartitionSynopsis&,
-         partition_synopsis&, size_t lazy_sketch_threshold);
+         partition_synopsis&, bool lazy_sketches);
 
   // Returns a raw pointer to a deep copy of this partition synopsis.
   // For use by the `caf::intrusive_cow_ptr`.
@@ -108,16 +108,15 @@ private:
 /// Unpacks a partition synopsis from its FlatBuffers representation.
 /// @param x The serialized partition synopsis.
 /// @param ps The synopsis to populate.
-/// @param lazy_sketch_threshold When non-zero, opaque per-field and per-type
-/// synopses (e.g. Bloom filters) whose serialized payload exceeds this many
-/// bytes are not deserialized. Such fields are still registered with a null
-/// synopsis so that the catalog conservatively treats predicates on them as
-/// candidates (never a false negative), trading sketch-based pruning for much
-/// lower resident memory and faster startup. Min/max, time, and bool synopses,
-/// which are small, are always loaded.
+/// @param lazy_sketches When set, Bloom-filter sketches (string and IP fields)
+/// are not deserialized. Such fields are still registered with a null synopsis
+/// so that the catalog conservatively treats predicates on them as candidates
+/// (never a false negative), trading sketch-based pruning for much lower
+/// resident memory and faster startup. Min/max, time, and bool synopses are
+/// always loaded.
 [[nodiscard]] caf::error
 unpack(const fbs::partition_synopsis::LegacyPartitionSynopsis& x,
-       partition_synopsis& ps, size_t lazy_sketch_threshold = 0);
+       partition_synopsis& ps, bool lazy_sketches = false);
 
 /// Some quantitative information about a partition.
 struct partition_info {

--- a/libtenzir/include/tenzir/partition_synopsis.hpp
+++ b/libtenzir/include/tenzir/partition_synopsis.hpp
@@ -47,6 +47,13 @@ struct partition_synopsis final : public caf::ref_counted {
   /// @related buffered_synopsis
   void shrink();
 
+  /// Drops the Bloom-filter sketches (string and IP fields), matching what
+  /// `unpack` does with `lazy_sketches`: field-level sketches are kept as null
+  /// entries and type-level Bloom-filter sketches are removed. Min/max, time,
+  /// and bool synopses are retained. Used to keep newly merged synopses out of
+  /// resident memory when lazy sketches are enabled.
+  void defer_bloom_filters();
+
   /// Estimate the memory footprint of this partition synopsis.
   /// @returns A best-effort estimate of the amount of memory used by this
   ///          synopsis.

--- a/libtenzir/include/tenzir/partition_transformer.hpp
+++ b/libtenzir/include/tenzir/partition_transformer.hpp
@@ -82,6 +82,10 @@ struct partition_transformer_state {
   /// The input partitions that the transformer actually consumed.
   std::vector<partition_info> transformed_input_partitions = {};
 
+  /// The input partitions whose on-disk state no longer existed when the
+  /// transformer tried to load them.
+  std::vector<partition_info> skipped_partitions = {};
+
   /// Whether the transformer consumed every selected input partition.
   bool input_complete = true;
 

--- a/libtenzir/src/active_partition.cpp
+++ b/libtenzir/src/active_partition.cpp
@@ -19,6 +19,7 @@
 #include "tenzir/fbs/flatbuffer_container.hpp"
 #include "tenzir/fbs/partition.hpp"
 #include "tenzir/fbs/utils.hpp"
+#include "tenzir/flatbuffer.hpp"
 #include "tenzir/ids.hpp"
 #include "tenzir/logger.hpp"
 #include "tenzir/plugin.hpp"
@@ -46,7 +47,8 @@ namespace tenzir {
 
 namespace {
 
-chunk_ptr serialize_partition_synopsis(const partition_synopsis& synopsis) {
+chunk_ptr
+serialize_partition_synopsis(const partition_synopsis& synopsis, bool verify) {
   flatbuffers::FlatBufferBuilder synopsis_builder;
   const auto ps = pack(synopsis_builder, synopsis);
   if (not ps) {
@@ -58,7 +60,20 @@ chunk_ptr serialize_partition_synopsis(const partition_synopsis& synopsis) {
   ps_builder.add_partition_synopsis(ps->Union());
   auto ps_offset = ps_builder.Finish();
   fbs::FinishPartitionSynopsisBuffer(synopsis_builder, ps_offset);
-  return fbs::release(synopsis_builder);
+  auto chunk = fbs::release(synopsis_builder);
+  // When the index is configured to skip verification on read, the synopsis
+  // must be verified here so that we never persist a buffer that cannot be
+  // read back safely.
+  if (verify and chunk) {
+    if (auto checked
+        = flatbuffer<fbs::PartitionSynopsis>::make(chunk_ptr{chunk});
+        not checked) {
+      TENZIR_ERROR("failed to verify freshly serialized partition synopsis: {}",
+                   checked.error());
+      return {};
+    }
+  }
+  return chunk;
 }
 
 /// Delivers persistance promise
@@ -104,8 +119,9 @@ void serialize(
   // regenerate the synopses as needed. This also means we don't
   // need to handle errors here, since Tenzir can still start
   // correctly (if a bit slower) when the write fails.
-  if (auto ps_chunk
-      = serialize_partition_synopsis(*self->state().data.synopsis)) {
+  if (auto ps_chunk = serialize_partition_synopsis(
+        *self->state().data.synopsis,
+        self->state().synopsis_index_config.skip_synopsis_verification)) {
     self->state().data.synopsis.unshared().sketches_file = {
       .url = fmt::format("file://{}", *self->state().synopsis_path),
       .size = ps_chunk->size(),

--- a/libtenzir/src/catalog.cpp
+++ b/libtenzir/src/catalog.cpp
@@ -774,13 +774,23 @@ auto catalog_state::lookup_impl(const expression& expr,
                 // The catalog couldn't rule out this partition, so we have
                 // to include it in the result set. If the missing synopsis is
                 // a deferred Bloom filter (a string or IP field that hasn't
-                // been loaded), record that loading it could prune further.
+                // been loaded), record that loading it could prune further --
+                // but only if a Bloom filter could actually answer this
+                // predicate. Its `lookup` only prunes equality against a
+                // concrete scalar and `in` against a list (see
+                // `bloom_filter_synopsis::lookup`); for anything else (`!=`,
+                // ranges, `!in`, patterns) loading the sketch would be wasted
+                // I/O that cannot prune the current query.
                 if (not loaded) {
+                  const auto bloom_prunable
+                    = (x.op == relational_operator::equal
+                       and not is<caf::none_t>(rhs) and not is<pattern>(rhs))
+                      or (x.op == relational_operator::in and is<list>(rhs));
                   const auto is_bloom_filter = tenzir::match(
                     field.type(), []<concrete_type T>(const T&) {
                       return detail::is_any_v<T, string_type, ip_type>;
                     });
-                  if (is_bloom_filter) {
+                  if (bloom_prunable and is_bloom_filter) {
                     encountered_deferred_sketch = true;
                   }
                 }

--- a/libtenzir/src/catalog.cpp
+++ b/libtenzir/src/catalog.cpp
@@ -603,7 +603,8 @@ auto catalog_state::lookup(expression expr)
   auto evaluate_all = [&] {
     auto result = catalog_lookup_result{};
     for (const auto& [type, resolved] : resolved_per_type) {
-      auto candidates_per_type = lookup_impl(resolved, type);
+      auto candidates_per_type
+        = lookup_impl(resolved, type, synopses_per_type.at(type));
       if (candidates_per_type.partition_infos.empty()) {
         continue;
       }
@@ -616,31 +617,48 @@ auto catalog_state::lookup(expression expr)
   // flag records whether loading them could prune further.
   encountered_deferred_sketch = false;
   auto total_candidates = evaluate_all();
-  // Phase 2: if a predicate hit a deferred Bloom filter, load the sketches of
-  // the surviving candidates (bounded by the cache budget) and re-evaluate so
-  // they can prune. Loading is naturally restricted to the partitions that
-  // survived the cheap (time/min-max) pruning of phase 1.
+  // Phase 2: if a predicate hit a deferred Bloom filter, prune on the go. For
+  // each surviving candidate we load its sketches and re-evaluate that single
+  // partition, dropping it if its now-visible Bloom filter rules it out. Only
+  // one partition's sketches need to be resident at a time, so pruning is not
+  // limited by the cache budget (which only governs how many sketches stay
+  // warm for later queries); the candidate set is already narrowed by the
+  // cheap time/min-max pruning of phase 1.
   if (encountered_deferred_sketch and sketches.budget() > 0) {
-    auto loaded_bytes = size_t{0};
-    auto loaded_any = false;
-    for (const auto& [type, candidates] : total_candidates.candidate_infos) {
-      for (const auto& info : candidates.partition_infos) {
-        // Keep the current query's working set within budget rather than
-        // evicting sketches we just loaded for this same query.
-        if (loaded_bytes >= sketches.budget()) {
-          break;
+    for (const auto& [type, resolved] : resolved_per_type) {
+      auto candidate_it = total_candidates.candidate_infos.find(type);
+      if (candidate_it == total_candidates.candidate_infos.end()) {
+        continue;
+      }
+      const auto& partition_synopses = synopses_per_type.at(type);
+      auto& partition_infos = candidate_it->second.partition_infos;
+      auto kept = std::vector<partition_info>{};
+      kept.reserve(partition_infos.size());
+      for (auto& info : partition_infos) {
+        ensure_sketches_loaded(info.uuid, type);
+        const auto resident = partition_synopses.find(info.uuid);
+        // If the sketches could not be loaded (remote/oversized/missing), keep
+        // the partition as a conservative candidate.
+        if (not sketches.peek(info.uuid)
+            or resident == partition_synopses.end()) {
+          kept.push_back(std::move(info));
+          continue;
         }
-        const auto bytes = ensure_sketches_loaded(info.uuid, type);
-        loaded_bytes += bytes;
-        loaded_any = loaded_any or bytes > 0;
+        // Re-evaluate this single partition; `lookup_impl` picks up its loaded
+        // sketches via the cache.
+        auto single = detail::flat_map<uuid, partition_synopsis_ptr>{};
+        single[resident->first] = resident->second;
+        if (not lookup_impl(resolved, type, single).partition_infos.empty()) {
+          kept.push_back(std::move(info));
+        }
       }
-      if (loaded_bytes >= sketches.budget()) {
-        break;
-      }
+      partition_infos = std::move(kept);
     }
-    if (loaded_any) {
-      total_candidates = evaluate_all();
-    }
+    // Drop schemas whose candidates were all pruned, matching phase 1's
+    // "skip empty" contract.
+    std::erase_if(total_candidates.candidate_infos, [](const auto& entry) {
+      return entry.second.partition_infos.empty();
+    });
   }
   // Sort each schema's partitions by recency and gather statistics.
   auto num_candidate_partitions = size_t{0};
@@ -668,15 +686,11 @@ auto catalog_state::lookup(expression expr)
   return total_candidates;
 }
 
-auto catalog_state::lookup_impl(const expression& expr,
-                                const type& schema) const
+auto catalog_state::lookup_impl(
+  const expression& expr, const type& schema,
+  const detail::flat_map<uuid, partition_synopsis_ptr>& partition_synopses) const
   -> catalog_lookup_result::candidate_info {
   TENZIR_ASSERT(not is<caf::none_t>(expr));
-  auto synopsis_map_per_type_it = synopses_per_type.find(schema);
-  if (synopsis_map_per_type_it == synopses_per_type.end()) {
-    return {};
-  }
-  const auto& partition_synopses = synopsis_map_per_type_it->second;
   // The partition UUIDs must be sorted, otherwise the invariants of the
   // inplace union and intersection algorithms are violated, leading to
   // wrong results. So all places where we return an assembled set must
@@ -698,13 +712,13 @@ auto catalog_state::lookup_impl(const expression& expr,
     [&](const conjunction& x) -> catalog_lookup_result::candidate_info {
       TENZIR_ASSERT(not x.empty());
       auto i = x.begin();
-      auto result = lookup_impl(*i, schema);
+      auto result = lookup_impl(*i, schema, partition_synopses);
       if (not result.partition_infos.empty()) {
         for (++i; i != x.end(); ++i) {
           // TODO: A conjunction means that we can restrict the lookup to the
           // remaining candidates. This could be achived by passing the `result`
           // set to `lookup` along with the child expression.
-          auto xs = lookup_impl(*i, schema);
+          auto xs = lookup_impl(*i, schema, partition_synopses);
           if (xs.partition_infos.empty()) {
             return xs; // short-circuit
           }
@@ -720,7 +734,7 @@ auto catalog_state::lookup_impl(const expression& expr,
       for (const auto& op : x) {
         // TODO: A disjunction means that we can restrict the lookup to the
         // set of partitions that are outside of the current result set.
-        auto xs = lookup_impl(op, schema);
+        auto xs = lookup_impl(op, schema, partition_synopses);
         if (xs.partition_infos.size() == partition_synopses.size()) {
           return xs; // short-circuit
         }
@@ -820,7 +834,7 @@ auto catalog_state::lookup_impl(const expression& expr,
         }
         TENZIR_DEBUG("{} checked {} partitions for predicate {} and got {} "
                      "results",
-                     detail::pretty_type_name(this), synopses_per_type.size(),
+                     detail::pretty_type_name(this), partition_synopses.size(),
                      x, result.partition_infos.size());
         // Some calling paths require the result to be sorted.
         TENZIR_ASSERT_EXPENSIVE(std::is_sorted(result.partition_infos.begin(),

--- a/libtenzir/src/catalog.cpp
+++ b/libtenzir/src/catalog.cpp
@@ -317,12 +317,19 @@ void sketch_cache::put(const uuid& id, partition_synopsis_ptr synopsis) {
   }
   erase(id);
   const auto bytes = synopsis->memusage();
+  // Never cache an entry that alone exceeds the budget; keeping it would
+  // violate the configured memory cap. The partition simply stays a
+  // conservative candidate.
+  if (bytes > budget_) {
+    return;
+  }
   lru_.push_front(id);
   used_ += bytes;
   entries_.emplace(id, entry{std::move(synopsis), bytes, lru_.begin()});
-  // Evict least-recently-used entries until within budget, but always keep at
-  // least the entry we just inserted.
-  while (used_ > budget_ and lru_.size() > 1) {
+  // Evict least-recently-used entries until within budget. The entry we just
+  // inserted fits (checked above) and is most-recently-used, so eviction only
+  // ever removes older entries.
+  while (used_ > budget_) {
     const auto victim = lru_.back();
     erase(victim);
   }

--- a/libtenzir/src/catalog.cpp
+++ b/libtenzir/src/catalog.cpp
@@ -9,6 +9,7 @@
 #include "tenzir/catalog.hpp"
 
 #include "tenzir/actors.hpp"
+#include "tenzir/chunk.hpp"
 #include "tenzir/data.hpp"
 #include "tenzir/defaults.hpp"
 #include "tenzir/detail/overload.hpp"
@@ -19,6 +20,7 @@
 #include "tenzir/duration_synopsis.hpp"
 #include "tenzir/error.hpp"
 #include "tenzir/expression.hpp"
+#include "tenzir/flatbuffer.hpp"
 #include "tenzir/instrumentation.hpp"
 #include "tenzir/int64_synopsis.hpp"
 #include "tenzir/io/read.hpp"
@@ -39,6 +41,7 @@
 #include <caf/detail/set_thread_name.hpp>
 #include <caf/expected.hpp>
 
+#include <filesystem>
 #include <ranges>
 #include <set>
 #include <string_view>
@@ -62,7 +65,7 @@ auto collect_synopses(const catalog_state& state)
   return result;
 }
 
-auto collect_synopses(const catalog_state& state, const expression& filter)
+auto collect_synopses(catalog_state& state, const expression& filter)
   -> caf::expected<std::vector<partition_synopsis_pair>> {
   auto result = std::vector<partition_synopsis_pair>{};
   const auto candidates = state.lookup(filter);
@@ -300,6 +303,97 @@ auto catalog_lookup_result::empty() const noexcept -> bool {
   return candidate_infos.empty();
 }
 
+auto sketch_cache::peek(const uuid& id) const -> partition_synopsis_ptr {
+  const auto it = entries_.find(id);
+  if (it == entries_.end()) {
+    return nullptr;
+  }
+  return it->second.synopsis;
+}
+
+void sketch_cache::put(const uuid& id, partition_synopsis_ptr synopsis) {
+  if (budget_ == 0 or not synopsis) {
+    return;
+  }
+  erase(id);
+  const auto bytes = synopsis->memusage();
+  lru_.push_front(id);
+  used_ += bytes;
+  entries_.emplace(id, entry{std::move(synopsis), bytes, lru_.begin()});
+  // Evict least-recently-used entries until within budget, but always keep at
+  // least the entry we just inserted.
+  while (used_ > budget_ and lru_.size() > 1) {
+    const auto victim = lru_.back();
+    erase(victim);
+  }
+}
+
+void sketch_cache::erase(const uuid& id) {
+  const auto it = entries_.find(id);
+  if (it == entries_.end()) {
+    return;
+  }
+  used_ -= it->second.bytes;
+  lru_.erase(it->second.pos);
+  entries_.erase(it);
+}
+
+auto catalog_state::ensure_sketches_loaded(const uuid& id, const type& schema)
+  -> size_t {
+  if (sketches.budget() == 0) {
+    return 0;
+  }
+  if (sketches.peek(id)) {
+    return 0; // already loaded
+  }
+  const auto type_it = synopses_per_type.find(schema);
+  if (type_it == synopses_per_type.end()) {
+    return 0;
+  }
+  const auto syn_it = type_it->second.find(id);
+  if (syn_it == type_it->second.end()) {
+    return 0;
+  }
+  const auto& resident = syn_it->second;
+  // The sketches live in the partition's `.mdx`; we can only mmap a local file,
+  // so remote stores (e.g. s3://) fall back to the conservative behavior.
+  constexpr auto prefix = std::string_view{"file://"};
+  const auto& url = resident->sketches_file.url;
+  if (not url.starts_with(prefix)) {
+    return 0;
+  }
+  const auto path = std::filesystem::path{url.substr(prefix.size())};
+  auto chunk = chunk::mmap(path);
+  if (not chunk) {
+    TENZIR_DEBUG("{} could not mmap sketches for partition {} at {}: {}", *self,
+                 id, path, chunk.error());
+    return 0;
+  }
+  auto synopsis_fb
+    = tenzir::flatbuffer<fbs::PartitionSynopsis>::make(std::move(*chunk));
+  if (not synopsis_fb) {
+    TENZIR_DEBUG("{} could not read sketches for partition {}: {}", *self, id,
+                 synopsis_fb.error());
+    return 0;
+  }
+  if ((*synopsis_fb)->partition_synopsis_type()
+      != fbs::partition_synopsis::PartitionSynopsis::legacy) {
+    return 0;
+  }
+  auto loaded = caf::make_copy_on_write<partition_synopsis>();
+  // Load fully, i.e. including the deferred Bloom-filter sketches.
+  if (auto error = unpack(*(*synopsis_fb)->partition_synopsis_as_legacy(),
+                          loaded.unshared(), /*lazy_sketches=*/false);
+      error.valid()) {
+    TENZIR_DEBUG("{} could not unpack sketches for partition {}: {}", *self, id,
+                 error);
+    return 0;
+  }
+  const auto bytes = loaded->memusage();
+  sketches.put(id, std::move(loaded));
+  return bytes;
+}
+
 auto catalog_state::initialize(std::vector<partition_synopsis_pair> partitions)
   -> caf::result<atom::ok> {
   auto unsupported_partitions = std::vector<uuid>{};
@@ -346,11 +440,14 @@ auto catalog_state::merge(std::vector<partition_synopsis_pair> partitions)
   for (auto& [id, synopsis] : partitions) {
     auto& entry = synopses_per_type[synopsis->schema][id];
     entry = std::move(synopsis);
+    // Drop any stale loaded sketches for a replaced partition.
+    sketches.erase(id);
   }
   return atom::ok_v;
 }
 
 void catalog_state::erase(const uuid& partition) {
+  sketches.erase(partition);
   for (auto it = synopses_per_type.begin(); it != synopses_per_type.end();
        ++it) {
     const auto num_erased = it->second.erase(partition);
@@ -459,12 +556,9 @@ auto catalog_state::erase_and_extract(const uuid& partition, std::string error)
   return rp;
 }
 
-auto catalog_state::lookup(expression expr) const
+auto catalog_state::lookup(expression expr)
   -> caf::expected<catalog_lookup_result> {
   auto start = stopwatch::now();
-  auto total_candidates = catalog_lookup_result{};
-  auto num_candidate_partitions = size_t{0};
-  auto num_candidate_events = size_t{0};
   if (expr == caf::none) {
     expr = trivially_true_expression();
   }
@@ -475,6 +569,9 @@ auto catalog_state::lookup(expression expr) const
                                        "epxression {}: {}",
                                        *self, expr, normalized.error()));
   }
+  // Resolve the expression once per schema; reused across both phases below.
+  auto resolved_per_type = std::vector<std::pair<type, expression>>{};
+  resolved_per_type.reserve(synopses_per_type.size());
   for (const auto& [type, _] : synopses_per_type) {
     auto resolved = resolve(taxonomies, *normalized, type);
     if (not resolved) {
@@ -483,26 +580,66 @@ auto catalog_state::lookup(expression expr) const
                                          "{}",
                                          *self, expr, resolved.error()));
     }
-    auto candidates_per_type = lookup_impl(*resolved, type);
-    if (candidates_per_type.partition_infos.empty()) {
-      continue;
+    resolved_per_type.emplace_back(type, std::move(*resolved));
+  }
+  auto evaluate_all = [&] {
+    auto result = catalog_lookup_result{};
+    for (const auto& [type, resolved] : resolved_per_type) {
+      auto candidates_per_type = lookup_impl(resolved, type);
+      if (candidates_per_type.partition_infos.empty()) {
+        continue;
+      }
+      result.candidate_infos[type] = std::move(candidates_per_type);
     }
-    // Sort partitions by their max import time, returning the most recent
-    // partitions first.
-    std::sort(candidates_per_type.partition_infos.begin(),
-              candidates_per_type.partition_infos.end(),
-              [&](const partition_info& lhs, const partition_info& rhs) {
+    return result;
+  };
+  // Phase 1: prune using the resident synopses. Deferred Bloom-filter sketches
+  // are treated conservatively (their partitions are kept as candidates); the
+  // flag records whether loading them could prune further.
+  encountered_deferred_sketch = false;
+  auto total_candidates = evaluate_all();
+  // Phase 2: if a predicate hit a deferred Bloom filter, load the sketches of
+  // the surviving candidates (bounded by the cache budget) and re-evaluate so
+  // they can prune. Loading is naturally restricted to the partitions that
+  // survived the cheap (time/min-max) pruning of phase 1.
+  if (encountered_deferred_sketch and sketches.budget() > 0) {
+    auto loaded_bytes = size_t{0};
+    auto loaded_any = false;
+    for (const auto& [type, candidates] : total_candidates.candidate_infos) {
+      for (const auto& info : candidates.partition_infos) {
+        // Keep the current query's working set within budget rather than
+        // evicting sketches we just loaded for this same query.
+        if (loaded_bytes >= sketches.budget()) {
+          break;
+        }
+        const auto bytes = ensure_sketches_loaded(info.uuid, type);
+        loaded_bytes += bytes;
+        loaded_any = loaded_any or bytes > 0;
+      }
+      if (loaded_bytes >= sketches.budget()) {
+        break;
+      }
+    }
+    if (loaded_any) {
+      total_candidates = evaluate_all();
+    }
+  }
+  // Sort each schema's partitions by recency and gather statistics.
+  auto num_candidate_partitions = size_t{0};
+  auto num_candidate_events = size_t{0};
+  for (auto& [type, candidates] : total_candidates.candidate_infos) {
+    std::sort(candidates.partition_infos.begin(),
+              candidates.partition_infos.end(),
+              [](const partition_info& lhs, const partition_info& rhs) {
                 return lhs.max_import_time > rhs.max_import_time;
               });
-    num_candidate_partitions += candidates_per_type.partition_infos.size();
+    num_candidate_partitions += candidates.partition_infos.size();
     num_candidate_events
-      += std::transform_reduce(candidates_per_type.partition_infos.begin(),
-                               candidates_per_type.partition_infos.end(),
-                               size_t{0}, std::plus<>{},
-                               [](const auto& partition) {
+      += std::transform_reduce(candidates.partition_infos.begin(),
+                               candidates.partition_infos.end(), size_t{0},
+                               std::plus<>{}, [](const auto& partition) {
                                  return partition.events;
                                });
-    total_candidates.candidate_infos[type] = std::move(candidates_per_type);
   }
   auto delta = std::chrono::duration_cast<std::chrono::microseconds>(
     stopwatch::now() - start);
@@ -598,7 +735,12 @@ auto catalog_state::lookup_impl(const expression& expr,
         // singular type all synopses loops -> relevant anymore? Use type as
         // synopses key
         for (const auto& [part_id, part_syn] : partition_synopses) {
-          for (const auto& [field, syn] : part_syn->field_synopses_) {
+          // Prefer an on-demand-loaded synopsis (with Bloom-filter sketches)
+          // when one is cached; otherwise use the resident synopsis, whose
+          // deferred sketches are null.
+          const auto loaded = sketches.peek(part_id);
+          const auto& effective = loaded ? loaded : part_syn;
+          for (const auto& [field, syn] : effective->field_synopses_) {
             if (match(field)) {
               // We need to prune the type's metadata here by converting it to
               // a concrete type and back, because the type synopses are
@@ -614,24 +756,35 @@ auto catalog_state::lookup_impl(const expression& expr,
                 if (not opt or *opt) {
                   TENZIR_TRACE("{} selects {} at predicate {}",
                                detail::pretty_type_name(this), part_id, x);
-                  result.partition_infos.emplace_back(part_id, *part_syn);
+                  result.partition_infos.emplace_back(part_id, *effective);
                   break;
                 }
                 // The field has no dedicated synopsis. Check if there is one
                 // for the type in general.
-              } else if (auto it = part_syn->type_synopses_.find(cleaned_type);
-                         it != part_syn->type_synopses_.end() and it->second) {
+              } else if (auto it = effective->type_synopses_.find(cleaned_type);
+                         it != effective->type_synopses_.end() and it->second) {
                 auto opt = it->second->lookup(x.op, make_view(rhs));
                 if (not opt or *opt) {
                   TENZIR_TRACE("{} selects {} at predicate {}",
                                detail::pretty_type_name(this), part_id, x);
-                  result.partition_infos.emplace_back(part_id, *part_syn);
+                  result.partition_infos.emplace_back(part_id, *effective);
                   break;
                 }
               } else {
                 // The catalog couldn't rule out this partition, so we have
-                // to include it in the result set.
-                result.partition_infos.emplace_back(part_id, *part_syn);
+                // to include it in the result set. If the missing synopsis is
+                // a deferred Bloom filter (a string or IP field that hasn't
+                // been loaded), record that loading it could prune further.
+                if (not loaded) {
+                  const auto is_bloom_filter = tenzir::match(
+                    field.type(), []<concrete_type T>(const T&) {
+                      return detail::is_any_v<T, string_type, ip_type>;
+                    });
+                  if (is_bloom_filter) {
+                    encountered_deferred_sketch = true;
+                  }
+                }
+                result.partition_infos.emplace_back(part_id, *effective);
                 break;
               }
             }
@@ -810,13 +963,17 @@ auto catalog_state::memusage() const -> size_t {
 }
 
 auto catalog(catalog_actor::stateful_pointer<catalog_state> self,
-             filesystem_actor filesystem) -> catalog_actor::behavior_type {
+             filesystem_actor filesystem, size_t sketch_cache_bytes)
+  -> catalog_actor::behavior_type {
   if (self->getf(caf::local_actor::is_detached_flag)) {
     caf::detail::set_thread_name("tnz.catalog");
   }
   self->state().self = self;
   self->state().filesystem = std::move(filesystem);
   self->state().taxonomies.concepts = modules::concepts();
+  // Initialize the sketch cache before the request cache below, so that any
+  // queries stashed during startup observe a ready cache once unstashed.
+  self->state().sketches = sketch_cache{sketch_cache_bytes};
   self->state().cache.emplace();
   return {
     [self](atom::start, std::vector<partition_synopsis_pair>& partitions)

--- a/libtenzir/src/catalog.cpp
+++ b/libtenzir/src/catalog.cpp
@@ -449,6 +449,13 @@ auto catalog_state::initialize(std::vector<partition_synopsis_pair> partitions)
 auto catalog_state::merge(std::vector<partition_synopsis_pair> partitions)
   -> caf::result<atom::ok> {
   for (auto& [id, synopsis] : partitions) {
+    // With lazy sketches, drop the Bloom filters of newly flushed or
+    // transformed partitions too; otherwise ongoing ingest would accumulate
+    // them in resident memory and bypass the bounded sketch cache. They are
+    // reloaded on demand from the partition's `.mdx`.
+    if (lazy_sketches and synopsis) {
+      synopsis.unshared().defer_bloom_filters();
+    }
     auto& entry = synopses_per_type[synopsis->schema][id];
     entry = std::move(synopsis);
     // Drop any stale loaded sketches for a replaced partition.
@@ -984,14 +991,15 @@ auto catalog_state::memusage() const -> size_t {
 }
 
 auto catalog(catalog_actor::stateful_pointer<catalog_state> self,
-             filesystem_actor filesystem, size_t sketch_cache_bytes)
-  -> catalog_actor::behavior_type {
+             filesystem_actor filesystem, size_t sketch_cache_bytes,
+             bool lazy_sketches) -> catalog_actor::behavior_type {
   if (self->getf(caf::local_actor::is_detached_flag)) {
     caf::detail::set_thread_name("tnz.catalog");
   }
   self->state().self = self;
   self->state().filesystem = std::move(filesystem);
   self->state().taxonomies.concepts = modules::concepts();
+  self->state().lazy_sketches = lazy_sketches;
   // Initialize the sketch cache before the request cache below, so that any
   // queries stashed during startup observe a ready cache once unstashed.
   self->state().sketches = sketch_cache{sketch_cache_bytes};

--- a/libtenzir/src/catalog.cpp
+++ b/libtenzir/src/catalog.cpp
@@ -41,6 +41,7 @@
 #include <caf/detail/set_thread_name.hpp>
 #include <caf/expected.hpp>
 
+#include <algorithm>
 #include <filesystem>
 #include <ranges>
 #include <set>
@@ -452,8 +453,10 @@ auto catalog_state::merge(std::vector<partition_synopsis_pair> partitions)
     // With lazy sketches, drop the Bloom filters of newly flushed or
     // transformed partitions too; otherwise ongoing ingest would accumulate
     // them in resident memory and bypass the bounded sketch cache. They are
-    // reloaded on demand from the partition's `.mdx`.
-    if (lazy_sketches and synopsis) {
+    // reloaded on demand from the partition's `.mdx`, so only defer when that
+    // file is locally loadable -- never strip sketches we could not reload.
+    if (lazy_sketches and synopsis
+        and synopsis->sketches_file.url.starts_with("file://")) {
       synopsis.unshared().defer_bloom_filters();
     }
     auto& entry = synopses_per_type[synopsis->schema][id];
@@ -805,24 +808,40 @@ auto catalog_state::lookup_impl(
               } else {
                 // The catalog couldn't rule out this partition, so we have
                 // to include it in the result set. If the missing synopsis is
-                // a deferred Bloom filter (a string or IP field that hasn't
-                // been loaded), record that loading it could prune further --
-                // but only if a Bloom filter could actually answer this
-                // predicate. Its `lookup` only prunes equality against a
-                // concrete scalar and `in` against a list (see
-                // `bloom_filter_synopsis::lookup`); for anything else (`!=`,
-                // ranges, `!in`, patterns) loading the sketch would be wasted
-                // I/O that cannot prune the current query.
+                // a deferred Bloom filter, record that loading it could prune
+                // further -- but only if the Bloom filter could actually answer
+                // this predicate. `bloom_filter_synopsis::lookup` only hashes
+                // literal values of the field type: it prunes `equal` against a
+                // literal and `in` against a list of literals. For anything
+                // else (`!=`, ranges, patterns, subnets/patterns inside an `in`
+                // list, type mismatches) it returns nullopt or silently skips
+                // the element, so loading the sketch could not prune -- or
+                // worse, could prune a partition exact evaluation would keep.
                 if (not loaded) {
-                  const auto bloom_prunable
-                    = (x.op == relational_operator::equal
-                       and not is<caf::none_t>(rhs) and not is<pattern>(rhs))
-                      or (x.op == relational_operator::in and is<list>(rhs));
-                  const auto is_bloom_filter = tenzir::match(
-                    field.type(), []<concrete_type T>(const T&) {
-                      return detail::is_any_v<T, string_type, ip_type>;
-                    });
-                  if (bloom_prunable and is_bloom_filter) {
+                  // True iff `value` is a literal a Bloom filter on this field
+                  // type can hash (string -> string, IP -> ip).
+                  const auto is_bloom_literal = [&](const data& value) {
+                    return tenzir::match(
+                      field.type(), [&]<concrete_type T>(const T&) {
+                        if constexpr (std::is_same_v<T, string_type>) {
+                          return is<std::string>(value);
+                        } else if constexpr (std::is_same_v<T, ip_type>) {
+                          return is<ip>(value);
+                        } else {
+                          return false;
+                        }
+                      });
+                  };
+                  auto bloom_prunable = false;
+                  if (x.op == relational_operator::equal) {
+                    bloom_prunable = is_bloom_literal(rhs);
+                  } else if (x.op == relational_operator::in) {
+                    if (const auto* xs = try_as<list>(&rhs)) {
+                      bloom_prunable
+                        = std::ranges::all_of(*xs, is_bloom_literal);
+                    }
+                  }
+                  if (bloom_prunable) {
                     encountered_deferred_sketch = true;
                   }
                 }

--- a/libtenzir/src/catalog.cpp
+++ b/libtenzir/src/catalog.cpp
@@ -311,17 +311,19 @@ auto sketch_cache::peek(const uuid& id) const -> partition_synopsis_ptr {
   return it->second.synopsis;
 }
 
-void sketch_cache::put(const uuid& id, partition_synopsis_ptr synopsis) {
+auto sketch_cache::put(const uuid& id, partition_synopsis_ptr synopsis)
+  -> size_t {
   if (budget_ == 0 or not synopsis) {
-    return;
+    return 0;
   }
   erase(id);
   const auto bytes = synopsis->memusage();
   // Never cache an entry that alone exceeds the budget; keeping it would
   // violate the configured memory cap. The partition simply stays a
-  // conservative candidate.
+  // conservative candidate. Returning zero also keeps the caller from
+  // spending its query budget on a sketch that wasn't cached.
   if (bytes > budget_) {
-    return;
+    return 0;
   }
   lru_.push_front(id);
   used_ += bytes;
@@ -333,6 +335,7 @@ void sketch_cache::put(const uuid& id, partition_synopsis_ptr synopsis) {
     const auto victim = lru_.back();
     erase(victim);
   }
+  return bytes;
 }
 
 void sketch_cache::erase(const uuid& id) {
@@ -396,9 +399,10 @@ auto catalog_state::ensure_sketches_loaded(const uuid& id, const type& schema)
                  error);
     return 0;
   }
-  const auto bytes = loaded->memusage();
-  sketches.put(id, std::move(loaded));
-  return bytes;
+  // Return the bytes actually cached: `put` refuses an entry larger than the
+  // whole budget, and the caller must not spend its query budget on a sketch
+  // that wasn't cached (it would stop loading later, smaller candidates).
+  return sketches.put(id, std::move(loaded));
 }
 
 auto catalog_state::initialize(std::vector<partition_synopsis_pair> partitions)

--- a/libtenzir/src/catalog.cpp
+++ b/libtenzir/src/catalog.cpp
@@ -54,6 +54,30 @@ namespace {
 
 TENZIR_ENUM(catalog_slice_selector, fields, schemas, partitions);
 
+auto contains_metadata(const expression& expr) -> bool {
+  return match(
+    expr,
+    [](caf::none_t) {
+      return false;
+    },
+    [](const predicate& pred) {
+      return is<meta_extractor>(pred.lhs) or is<meta_extractor>(pred.rhs);
+    },
+    [](const conjunction& expressions) {
+      return std::ranges::any_of(expressions, [](const auto& expression) {
+        return contains_metadata(expression);
+      });
+    },
+    [](const disjunction& expressions) {
+      return std::ranges::any_of(expressions, [](const auto& expression) {
+        return contains_metadata(expression);
+      });
+    },
+    [](const negation& expression) {
+      return contains_metadata(expression.expr());
+    });
+}
+
 auto collect_synopses(const catalog_state& state)
   -> std::vector<partition_synopsis_pair> {
   auto result = std::vector<partition_synopsis_pair>{};
@@ -727,41 +751,54 @@ auto catalog_state::lookup_impl(
   auto f = detail::overload{
     [&](const conjunction& x) -> catalog_lookup_result::candidate_info {
       TENZIR_ASSERT(not x.empty());
-      auto i = x.begin();
-      auto result = lookup_impl(*i, schema, partition_synopses,
-                                deferred_sketch_partitions);
-      if (not result.partition_infos.empty()) {
-        for (++i; i != x.end(); ++i) {
+      auto result = catalog_lookup_result::candidate_info{};
+      auto initialized = false;
+      for (const auto metadata : {true, false}) {
+        for (const auto& op : x) {
+          if (contains_metadata(op) != metadata) {
+            continue;
+          }
           // TODO: A conjunction means that we can restrict the lookup to the
           // remaining candidates. This could be achived by passing the `result`
           // set to `lookup` along with the child expression.
-          auto xs = lookup_impl(*i, schema, partition_synopses,
+          auto xs = lookup_impl(op, schema, partition_synopses,
                                 deferred_sketch_partitions);
-          if (xs.partition_infos.empty()) {
-            return xs; // short-circuit
+          if (not initialized) {
+            result = std::move(xs);
+            initialized = true;
+          } else {
+            detail::inplace_intersect(result.partition_infos,
+                                      xs.partition_infos);
+            TENZIR_ASSERT_EXPENSIVE(std::is_sorted(
+              result.partition_infos.begin(), result.partition_infos.end()));
           }
-          detail::inplace_intersect(result.partition_infos, xs.partition_infos);
-          TENZIR_ASSERT_EXPENSIVE(std::is_sorted(result.partition_infos.begin(),
-                                                 result.partition_infos.end()));
+          if (result.partition_infos.empty()) {
+            return result; // short-circuit
+          }
         }
       }
       return result;
     },
     [&](const disjunction& x) -> catalog_lookup_result::candidate_info {
       catalog_lookup_result::candidate_info result;
-      for (const auto& op : x) {
-        // TODO: A disjunction means that we can restrict the lookup to the
-        // set of partitions that are outside of the current result set.
-        auto xs = lookup_impl(op, schema, partition_synopses,
-                              deferred_sketch_partitions);
-        if (xs.partition_infos.size() == partition_synopses.size()) {
-          return xs; // short-circuit
+      for (const auto metadata : {true, false}) {
+        for (const auto& op : x) {
+          if (contains_metadata(op) != metadata) {
+            continue;
+          }
+          // TODO: A disjunction means that we can restrict the lookup to the
+          // set of partitions that are outside of the current result set.
+          auto xs = lookup_impl(op, schema, partition_synopses,
+                                deferred_sketch_partitions);
+          if (xs.partition_infos.size() == partition_synopses.size()) {
+            return xs; // short-circuit
+          }
+          TENZIR_ASSERT_EXPENSIVE(std::is_sorted(xs.partition_infos.begin(),
+                                                 xs.partition_infos.end()));
+          detail::inplace_unify(result.partition_infos, xs.partition_infos);
+          TENZIR_ASSERT_EXPENSIVE(std::is_sorted(result.partition_infos.begin(),
+                                                 result.partition_infos.end()));
         }
-        TENZIR_ASSERT_EXPENSIVE(
-          std::is_sorted(xs.partition_infos.begin(), xs.partition_infos.end()));
-        detail::inplace_unify(result.partition_infos, xs.partition_infos);
-        TENZIR_ASSERT_EXPENSIVE(std::is_sorted(result.partition_infos.begin(),
-                                               result.partition_infos.end()));
       }
       return result;
     },

--- a/libtenzir/src/catalog.cpp
+++ b/libtenzir/src/catalog.cpp
@@ -603,34 +603,38 @@ auto catalog_state::lookup(expression expr)
     }
     resolved_per_type.emplace_back(type, std::move(*resolved));
   }
-  auto evaluate_all = [&] {
-    auto result = catalog_lookup_result{};
-    for (const auto& [type, resolved] : resolved_per_type) {
-      auto candidates_per_type
-        = lookup_impl(resolved, type, synopses_per_type.at(type));
-      if (candidates_per_type.partition_infos.empty()) {
-        continue;
-      }
-      result.candidate_infos[type] = std::move(candidates_per_type);
-    }
-    return result;
-  };
   // Phase 1: prune using the resident synopses. Deferred Bloom-filter sketches
-  // are treated conservatively (their partitions are kept as candidates); the
-  // flag records whether loading them could prune further.
-  encountered_deferred_sketch = false;
-  auto total_candidates = evaluate_all();
-  // Phase 2: if a predicate hit a deferred Bloom filter, prune on the go. For
-  // each surviving candidate we load its sketches and re-evaluate that single
+  // are treated conservatively (their partitions are kept as candidates);
+  // `deferred_per_type` collects, per schema, the ids of partitions that were
+  // kept only because such a sketch could prune them if loaded.
+  auto deferred_per_type = std::unordered_map<type, std::unordered_set<uuid>>{};
+  auto total_candidates = catalog_lookup_result{};
+  for (const auto& [type, resolved] : resolved_per_type) {
+    auto& deferred = deferred_per_type[type];
+    auto candidates_per_type
+      = lookup_impl(resolved, type, synopses_per_type.at(type), deferred);
+    if (candidates_per_type.partition_infos.empty()) {
+      continue;
+    }
+    total_candidates.candidate_infos[type] = std::move(candidates_per_type);
+  }
+  // Phase 2: prune on the go. For each candidate that was kept only because of
+  // a deferred Bloom filter, load its sketches and re-evaluate that single
   // partition, dropping it if its now-visible Bloom filter rules it out. Only
   // one partition's sketches need to be resident at a time, so pruning is not
   // limited by the cache budget (which only governs how many sketches stay
   // warm for later queries); the candidate set is already narrowed by the
-  // cheap time/min-max pruning of phase 1.
-  if (encountered_deferred_sketch and sketches.budget() > 0) {
+  // cheap time/min-max pruning of phase 1. Restricting to `deferred` ids avoids
+  // loading sketches for candidates a Bloom filter cannot prune (e.g. those
+  // matched only by a `#schema` or other branch of a disjunction).
+  if (sketches.budget() > 0) {
     for (const auto& [type, resolved] : resolved_per_type) {
       auto candidate_it = total_candidates.candidate_infos.find(type);
       if (candidate_it == total_candidates.candidate_infos.end()) {
+        continue;
+      }
+      const auto& deferred = deferred_per_type[type];
+      if (deferred.empty()) {
         continue;
       }
       const auto& partition_synopses = synopses_per_type.at(type);
@@ -638,20 +642,28 @@ auto catalog_state::lookup(expression expr)
       auto kept = std::vector<partition_info>{};
       kept.reserve(partition_infos.size());
       for (auto& info : partition_infos) {
-        ensure_sketches_loaded(info.uuid, type);
         const auto resident = partition_synopses.find(info.uuid);
-        // If the sketches could not be loaded (remote/oversized/missing), keep
-        // the partition as a conservative candidate.
-        if (not sketches.peek(info.uuid)
+        // Only candidates kept because of a deferred Bloom filter are worth
+        // loading; everything else stays as-is.
+        if (not deferred.contains(info.uuid)
             or resident == partition_synopses.end()) {
           kept.push_back(std::move(info));
           continue;
         }
+        ensure_sketches_loaded(info.uuid, type);
+        // If the sketches could not be loaded (remote/oversized/missing), keep
+        // the partition as a conservative candidate.
+        if (not sketches.peek(info.uuid)) {
+          kept.push_back(std::move(info));
+          continue;
+        }
         // Re-evaluate this single partition; `lookup_impl` picks up its loaded
-        // sketches via the cache.
+        // sketches via the cache. The throwaway deferred set is unused here.
         auto single = detail::flat_map<uuid, partition_synopsis_ptr>{};
         single[resident->first] = resident->second;
-        if (not lookup_impl(resolved, type, single).partition_infos.empty()) {
+        auto ignored = std::unordered_set<uuid>{};
+        if (not lookup_impl(resolved, type, single, ignored)
+                  .partition_infos.empty()) {
           kept.push_back(std::move(info));
         }
       }
@@ -691,7 +703,8 @@ auto catalog_state::lookup(expression expr)
 
 auto catalog_state::lookup_impl(
   const expression& expr, const type& schema,
-  const detail::flat_map<uuid, partition_synopsis_ptr>& partition_synopses) const
+  const detail::flat_map<uuid, partition_synopsis_ptr>& partition_synopses,
+  std::unordered_set<uuid>& deferred_sketch_partitions) const
   -> catalog_lookup_result::candidate_info {
   TENZIR_ASSERT(not is<caf::none_t>(expr));
   // The partition UUIDs must be sorted, otherwise the invariants of the
@@ -715,13 +728,15 @@ auto catalog_state::lookup_impl(
     [&](const conjunction& x) -> catalog_lookup_result::candidate_info {
       TENZIR_ASSERT(not x.empty());
       auto i = x.begin();
-      auto result = lookup_impl(*i, schema, partition_synopses);
+      auto result = lookup_impl(*i, schema, partition_synopses,
+                                deferred_sketch_partitions);
       if (not result.partition_infos.empty()) {
         for (++i; i != x.end(); ++i) {
           // TODO: A conjunction means that we can restrict the lookup to the
           // remaining candidates. This could be achived by passing the `result`
           // set to `lookup` along with the child expression.
-          auto xs = lookup_impl(*i, schema, partition_synopses);
+          auto xs = lookup_impl(*i, schema, partition_synopses,
+                                deferred_sketch_partitions);
           if (xs.partition_infos.empty()) {
             return xs; // short-circuit
           }
@@ -737,7 +752,8 @@ auto catalog_state::lookup_impl(
       for (const auto& op : x) {
         // TODO: A disjunction means that we can restrict the lookup to the
         // set of partitions that are outside of the current result set.
-        auto xs = lookup_impl(op, schema, partition_synopses);
+        auto xs = lookup_impl(op, schema, partition_synopses,
+                              deferred_sketch_partitions);
         if (xs.partition_infos.size() == partition_synopses.size()) {
           return xs; // short-circuit
         }
@@ -842,7 +858,7 @@ auto catalog_state::lookup_impl(
                     }
                   }
                   if (bloom_prunable) {
-                    encountered_deferred_sketch = true;
+                    deferred_sketch_partitions.insert(part_id);
                   }
                 }
                 result.partition_infos.emplace_back(part_id, *effective);

--- a/libtenzir/src/index.cpp
+++ b/libtenzir/src/index.cpp
@@ -614,6 +614,11 @@ caf::error index_state::load_from_disk() {
   const auto archive_dir = resolve_dir(dir / ".." / "archive");
   const auto lazy_sketch_threshold = synopsis_opts.lazy_sketch_threshold;
   const auto skip_verification = synopsis_opts.skip_synopsis_verification;
+  // `synopsis_files` was scanned from `dir`, but synopses live under
+  // `synopsisdir`. These are the same in the default configuration; when they
+  // differ we must check the actual synopsis path instead of the scan result,
+  // otherwise we would regenerate every synopsis on each startup.
+  const auto synopsis_in_index_dir = synopsisdir == dir;
   // Loads a single partition synopsis from disk. This is invoked concurrently
   // from multiple worker threads below, so it must not touch shared mutable
   // state: it only reads data prepared above (all immutable during the load)
@@ -624,12 +629,16 @@ caf::error index_state::load_from_disk() {
     [&](const uuid& partition_uuid) -> caf::expected<partition_synopsis_pair> {
     auto part_path = partition_path(partition_uuid);
     auto synopsis_path = partition_synopsis_path(partition_uuid);
-    // Generate the external partition synopsis file if it doesn't exist. We
-    // know which `.mdx` files exist from the directory scan above, so this
-    // avoids a stat. When verification is skipped on read, verify the freshly
-    // written synopsis instead.
-    if (not std::binary_search(synopsis_files.begin(), synopsis_files.end(),
-                               partition_uuid)) {
+    // Generate the external partition synopsis file if it doesn't exist. In the
+    // common case the synopsis lives in the scanned index directory, so we can
+    // use the scan result and avoid a stat; otherwise we check the actual path.
+    // When verification is skipped on read, verify the freshly written synopsis.
+    const auto synopsis_exists
+      = synopsis_in_index_dir
+          ? std::binary_search(synopsis_files.begin(), synopsis_files.end(),
+                               partition_uuid)
+          : std::filesystem::exists(synopsis_path);
+    if (not synopsis_exists) {
       if (auto error = extract_partition_synopsis(part_path, synopsis_path,
                                                   skip_verification);
           error.valid()) {

--- a/libtenzir/src/index.cpp
+++ b/libtenzir/src/index.cpp
@@ -612,7 +612,7 @@ caf::error index_state::load_from_disk() {
   const auto index_dir = resolve_dir(dir);
   const auto synopsis_dir = resolve_dir(synopsisdir);
   const auto archive_dir = resolve_dir(dir / ".." / "archive");
-  const auto lazy_sketch_threshold = synopsis_opts.lazy_sketch_threshold;
+  const auto lazy_sketches = synopsis_opts.lazy_sketches;
   const auto skip_verification = synopsis_opts.skip_synopsis_verification;
   // `synopsis_files` was scanned from `dir`, but synopses live under
   // `synopsisdir`. These are the same in the default configuration; when they
@@ -666,8 +666,7 @@ caf::error index_state::load_from_disk() {
     TENZIR_ASSERT(ps_flatbuffer->partition_synopsis_as_legacy());
     const auto& synopsis_legacy
       = *ps_flatbuffer->partition_synopsis_as_legacy();
-    if (auto error
-        = unpack(synopsis_legacy, ps.unshared(), lazy_sketch_threshold);
+    if (auto error = unpack(synopsis_legacy, ps.unshared(), lazy_sketches);
         error.valid()) {
       return error;
     }
@@ -722,11 +721,9 @@ caf::error index_state::load_from_disk() {
   // stay quiet for small ones to avoid log noise.
   const auto report_progress = num_partitions >= size_t{1000};
   const auto progress_step = std::max<size_t>(1, num_partitions / 20);
-  const auto lazy_suffix
-    = lazy_sketch_threshold > 0
-        ? fmt::format(" deferring sketches larger than {} bytes;",
-                      lazy_sketch_threshold)
-        : std::string{};
+  const auto lazy_suffix = lazy_sketches
+                             ? std::string{" deferring Bloom-filter sketches;"}
+                             : std::string{};
   const auto verify_suffix = skip_verification
                                ? std::string{" skipping verification;"}
                                : std::string{};

--- a/libtenzir/src/index.cpp
+++ b/libtenzir/src/index.cpp
@@ -71,6 +71,7 @@
 #include <span>
 #include <thread>
 #include <unistd.h>
+#include <unordered_map>
 #include <vector>
 
 // clang-format off
@@ -188,9 +189,10 @@ store_path_for_partition(const std::filesystem::path& base_path,
   return std::nullopt;
 }
 
-caf::error extract_partition_synopsis(
-  const std::filesystem::path& partition_path,
-  const std::filesystem::path& partition_synopsis_path) {
+caf::error
+extract_partition_synopsis(const std::filesystem::path& partition_path,
+                           const std::filesystem::path& partition_synopsis_path,
+                           bool verify) {
   // Use blocking operations here since this is part of the startup.
   auto chunk = chunk::mmap(partition_path);
   if (not chunk) {
@@ -229,6 +231,19 @@ caf::error extract_partition_synopsis(
   auto flatbuffer = ps_builder.Finish();
   fbs::FinishPartitionSynopsisBuffer(builder, flatbuffer);
   auto chunk_out = fbs::release(builder);
+  // Verify the freshly built buffer when callers intend to read it back
+  // without verification, so a corrupt synopsis is caught at the source.
+  if (verify) {
+    if (auto checked = tenzir::flatbuffer<fbs::PartitionSynopsis>::make(
+          chunk_ptr{chunk_out});
+        not checked) {
+      return caf::make_error(
+        ec::format_error,
+        fmt::format("refusing to write malformed partition "
+                    "synopsis to {}: {}",
+                    partition_synopsis_path, checked.error()));
+    }
+  }
   return io::save(partition_synopsis_path,
                   std::span{chunk_out->data(), chunk_out->size()});
 }
@@ -503,6 +518,9 @@ caf::error index_state::load_from_disk() {
   auto oversized_partition_ids = std::vector<uuid>{};
   auto synopsis_files = std::vector<uuid>{};
   auto synopses = std::vector<partition_synopsis_pair>{};
+  // Partition index file sizes captured during the scan so that the load below
+  // does not need an additional stat per partition.
+  auto partition_index_sizes = std::unordered_map<uuid, uint64_t>{};
   for (const auto& entry : dir_iter) {
     const auto stem = entry.path().stem();
     tenzir::uuid partition_uuid{};
@@ -512,10 +530,12 @@ caf::error index_state::load_from_disk() {
     }
     auto ext = entry.path().extension();
     if (ext.empty()) {
+      auto size_err = std::error_code{};
+      const auto file_size = entry.file_size(size_err);
       // Newer partitions are not limited to FLATBUFFERS_MAX_BUFFER_SIZE,
       // this is only a problem for older ones that still have `fbs::Partition`
       // as root type.
-      if (entry.file_size() >= FLATBUFFERS_MAX_BUFFER_SIZE
+      if (not size_err and file_size >= FLATBUFFERS_MAX_BUFFER_SIZE
           and test_file_identifier(entry, fbs::PartitionIdentifier())) {
         auto store_path
           = dir / ".." / "archive" / fmt::format("{:u}.store", partition_uuid);
@@ -528,6 +548,8 @@ caf::error index_state::load_from_disk() {
         }
       } else {
         partition_ids.push_back(partition_uuid);
+        partition_index_sizes.emplace(partition_uuid,
+                                      size_err ? uint64_t{0} : file_size);
       }
     } else if (ext == std::filesystem::path{".mdx"}) {
       synopsis_files.push_back(partition_uuid);
@@ -546,9 +568,14 @@ caf::error index_state::load_from_disk() {
     std::filesystem::remove(dir / fmt::format("{}.mdx", orphan), err);
   }
   // We build an in-memory representation of the archive folder for quicker
-  // lookup when we add file paths to the in-memory synopsis.
+  // lookup when we add file paths and sizes to the in-memory synopsis. Sizes
+  // are captured here so the load below needs no additional stat per store.
+  struct store_info {
+    std::filesystem::path path = {};
+    uint64_t size = 0;
+  };
   const auto store_map = [&] {
-    auto result = std::map<uuid, std::filesystem::path>{};
+    auto result = std::map<uuid, store_info>{};
     auto store_path = dir / ".." / "archive";
     if (not std::filesystem::is_directory(store_path, err)) {
       return result;
@@ -559,32 +586,68 @@ caf::error index_state::load_from_disk() {
       if (not parsers::uuid(store_file.path().stem().string(), store_uuid)) {
         continue;
       }
-      result.emplace(store_uuid, store_file.path());
+      auto size_err = std::error_code{};
+      const auto size = store_file.file_size(size_err);
+      result.emplace(store_uuid, store_info{store_file.path(),
+                                            size_err ? uint64_t{0} : size});
     }
     return result;
   }();
+  // Resolve the base directories once instead of paying a `canonical()` (a
+  // symlink-resolving `realpath`, i.e. several stats) per partition; the
+  // per-partition file names are appended to the resolved base. This matters
+  // on networked storage where each such call is a round-trip.
+  auto resolve_dir
+    = [](const std::filesystem::path& p) -> std::filesystem::path {
+    std::error_code ec{};
+    if (auto result = std::filesystem::canonical(p, ec); not ec) {
+      return result;
+    }
+    ec.clear();
+    if (auto result = std::filesystem::absolute(p, ec); not ec) {
+      return result.lexically_normal();
+    }
+    return p.lexically_normal();
+  };
+  const auto index_dir = resolve_dir(dir);
+  const auto synopsis_dir = resolve_dir(synopsisdir);
+  const auto archive_dir = resolve_dir(dir / ".." / "archive");
+  const auto lazy_sketch_threshold = synopsis_opts.lazy_sketch_threshold;
+  const auto skip_verification = synopsis_opts.skip_synopsis_verification;
   // Loads a single partition synopsis from disk. This is invoked concurrently
   // from multiple worker threads below, so it must not touch shared mutable
-  // state: it only reads `store_map` and the (immutable during startup)
-  // synopsis factory, uses a local `std::error_code`, and produces a fresh
-  // synopsis. The result is merged into the shared collections after all
+  // state: it only reads data prepared above (all immutable during the load)
+  // and the (post-initialization, immutable) synopsis factory, and produces a
+  // fresh synopsis. Results are merged into the shared collections after all
   // workers have finished.
-  const auto lazy_sketch_threshold = synopsis_opts.lazy_sketch_threshold;
   auto load_one =
     [&](const uuid& partition_uuid) -> caf::expected<partition_synopsis_pair> {
-    std::error_code local_err{};
     auto part_path = partition_path(partition_uuid);
-    // Generate external partition synopsis file if it doesn't exist.
     auto synopsis_path = partition_synopsis_path(partition_uuid);
-    if (not exists(synopsis_path)) {
-      if (auto error = extract_partition_synopsis(part_path, synopsis_path);
+    // Generate the external partition synopsis file if it doesn't exist. We
+    // know which `.mdx` files exist from the directory scan above, so this
+    // avoids a stat. When verification is skipped on read, verify the freshly
+    // written synopsis instead.
+    if (not std::binary_search(synopsis_files.begin(), synopsis_files.end(),
+                               partition_uuid)) {
+      if (auto error = extract_partition_synopsis(part_path, synopsis_path,
+                                                  skip_verification);
           error.valid()) {
         return error;
       }
     }
     TRY(auto chunk, chunk::mmap(synopsis_path));
-    TRY(const auto ps_flatbuffer,
-        flatbuffer<fbs::PartitionSynopsis>::make(std::move(chunk)));
+    // Skipping verification avoids faulting in the entire buffer (including
+    // sketch payloads that are never decoded); it is only safe because such
+    // synopses are verified when written.
+    auto maybe_flatbuffer
+      = skip_verification
+          ? flatbuffer<fbs::PartitionSynopsis>::make_unsafe(std::move(chunk))
+          : flatbuffer<fbs::PartitionSynopsis>::make(std::move(chunk));
+    if (not maybe_flatbuffer) {
+      return std::move(maybe_flatbuffer.error());
+    }
+    const auto ps_flatbuffer = std::move(*maybe_flatbuffer);
     partition_synopsis_ptr ps = caf::make_copy_on_write<partition_synopsis>();
     if (ps_flatbuffer->partition_synopsis_type()
         != fbs::partition_synopsis::PartitionSynopsis::legacy) {
@@ -599,30 +662,22 @@ caf::error index_state::load_from_disk() {
         error.valid()) {
       return error;
     }
-    // Add partition file sizes.
-    uint64_t bitmap_file_size
-      = std::filesystem::file_size(part_path, local_err);
-    if (local_err) {
-      TENZIR_WARN("failed to get the size of the partition index file at "
-                  "{}: {}",
-                  part_path, local_err.message());
-      bitmap_file_size = 0u;
-    }
-    if (const auto canonical_part_path = canonical(part_path, local_err);
-        not local_err) {
+    // Attach file locations and sizes. Sizes were captured during the
+    // directory scans above and URLs are built from the pre-resolved base
+    // directories, so this needs no further filesystem access.
+    if (const auto it = partition_index_sizes.find(partition_uuid);
+        it != partition_index_sizes.end()) {
       ps.unshared().indexes_file = {
-        .url = fmt::format("file://{}", canonical_part_path),
-        .size = bitmap_file_size,
+        .url
+        = fmt::format("file://{}", (index_dir / part_path.filename()).string()),
+        .size = it->second,
       };
     }
-    if (const auto canonical_synopsis_path
-        = canonical(synopsis_path, local_err);
-        not local_err) {
-      ps.unshared().sketches_file = {
-        .url = fmt::format("file://{}", canonical_synopsis_path),
-        .size = ps_flatbuffer.chunk()->size(),
-      };
-    }
+    ps.unshared().sketches_file = {
+      .url = fmt::format("file://{}",
+                         (synopsis_dir / synopsis_path.filename()).string()),
+      .size = ps_flatbuffer.chunk()->size(),
+    };
     auto f = store_map.find(partition_uuid);
     if (f == store_map.end()) {
       // For completeness sake we could open the partition and look if the
@@ -634,21 +689,11 @@ caf::error index_state::load_from_disk() {
               partition_uuid)
         .to_error();
     }
-    auto store_path = f->second;
-    auto store_size = std::filesystem::file_size(store_path, local_err);
-    if (local_err) {
-      TENZIR_WARN("failed to get the size of the partition store file at "
-                  "{}: {}",
-                  store_path, local_err.message());
-      store_size = 0u;
-    }
-    if (const auto canonical_store_path = canonical(store_path, local_err);
-        not local_err) {
-      ps.unshared().store_file = {
-        .url = fmt::format("file://{}", canonical_store_path),
-        .size = store_size,
-      };
-    }
+    ps.unshared().store_file = {
+      .url = fmt::format("file://{}",
+                         (archive_dir / f->second.path.filename()).string()),
+      .size = f->second.size,
+    };
     return partition_synopsis_pair{partition_uuid, std::move(ps)};
   };
   // Load the partitions concurrently. Each partition is independent, so we
@@ -664,12 +709,27 @@ caf::error index_state::load_from_disk() {
   }
   concurrency
     = std::min<size_t>(concurrency, std::max<size_t>(1, num_partitions));
-  TENZIR_VERBOSE("{} loads {} partitions using {} thread(s){}", *self,
-                 num_partitions, concurrency,
-                 lazy_sketch_threshold > 0
-                   ? fmt::format(" (deferring sketches larger than {} bytes)",
-                                 lazy_sketch_threshold)
-                   : std::string{});
+  // Report progress for large loads so operators can see startup advancing;
+  // stay quiet for small ones to avoid log noise.
+  const auto report_progress = num_partitions >= size_t{1000};
+  const auto progress_step = std::max<size_t>(1, num_partitions / 20);
+  const auto lazy_suffix
+    = lazy_sketch_threshold > 0
+        ? fmt::format(" deferring sketches larger than {} bytes;",
+                      lazy_sketch_threshold)
+        : std::string{};
+  const auto verify_suffix = skip_verification
+                               ? std::string{" skipping verification;"}
+                               : std::string{};
+  if (report_progress) {
+    TENZIR_INFO("{} loads {} partition synopses using {} thread(s);{}{}", *self,
+                num_partitions, concurrency, lazy_suffix, verify_suffix);
+  } else {
+    TENZIR_VERBOSE("{} loads {} partition synopses using {} thread(s);{}{}",
+                   *self, num_partitions, concurrency, lazy_suffix,
+                   verify_suffix);
+  }
+  const auto load_start = std::chrono::steady_clock::now();
   auto worker_synopses
     = std::vector<std::vector<partition_synopsis_pair>>(concurrency);
   std::atomic<size_t> next_index{0};
@@ -693,8 +753,9 @@ caf::error index_state::load_from_disk() {
         continue;
       }
       if (const auto n = loaded.fetch_add(1, std::memory_order_relaxed) + 1;
-          n % 100000 == 0) {
-        TENZIR_VERBOSE("{} loaded {}/{} partitions", *self, n, num_partitions);
+          report_progress and n % progress_step == 0) {
+        TENZIR_INFO("{} loaded {}/{} partition synopses ({}%)", *self, n,
+                    num_partitions, n * 100 / num_partitions);
       }
     }
   };
@@ -715,6 +776,16 @@ caf::error index_state::load_from_disk() {
       persisted_partitions.emplace(pair.uuid);
       synopses.push_back(std::move(pair));
     }
+  }
+  const auto load_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                         std::chrono::steady_clock::now() - load_start)
+                         .count();
+  if (report_progress) {
+    TENZIR_INFO("{} loaded {} partition synopses in {} ms", *self,
+                synopses.size(), load_ms);
+  } else {
+    TENZIR_VERBOSE("{} loaded {} partition synopses in {} ms", *self,
+                   synopses.size(), load_ms);
   }
   // Recommend the user to run 'tenzir-ctl rebuild' if any partition syopses
   // are outdated. We need to nudge them a bit so we can drop support for older

--- a/libtenzir/src/index.cpp
+++ b/libtenzir/src/index.cpp
@@ -1790,6 +1790,18 @@ index(index_actor::stateful_pointer<index_state> self,
               old_partition_ids.emplace_back(partition.uuid);
             }
             auto apsv = std::move(transform_result.output_partitions);
+            // Point each output synopsis at its final `.mdx` path (the marker
+            // is renamed there before the merge below). With lazy sketches the
+            // catalog drops the Bloom filters on merge and reloads them on
+            // demand from this path, so it must be set or pruning would be
+            // lost for transformed/rebuilt partitions until the next restart.
+            for (auto& aps : apsv) {
+              if (aps.synopsis) {
+                aps.synopsis.unshared().sketches_file.url = fmt::format(
+                  "file://{}",
+                  self->state().partition_synopsis_path(aps.uuid).string());
+              }
+            }
             std::vector<uuid> new_partition_ids;
             new_partition_ids.reserve(apsv.size());
             for (auto const& [uuid, _] : apsv) {

--- a/libtenzir/src/index.cpp
+++ b/libtenzir/src/index.cpp
@@ -30,7 +30,6 @@
 #include "tenzir/detail/narrow.hpp"
 #include "tenzir/detail/weak_run_delayed.hpp"
 #include "tenzir/error.hpp"
-#include "tenzir/fbs/index.hpp"
 #include "tenzir/fbs/partition.hpp"
 #include "tenzir/fbs/partition_transform.hpp"
 #include "tenzir/fbs/utils.hpp"
@@ -248,42 +247,6 @@ extract_partition_synopsis(const std::filesystem::path& partition_path,
                   std::span{chunk_out->data(), chunk_out->size()});
 }
 
-caf::expected<flatbuffers::Offset<fbs::Index>>
-pack(flatbuffers::FlatBufferBuilder& builder, const index_state& state) {
-  TENZIR_DEBUG("index persists {} uuids of definitely persisted and {}"
-               "uuids of maybe persisted partitions",
-               state.persisted_partitions.size(), state.unpersisted.size());
-  std::vector<flatbuffers::Offset<fbs::LegacyUUID>> partition_offsets;
-  for (const auto& uuid : state.persisted_partitions) {
-    if (auto uuid_fb = pack(builder, uuid)) {
-      partition_offsets.push_back(*uuid_fb);
-    } else {
-      return uuid_fb.error();
-    }
-  }
-  // We don't know if these will make it to disk before the index and the rest
-  // of the system is shut down (in case of a hard/dirty shutdown), so we just
-  // store everything and throw out the missing partitions when loading the
-  // index.
-  for (const auto& kv : state.unpersisted) {
-    if (auto uuid_fb = pack(builder, kv.first)) {
-      partition_offsets.push_back(*uuid_fb);
-    } else {
-      return uuid_fb.error();
-    }
-  }
-  auto partitions = builder.CreateVector(partition_offsets);
-  fbs::index::v0Builder v0_builder(builder);
-  v0_builder.add_partitions(partitions);
-  auto index_v0 = v0_builder.Finish();
-  fbs::IndexBuilder index_builder(builder);
-  index_builder.add_index_type(tenzir::fbs::index::Index::v0);
-  index_builder.add_index(index_v0.Union());
-  auto index = index_builder.Finish();
-  fbs::FinishIndexBuffer(builder, index);
-  return index;
-}
-
 tenzir::chunk_ptr create_marker(const std::vector<tenzir::uuid>& in,
                                 const std::vector<tenzir::uuid>& out,
                                 keep_original_partition keep) {
@@ -323,13 +286,6 @@ filesystem_actor& partition_factory::filesystem() {
 
 partition_actor partition_factory::operator()(const uuid& id) const {
   // Load partition from disk.
-  if (state_.persisted_partitions.find(id)
-      == state_.persisted_partitions.end()) {
-    TENZIR_WARN("{} did not find partition {} in it's internal state, but "
-                "tries "
-                "to load it regardless",
-                *state_.self, id);
-  }
   const auto path = state_.partition_path(id);
   TENZIR_TRACE("{} loads partition {} for path {}", *state_.self, id, path);
   materializations_++;
@@ -348,11 +304,6 @@ index_state::index_state(index_actor::pointer self)
 }
 
 // -- persistence --------------------------------------------------------------
-
-std::filesystem::path
-index_state::index_filename(const std::filesystem::path& basename) const {
-  return basename / dir / "index.bin";
-}
 
 std::filesystem::path index_state::marker_path(const uuid& id) const {
   return markersdir / fmt::format("{:l}.marker", id);
@@ -779,7 +730,6 @@ caf::error index_state::load_from_disk() {
   }
   for (auto& batch : worker_synopses) {
     for (auto& pair : batch) {
-      persisted_partitions.emplace(pair.uuid);
       synopses.push_back(std::move(pair));
     }
   }
@@ -826,26 +776,6 @@ caf::error index_state::load_from_disk() {
   return caf::none;
 }
 
-/// Persists the state to disk.
-void index_state::flush_to_disk() {
-  auto builder = flatbuffers::FlatBufferBuilder{};
-  auto index = pack(builder, *this);
-  if (not index) {
-    TENZIR_WARN("{} failed to pack index: {}", *self, index.error());
-    return;
-  }
-  auto chunk = fbs::release(builder);
-  self->mail(atom::write_v, index_filename(), chunk)
-    .request(filesystem, caf::infinite)
-    .then(
-      [this](atom::ok) {
-        TENZIR_DEBUG("{} successfully persisted index state", *self);
-      },
-      [this](const caf::error& err) {
-        TENZIR_WARN("{} failed to persist index state: {}", *self, render(err));
-      });
-}
-
 // -- inbound path -----------------------------------------------------------
 
 void index_state::handle_slice(table_slice x) {
@@ -867,7 +797,6 @@ void index_state::handle_slice(table_slice x) {
                  *self, schema, active_partition->second.events,
                  partition_capacity, x.rows());
     decommission_active_partition(schema, {});
-    flush_to_disk();
     auto part = create_active_partition(schema);
     if (not part) {
       self->quit(caf::make_error(ec::logic_error,
@@ -892,7 +821,6 @@ void index_state::handle_slice(table_slice x) {
                  *self, schema, active_partition->second.events,
                  partition_capacity, x.rows());
     decommission_active_partition(schema, {});
-    flush_to_disk();
   }
   // When the total number of events in active partitions exceeds the configured
   // limit, we flush the largest partition repeatedly until we are below it.
@@ -913,7 +841,6 @@ void index_state::handle_slice(table_slice x) {
                    *self, max->first, max->second.events, partition_capacity,
                    buffered_events, max_buffered_events);
     decommission_active_partition(max->first, {});
-    flush_to_disk();
   }
 }
 
@@ -950,7 +877,6 @@ index_state::create_active_partition(const type& schema) {
                     *self, id, schema, data{active_partition_timeout}, err);
       }
     });
-    flush_to_disk();
   });
   TENZIR_TRACE("{} created new partition {}", *self, id);
   return active_partition;
@@ -1004,7 +930,6 @@ void index_state::decommission_active_partition(
                 self->mail(atom::update_v, partition_synopsis_pair{id, ps})
                   .send(listener);
               }
-              persisted_partitions.emplace(id);
               retire_partition(id, caf::exit_reason::normal);
               if (completion) {
                 completion(caf::none);
@@ -1186,8 +1111,10 @@ auto index_state::schedule_lookups() -> size_t {
       if (not part) {
         if (auto it = unpersisted.find(partition_id); it != unpersisted.end()) {
           part = it->second.actor;
-        } else if (auto it = persisted_partitions.find(partition_id);
-                   it != persisted_partitions.end()) {
+        } else {
+          // The partition was a catalog candidate, so it must be on disk. If
+          // it was erased in the meantime the spawned partition fails and the
+          // query completes with an error for it.
           part = inmem_partitions.get_or_load(partition_id);
         }
       }
@@ -1296,8 +1223,6 @@ std::size_t index_state::memusage() const {
   for (const auto& [id, partition] : unpersisted) {
     usage += sizeof(id) + as_bytes(partition.schema).size() + sizeof(partition);
   }
-  usage += persisted_partitions.size()
-           * sizeof(decltype(persisted_partitions)::value_type);
   usage += pending_queries.memusage();
   usage += calculate_usage(flush_listeners);
   usage += calculate_usage(partition_creation_listeners);
@@ -1508,15 +1433,26 @@ index(index_actor::stateful_pointer<index_state> self,
       auto rp = self->make_response_promise<atom::done>();
       auto path = self->state().partition_path(partition_id);
       auto synopsis_path = self->state().partition_synopsis_path(partition_id);
-      if (not self->state().persisted_partitions.contains(partition_id)) {
-        std::error_code err{};
-        const auto file_exists = std::filesystem::exists(path, err);
-        if (not file_exists) {
-          rp.deliver(caf::make_error(
-            ec::logic_error, fmt::format("unknown partition for path {}: {}",
-                                         path, err.message())));
-          return rp;
-        }
+      auto err = std::error_code{};
+      if (not std::filesystem::exists(path, err)) {
+        // The partition is not on disk. Erase it from the catalog anyway so
+        // that a stale entry cannot outlive its data, but report the failure
+        // to the caller.
+        self->mail(atom::erase_v, partition_id)
+          .urgent()
+          .request(self->state().catalog, caf::infinite)
+          .then(
+            [self, partition_id, path, err, rp](atom::ok) mutable {
+              self->state().pending_queries.mark_partition_erased(partition_id);
+              rp.deliver(caf::make_error(
+                ec::logic_error, fmt::format("unknown partition for path {}: "
+                                             "{}",
+                                             path, err.message())));
+            },
+            [rp](caf::error& e) mutable {
+              rp.deliver(std::move(e));
+            });
+        return rp;
       }
       self->mail(atom::erase_v, partition_id)
         .urgent()
@@ -1525,7 +1461,6 @@ index(index_actor::stateful_pointer<index_state> self,
           [self, partition_id, path, synopsis_path, rp](atom::ok) mutable {
             TENZIR_DEBUG("{} erased partition {} from catalog", *self,
                          partition_id);
-            self->state().persisted_partitions.erase(partition_id);
             // We don't remove the partition from the queue directly because the
             // query API requires clients to keep track of the number of
             // candidate partitions. Removing the partition from the queue
@@ -1644,6 +1579,9 @@ index(index_actor::stateful_pointer<index_state> self,
       // TODO: It would probably be more efficient to implement the
       // handler for multiple ids directly as opposed to dispatching
       // onto the single-id erase handler.
+      if (partition_ids.empty()) {
+        return atom::done_v;
+      }
       auto rp = self->make_response_promise<atom::done>();
       auto fanout_counter = detail::make_fanout_counter(
         partition_ids.size(),
@@ -1678,14 +1616,6 @@ index(index_actor::stateful_pointer<index_state> self,
       TENZIR_ASSERT(self->state().store_actor_plugin);
       auto input_partitions = std::vector<partition_info>{};
       input_partitions.reserve(selected_partitions.size());
-      std::erase_if(selected_partitions, [&](const auto& entry) {
-        if (self->state().persisted_partitions.contains(entry.uuid)) {
-          return false;
-        }
-        TENZIR_WARN("{} skips unknown partition {} for pipeline {:?}", *self,
-                    entry.uuid, pipe);
-        return true;
-      });
       auto corrected_partitions = catalog_lookup_result{};
       for (const auto& partition : selected_partitions) {
         if (self->state()
@@ -1821,7 +1751,30 @@ index(index_actor::stateful_pointer<index_state> self,
             }
             auto transformed_input_partitions
               = std::move(transform_result.input_partitions);
+            auto skipped_partitions
+              = std::move(transform_result.skipped_partitions);
             auto input_complete = transform_result.input_complete;
+            // Partitions whose on-disk state vanished mid-transform were
+            // usually erased through the regular erase path already, but a
+            // stale catalog entry would get selected again on every future
+            // run, so we proactively erase them from the catalog.
+            if (not skipped_partitions.empty()) {
+              auto skipped_ids = std::vector<uuid>{};
+              skipped_ids.reserve(skipped_partitions.size());
+              for (const auto& partition : skipped_partitions) {
+                skipped_ids.push_back(partition.uuid);
+              }
+              self->mail(atom::erase_v, std::move(skipped_ids))
+                .request(static_cast<index_actor>(self), caf::infinite)
+                .then([](atom::done) { /* nop */ },
+                      [self](const caf::error& e) {
+                        // The partition data is already gone, so failing to
+                        // erase the leftovers is expected.
+                        TENZIR_DEBUG("{} failed to clean up vanished "
+                                     "partitions: {}",
+                                     *self, e);
+                      });
+            }
             // Record in-progress marker.
             auto marker_chunk
               = create_marker(old_partition_ids, new_partition_ids, keep);
@@ -1857,20 +1810,15 @@ index(index_actor::stateful_pointer<index_state> self,
                             self->mail(atom::merge_v, apsv)
                               .request(self->state().catalog, caf::infinite)
                               .then(
-                                [self, deliver, transformed_input_partitions,
-                                 result, input_complete,
-                                 apsv](atom::ok) mutable {
-                                  // Update index statistics and list of
-                                  // persisted partitions.
-                                  for (auto const& aps : apsv) {
-                                    self->state().persisted_partitions.emplace(
-                                      aps.uuid);
-                                  }
-                                  self->state().flush_to_disk();
+                                [deliver, transformed_input_partitions, result,
+                                 skipped_partitions,
+                                 input_complete](atom::ok) mutable {
                                   deliver(partition_apply_result{
                                     .input_partitions
                                     = std::move(transformed_input_partitions),
                                     .output_partitions = std::move(result),
+                                    .skipped_partitions
+                                    = std::move(skipped_partitions),
                                     .input_complete = input_complete,
                                   });
                                 },
@@ -1882,6 +1830,8 @@ index(index_actor::stateful_pointer<index_state> self,
                               .input_partitions
                               = std::move(transformed_input_partitions),
                               .output_partitions = std::move(result),
+                              .skipped_partitions
+                              = std::move(skipped_partitions),
                               .input_complete = input_complete,
                             });
                           }
@@ -1890,13 +1840,9 @@ index(index_actor::stateful_pointer<index_state> self,
                             .request(self->state().catalog, caf::infinite)
                             .then(
                               [self, deliver, old_partition_ids,
-                               transformed_input_partitions, result, apsv,
+                               transformed_input_partitions, result,
+                               skipped_partitions,
                                input_complete](atom::ok) mutable {
-                                for (auto const& aps : apsv) {
-                                  self->state().persisted_partitions.emplace(
-                                    aps.uuid);
-                                }
-                                self->state().flush_to_disk();
                                 self->mail(atom::erase_v, old_partition_ids)
                                   .request(static_cast<index_actor>(self),
                                            caf::infinite)
@@ -1906,6 +1852,8 @@ index(index_actor::stateful_pointer<index_state> self,
                                         .input_partitions = std::move(
                                           transformed_input_partitions),
                                         .output_partitions = std::move(result),
+                                        .skipped_partitions
+                                        = std::move(skipped_partitions),
                                         .input_complete = input_complete,
                                       });
                                     },

--- a/libtenzir/src/index.cpp
+++ b/libtenzir/src/index.cpp
@@ -61,6 +61,7 @@
 #include <flatbuffers/flatbuffers.h>
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <ctime>
 #include <deque>
@@ -68,7 +69,9 @@
 #include <memory>
 #include <numeric>
 #include <span>
+#include <thread>
 #include <unistd.h>
+#include <vector>
 
 // clang-format off
 //
@@ -560,93 +563,157 @@ caf::error index_state::load_from_disk() {
     }
     return result;
   }();
-  // Now try to load the partitions - with a progress indicator.
-  for (size_t idx = 0; idx < partition_ids.size(); ++idx) {
-    auto partition_uuid = partition_ids[idx];
-    auto error = [&]() -> caf::error {
-      auto part_path = partition_path(partition_uuid);
-      TENZIR_TRACE("{} unpacks partition {} ({}/{})", *self, partition_uuid,
-                   idx, partition_ids.size());
-      // Generate external partition synopsis file if it doesn't exist.
-      auto synopsis_path = partition_synopsis_path(partition_uuid);
-      if (not exists(synopsis_path)) {
-        if (auto error = extract_partition_synopsis(part_path, synopsis_path);
-            error.valid()) {
-          return error;
-        }
-      }
-      TRY(auto chunk, chunk::mmap(synopsis_path));
-      TRY(const auto ps_flatbuffer,
-          flatbuffer<fbs::PartitionSynopsis>::make(std::move(chunk)));
-      partition_synopsis_ptr ps = caf::make_copy_on_write<partition_synopsis>();
-      if (ps_flatbuffer->partition_synopsis_type()
-          != fbs::partition_synopsis::PartitionSynopsis::legacy) {
-        return caf::make_error(ec::format_error, "invalid partition synopsis "
-                                                 "version");
-      }
-      TENZIR_ASSERT(ps_flatbuffer->partition_synopsis_as_legacy());
-      const auto& synopsis_legacy
-        = *ps_flatbuffer->partition_synopsis_as_legacy();
-      if (auto error = unpack(synopsis_legacy, ps.unshared()); error.valid()) {
+  // Loads a single partition synopsis from disk. This is invoked concurrently
+  // from multiple worker threads below, so it must not touch shared mutable
+  // state: it only reads `store_map` and the (immutable during startup)
+  // synopsis factory, uses a local `std::error_code`, and produces a fresh
+  // synopsis. The result is merged into the shared collections after all
+  // workers have finished.
+  const auto lazy_sketch_threshold = synopsis_opts.lazy_sketch_threshold;
+  auto load_one =
+    [&](const uuid& partition_uuid) -> caf::expected<partition_synopsis_pair> {
+    std::error_code local_err{};
+    auto part_path = partition_path(partition_uuid);
+    // Generate external partition synopsis file if it doesn't exist.
+    auto synopsis_path = partition_synopsis_path(partition_uuid);
+    if (not exists(synopsis_path)) {
+      if (auto error = extract_partition_synopsis(part_path, synopsis_path);
+          error.valid()) {
         return error;
       }
-      // Add partition file sizes.
-      {
-        uint64_t bitmap_file_size = std::filesystem::file_size(part_path, err);
-        if (err) {
-          TENZIR_WARN("failed to get the size of the partition index file at "
-                      "{}: {}",
-                      part_path, err.message());
-          bitmap_file_size = 0u;
+    }
+    TRY(auto chunk, chunk::mmap(synopsis_path));
+    TRY(const auto ps_flatbuffer,
+        flatbuffer<fbs::PartitionSynopsis>::make(std::move(chunk)));
+    partition_synopsis_ptr ps = caf::make_copy_on_write<partition_synopsis>();
+    if (ps_flatbuffer->partition_synopsis_type()
+        != fbs::partition_synopsis::PartitionSynopsis::legacy) {
+      return caf::make_error(ec::format_error, "invalid partition synopsis "
+                                               "version");
+    }
+    TENZIR_ASSERT(ps_flatbuffer->partition_synopsis_as_legacy());
+    const auto& synopsis_legacy
+      = *ps_flatbuffer->partition_synopsis_as_legacy();
+    if (auto error
+        = unpack(synopsis_legacy, ps.unshared(), lazy_sketch_threshold);
+        error.valid()) {
+      return error;
+    }
+    // Add partition file sizes.
+    uint64_t bitmap_file_size
+      = std::filesystem::file_size(part_path, local_err);
+    if (local_err) {
+      TENZIR_WARN("failed to get the size of the partition index file at "
+                  "{}: {}",
+                  part_path, local_err.message());
+      bitmap_file_size = 0u;
+    }
+    if (const auto canonical_part_path = canonical(part_path, local_err);
+        not local_err) {
+      ps.unshared().indexes_file = {
+        .url = fmt::format("file://{}", canonical_part_path),
+        .size = bitmap_file_size,
+      };
+    }
+    if (const auto canonical_synopsis_path
+        = canonical(synopsis_path, local_err);
+        not local_err) {
+      ps.unshared().sketches_file = {
+        .url = fmt::format("file://{}", canonical_synopsis_path),
+        .size = ps_flatbuffer.chunk()->size(),
+      };
+    }
+    auto f = store_map.find(partition_uuid);
+    if (f == store_map.end()) {
+      // For completeness sake we could open the partition and look if the
+      // data is somewhere else entirely, but no known implementation ever
+      // deviated from the default path scheme, so we assume filesystem
+      // corruption here.
+      return diagnostic::error(ec::no_such_file)
+        .note("discarding partition {} due to a missing store file",
+              partition_uuid)
+        .to_error();
+    }
+    auto store_path = f->second;
+    auto store_size = std::filesystem::file_size(store_path, local_err);
+    if (local_err) {
+      TENZIR_WARN("failed to get the size of the partition store file at "
+                  "{}: {}",
+                  store_path, local_err.message());
+      store_size = 0u;
+    }
+    if (const auto canonical_store_path = canonical(store_path, local_err);
+        not local_err) {
+      ps.unshared().store_file = {
+        .url = fmt::format("file://{}", canonical_store_path),
+        .size = store_size,
+      };
+    }
+    return partition_synopsis_pair{partition_uuid, std::move(ps)};
+  };
+  // Load the partitions concurrently. Each partition is independent, so we
+  // distribute them across a pool of worker threads using a shared atomic
+  // cursor. This is particularly effective on networked storage (e.g. NFS),
+  // where loading is dominated by I/O latency that overlaps across requests.
+  // The index actor is detached and blocked here during startup, and no other
+  // actor interacts with this state yet, so using plain threads is safe.
+  const auto num_partitions = partition_ids.size();
+  auto concurrency = synopsis_opts.load_concurrency;
+  if (concurrency == 0) {
+    concurrency = std::max<size_t>(1, std::thread::hardware_concurrency());
+  }
+  concurrency
+    = std::min<size_t>(concurrency, std::max<size_t>(1, num_partitions));
+  TENZIR_VERBOSE("{} loads {} partitions using {} thread(s){}", *self,
+                 num_partitions, concurrency,
+                 lazy_sketch_threshold > 0
+                   ? fmt::format(" (deferring sketches larger than {} bytes)",
+                                 lazy_sketch_threshold)
+                   : std::string{});
+  auto worker_synopses
+    = std::vector<std::vector<partition_synopsis_pair>>(concurrency);
+  std::atomic<size_t> next_index{0};
+  std::atomic<size_t> loaded{0};
+  auto work = [&](size_t worker) {
+    for (auto idx = next_index.fetch_add(1, std::memory_order_relaxed);
+         idx < num_partitions;
+         idx = next_index.fetch_add(1, std::memory_order_relaxed)) {
+      const auto& partition_uuid = partition_ids[idx];
+      try {
+        auto result = load_one(partition_uuid);
+        if (not result) {
+          TENZIR_VERBOSE("{} failed to load partition {}: {}", *self,
+                         partition_uuid, result.error());
+          continue;
         }
-        if (const auto canonical_part_path = canonical(part_path, err);
-            not err) {
-          ps.unshared().indexes_file = {
-            .url = fmt::format("file://{}", canonical_part_path),
-            .size = bitmap_file_size,
-          };
-        }
-        if (const auto canonical_synopsis_path = canonical(synopsis_path, err);
-            not err) {
-          ps.unshared().sketches_file = {
-            .url = fmt::format("file://{}", canonical_synopsis_path),
-            .size = ps_flatbuffer.chunk()->size(),
-          };
-        }
-        auto f = store_map.find(partition_uuid);
-        if (f == store_map.end()) {
-          // For completeness sake we could open the partition and look if the
-          // data is somewhere else entirely, but no known implementation ever
-          // deviated from the default path scheme, so we assume filesystem
-          // corruption here.
-          return diagnostic::error(ec::no_such_file)
-            .note("discarding partition {} due to a missing store file",
-                  partition_uuid)
-            .to_error();
-        }
-        auto store_path = f->second;
-        auto store_size = std::filesystem::file_size(store_path, err);
-        if (err) {
-          TENZIR_WARN("failed to get the size of the partition store file at "
-                      "{}: {}",
-                      store_path, err.message());
-          store_size = 0u;
-        }
-        if (const auto canonical_store_path = canonical(store_path, err);
-            not err) {
-          ps.unshared().store_file = {
-            .url = fmt::format("file://{}", canonical_store_path),
-            .size = store_size,
-          };
-        }
+        worker_synopses[worker].push_back(std::move(*result));
+      } catch (const std::exception& ex) {
+        TENZIR_VERBOSE("{} failed to load partition {}: {}", *self,
+                       partition_uuid, ex.what());
+        continue;
       }
-      persisted_partitions.emplace(partition_uuid);
-      synopses.emplace_back(partition_uuid, std::move(ps));
-      return caf::none;
-    }();
-    if (error.valid()) {
-      TENZIR_VERBOSE("{} failed to load partition {}: {}", *self,
-                     partition_uuid, error);
+      if (const auto n = loaded.fetch_add(1, std::memory_order_relaxed) + 1;
+          n % 100000 == 0) {
+        TENZIR_VERBOSE("{} loaded {}/{} partitions", *self, n, num_partitions);
+      }
+    }
+  };
+  if (concurrency <= 1) {
+    work(0);
+  } else {
+    auto threads = std::vector<std::thread>{};
+    threads.reserve(concurrency);
+    for (size_t worker = 0; worker < concurrency; ++worker) {
+      threads.emplace_back(work, worker);
+    }
+    for (auto& thread : threads) {
+      thread.join();
+    }
+  }
+  for (auto& batch : worker_synopses) {
+    for (auto& pair : batch) {
+      persisted_partitions.emplace(pair.uuid);
+      synopses.push_back(std::move(pair));
     }
   }
   // Recommend the user to run 'tenzir-ctl rebuild' if any partition syopses

--- a/libtenzir/src/index_config.cpp
+++ b/libtenzir/src/index_config.cpp
@@ -133,6 +133,21 @@ caf::error convert(const data& src, index_config& dst) {
       dst.rules.push_back(std::move(rule));
     }
   }
+  if (auto load_concurrency = try_get<int64_t>(*rec, "load-concurrency")) {
+    if (*load_concurrency && **load_concurrency > 0) {
+      dst.load_concurrency = static_cast<size_t>(**load_concurrency);
+    }
+  } else {
+    return std::move(load_concurrency.error());
+  }
+  if (auto lazy_sketch_threshold
+      = try_get<int64_t>(*rec, "lazy-sketch-threshold")) {
+    if (*lazy_sketch_threshold && **lazy_sketch_threshold > 0) {
+      dst.lazy_sketch_threshold = static_cast<size_t>(**lazy_sketch_threshold);
+    }
+  } else {
+    return std::move(lazy_sketch_threshold.error());
+  }
   return caf::none;
 }
 

--- a/libtenzir/src/index_config.cpp
+++ b/libtenzir/src/index_config.cpp
@@ -148,6 +148,14 @@ caf::error convert(const data& src, index_config& dst) {
   } else {
     return std::move(lazy_sketch_threshold.error());
   }
+  if (auto skip_synopsis_verification
+      = try_get<bool>(*rec, "skip-synopsis-verification")) {
+    if (*skip_synopsis_verification) {
+      dst.skip_synopsis_verification = **skip_synopsis_verification;
+    }
+  } else {
+    return std::move(skip_synopsis_verification.error());
+  }
   return caf::none;
 }
 

--- a/libtenzir/src/index_config.cpp
+++ b/libtenzir/src/index_config.cpp
@@ -140,13 +140,12 @@ caf::error convert(const data& src, index_config& dst) {
   } else {
     return std::move(load_concurrency.error());
   }
-  if (auto lazy_sketch_threshold
-      = try_get<int64_t>(*rec, "lazy-sketch-threshold")) {
-    if (*lazy_sketch_threshold && **lazy_sketch_threshold > 0) {
-      dst.lazy_sketch_threshold = static_cast<size_t>(**lazy_sketch_threshold);
+  if (auto lazy_sketches = try_get<bool>(*rec, "lazy-sketches")) {
+    if (*lazy_sketches) {
+      dst.lazy_sketches = **lazy_sketches;
     }
   } else {
-    return std::move(lazy_sketch_threshold.error());
+    return std::move(lazy_sketches.error());
   }
   if (auto skip_synopsis_verification
       = try_get<bool>(*rec, "skip-synopsis-verification")) {

--- a/libtenzir/src/node.cpp
+++ b/libtenzir/src/node.cpp
@@ -162,8 +162,10 @@ auto spawn_catalog(node_actor::stateful_pointer<node_state> self,
                    const caf::settings& settings) -> catalog_actor {
   const auto sketch_cache_bytes = get_or(
     settings, "tenzir.index.sketch-cache-bytes", defaults::sketch_cache_bytes);
-  auto catalog
-    = self->spawn<caf::detached>(tenzir::catalog, filesystem, sketch_cache_bytes);
+  const auto lazy_sketches
+    = get_or(settings, "tenzir.index.lazy-sketches", false);
+  auto catalog = self->spawn<caf::detached>(tenzir::catalog, filesystem,
+                                            sketch_cache_bytes, lazy_sketches);
   TENZIR_ASSERT(catalog);
   if (auto err = register_component(self, caf::actor_cast<caf::actor>(catalog),
                                     "catalog");

--- a/libtenzir/src/node.cpp
+++ b/libtenzir/src/node.cpp
@@ -158,8 +158,12 @@ auto spawn_filesystem(node_actor::stateful_pointer<node_state> self)
 }
 
 auto spawn_catalog(node_actor::stateful_pointer<node_state> self,
-                   const filesystem_actor& filesystem) -> catalog_actor {
-  auto catalog = self->spawn<caf::detached>(tenzir::catalog, filesystem);
+                   const filesystem_actor& filesystem,
+                   const caf::settings& settings) -> catalog_actor {
+  const auto sketch_cache_bytes = get_or(
+    settings, "tenzir.index.sketch-cache-bytes", defaults::sketch_cache_bytes);
+  auto catalog
+    = self->spawn<caf::detached>(tenzir::catalog, filesystem, sketch_cache_bytes);
   TENZIR_ASSERT(catalog);
   if (auto err = register_component(self, caf::actor_cast<caf::actor>(catalog),
                                     "catalog");
@@ -294,7 +298,7 @@ auto spawn_components(node_actor::stateful_pointer<node_state> self) -> void {
   // Before we laod any component plugins, we first load all the core components.
   const auto& settings = content(self->system().config());
   const auto filesystem = spawn_filesystem(self);
-  const auto catalog = spawn_catalog(self, filesystem);
+  const auto catalog = spawn_catalog(self, filesystem, settings);
   const auto index = spawn_index(self, settings, filesystem, catalog);
   [[maybe_unused]] const auto importer = spawn_importer(self, index);
   [[maybe_unused]] const auto disk_monitor

--- a/libtenzir/src/partition_synopsis.cpp
+++ b/libtenzir/src/partition_synopsis.cpp
@@ -220,6 +220,9 @@ size_t partition_synopsis::memusage() const {
 
 partition_synopsis* partition_synopsis::copy() const {
   auto result = std::make_unique<partition_synopsis>();
+  result->store_file = store_file;
+  result->indexes_file = indexes_file;
+  result->sketches_file = sketches_file;
   result->events = events;
   result->min_import_time = min_import_time;
   result->max_import_time = max_import_time;

--- a/libtenzir/src/partition_synopsis.cpp
+++ b/libtenzir/src/partition_synopsis.cpp
@@ -69,6 +69,28 @@ void partition_synopsis::shrink() {
   }
 }
 
+void partition_synopsis::defer_bloom_filters() {
+  const auto is_bloom_filter = []<concrete_type T>(const T&) {
+    return detail::is_any_v<T, string_type, ip_type>;
+  };
+  auto changed = false;
+  for (auto& [field, synopsis] : field_synopses_) {
+    if (synopsis and match(field.type(), is_bloom_filter)) {
+      // Keep the key (the catalog relies on it) but drop the sketch.
+      synopsis = nullptr;
+      changed = true;
+    }
+  }
+  changed |= std::erase_if(type_synopses_,
+                           [&](const auto& entry) {
+                             return match(entry.first, is_bloom_filter);
+                           })
+             > 0;
+  if (changed) {
+    memusage_ = 0; // Invalidate cached size.
+  }
+}
+
 // TODO: Use a more efficient data structure for rule lookup.
 std::optional<double> get_field_fprate(const index_config& config,
                                        const qualified_record_field& field) {

--- a/libtenzir/src/partition_synopsis.cpp
+++ b/libtenzir/src/partition_synopsis.cpp
@@ -268,7 +268,7 @@ namespace {
 caf::error unpack_(
   const flatbuffers::Vector<flatbuffers::Offset<fbs::synopsis::LegacySynopsis>>&
     synopses,
-  partition_synopsis& ps, size_t lazy_sketch_threshold) {
+  partition_synopsis& ps, bool lazy_sketches) {
   for (const auto* synopsis : synopses) {
     if (not synopsis) {
       return caf::make_error(ec::format_error, "synopsis is null");
@@ -284,21 +284,15 @@ caf::error unpack_(
     // synopsis size. Only string and IP fields use Bloom filters; numeric and
     // duration fields use small min/max synopses and time/bool fields use
     // inline encodings, none of which are ever deferred so that range pruning
-    // is unaffected regardless of the threshold. The field is still registered
-    // below (with a null synopsis), which the catalog interprets as "cannot
-    // prune" rather than "no match", so deferring never introduces false
-    // negatives. The serialized payload size is read in O(1) from the
-    // flatbuffer without decoding it.
-    const auto uses_bloom_filter
-      = lazy_sketch_threshold > 0
-        and match(qf.type(), []<concrete_type T>(const T&) {
-              return detail::is_any_v<T, string_type, ip_type>;
-            });
+    // is unaffected. The field is still registered below (with a null
+    // synopsis), which the catalog interprets as "cannot prune" rather than "no
+    // match", so deferring never introduces false negatives.
+    const auto is_bloom_filter
+      = lazy_sketches and match(qf.type(), []<concrete_type T>(const T&) {
+          return detail::is_any_v<T, string_type, ip_type>;
+        });
     const auto* opaque = synopsis->opaque_synopsis();
-    const auto defer
-      = uses_bloom_filter and opaque != nullptr
-        and opaque->caf_0_18_data() != nullptr
-        and opaque->caf_0_18_data()->size() > lazy_sketch_threshold;
+    const auto defer = is_bloom_filter and opaque != nullptr;
     if (not defer) {
       if (auto error = unpack(*synopsis, ptr); error.valid()) {
         return error;
@@ -323,7 +317,7 @@ caf::error unpack_(
 } // namespace
 
 caf::error unpack(const fbs::partition_synopsis::LegacyPartitionSynopsis& x,
-                  partition_synopsis& ps, size_t lazy_sketch_threshold) {
+                  partition_synopsis& ps, bool lazy_sketches) {
   if (not x.id_range()) {
     return caf::make_error(ec::format_error, "missing id range");
   }
@@ -348,7 +342,7 @@ caf::error unpack(const fbs::partition_synopsis::LegacyPartitionSynopsis& x,
   if (not x.synopses()) {
     return caf::make_error(ec::format_error, "missing synopses");
   }
-  return unpack_(*x.synopses(), ps, lazy_sketch_threshold);
+  return unpack_(*x.synopses(), ps, lazy_sketches);
 }
 
 } // namespace tenzir

--- a/libtenzir/src/partition_synopsis.cpp
+++ b/libtenzir/src/partition_synopsis.cpp
@@ -280,15 +280,23 @@ caf::error unpack_(
       return error;
     }
     synopsis_ptr ptr;
-    // Optionally skip deserializing large opaque synopses (e.g. Bloom filters).
-    // The serialized payload size is available in O(1) from the flatbuffer
-    // without decoding it. The field is still registered below (with a null
-    // synopsis), which the catalog interprets as "cannot prune" rather than "no
-    // match", so deferring never introduces false negatives. Inline time/bool
-    // synopses and small opaque synopses (min/max) are always decoded.
+    // Optionally skip deserializing Bloom-filter sketches, which dominate the
+    // synopsis size. Only string and IP fields use Bloom filters; numeric and
+    // duration fields use small min/max synopses and time/bool fields use
+    // inline encodings, none of which are ever deferred so that range pruning
+    // is unaffected regardless of the threshold. The field is still registered
+    // below (with a null synopsis), which the catalog interprets as "cannot
+    // prune" rather than "no match", so deferring never introduces false
+    // negatives. The serialized payload size is read in O(1) from the
+    // flatbuffer without decoding it.
+    const auto uses_bloom_filter
+      = lazy_sketch_threshold > 0
+        and match(qf.type(), []<concrete_type T>(const T&) {
+              return detail::is_any_v<T, string_type, ip_type>;
+            });
     const auto* opaque = synopsis->opaque_synopsis();
     const auto defer
-      = lazy_sketch_threshold > 0 and opaque != nullptr
+      = uses_bloom_filter and opaque != nullptr
         and opaque->caf_0_18_data() != nullptr
         and opaque->caf_0_18_data()->size() > lazy_sketch_threshold;
     if (not defer) {

--- a/libtenzir/src/partition_synopsis.cpp
+++ b/libtenzir/src/partition_synopsis.cpp
@@ -268,7 +268,7 @@ namespace {
 caf::error unpack_(
   const flatbuffers::Vector<flatbuffers::Offset<fbs::synopsis::LegacySynopsis>>&
     synopses,
-  partition_synopsis& ps) {
+  partition_synopsis& ps, size_t lazy_sketch_threshold) {
   for (const auto* synopsis : synopses) {
     if (not synopsis) {
       return caf::make_error(ec::format_error, "synopsis is null");
@@ -280,13 +280,32 @@ caf::error unpack_(
       return error;
     }
     synopsis_ptr ptr;
-    if (auto error = unpack(*synopsis, ptr); error.valid()) {
-      return error;
+    // Optionally skip deserializing large opaque synopses (e.g. Bloom filters).
+    // The serialized payload size is available in O(1) from the flatbuffer
+    // without decoding it. The field is still registered below (with a null
+    // synopsis), which the catalog interprets as "cannot prune" rather than "no
+    // match", so deferring never introduces false negatives. Inline time/bool
+    // synopses and small opaque synopses (min/max) are always decoded.
+    const auto* opaque = synopsis->opaque_synopsis();
+    const auto defer
+      = lazy_sketch_threshold > 0 and opaque != nullptr
+        and opaque->caf_0_18_data() != nullptr
+        and opaque->caf_0_18_data()->size() > lazy_sketch_threshold;
+    if (not defer) {
+      if (auto error = unpack(*synopsis, ptr); error.valid()) {
+        return error;
+      }
     }
     // We mark type-level synopses by using an empty string as name.
     if (qf.is_standalone_type()) {
-      ps.type_synopses_[qf.type()] = std::move(ptr);
+      // A missing type synopsis is handled conservatively by the catalog, so a
+      // deferred (null) one can simply be omitted.
+      if (ptr) {
+        ps.type_synopses_[qf.type()] = std::move(ptr);
+      }
     } else {
+      // The catalog relies on the presence of the field key (even mapped to a
+      // null synopsis) to consider the partition a candidate, so always insert.
       ps.field_synopses_[qf] = std::move(ptr);
     }
   }
@@ -296,7 +315,7 @@ caf::error unpack_(
 } // namespace
 
 caf::error unpack(const fbs::partition_synopsis::LegacyPartitionSynopsis& x,
-                  partition_synopsis& ps) {
+                  partition_synopsis& ps, size_t lazy_sketch_threshold) {
   if (not x.id_range()) {
     return caf::make_error(ec::format_error, "missing id range");
   }
@@ -321,7 +340,7 @@ caf::error unpack(const fbs::partition_synopsis::LegacyPartitionSynopsis& x,
   if (not x.synopses()) {
     return caf::make_error(ec::format_error, "missing synopses");
   }
-  return unpack_(*x.synopses(), ps);
+  return unpack_(*x.synopses(), ps, lazy_sketch_threshold);
 }
 
 } // namespace tenzir

--- a/libtenzir/src/partition_transformer.cpp
+++ b/libtenzir/src/partition_transformer.cpp
@@ -186,8 +186,8 @@ struct partition_source_state {
   tenzir::time max_import_time = tenzir::time::min();
   std::atomic<duration::rep> loaded_min_import_time
     = time::max().time_since_epoch().count();
-  std::vector<partition_info> selected_partitions = {};
   std::vector<partition_info> loaded_partitions = {};
+  std::vector<partition_info> skipped_partitions = {};
   bool input_complete = true;
 
   auto observe_import_time(time import_time) -> void {
@@ -245,7 +245,6 @@ public:
       memory_budget_{make_memory_budget()},
       state_{std::move(state)} {
     TENZIR_ASSERT(state_);
-    state_->selected_partitions = partitions_;
   }
 
   auto feed(Push<OperatorMsg<table_slice>>& push_input) const -> Task<void> {
@@ -279,6 +278,19 @@ public:
       }
       auto maybe_slices = co_await load_partition(partition);
       if (not maybe_slices) {
+        // Partitions can legitimately disappear between their selection and
+        // this load, e.g., when compaction or the disk monitor erase them
+        // concurrently. Skip them instead of failing the whole transform, and
+        // report them so callers do not retry.
+        auto ec = std::error_code{};
+        if (not std::filesystem::exists(partition_path(partition), ec)) {
+          TENZIR_VERBOSE("{} skips partition {} that no longer exists on "
+                         "disk: {}",
+                         "partition-transformer", partition.uuid,
+                         maybe_slices.error());
+          state_->skipped_partitions.push_back(partition);
+          continue;
+        }
         fail(std::move(maybe_slices.error()));
         co_await push_input(OperatorMsg<table_slice>{Signal{EndOfData{}}});
         co_return;
@@ -304,11 +316,15 @@ private:
     state_->error = std::move(error);
   }
 
+  auto partition_path(const partition_info& partition) const
+    -> std::filesystem::path {
+    return std::filesystem::path{fmt::format(
+      TENZIR_FMT_RUNTIME(partition_path_template_), partition.uuid)};
+  }
+
   auto load_partition(const partition_info& partition) const
     -> Task<caf::expected<std::vector<table_slice>>> {
-    const auto filename = fmt::format(
-      TENZIR_FMT_RUNTIME(partition_path_template_), partition.uuid);
-    auto partition_path = std::filesystem::path{filename};
+    auto partition_path = this->partition_path(partition);
     auto partition_chunk = chunk::mmap(partition_path);
     if (not partition_chunk) {
       co_return wrap_store_error(std::move(partition_chunk.error()),
@@ -535,6 +551,7 @@ void partition_transformer_state::fulfill(
     promise.deliver(partition_transformer_result{
       .input_partitions = self->state().transformed_input_partitions,
       .output_partitions = {},
+      .skipped_partitions = self->state().skipped_partitions,
       .input_complete = self->state().input_complete,
     });
     self->quit();
@@ -583,6 +600,8 @@ void partition_transformer_state::fulfill(
                           .input_partitions
                           = self->state().transformed_input_partitions,
                           .output_partitions = std::move(result),
+                          .skipped_partitions
+                          = self->state().skipped_partitions,
                           .input_complete = self->state().input_complete,
                         },
                       });
@@ -875,9 +894,9 @@ auto partition_transformer(
             self->state().min_import_time = source_state->min_import_time;
             self->state().max_import_time = source_state->max_import_time;
             self->state().transformed_input_partitions
-              = source_state->input_complete
-                  ? std::move(source_state->selected_partitions)
-                  : std::move(source_state->loaded_partitions);
+              = std::move(source_state->loaded_partitions);
+            self->state().skipped_partitions
+              = std::move(source_state->skipped_partitions);
             self->state().input_complete = source_state->input_complete;
             finish_transform();
           });

--- a/libtenzir/src/partition_transformer.cpp
+++ b/libtenzir/src/partition_transformer.cpp
@@ -17,6 +17,7 @@
 #include "tenzir/detail/available_memory.hpp"
 #include "tenzir/detail/fanout_counter.hpp"
 #include "tenzir/fbs/utils.hpp"
+#include "tenzir/flatbuffer.hpp"
 #include "tenzir/ir.hpp"
 #include "tenzir/logger.hpp"
 #include "tenzir/partition_synopsis.hpp"
@@ -974,8 +975,24 @@ auto partition_transformer(
           ps_builder.add_partition_synopsis(synopsis->Union());
           auto ps_offset = ps_builder.Finish();
           fbs::FinishPartitionSynopsisBuffer(builder, ps_offset);
+          auto ps_chunk = fbs::release(builder);
+          // When the index reads synopses without verification, transformed
+          // synopses must be verified here so the write-once guarantee also
+          // holds for partitions produced by rebuilds and transforms.
+          if (self->state().synopsis_opts.skip_synopsis_verification) {
+            if (auto checked
+                = flatbuffer<fbs::PartitionSynopsis>::make(chunk_ptr{ps_chunk});
+                not checked) {
+              stream_data.synopsis_chunks = caf::make_error(
+                ec::format_error,
+                fmt::format("failed to verify transformed partition "
+                            "synopsis: {}",
+                            checked.error()));
+              return;
+            }
+          }
           stream_data.synopsis_chunks->emplace_back(
-            std::make_tuple(partition_data.id, fbs::release(builder)));
+            std::make_tuple(partition_data.id, std::move(ps_chunk)));
         }
       }();
       store_or_fulfill(self, std::move(stream_data));

--- a/libtenzir/test/catalog_lazy_lookup.cpp
+++ b/libtenzir/test/catalog_lazy_lookup.cpp
@@ -136,6 +136,19 @@ TEST("catalog loads deferred bloom filters on demand to prune") {
   CHECK_EQUAL(present->size(), 1u);
 }
 
+TEST("catalog does not load sketches for non-bloom-answerable predicates") {
+  auto f = fixture{};
+  auto state = catalog_state{};
+  state.sketches = sketch_cache{size_t{1} << 20};
+  state.synopses_per_type[f.schema][f.id] = f.resident;
+  // A Bloom filter cannot answer `!=`, so loading its sketch could not prune
+  // the query; the partition stays a candidate and nothing is loaded.
+  auto result = state.lookup(unbox(to<expression>("msg != \"hello\"")));
+  REQUIRE(result);
+  CHECK_EQUAL(result->size(), 1u);
+  CHECK_EQUAL(state.sketches.peek(f.id), nullptr);
+}
+
 TEST("catalog without a sketch budget keeps deferred partitions as "
      "candidates") {
   auto f = fixture{};

--- a/libtenzir/test/catalog_lazy_lookup.cpp
+++ b/libtenzir/test/catalog_lazy_lookup.cpp
@@ -1,0 +1,151 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2024 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "tenzir/catalog.hpp"
+#include "tenzir/chunk.hpp"
+#include "tenzir/concept/parseable/tenzir/expression.hpp"
+#include "tenzir/concept/parseable/to.hpp"
+#include "tenzir/expression.hpp"
+#include "tenzir/fbs/partition_synopsis.hpp"
+#include "tenzir/fbs/utils.hpp"
+#include "tenzir/flatbuffer.hpp"
+#include "tenzir/io/save.hpp"
+#include "tenzir/partition_synopsis.hpp"
+#include "tenzir/qualified_record_field.hpp"
+#include "tenzir/series.hpp"
+#include "tenzir/synopsis_factory.hpp"
+#include "tenzir/test/test.hpp"
+#include "tenzir/type.hpp"
+#include "tenzir/uuid.hpp"
+
+#include <arrow/builder.h>
+#include <caf/make_copy_on_write.hpp>
+#include <flatbuffers/flatbuffers.h>
+
+#include <filesystem>
+
+using namespace tenzir;
+
+namespace {
+
+auto make_string_series(std::vector<std::string> values) -> series {
+  auto builder = arrow::StringBuilder{};
+  for (const auto& value : values) {
+    TENZIR_ASSERT(builder.Append(value).ok());
+  }
+  auto array = builder.Finish();
+  TENZIR_ASSERT(array.ok());
+  return series{type{string_type{}}, std::move(*array)};
+}
+
+// Serializes a partition synopsis (with its Bloom-filter sketch) to a `.mdx`
+// file and returns the path.
+auto write_mdx(const partition_synopsis& ps) -> std::filesystem::path {
+  flatbuffers::FlatBufferBuilder builder;
+  auto offset = pack(builder, ps);
+  TENZIR_ASSERT(offset);
+  fbs::PartitionSynopsisBuilder ps_builder(builder);
+  ps_builder.add_partition_synopsis_type(
+    fbs::partition_synopsis::PartitionSynopsis::legacy);
+  ps_builder.add_partition_synopsis(offset->Union());
+  fbs::FinishPartitionSynopsisBuffer(builder, ps_builder.Finish());
+  auto chunk = fbs::release(builder);
+  auto path = std::filesystem::temp_directory_path()
+              / fmt::format("tnz-test-{}.mdx", uuid::random());
+  auto error = io::save(path, std::span{chunk->data(), chunk->size()});
+  TENZIR_ASSERT(not error);
+  return path;
+}
+
+// Reads a `.mdx` back, unpacking with the given laziness.
+auto read_mdx(const std::filesystem::path& path, bool lazy)
+  -> partition_synopsis_ptr {
+  auto chunk = chunk::mmap(path);
+  TENZIR_ASSERT(chunk);
+  auto fb = flatbuffer<fbs::PartitionSynopsis>::make(std::move(*chunk));
+  TENZIR_ASSERT(fb);
+  auto ps = caf::make_copy_on_write<partition_synopsis>();
+  auto error
+    = unpack(*(*fb)->partition_synopsis_as_legacy(), ps.unshared(), lazy);
+  TENZIR_ASSERT(not error);
+  return ps;
+}
+
+// Builds a resident (Bloom-filter-deferred) synopsis whose sketch lives in a
+// `.mdx` on disk, plus that schema/id, for use across the tests below.
+struct fixture {
+  type schema = type{"test", record_type{{"msg", string_type{}}}};
+  qualified_record_field msg
+    = qualified_record_field{"test", "msg", type{string_type{}}};
+  uuid id = uuid::random();
+  std::filesystem::path mdx;
+  partition_synopsis_ptr resident;
+
+  fixture() {
+    factory<synopsis>::initialize();
+    auto full = caf::make_copy_on_write<partition_synopsis>();
+    full.unshared().schema = schema;
+    full.unshared().events = 1;
+    auto opts = caf::settings{};
+    opts["buffer-input-data"] = true;
+    opts["max-partition-size"] = uint64_t{1024};
+    // A very low false-positive rate makes the "absent" lookup deterministic.
+    opts["string-synopsis-fp-rate"] = 0.000001;
+    auto bloom = factory<synopsis>::make(type{string_type{}}, opts);
+    TENZIR_ASSERT(bloom);
+    bloom->add(make_string_series({"hello"}));
+    full.unshared().field_synopses_[msg] = std::move(bloom);
+    full.unshared().shrink();
+    mdx = write_mdx(*full);
+    resident = read_mdx(mdx, /*lazy=*/true);
+    resident.unshared().sketches_file
+      = {.url = fmt::format("file://{}", mdx.string()), .size = 0};
+  }
+
+  ~fixture() {
+    std::error_code ec{};
+    std::filesystem::remove(mdx, ec);
+  }
+};
+
+} // namespace
+
+TEST("catalog loads deferred bloom filters on demand to prune") {
+  auto f = fixture{};
+  // The resident synopsis has a deferred (null) Bloom-filter sketch.
+  REQUIRE_EQUAL(f.resident->field_synopses_.at(f.msg), nullptr);
+  auto state = catalog_state{};
+  state.sketches = sketch_cache{size_t{1} << 20};
+  state.synopses_per_type[f.schema][f.id] = f.resident;
+  // A non-matching equality predicate prunes the partition only if the Bloom
+  // filter is loaded on demand.
+  auto absent = state.lookup(unbox(to<expression>("msg == \"absent\"")));
+  REQUIRE(absent);
+  CHECK_EQUAL(absent->size(), 0u);
+  // The sketch was loaded into the cache as a side effect.
+  CHECK_NOT_EQUAL(state.sketches.peek(f.id), nullptr);
+  // A matching predicate keeps the partition (Bloom filters never yield false
+  // negatives).
+  auto present = state.lookup(unbox(to<expression>("msg == \"hello\"")));
+  REQUIRE(present);
+  CHECK_EQUAL(present->size(), 1u);
+}
+
+TEST("catalog without a sketch budget keeps deferred partitions as "
+     "candidates") {
+  auto f = fixture{};
+  auto state = catalog_state{};
+  state.sketches = sketch_cache{0}; // on-demand loading disabled
+  state.synopses_per_type[f.schema][f.id] = f.resident;
+  // Without loading, the catalog cannot rule the partition out and must keep
+  // it as a conservative candidate (correct, just coarser).
+  auto absent = state.lookup(unbox(to<expression>("msg == \"absent\"")));
+  REQUIRE(absent);
+  CHECK_EQUAL(absent->size(), 1u);
+  CHECK_EQUAL(state.sketches.peek(f.id), nullptr);
+}

--- a/libtenzir/test/catalog_lazy_lookup.cpp
+++ b/libtenzir/test/catalog_lazy_lookup.cpp
@@ -136,6 +136,45 @@ TEST("catalog loads deferred bloom filters on demand to prune") {
   CHECK_EQUAL(present->size(), 1u);
 }
 
+TEST("catalog evaluates metadata before deferred bloom filters in "
+     "disjunctions") {
+  auto f = fixture{};
+  auto state = catalog_state{};
+  state.sketches = sketch_cache{size_t{1} << 20};
+  state.synopses_per_type[f.schema][f.id] = f.resident;
+  // `@name == "test"` is represented as a schema meta extractor in the
+  // catalog expression. It makes the disjunction true without a Bloom lookup.
+  auto expression = disjunction{
+    predicate{field_extractor{"msg"}, relational_operator::equal,
+              data{std::string{"absent"}}},
+    predicate{meta_extractor{meta_extractor::schema},
+              relational_operator::equal, data{std::string{"test"}}},
+  };
+  auto result = state.lookup(std::move(expression));
+  REQUIRE(result);
+  CHECK_EQUAL(result->size(), 1u);
+  CHECK_EQUAL(state.sketches.peek(f.id), nullptr);
+}
+
+TEST("catalog evaluates metadata before deferred bloom filters in "
+     "conjunctions") {
+  auto f = fixture{};
+  auto state = catalog_state{};
+  state.sketches = sketch_cache{size_t{1} << 20};
+  state.synopses_per_type[f.schema][f.id] = f.resident;
+  // `@name == "other"` rules out the partition without a Bloom lookup.
+  auto expression = conjunction{
+    predicate{field_extractor{"msg"}, relational_operator::equal,
+              data{std::string{"absent"}}},
+    predicate{meta_extractor{meta_extractor::schema},
+              relational_operator::equal, data{std::string{"other"}}},
+  };
+  auto result = state.lookup(std::move(expression));
+  REQUIRE(result);
+  CHECK_EQUAL(result->size(), 0u);
+  CHECK_EQUAL(state.sketches.peek(f.id), nullptr);
+}
+
 TEST("catalog prunes more partitions than fit in the sketch cache budget") {
   auto f = fixture{};
   // Budget large enough for a single loaded synopsis but not for several.

--- a/libtenzir/test/catalog_lazy_lookup.cpp
+++ b/libtenzir/test/catalog_lazy_lookup.cpp
@@ -136,6 +136,29 @@ TEST("catalog loads deferred bloom filters on demand to prune") {
   CHECK_EQUAL(present->size(), 1u);
 }
 
+TEST("catalog prunes more partitions than fit in the sketch cache budget") {
+  auto f = fixture{};
+  // Budget large enough for a single loaded synopsis but not for several.
+  const auto one = read_mdx(f.mdx, /*lazy=*/false)->memusage();
+  REQUIRE_GREATER(one, 0u);
+  auto state = catalog_state{};
+  state.sketches = sketch_cache{one + one / 2};
+  // Three partitions of the same schema, all with deferred sketches on disk.
+  for (auto i = 0; i < 3; ++i) {
+    const auto id = uuid::random();
+    auto resident = read_mdx(f.mdx, /*lazy=*/true);
+    resident.unshared().sketches_file
+      = {.url = fmt::format("file://{}", f.mdx.string()), .size = 0};
+    state.synopses_per_type[f.schema][id] = std::move(resident);
+  }
+  // Even though the cache can hold only one sketch at a time, all three are
+  // pruned because phase 2 loads, checks, and evicts incrementally -- pruning
+  // is not limited by the cache budget.
+  auto absent = state.lookup(unbox(to<expression>("msg == \"absent\"")));
+  REQUIRE(absent);
+  CHECK_EQUAL(absent->size(), 0u);
+}
+
 TEST("catalog defers bloom filters of merged partitions when lazy") {
   auto f = fixture{};
   // A freshly flushed/transformed partition arrives with its full Bloom filter.

--- a/libtenzir/test/catalog_lazy_lookup.cpp
+++ b/libtenzir/test/catalog_lazy_lookup.cpp
@@ -161,8 +161,10 @@ TEST("catalog prunes more partitions than fit in the sketch cache budget") {
 
 TEST("catalog defers bloom filters of merged partitions when lazy") {
   auto f = fixture{};
-  // A freshly flushed/transformed partition arrives with its full Bloom filter.
+  // A freshly flushed/transformed partition arrives with its full Bloom filter
+  // and a loadable sketch path.
   auto full = read_mdx(f.mdx, /*lazy=*/false);
+  full.unshared().sketches_file.url = fmt::format("file://{}", f.mdx.string());
   REQUIRE_NOT_EQUAL(full->field_synopses_.at(f.msg), nullptr);
   auto state = catalog_state{};
   state.lazy_sketches = true;
@@ -176,7 +178,21 @@ TEST("catalog defers bloom filters of merged partitions when lazy") {
 TEST("catalog keeps bloom filters of merged partitions when not lazy") {
   auto f = fixture{};
   auto full = read_mdx(f.mdx, /*lazy=*/false);
+  full.unshared().sketches_file.url = fmt::format("file://{}", f.mdx.string());
   auto state = catalog_state{}; // lazy_sketches defaults to false
+  static_cast<void>(state.merge({{f.id, full}}));
+  const auto& stored = state.synopses_per_type.at(f.schema).at(f.id);
+  CHECK_NOT_EQUAL(stored->field_synopses_.at(f.msg), nullptr);
+}
+
+TEST("catalog keeps merged bloom filters without a loadable sketch path") {
+  auto f = fixture{};
+  // No `sketches_file.url`: the sketches could not be reloaded, so they must
+  // not be deferred even with lazy sketches enabled.
+  auto full = read_mdx(f.mdx, /*lazy=*/false);
+  REQUIRE(full->sketches_file.url.empty());
+  auto state = catalog_state{};
+  state.lazy_sketches = true;
   static_cast<void>(state.merge({{f.id, full}}));
   const auto& stored = state.synopses_per_type.at(f.schema).at(f.id);
   CHECK_NOT_EQUAL(stored->field_synopses_.at(f.msg), nullptr);

--- a/libtenzir/test/catalog_lazy_lookup.cpp
+++ b/libtenzir/test/catalog_lazy_lookup.cpp
@@ -173,6 +173,10 @@ TEST("catalog defers bloom filters of merged partitions when lazy") {
   // ingest would grow resident memory unbounded.
   const auto& stored = state.synopses_per_type.at(f.schema).at(f.id);
   CHECK_EQUAL(stored->field_synopses_.at(f.msg), nullptr);
+  // Deferring here COW-copies the synopsis (the test still holds a reference),
+  // so the copy must preserve the sketch URL -- otherwise the deferred sketch
+  // could never be reloaded.
+  CHECK(stored->sketches_file.url.starts_with("file://"));
 }
 
 TEST("catalog keeps bloom filters of merged partitions when not lazy") {

--- a/libtenzir/test/catalog_lazy_lookup.cpp
+++ b/libtenzir/test/catalog_lazy_lookup.cpp
@@ -136,6 +136,29 @@ TEST("catalog loads deferred bloom filters on demand to prune") {
   CHECK_EQUAL(present->size(), 1u);
 }
 
+TEST("catalog defers bloom filters of merged partitions when lazy") {
+  auto f = fixture{};
+  // A freshly flushed/transformed partition arrives with its full Bloom filter.
+  auto full = read_mdx(f.mdx, /*lazy=*/false);
+  REQUIRE_NOT_EQUAL(full->field_synopses_.at(f.msg), nullptr);
+  auto state = catalog_state{};
+  state.lazy_sketches = true;
+  static_cast<void>(state.merge({{f.id, full}}));
+  // The resident synopsis must not retain the Bloom filter, otherwise ongoing
+  // ingest would grow resident memory unbounded.
+  const auto& stored = state.synopses_per_type.at(f.schema).at(f.id);
+  CHECK_EQUAL(stored->field_synopses_.at(f.msg), nullptr);
+}
+
+TEST("catalog keeps bloom filters of merged partitions when not lazy") {
+  auto f = fixture{};
+  auto full = read_mdx(f.mdx, /*lazy=*/false);
+  auto state = catalog_state{}; // lazy_sketches defaults to false
+  static_cast<void>(state.merge({{f.id, full}}));
+  const auto& stored = state.synopses_per_type.at(f.schema).at(f.id);
+  CHECK_NOT_EQUAL(stored->field_synopses_.at(f.msg), nullptr);
+}
+
 TEST("catalog does not load sketches for non-bloom-answerable predicates") {
   auto f = fixture{};
   auto state = catalog_state{};

--- a/libtenzir/test/lazy_partition_synopsis.cpp
+++ b/libtenzir/test/lazy_partition_synopsis.cpp
@@ -38,8 +38,8 @@ auto make_string_series(std::vector<std::string> values) -> series {
 
 // Builds a partition synopsis with a Bloom-filter (string) field, an opaque
 // min/max (int64) field, and an inline (time) field, packs it, and unpacks it
-// again with the given lazy sketch threshold.
-auto roundtrip(size_t lazy_sketch_threshold) -> partition_synopsis {
+// again with the given lazy-sketch setting.
+auto roundtrip(bool lazy_sketches) -> partition_synopsis {
   factory<synopsis>::initialize();
   partition_synopsis ps;
   ps.schema = type{record_type{
@@ -81,7 +81,7 @@ auto roundtrip(size_t lazy_sketch_threshold) -> partition_synopsis {
   const auto* legacy = fb->partition_synopsis_as_legacy();
   REQUIRE(legacy != nullptr);
   partition_synopsis out;
-  REQUIRE_EQUAL(unpack(*legacy, out, lazy_sketch_threshold), caf::none);
+  REQUIRE_EQUAL(unpack(*legacy, out, lazy_sketches), caf::none);
   return out;
 }
 
@@ -97,8 +97,8 @@ auto field_is_null(const partition_synopsis& ps)
 
 } // namespace
 
-TEST("lazy sketch threshold of zero loads every synopsis") {
-  const auto ps = roundtrip(0);
+TEST("lazy sketches disabled loads every synopsis") {
+  const auto ps = roundtrip(false);
   const auto fields = field_is_null(ps);
   REQUIRE_EQUAL(fields.size(), 3u);
   CHECK(not fields.at("msg"));
@@ -106,12 +106,12 @@ TEST("lazy sketch threshold of zero loads every synopsis") {
   CHECK(not fields.at("ts"));
 }
 
-TEST("lazy sketch threshold only defers bloom filters") {
-  // A small threshold defers the Bloom-filter sketch but must never defer the
-  // numeric min/max or the inline time synopsis, regardless of their size --
-  // otherwise range pruning would silently break. All field keys must remain
-  // present so the catalog never drops a partition (a false negative).
-  const auto ps = roundtrip(8);
+TEST("lazy sketches only defers bloom filters") {
+  // With lazy sketches enabled, only the Bloom-filter sketch is deferred; the
+  // numeric min/max and the inline time synopsis must stay resident, otherwise
+  // range pruning would silently break. All field keys must remain present so
+  // the catalog never drops a partition (a false negative).
+  const auto ps = roundtrip(true);
   const auto fields = field_is_null(ps);
   REQUIRE_EQUAL(fields.size(), 3u);
   CHECK(fields.at("msg"));    // string Bloom filter: deferred

--- a/libtenzir/test/lazy_partition_synopsis.cpp
+++ b/libtenzir/test/lazy_partition_synopsis.cpp
@@ -1,0 +1,91 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2024 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "tenzir/fbs/partition_synopsis.hpp"
+#include "tenzir/partition_synopsis.hpp"
+#include "tenzir/qualified_record_field.hpp"
+#include "tenzir/synopsis_factory.hpp"
+#include "tenzir/test/test.hpp"
+#include "tenzir/type.hpp"
+
+#include <flatbuffers/flatbuffers.h>
+
+#include <map>
+#include <string>
+
+using namespace tenzir;
+
+namespace {
+
+// Builds a partition synopsis with one inline (time) and one opaque (int64
+// min/max) field synopsis, packs it, and unpacks it again with the given lazy
+// sketch threshold.
+auto roundtrip(size_t lazy_sketch_threshold) -> partition_synopsis {
+  factory<synopsis>::initialize();
+  partition_synopsis ps;
+  ps.schema = type{record_type{{"ts", time_type{}}, {"n", int64_type{}}}};
+  const auto ts_field = qualified_record_field{"test", "ts", type{time_type{}}};
+  const auto n_field = qualified_record_field{"test", "n", type{int64_type{}}};
+  // A time synopsis is serialized inline (never deferred); an int64 min/max
+  // synopsis is serialized as an opaque blob (deferred above the threshold).
+  ps.field_synopses_[ts_field]
+    = factory<synopsis>::make(type{time_type{}}, caf::settings{});
+  ps.field_synopses_[n_field]
+    = factory<synopsis>::make(type{int64_type{}}, caf::settings{});
+  REQUIRE_NOT_EQUAL(ps.field_synopses_[ts_field], nullptr);
+  REQUIRE_NOT_EQUAL(ps.field_synopses_[n_field], nullptr);
+  flatbuffers::FlatBufferBuilder builder;
+  auto offset = pack(builder, ps);
+  REQUIRE(static_cast<bool>(offset));
+  fbs::PartitionSynopsisBuilder ps_builder(builder);
+  ps_builder.add_partition_synopsis_type(
+    fbs::partition_synopsis::PartitionSynopsis::legacy);
+  ps_builder.add_partition_synopsis(offset->Union());
+  auto root = ps_builder.Finish();
+  fbs::FinishPartitionSynopsisBuffer(builder, root);
+  const auto* fb = fbs::GetPartitionSynopsis(builder.GetBufferPointer());
+  REQUIRE(fb != nullptr);
+  const auto* legacy = fb->partition_synopsis_as_legacy();
+  REQUIRE(legacy != nullptr);
+  partition_synopsis out;
+  REQUIRE_EQUAL(unpack(*legacy, out, lazy_sketch_threshold), caf::none);
+  return out;
+}
+
+// Maps each field name to whether its synopsis is null (deferred).
+auto field_is_null(const partition_synopsis& ps)
+  -> std::map<std::string, bool> {
+  std::map<std::string, bool> result;
+  for (const auto& [field, synopsis] : ps.field_synopses_) {
+    result[std::string{field.field_name()}] = synopsis == nullptr;
+  }
+  return result;
+}
+
+} // namespace
+
+TEST("lazy sketch threshold of zero loads every synopsis") {
+  const auto ps = roundtrip(0);
+  const auto fields = field_is_null(ps);
+  REQUIRE_EQUAL(fields.size(), 2u);
+  CHECK(not fields.at("ts"));
+  CHECK(not fields.at("n"));
+}
+
+TEST("lazy sketch threshold defers opaque synopses but keeps the field keys") {
+  // A threshold of 8 bytes is below the serialized size of the int64 min/max
+  // synopsis, so it is deferred, while the inline time synopsis is unaffected.
+  const auto ps = roundtrip(8);
+  const auto fields = field_is_null(ps);
+  // Crucially, both field keys are still present: the catalog relies on this to
+  // treat predicates on the deferred field as candidates rather than silently
+  // dropping the partition (which would be a false negative).
+  REQUIRE_EQUAL(fields.size(), 2u);
+  CHECK(not fields.at("ts"));
+  CHECK(fields.at("n"));
+}

--- a/libtenzir/test/lazy_partition_synopsis.cpp
+++ b/libtenzir/test/lazy_partition_synopsis.cpp
@@ -9,10 +9,13 @@
 #include "tenzir/fbs/partition_synopsis.hpp"
 #include "tenzir/partition_synopsis.hpp"
 #include "tenzir/qualified_record_field.hpp"
+#include "tenzir/series.hpp"
 #include "tenzir/synopsis_factory.hpp"
 #include "tenzir/test/test.hpp"
 #include "tenzir/type.hpp"
 
+#include <arrow/builder.h>
+#include <caf/settings.hpp>
 #include <flatbuffers/flatbuffers.h>
 
 #include <map>
@@ -22,23 +25,48 @@ using namespace tenzir;
 
 namespace {
 
-// Builds a partition synopsis with one inline (time) and one opaque (int64
-// min/max) field synopsis, packs it, and unpacks it again with the given lazy
-// sketch threshold.
+auto make_string_series(std::vector<std::string> values) -> series {
+  auto builder = arrow::StringBuilder{};
+  for (const auto& value : values) {
+    const auto status = builder.Append(value);
+    TENZIR_ASSERT(status.ok());
+  }
+  auto result = builder.Finish();
+  TENZIR_ASSERT(result.ok());
+  return series{type{string_type{}}, std::move(*result)};
+}
+
+// Builds a partition synopsis with a Bloom-filter (string) field, an opaque
+// min/max (int64) field, and an inline (time) field, packs it, and unpacks it
+// again with the given lazy sketch threshold.
 auto roundtrip(size_t lazy_sketch_threshold) -> partition_synopsis {
   factory<synopsis>::initialize();
   partition_synopsis ps;
-  ps.schema = type{record_type{{"ts", time_type{}}, {"n", int64_type{}}}};
-  const auto ts_field = qualified_record_field{"test", "ts", type{time_type{}}};
+  ps.schema = type{record_type{
+    {"msg", string_type{}}, {"n", int64_type{}}, {"ts", time_type{}}}};
+  const auto msg_field
+    = qualified_record_field{"test", "msg", type{string_type{}}};
   const auto n_field = qualified_record_field{"test", "n", type{int64_type{}}};
-  // A time synopsis is serialized inline (never deferred); an int64 min/max
-  // synopsis is serialized as an opaque blob (deferred above the threshold).
-  ps.field_synopses_[ts_field]
-    = factory<synopsis>::make(type{time_type{}}, caf::settings{});
+  const auto ts_field = qualified_record_field{"test", "ts", type{time_type{}}};
+  // The string synopsis is a Bloom filter (opaque, deferrable); the int64
+  // synopsis is an opaque min/max; the time synopsis is encoded inline.
+  auto string_opts = caf::settings{};
+  string_opts["buffer-input-data"] = true;
+  string_opts["max-partition-size"] = uint64_t{1024};
+  string_opts["string-synopsis-fp-rate"] = 0.01;
+  auto bloom = factory<synopsis>::make(type{string_type{}}, string_opts);
+  REQUIRE_NOT_EQUAL(bloom, nullptr);
+  bloom->add(make_string_series({"alpha", "beta", "gamma"}));
+  ps.field_synopses_[msg_field] = std::move(bloom);
   ps.field_synopses_[n_field]
     = factory<synopsis>::make(type{int64_type{}}, caf::settings{});
-  REQUIRE_NOT_EQUAL(ps.field_synopses_[ts_field], nullptr);
+  ps.field_synopses_[ts_field]
+    = factory<synopsis>::make(type{time_type{}}, caf::settings{});
   REQUIRE_NOT_EQUAL(ps.field_synopses_[n_field], nullptr);
+  REQUIRE_NOT_EQUAL(ps.field_synopses_[ts_field], nullptr);
+  // Materialize buffered synopses, as the partition persist path does before
+  // packing.
+  ps.shrink();
   flatbuffers::FlatBufferBuilder builder;
   auto offset = pack(builder, ps);
   REQUIRE(static_cast<bool>(offset));
@@ -72,20 +100,21 @@ auto field_is_null(const partition_synopsis& ps)
 TEST("lazy sketch threshold of zero loads every synopsis") {
   const auto ps = roundtrip(0);
   const auto fields = field_is_null(ps);
-  REQUIRE_EQUAL(fields.size(), 2u);
-  CHECK(not fields.at("ts"));
+  REQUIRE_EQUAL(fields.size(), 3u);
+  CHECK(not fields.at("msg"));
   CHECK(not fields.at("n"));
+  CHECK(not fields.at("ts"));
 }
 
-TEST("lazy sketch threshold defers opaque synopses but keeps the field keys") {
-  // A threshold of 8 bytes is below the serialized size of the int64 min/max
-  // synopsis, so it is deferred, while the inline time synopsis is unaffected.
+TEST("lazy sketch threshold only defers bloom filters") {
+  // A small threshold defers the Bloom-filter sketch but must never defer the
+  // numeric min/max or the inline time synopsis, regardless of their size --
+  // otherwise range pruning would silently break. All field keys must remain
+  // present so the catalog never drops a partition (a false negative).
   const auto ps = roundtrip(8);
   const auto fields = field_is_null(ps);
-  // Crucially, both field keys are still present: the catalog relies on this to
-  // treat predicates on the deferred field as candidates rather than silently
-  // dropping the partition (which would be a false negative).
-  REQUIRE_EQUAL(fields.size(), 2u);
-  CHECK(not fields.at("ts"));
-  CHECK(fields.at("n"));
+  REQUIRE_EQUAL(fields.size(), 3u);
+  CHECK(fields.at("msg"));    // string Bloom filter: deferred
+  CHECK(not fields.at("n"));  // int64 min/max: always loaded
+  CHECK(not fields.at("ts")); // time: always loaded
 }

--- a/libtenzir/test/sketch_cache.cpp
+++ b/libtenzir/test/sketch_cache.cpp
@@ -82,11 +82,15 @@ TEST("sketch cache does not cache an entry larger than the budget") {
   const auto one = make_synopsis()->memusage();
   REQUIRE_GREATER(one, 0u);
   // A budget below a single entry must keep the cache empty rather than retain
-  // an oversized entry over budget.
+  // an oversized entry over budget, and must report zero bytes cached so the
+  // caller doesn't charge its query budget for an uncached sketch.
   auto cache = sketch_cache{one - 1};
-  cache.put(a, make_synopsis());
+  CHECK_EQUAL(cache.put(a, make_synopsis()), 0u);
   CHECK_EQUAL(cache.peek(a), nullptr);
   CHECK_EQUAL(cache.used(), 0u);
+  // A fitting entry reports its cached size.
+  auto ok = sketch_cache{one + 1};
+  CHECK_EQUAL(ok.put(a, make_synopsis()), one);
 }
 
 TEST("sketch cache with zero budget never caches") {

--- a/libtenzir/test/sketch_cache.cpp
+++ b/libtenzir/test/sketch_cache.cpp
@@ -1,0 +1,86 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2024 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "tenzir/catalog.hpp"
+#include "tenzir/partition_synopsis.hpp"
+#include "tenzir/qualified_record_field.hpp"
+#include "tenzir/synopsis_factory.hpp"
+#include "tenzir/test/test.hpp"
+#include "tenzir/type.hpp"
+#include "tenzir/uuid.hpp"
+
+#include <caf/make_copy_on_write.hpp>
+
+using namespace tenzir;
+
+namespace {
+
+// A synopsis with a single (small, non-empty) min/max synopsis, so that its
+// `memusage()` is positive and identical across instances.
+auto make_synopsis() -> partition_synopsis_ptr {
+  factory<synopsis>::initialize();
+  auto ps = caf::make_copy_on_write<partition_synopsis>();
+  ps.unshared()
+    .field_synopses_[qualified_record_field{"t", "n", type{int64_type{}}}]
+    = factory<synopsis>::make(type{int64_type{}}, caf::settings{});
+  return ps;
+}
+
+} // namespace
+
+TEST("sketch cache evicts the least recently used entry") {
+  const auto a = uuid::random();
+  const auto b = uuid::random();
+  const auto c = uuid::random();
+  const auto one = make_synopsis()->memusage();
+  REQUIRE_GREATER(one, 0u);
+  // Budget holds two entries but not three.
+  auto cache = sketch_cache{2 * one + 1};
+  cache.put(a, make_synopsis());
+  cache.put(b, make_synopsis());
+  cache.put(c, make_synopsis());
+  // `a` was least-recently-used and is evicted; `b` and `c` remain.
+  CHECK_EQUAL(cache.peek(a), nullptr);
+  CHECK_NOT_EQUAL(cache.peek(b), nullptr);
+  CHECK_NOT_EQUAL(cache.peek(c), nullptr);
+  CHECK_LESS_EQUAL(cache.used(), cache.budget());
+}
+
+TEST("sketch cache peek does not change recency") {
+  const auto a = uuid::random();
+  const auto b = uuid::random();
+  const auto c = uuid::random();
+  const auto one = make_synopsis()->memusage();
+  auto cache = sketch_cache{2 * one + 1};
+  cache.put(a, make_synopsis());
+  cache.put(b, make_synopsis()); // a is now LRU, b is MRU
+  // Peeking must not promote `a`, so inserting `c` still evicts `a`.
+  CHECK_NOT_EQUAL(cache.peek(a), nullptr);
+  cache.put(c, make_synopsis());
+  CHECK_EQUAL(cache.peek(a), nullptr);
+  CHECK_NOT_EQUAL(cache.peek(b), nullptr);
+  CHECK_NOT_EQUAL(cache.peek(c), nullptr);
+}
+
+TEST("sketch cache erase removes an entry and frees budget") {
+  const auto a = uuid::random();
+  auto cache = sketch_cache{1024 * 1024};
+  cache.put(a, make_synopsis());
+  REQUIRE_GREATER(cache.used(), 0u);
+  cache.erase(a);
+  CHECK_EQUAL(cache.peek(a), nullptr);
+  CHECK_EQUAL(cache.used(), 0u);
+}
+
+TEST("sketch cache with zero budget never caches") {
+  const auto a = uuid::random();
+  auto cache = sketch_cache{0};
+  cache.put(a, make_synopsis());
+  CHECK_EQUAL(cache.peek(a), nullptr);
+  CHECK_EQUAL(cache.used(), 0u);
+}

--- a/libtenzir/test/sketch_cache.cpp
+++ b/libtenzir/test/sketch_cache.cpp
@@ -77,6 +77,18 @@ TEST("sketch cache erase removes an entry and frees budget") {
   CHECK_EQUAL(cache.used(), 0u);
 }
 
+TEST("sketch cache does not cache an entry larger than the budget") {
+  const auto a = uuid::random();
+  const auto one = make_synopsis()->memusage();
+  REQUIRE_GREATER(one, 0u);
+  // A budget below a single entry must keep the cache empty rather than retain
+  // an oversized entry over budget.
+  auto cache = sketch_cache{one - 1};
+  cache.put(a, make_synopsis());
+  CHECK_EQUAL(cache.peek(a), nullptr);
+  CHECK_EQUAL(cache.used(), 0u);
+}
+
 TEST("sketch cache with zero budget never caches") {
   const auto a = uuid::random();
   auto cache = sketch_cache{0};


### PR DESCRIPTION
## 🔍 Problem

The index tracks persisted partitions in its own `persisted_partitions` set, duplicating the catalog's key set. The two views drift when partitions are erased while a rebuild is in flight (compaction, disk monitor): the rebuilder holds a stale candidate list, and since #6216 the requeue logic misclassifies index-skipped partitions as "not loaded under memory pressure" and retries them at the front of the queue — producing an `index skips unknown partition` warning once per batch for the rest of the run.

## 🛠️ Solution

- Remove `persisted_partitions` entirely. The catalog and the filesystem are the only sources of truth.
- The partition transformer now detects inputs whose on-disk state vanished, skips them instead of failing the whole batch, and reports them via a new `skipped_partitions` field on `partition_transformer_result`/`partition_apply_result`.
- The rebuilder drops skipped partitions from the run instead of requeueing them; the index proactively erases their stale catalog entries so future runs cannot re-select them.
- The erase handler keys off file existence instead of the set and still cleans the catalog when the file is gone. Batch-erase with an empty ID list now resolves immediately instead of hanging its response promise (`make_fanout_counter(0, …)` never fires).
- Delete the dead persistence path: `pack(index_state)`, `flush_to_disk()`, and the `index.bin` file, which is write-only — startup discovers partitions by directory scan.

## 💬 Review

- The apply pre-filter (and its warning) is gone; vanish detection moved into the transformer's loader. A missing partition file means "vanished" (skip); a present-but-unreadable file or missing store still fails the transform as corruption.
- `fbs/index.fbs` stays for now: pipeline-manager in tenzir-plugins still includes the generated header; removing the schema needs a plugins-side cleanup first.
- Verified end-to-end: import → rebuild (11→4 partitions, data intact) → restart, and a race simulation deleting one partition's files behind the node's back: the run logs `rebuilt 10 into 5`, drops the vanished partition silently, self-heals its catalog entry, and surviving data exports correctly.
- Unit tests 7003/7003; contrib plugins (compaction) compile against the changed structs.

<sub>
📎 Related: tenzir/tenzir#6368, tenzir/tenzir#6216
</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)