### PR TITLE
Add channel scatter & gather

### DIFF
--- a/libtenzir/builtins/operators/parallel2.cpp
+++ b/libtenzir/builtins/operators/parallel2.cpp
@@ -7,22 +7,18 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "tenzir/async.hpp"
+#include "tenzir/async/routing.hpp"
 #include "tenzir/operator_plugin.hpp"
 #include "tenzir/plugin/register.hpp"
 #include "tenzir/substitute_ctx.hpp"
 #include "tenzir/table_slice.hpp"
 #include "tenzir/tql2/eval.hpp"
-#include "tenzir/view.hpp"
 
-#include <algorithm>
-#include <numeric>
 #include <thread>
 
 namespace tenzir::plugins::parallel2 {
 
 namespace {
-
-constexpr auto fairness_factor = 2.0;
 
 struct ParallelArgs {
   Option<located<uint64_t>> jobs;
@@ -30,109 +26,6 @@ struct ParallelArgs {
   bool fuse = true;
   located<ir::pipeline> pipe;
 };
-
-/// Distributes `total` rows across `k` workers, leveling them up from the
-/// least-loaded first. Workers with fewer rows assigned get more rows, bringing
-/// everyone as close to equal as possible. Any leftover rows after leveling are
-/// split evenly.
-///
-/// The `sorted_indices` must be sorted by ascending `rows_assigned`.
-///
-/// Example: rows_assigned = [100, 300, 500], total = 1000
-///   Level up worker 0 by 200 to match worker 1 (cost: 200)
-///   Level up workers 0,1 by 200 each to match worker 2 (cost: 400)
-///   Remaining 400 split evenly: 134, 133, 133
-///   Result: [534, 333, 133], new totals: [634, 633, 633]
-auto water_fill(uint64_t total, std::span<const size_t> sorted_indices,
-                std::span<const uint64_t> rows_assigned)
-  -> std::vector<uint64_t> {
-  auto k = sorted_indices.size();
-  auto alloc = std::vector<uint64_t>(k, 0);
-  auto remaining = total;
-  for (auto level = size_t{0}; level + 1 < k; ++level) {
-    auto gap = rows_assigned[sorted_indices[level + 1]]
-               - rows_assigned[sorted_indices[level]];
-    auto needed = gap * (level + 1);
-    if (needed <= remaining) {
-      for (auto j = size_t{0}; j <= level; ++j) {
-        alloc[j] += gap;
-      }
-      remaining -= needed;
-    } else {
-      auto per = remaining / (level + 1);
-      auto extra = remaining % (level + 1);
-      for (auto j = size_t{0}; j <= level; ++j) {
-        alloc[j] += per + (j < extra ? 1 : 0);
-      }
-      remaining = 0;
-      break;
-    }
-  }
-  if (remaining > 0) {
-    auto per = remaining / k;
-    auto extra = remaining % k;
-    for (auto j = size_t{0}; j < k; ++j) {
-      alloc[j] += per + (j < extra ? 1 : 0);
-    }
-  }
-  return alloc;
-}
-
-/// Distributes `total_rows` across workers while maintaining fairness.
-///
-/// Tries to use as few workers as possible (for better locality) while keeping
-/// the max/min ratio of total rows assigned across all workers within
-/// `fairness_factor`. Starts by trying to send everything to the most-starved
-/// worker (k=1), then considers spreading across 2, 3, ... workers until the
-/// fairness constraint is satisfied. At k=n (all workers), always accepts.
-///
-/// Updates `rows_assigned` in place and returns (worker_index, row_count) pairs.
-///
-/// Example: 4 workers at [0, 0, 0, 0], distributing 1000 rows
-///   k=1: all to worker 0 → [1000, 0, 0, 0], unfair → rejected
-///   k=4: 250 each → [250, 250, 250, 250] → accepted
-///
-/// Example: 4 workers at [500, 300, 200, 100], distributing 400 rows
-///   k=1: all to worker 3 → [500, 300, 200, 500], max/min = 2.5 → rejected
-///   k=2: water-fill workers 3,2 → [500, 300, 300, 300], max/min = 1.67 → ok
-auto distribute_adaptive(uint64_t total_rows,
-                         std::vector<uint64_t>& rows_assigned)
-  -> std::vector<std::pair<size_t, uint64_t>> {
-  auto n = rows_assigned.size();
-  // Sort worker indices by rows_assigned ascending.
-  auto sorted = std::vector<size_t>(n);
-  std::iota(sorted.begin(), sorted.end(), size_t{0});
-  std::sort(sorted.begin(), sorted.end(), [&](size_t a, size_t b) {
-    return rows_assigned[a] < rows_assigned[b];
-  });
-  auto alloc = std::vector<uint64_t>{};
-  for (auto k = size_t{1}; k <= n; ++k) {
-    alloc = water_fill(total_rows, std::span{sorted.data(), k}, rows_assigned);
-    if (k == n) {
-      break;
-    }
-    // Check whether this distribution satisfies the fairness constraint.
-    auto new_totals = rows_assigned;
-    for (auto i = size_t{0}; i < k; ++i) {
-      new_totals[sorted[i]] += alloc[i];
-    }
-    auto [min_it, max_it]
-      = std::minmax_element(new_totals.begin(), new_totals.end());
-    auto is_fair = static_cast<double>(*max_it)
-                   <= static_cast<double>(*min_it) * fairness_factor;
-    if (is_fair) {
-      break;
-    }
-  }
-  auto result = std::vector<std::pair<size_t, uint64_t>>{};
-  for (auto i = size_t{0}; i < alloc.size(); ++i) {
-    if (alloc[i] > 0) {
-      rows_assigned[sorted[i]] += alloc[i];
-      result.emplace_back(sorted[i], alloc[i]);
-    }
-  }
-  return result;
-}
 
 /// Shared implementation for both transform and sink variants.
 class ParallelImpl {
@@ -176,7 +69,7 @@ public:
     serde("rows_assigned", rows_assigned_);
   }
 
-  auto finalize(OpCtx& ctx) -> Task<void> {
+  auto finalize(OpCtx& ctx) const -> Task<void> {
     for (auto i = uint64_t{0}; i < jobs_; ++i) {
       auto sub = ctx.get_sub(int64_t(i));
       if (sub) {
@@ -189,29 +82,19 @@ public:
 private:
   auto process_hash(table_slice input, OpCtx& ctx) -> Task<void> {
     auto values = eval(*route_by_, input, ctx.dh());
-    auto num_rows = static_cast<int64_t>(input.rows());
     // Find runs of same-bucket rows and push subslices.
-    auto begin = int64_t{0};
-    while (begin < num_rows) {
-      auto bucket = std::hash<data_view3>{}(values.view3_at(begin)) % jobs_;
-      auto end = begin + 1;
-      while (end < num_rows
-             and std::hash<data_view3>{}(values.view3_at(end)) % jobs_
-                   == bucket) {
-        ++end;
-      }
+    for (auto [bucket, begin, end] : routing::hash_runs(values, jobs_)) {
       auto slice = subslice(input, begin, end);
       auto sub = ctx.get_sub(int64_t(bucket));
       TENZIR_ASSERT(sub);
       auto& pipe = as<SubHandle<table_slice>>(*sub);
       std::ignore = co_await pipe.push(std::move(slice));
-      begin = end;
     }
   }
 
   auto process_round_robin(table_slice input, OpCtx& ctx) -> Task<void> {
     auto total_rows = static_cast<uint64_t>(input.rows());
-    auto assignments = distribute_adaptive(total_rows, rows_assigned_);
+    auto assignments = routing::distribute_adaptive(total_rows, rows_assigned_);
     auto offset = size_t{0};
     for (auto [worker, count] : assignments) {
       auto slice = subslice(input, offset, offset + count);

--- a/libtenzir/include/tenzir/async/routing.hpp
+++ b/libtenzir/include/tenzir/async/routing.hpp
@@ -10,16 +10,12 @@
 
 #include "tenzir/async/executor.hpp"
 #include "tenzir/async/push_pull.hpp"
-#include "tenzir/async/select_set.hpp"
 #include "tenzir/async/signal.hpp"
 #include "tenzir/box.hpp"
-#include "tenzir/co_match.hpp"
 #include "tenzir/detail/assert.hpp"
 #include "tenzir/multi_series.hpp"
-#include "tenzir/panic.hpp"
 #include "tenzir/table_slice.hpp"
 
-#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <span>
@@ -102,116 +98,35 @@ namespace tenzir {
 /// The fan-out endpoint of a scatter exchange.
 ///
 /// A `ScatterPush` is held by the single upstream operator and forwards each
-/// message to one or more of its `n` downstream lanes:
+/// `table_slice` to one or more of its `n` downstream lanes:
 ///
-/// - Data is routed round-robin with adaptive load balancing: event slices are
-///   split across lanes by row (via `routing::distribute_adaptive`) while other
-///   element types round-robin whole messages.
+/// - Data is split across lanes by row via `routing::distribute_adaptive`,
+///   keeping total rows assigned as balanced as possible.
 /// - Signals are broadcast to every open lane, sequentially. Blocking on a slow
 ///   lane is correct: it applies backpressure.
 ///
 /// The control plane may retire a lane with `close_lane` once its downstream
 /// finished (e.g. `head`); the scatter then stops routing data to it while
 /// still forwarding signals to the remaining lanes.
-template <class T>
-class ScatterPush final : public Push<OperatorMsg<T>> {
+class ScatterPush final : public Push<OperatorMsg<table_slice>> {
 public:
-  explicit ScatterPush(std::vector<Box<Push<OperatorMsg<T>>>> lanes)
-    : lanes_{std::move(lanes)},
-      open_(lanes_.size(), true),
-      rows_assigned_(lanes_.size(), 0) {
-    TENZIR_ASSERT(not lanes_.empty());
-  }
+  explicit ScatterPush(std::vector<Box<Push<OperatorMsg<table_slice>>>> lanes);
 
-  auto operator()(OperatorMsg<T> msg) -> Task<void> override {
-    // Note the `co_await`: `operator()` must itself be a coroutine so the
-    // handler lambda temporaries created by `co_match` stay alive across the
-    // suspension. A plain `return co_match(...)` would destroy them at the end
-    // of the full expression, leaving the returned (lazily-started) handler
-    // coroutine with a dangling reference to its captured `this`.
-    co_await co_match(
-      std::move(msg),
-      [this](Signal signal) -> Task<void> {
-        // Broadcast signals to every open lane, sequentially.
-        for (auto i = size_t{0}; i < lanes_.size(); ++i) {
-          if (open_[i]) {
-            co_await (*lanes_[i])(OperatorMsg<T>{signal});
-          }
-        }
-      },
-      [this](T data) -> Task<void> {
-        co_await route_data(std::move(data));
-      });
-  }
+  auto operator()(OperatorMsg<table_slice> msg) -> Task<void> override;
 
   /// Retires a lane so no further data is routed to it. Signals are still
   /// broadcast to open lanes only.
-  auto close_lane(size_t lane) -> void {
-    TENZIR_ASSERT(lane < open_.size());
-    open_[lane] = false;
-  }
+  auto close_lane(size_t lane) -> void;
 
   /// Returns the number of lanes still receiving data.
-  auto open_lanes() const -> size_t {
-    return std::ranges::count(open_, true);
-  }
+  auto open_lanes() const -> size_t;
 
 private:
-  auto route_data(T data) -> Task<void> {
-    if constexpr (std::same_as<T, table_slice>) {
-      // Split the slice across open lanes by row, keeping load balanced.
-      auto total = static_cast<uint64_t>(data.rows());
-      if (total == 0) {
-        co_return;
-      }
-      // Distribute across open lanes only. Retired lanes are excluded from the
-      // load vector entirely, so they neither receive rows nor skew the
-      // fairness check (a pinned sentinel would reject every `k < n`, forcing
-      // needless fragmentation across all open lanes).
-      auto open_lane_ids = std::vector<size_t>{};
-      auto open_loads = std::vector<uint64_t>{};
-      for (auto i = size_t{0}; i < open_.size(); ++i) {
-        if (open_[i]) {
-          open_lane_ids.push_back(i);
-          open_loads.push_back(rows_assigned_[i]);
-        }
-      }
-      if (open_lane_ids.empty()) {
-        panic("scatter has no open lane to route to");
-      }
-      // `distribute_adaptive` updates `open_loads` in place for the lanes it
-      // fills; fold those back into the real per-lane load vector.
-      auto assignments = routing::distribute_adaptive(total, open_loads);
-      auto offset = size_t{0};
-      for (auto [compact, count] : assignments) {
-        auto lane = open_lane_ids[compact];
-        rows_assigned_[lane] = open_loads[compact];
-        auto slice = subslice(data, offset, offset + count);
-        offset += count;
-        co_await (*lanes_[lane])(OperatorMsg<table_slice>{std::move(slice)});
-      }
-    } else {
-      // Round-robin whole messages across open lanes.
-      auto lane = next_open_lane();
-      co_await (*lanes_[lane])(OperatorMsg<T>{std::move(data)});
-    }
-  }
+  auto route_data(table_slice data) -> Task<void>;
 
-  auto next_open_lane() -> size_t {
-    for (auto step = size_t{0}; step < lanes_.size(); ++step) {
-      auto lane = (rr_cursor_ + step) % lanes_.size();
-      if (open_[lane]) {
-        rr_cursor_ = (lane + 1) % lanes_.size();
-        return lane;
-      }
-    }
-    panic("scatter has no open lane to route to");
-  }
-
-  std::vector<Box<Push<OperatorMsg<T>>>> lanes_;
+  std::vector<Box<Push<OperatorMsg<table_slice>>>> lanes_;
   std::vector<bool> open_;
   std::vector<uint64_t> rows_assigned_;
-  size_t rr_cursor_ = 0;
 };
 
 /// Drives the fan-in of a gather exchange.
@@ -229,84 +144,21 @@ private:
 ///
 /// Pull-based selection makes this cheap: a fast lane naturally stalls under
 /// backpressure while a slow lane catches up.
-template <class T>
-auto run_gather(std::vector<Box<Pull<OperatorMsg<T>>>> lanes,
-                Box<Push<OperatorMsg<T>>> out) -> Task<void> {
-  struct LaneMsg {
-    size_t lane;
-    Option<OperatorMsg<T>> msg;
-  };
-  const auto n = lanes.size();
-  TENZIR_ASSERT(n > 0);
-  auto eod_count = size_t{0};
-  auto drained = size_t{0};
-  auto set = SelectSet<LaneMsg>{};
-  co_await set.activate([&]() -> Task<void> {
-    auto arm = [&](size_t lane) {
-      set.add([&lanes, lane]() -> Task<LaneMsg> {
-        co_return LaneMsg{lane, co_await (*lanes[lane])()};
-      });
-    };
-    for (auto lane = size_t{0}; lane < n; ++lane) {
-      arm(lane);
-    }
-    while (auto next = co_await set.next([](const LaneMsg&) {
-      return true;
-    })) {
-      auto lane = next->lane;
-      if (not next->msg) {
-        // The lane drained; do not re-arm it.
-        ++drained;
-        if (drained == n) {
-          break;
-        }
-        continue;
-      }
-      auto stop = co_await co_match(
-        std::move(*next->msg),
-        [&](T data) -> Task<bool> {
-          co_await (*out)(OperatorMsg<T>{std::move(data)});
-          arm(lane);
-          co_return false;
-        },
-        [&](Signal signal) -> Task<bool> {
-          co_return co_await co_match(
-            std::move(signal),
-            [&](EndOfData) -> Task<bool> {
-              // Emit a single aligned end-of-data once all lanes delivered it.
-              if (++eod_count == n) {
-                co_await (*out)(OperatorMsg<T>{Signal{EndOfData{}}});
-                eod_count = 0;
-              }
-              // Keep polling the lane for its eventual drain.
-              arm(lane);
-              co_return false;
-            },
-            [&](Checkpoint) -> Task<bool> {
-              // Aligned barrier handling is deferred to the checkpointing epic.
-              TENZIR_TODO();
-              co_return true;
-            });
-        });
-      if (stop) {
-        break;
-      }
-    }
-  });
-}
+auto run_gather(std::vector<Box<Pull<OperatorMsg<table_slice>>>> lanes,
+                Box<Push<OperatorMsg<table_slice>>> out) -> Task<void>;
 
 /// Creates a scatter exchange with `lanes` downstream lanes.
 ///
 /// Returns the single upstream `Push` (a `ScatterPush`) and the `lanes` lane
 /// `Pull`s. `make_channel` produces one internal SPSC channel per lane, e.g.
-/// `ExecCtx::make_channel<T>`.
-template <class T, class Factory>
+/// `ExecCtx::make_channel<table_slice>`.
+template <class Factory>
 auto make_scatter(size_t lanes, Factory make_channel, ChannelId id)
-  -> std::pair<Box<Push<OperatorMsg<T>>>,
-               std::vector<Box<Pull<OperatorMsg<T>>>>> {
+  -> std::pair<Box<Push<OperatorMsg<table_slice>>>,
+               std::vector<Box<Pull<OperatorMsg<table_slice>>>>> {
   TENZIR_ASSERT(lanes > 0);
-  auto lane_pushes = std::vector<Box<Push<OperatorMsg<T>>>>{};
-  auto lane_pulls = std::vector<Box<Pull<OperatorMsg<T>>>>{};
+  auto lane_pushes = std::vector<Box<Push<OperatorMsg<table_slice>>>>{};
+  auto lane_pulls = std::vector<Box<Pull<OperatorMsg<table_slice>>>>{};
   lane_pushes.reserve(lanes);
   lane_pulls.reserve(lanes);
   for (auto lane = size_t{0}; lane < lanes; ++lane) {
@@ -316,17 +168,16 @@ auto make_scatter(size_t lanes, Factory make_channel, ChannelId id)
     lane_pulls.push_back(std::move(pair.pull));
   }
   auto scatter
-    = Box<Push<OperatorMsg<T>>>{ScatterPush<T>{std::move(lane_pushes)}};
+    = Box<Push<OperatorMsg<table_slice>>>{ScatterPush{std::move(lane_pushes)}};
   return {std::move(scatter), std::move(lane_pulls)};
 }
 
 /// The parts of a gather exchange with `lanes` upstream lanes.
-template <class T>
 struct GatherParts {
   /// One `Push` per lane, held by each upstream lane operator.
-  std::vector<Box<Push<OperatorMsg<T>>>> lanes;
+  std::vector<Box<Push<OperatorMsg<table_slice>>>> lanes;
   /// The single downstream `Pull`, held by the downstream operator.
-  Box<Pull<OperatorMsg<T>>> pull;
+  Box<Pull<OperatorMsg<table_slice>>> pull;
   /// The merge loop; the caller must spawn this task.
   Task<void> merger;
 };
@@ -335,13 +186,13 @@ struct GatherParts {
 ///
 /// The caller is responsible for spawning `GatherParts::merger` on a suitable
 /// scope. `make_channel` produces the internal SPSC channels, e.g.
-/// `ExecCtx::make_channel<T>`.
-template <class T, class Factory>
+/// `ExecCtx::make_channel<table_slice>`.
+template <class Factory>
 auto make_gather(size_t lanes, Factory make_channel, ChannelId id)
-  -> GatherParts<T> {
+  -> GatherParts {
   TENZIR_ASSERT(lanes > 0);
-  auto lane_pushes = std::vector<Box<Push<OperatorMsg<T>>>>{};
-  auto lane_pulls = std::vector<Box<Pull<OperatorMsg<T>>>>{};
+  auto lane_pushes = std::vector<Box<Push<OperatorMsg<table_slice>>>>{};
+  auto lane_pulls = std::vector<Box<Pull<OperatorMsg<table_slice>>>>{};
   lane_pushes.reserve(lanes);
   lane_pulls.reserve(lanes);
   for (auto lane = size_t{0}; lane < lanes; ++lane) {
@@ -351,10 +202,10 @@ auto make_gather(size_t lanes, Factory make_channel, ChannelId id)
     lane_pulls.push_back(std::move(pair.pull));
   }
   auto out = make_channel(ChannelId{fmt::format("{}#gather/out", id.value)});
-  return GatherParts<T>{
+  return GatherParts{
     .lanes = std::move(lane_pushes),
     .pull = std::move(out.pull),
-    .merger = run_gather<T>(std::move(lane_pulls), std::move(out.push)),
+    .merger = run_gather(std::move(lane_pulls), std::move(out.push)),
   };
 }
 

--- a/libtenzir/include/tenzir/async/routing.hpp
+++ b/libtenzir/include/tenzir/async/routing.hpp
@@ -22,7 +22,6 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
-#include <limits>
 #include <span>
 #include <utility>
 #include <vector>
@@ -179,15 +178,28 @@ private:
       if (total == 0) {
         co_return;
       }
-      if (open_lanes() == 0) {
+      // Distribute across open lanes only. Retired lanes are excluded from the
+      // load vector entirely, so they neither receive rows nor skew the
+      // fairness check (a pinned sentinel would reject every `k < n`, forcing
+      // needless fragmentation across all open lanes).
+      auto open_lane_ids = std::vector<size_t>{};
+      auto open_loads = std::vector<uint64_t>{};
+      for (auto i = size_t{0}; i < open_.size(); ++i) {
+        if (open_[i]) {
+          open_lane_ids.push_back(i);
+          open_loads.push_back(rows_assigned_[i]);
+        }
+      }
+      if (open_lane_ids.empty()) {
         panic("scatter has no open lane to route to");
       }
-      // `distribute_adaptive` works over all lanes; funnel closed lanes by
-      // pre-loading them so they are never selected.
-      auto assignments
-        = routing::distribute_adaptive(total, effective_rows_assigned());
+      // `distribute_adaptive` updates `open_loads` in place for the lanes it
+      // fills; fold those back into the real per-lane load vector.
+      auto assignments = routing::distribute_adaptive(total, open_loads);
       auto offset = size_t{0};
-      for (auto [lane, count] : assignments) {
+      for (auto [compact, count] : assignments) {
+        auto lane = open_lane_ids[compact];
+        rows_assigned_[lane] = open_loads[compact];
         auto slice = subslice(data, offset, offset + count);
         offset += count;
         co_await (*lanes_[lane])(OperatorMsg<table_slice>{std::move(slice)});
@@ -197,21 +209,6 @@ private:
       auto lane = next_open_lane();
       co_await (*lanes_[lane])(OperatorMsg<T>{std::move(data)});
     }
-  }
-
-  /// For adaptive routing, returns a load vector where closed lanes are pinned
-  /// to the maximum so they never receive rows, and records the real assignment
-  /// back into `rows_assigned_`.
-  auto effective_rows_assigned() -> std::vector<uint64_t>& {
-    // Closed lanes are excluded by setting their load extremely high, which
-    // keeps `distribute_adaptive` from ever choosing them (it always fills the
-    // least-loaded first and checks fairness against the minimum).
-    for (auto i = size_t{0}; i < open_.size(); ++i) {
-      if (not open_[i]) {
-        rows_assigned_[i] = std::numeric_limits<uint64_t>::max();
-      }
-    }
-    return rows_assigned_;
   }
 
   auto next_open_lane() -> size_t {

--- a/libtenzir/include/tenzir/async/routing.hpp
+++ b/libtenzir/include/tenzir/async/routing.hpp
@@ -124,7 +124,12 @@ public:
   }
 
   auto operator()(OperatorMsg<T> msg) -> Task<void> override {
-    return co_match(
+    // Note the `co_await`: `operator()` must itself be a coroutine so the
+    // handler lambda temporaries created by `co_match` stay alive across the
+    // suspension. A plain `return co_match(...)` would destroy them at the end
+    // of the full expression, leaving the returned (lazily-started) handler
+    // coroutine with a dangling reference to its captured `this`.
+    co_await co_match(
       std::move(msg),
       [this](Signal signal) -> Task<void> {
         // Broadcast signals to every open lane, sequentially.

--- a/libtenzir/include/tenzir/async/routing.hpp
+++ b/libtenzir/include/tenzir/async/routing.hpp
@@ -179,6 +179,9 @@ private:
       if (total == 0) {
         co_return;
       }
+      if (open_lanes() == 0) {
+        panic("scatter has no open lane to route to");
+      }
       // `distribute_adaptive` works over all lanes; funnel closed lanes by
       // pre-loading them so they are never selected.
       auto assignments

--- a/libtenzir/include/tenzir/async/routing.hpp
+++ b/libtenzir/include/tenzir/async/routing.hpp
@@ -1,0 +1,377 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "tenzir/async/executor.hpp"
+#include "tenzir/async/push_pull.hpp"
+#include "tenzir/async/select_set.hpp"
+#include "tenzir/async/signal.hpp"
+#include "tenzir/box.hpp"
+#include "tenzir/co_match.hpp"
+#include "tenzir/detail/assert.hpp"
+#include "tenzir/multi_series.hpp"
+#include "tenzir/panic.hpp"
+#include "tenzir/table_slice.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <span>
+#include <utility>
+#include <vector>
+
+/// Routing policies shared between the explicit `parallel` operator and the
+/// implicit parallelization exchanges (scatter/gather).
+namespace tenzir::routing {
+
+/// The maximum allowed ratio between the most- and least-loaded worker for a
+/// distribution to be considered fair by `distribute_adaptive`.
+inline constexpr auto fairness_factor = 2.0;
+
+/// Distributes `total` rows across `k` workers, leveling them up from the
+/// least-loaded first. Workers with fewer rows assigned get more rows, bringing
+/// everyone as close to equal as possible. Any leftover rows after leveling are
+/// split evenly.
+///
+/// The `sorted_indices` must be sorted by ascending `rows_assigned`.
+///
+/// Example: rows_assigned = [100, 300, 500], total = 1000
+///   Level up worker 0 by 200 to match worker 1 (cost: 200)
+///   Level up workers 0,1 by 200 each to match worker 2 (cost: 400)
+///   Remaining 400 split evenly: 134, 133, 133
+///   Result: [534, 333, 133], new totals: [634, 633, 633]
+///
+/// The returned vector has size `k` and is indexed by position within
+/// `sorted_indices` (not by worker id).
+auto water_fill(uint64_t total, std::span<const size_t> sorted_indices,
+                std::span<const uint64_t> rows_assigned)
+  -> std::vector<uint64_t>;
+
+/// Distributes `total_rows` across workers while maintaining fairness.
+///
+/// Tries to use as few workers as possible (for better locality) while keeping
+/// the max/min ratio of total rows assigned across all workers within
+/// `fairness_factor`. Starts by trying to send everything to the most-starved
+/// worker (k=1), then considers spreading across 2, 3, ... workers until the
+/// fairness constraint is satisfied. At k=n (all workers), always accepts.
+///
+/// Updates `rows_assigned` in place and returns (worker_index, row_count)
+/// pairs. Only workers that receive a non-zero number of rows are included.
+///
+/// Example: 4 workers at [0, 0, 0, 0], distributing 1000 rows
+///   k=1: all to worker 0 → [1000, 0, 0, 0], unfair → rejected
+///   k=4: 250 each → [250, 250, 250, 250] → accepted
+///
+/// Example: 4 workers at [500, 300, 200, 100], distributing 400 rows
+///   k=1: all to worker 3 → [500, 300, 200, 500], max/min = 2.5 → rejected
+///   k=2: water-fill workers 3,2 → [500, 300, 350, 350], max/min = 1.67 → ok
+auto distribute_adaptive(uint64_t total_rows,
+                         std::vector<uint64_t>& rows_assigned)
+  -> std::vector<std::pair<size_t, uint64_t>>;
+
+/// A contiguous run of rows `[begin, end)` that all hash to the same `bucket`.
+struct hash_run {
+  uint64_t bucket;
+  int64_t begin;
+  int64_t end;
+
+  friend auto operator==(const hash_run&, const hash_run&) -> bool = default;
+};
+
+/// Splits `values` into maximal contiguous runs of rows that hash to the same
+/// bucket, where `bucket = hash(value) % jobs`. Preserves input order: the
+/// returned runs partition `[0, values.length())` from front to back.
+///
+/// This is the routing primitive behind hash-partitioned exchanges: rows within
+/// a run can be pushed as a single subslice to the owning lane.
+///
+/// Requires `jobs > 0`.
+auto hash_runs(const multi_series& values, uint64_t jobs)
+  -> std::vector<hash_run>;
+
+} // namespace tenzir::routing
+
+namespace tenzir {
+
+/// Routing policy for a scatter exchange: distribute stateless work across
+/// lanes while balancing load. For events, this splits slices by row using the
+/// adaptive water-fill policy; for other element types it round-robins whole
+/// messages.
+struct RoundRobinAdaptive {};
+
+/// The routing policy of a scatter exchange.
+///
+/// Hash-partitioned routing is a later phase; only round-robin exists today.
+using ScatterPolicy = variant<RoundRobinAdaptive>;
+
+/// The fan-out endpoint of a scatter exchange.
+///
+/// A `ScatterPush` is held by the single upstream operator and forwards each
+/// message to one or more of its `n` downstream lanes:
+///
+/// - Data is routed by the `ScatterPolicy`. `RoundRobinAdaptive` splits event
+///   slices across lanes by row (via `routing::distribute_adaptive`) and
+///   round-robins non-event messages.
+/// - Signals are broadcast to every open lane, sequentially. Blocking on a slow
+///   lane is correct: it applies backpressure.
+///
+/// The control plane may retire a lane with `close_lane` once its downstream
+/// finished (e.g. `head`); the scatter then stops routing data to it while
+/// still forwarding signals to the remaining lanes.
+template <class T>
+class ScatterPush final : public Push<OperatorMsg<T>> {
+public:
+  ScatterPush(std::vector<Box<Push<OperatorMsg<T>>>> lanes,
+              ScatterPolicy policy)
+    : lanes_{std::move(lanes)},
+      open_(lanes_.size(), true),
+      policy_{policy},
+      rows_assigned_(lanes_.size(), 0) {
+    TENZIR_ASSERT(not lanes_.empty());
+  }
+
+  auto operator()(OperatorMsg<T> msg) -> Task<void> override {
+    return co_match(
+      std::move(msg),
+      [this](Signal signal) -> Task<void> {
+        // Broadcast signals to every open lane, sequentially.
+        for (auto i = size_t{0}; i < lanes_.size(); ++i) {
+          if (open_[i]) {
+            co_await (*lanes_[i])(OperatorMsg<T>{signal});
+          }
+        }
+      },
+      [this](T data) -> Task<void> {
+        co_await route_data(std::move(data));
+      });
+  }
+
+  /// Retires a lane so no further data is routed to it. Signals are still
+  /// broadcast to open lanes only.
+  auto close_lane(size_t lane) -> void {
+    TENZIR_ASSERT(lane < open_.size());
+    open_[lane] = false;
+  }
+
+  /// Returns the number of lanes still receiving data.
+  auto open_lanes() const -> size_t {
+    return std::ranges::count(open_, true);
+  }
+
+private:
+  auto route_data(T data) -> Task<void> {
+    return match(policy_, [&](const RoundRobinAdaptive&) -> Task<void> {
+      return route_round_robin(std::move(data));
+    });
+  }
+
+  auto route_round_robin(T data) -> Task<void> {
+    if constexpr (std::same_as<T, table_slice>) {
+      // Split the slice across open lanes by row, keeping load balanced.
+      auto total = static_cast<uint64_t>(data.rows());
+      if (total == 0) {
+        co_return;
+      }
+      // `distribute_adaptive` works over all lanes; funnel closed lanes by
+      // pre-loading them so they are never selected.
+      auto assignments
+        = routing::distribute_adaptive(total, effective_rows_assigned());
+      auto offset = size_t{0};
+      for (auto [lane, count] : assignments) {
+        auto slice = subslice(data, offset, offset + count);
+        offset += count;
+        co_await (*lanes_[lane])(OperatorMsg<table_slice>{std::move(slice)});
+      }
+    } else {
+      // Round-robin whole messages across open lanes.
+      auto lane = next_open_lane();
+      co_await (*lanes_[lane])(OperatorMsg<T>{std::move(data)});
+    }
+  }
+
+  /// For adaptive routing, returns a load vector where closed lanes are pinned
+  /// to the maximum so they never receive rows, and records the real assignment
+  /// back into `rows_assigned_`.
+  auto effective_rows_assigned() -> std::vector<uint64_t>& {
+    // Closed lanes are excluded by setting their load extremely high, which
+    // keeps `distribute_adaptive` from ever choosing them (it always fills the
+    // least-loaded first and checks fairness against the minimum).
+    for (auto i = size_t{0}; i < open_.size(); ++i) {
+      if (not open_[i]) {
+        rows_assigned_[i] = std::numeric_limits<uint64_t>::max();
+      }
+    }
+    return rows_assigned_;
+  }
+
+  auto next_open_lane() -> size_t {
+    for (auto step = size_t{0}; step < lanes_.size(); ++step) {
+      auto lane = (rr_cursor_ + step) % lanes_.size();
+      if (open_[lane]) {
+        rr_cursor_ = (lane + 1) % lanes_.size();
+        return lane;
+      }
+    }
+    panic("scatter has no open lane to route to");
+  }
+
+  std::vector<Box<Push<OperatorMsg<T>>>> lanes_;
+  std::vector<bool> open_;
+  ScatterPolicy policy_;
+  std::vector<uint64_t> rows_assigned_;
+  size_t rr_cursor_ = 0;
+};
+
+/// Drives the fan-in of a gather exchange.
+///
+/// Runs the merge loop that reads the `n` upstream lane pulls and writes the
+/// aligned stream into `out`. Intended to be spawned as a background task; when
+/// it returns, `out` is dropped and the downstream `Pull` observes closure.
+///
+/// Per-signal alignment policy:
+///
+/// - data: forwarded as received (interleaved).
+/// - `EndOfData`: counted; emitted once after every lane delivered it.
+/// - lane drained (`None`): counted; when all lanes drained the loop stops.
+/// - `Checkpoint`: aligned barrier, not yet implemented.
+///
+/// Pull-based selection makes this cheap: a fast lane naturally stalls under
+/// backpressure while a slow lane catches up.
+template <class T>
+auto run_gather(std::vector<Box<Pull<OperatorMsg<T>>>> lanes,
+                Box<Push<OperatorMsg<T>>> out) -> Task<void> {
+  struct LaneMsg {
+    size_t lane;
+    Option<OperatorMsg<T>> msg;
+  };
+  const auto n = lanes.size();
+  TENZIR_ASSERT(n > 0);
+  auto eod_count = size_t{0};
+  auto drained = size_t{0};
+  auto set = SelectSet<LaneMsg>{};
+  co_await set.activate([&]() -> Task<void> {
+    auto arm = [&](size_t lane) {
+      set.add([&lanes, lane]() -> Task<LaneMsg> {
+        co_return LaneMsg{lane, co_await (*lanes[lane])()};
+      });
+    };
+    for (auto lane = size_t{0}; lane < n; ++lane) {
+      arm(lane);
+    }
+    while (auto next = co_await set.next([](const LaneMsg&) {
+      return true;
+    })) {
+      auto lane = next->lane;
+      if (not next->msg) {
+        // The lane drained; do not re-arm it.
+        ++drained;
+        if (drained == n) {
+          break;
+        }
+        continue;
+      }
+      auto stop = co_await co_match(
+        std::move(*next->msg),
+        [&](T data) -> Task<bool> {
+          co_await (*out)(OperatorMsg<T>{std::move(data)});
+          arm(lane);
+          co_return false;
+        },
+        [&](Signal signal) -> Task<bool> {
+          co_return co_await co_match(
+            std::move(signal),
+            [&](EndOfData) -> Task<bool> {
+              // Emit a single aligned end-of-data once all lanes delivered it.
+              if (++eod_count == n) {
+                co_await (*out)(OperatorMsg<T>{Signal{EndOfData{}}});
+                eod_count = 0;
+              }
+              // Keep polling the lane for its eventual drain.
+              arm(lane);
+              co_return false;
+            },
+            [&](Checkpoint) -> Task<bool> {
+              // Aligned barrier handling is deferred to the checkpointing epic.
+              TENZIR_TODO();
+              co_return true;
+            });
+        });
+      if (stop) {
+        break;
+      }
+    }
+  });
+}
+
+/// Creates a scatter exchange with `lanes` downstream lanes.
+///
+/// Returns the single upstream `Push` (a `ScatterPush`) and the `lanes` lane
+/// `Pull`s. `make_channel` produces one internal SPSC channel per lane, e.g.
+/// `ExecCtx::make_channel<T>`.
+template <class T, class Factory>
+auto make_scatter(size_t lanes, ScatterPolicy policy, Factory make_channel,
+                  ChannelId id)
+  -> std::pair<Box<Push<OperatorMsg<T>>>,
+               std::vector<Box<Pull<OperatorMsg<T>>>>> {
+  TENZIR_ASSERT(lanes > 0);
+  auto lane_pushes = std::vector<Box<Push<OperatorMsg<T>>>>{};
+  auto lane_pulls = std::vector<Box<Pull<OperatorMsg<T>>>>{};
+  lane_pushes.reserve(lanes);
+  lane_pulls.reserve(lanes);
+  for (auto lane = size_t{0}; lane < lanes; ++lane) {
+    auto pair
+      = make_channel(ChannelId{fmt::format("{}#scatter/{}", id.value, lane)});
+    lane_pushes.push_back(std::move(pair.push));
+    lane_pulls.push_back(std::move(pair.pull));
+  }
+  auto scatter
+    = Box<Push<OperatorMsg<T>>>{ScatterPush<T>{std::move(lane_pushes), policy}};
+  return {std::move(scatter), std::move(lane_pulls)};
+}
+
+/// The parts of a gather exchange with `lanes` upstream lanes.
+template <class T>
+struct GatherParts {
+  /// One `Push` per lane, held by each upstream lane operator.
+  std::vector<Box<Push<OperatorMsg<T>>>> lanes;
+  /// The single downstream `Pull`, held by the downstream operator.
+  Box<Pull<OperatorMsg<T>>> pull;
+  /// The merge loop; the caller must spawn this task.
+  Task<void> merger;
+};
+
+/// Creates a gather exchange with `lanes` upstream lanes.
+///
+/// The caller is responsible for spawning `GatherParts::merger` on a suitable
+/// scope. `make_channel` produces the internal SPSC channels, e.g.
+/// `ExecCtx::make_channel<T>`.
+template <class T, class Factory>
+auto make_gather(size_t lanes, Factory make_channel, ChannelId id)
+  -> GatherParts<T> {
+  TENZIR_ASSERT(lanes > 0);
+  auto lane_pushes = std::vector<Box<Push<OperatorMsg<T>>>>{};
+  auto lane_pulls = std::vector<Box<Pull<OperatorMsg<T>>>>{};
+  lane_pushes.reserve(lanes);
+  lane_pulls.reserve(lanes);
+  for (auto lane = size_t{0}; lane < lanes; ++lane) {
+    auto pair
+      = make_channel(ChannelId{fmt::format("{}#gather/{}", id.value, lane)});
+    lane_pushes.push_back(std::move(pair.push));
+    lane_pulls.push_back(std::move(pair.pull));
+  }
+  auto out = make_channel(ChannelId{fmt::format("{}#gather/out", id.value)});
+  return GatherParts<T>{
+    .lanes = std::move(lane_pushes),
+    .pull = std::move(out.pull),
+    .merger = run_gather<T>(std::move(lane_pulls), std::move(out.push)),
+  };
+}
+
+} // namespace tenzir

--- a/libtenzir/include/tenzir/async/routing.hpp
+++ b/libtenzir/include/tenzir/async/routing.hpp
@@ -99,25 +99,14 @@ auto hash_runs(const multi_series& values, uint64_t jobs)
 
 namespace tenzir {
 
-/// Routing policy for a scatter exchange: distribute stateless work across
-/// lanes while balancing load. For events, this splits slices by row using the
-/// adaptive water-fill policy; for other element types it round-robins whole
-/// messages.
-struct RoundRobinAdaptive {};
-
-/// The routing policy of a scatter exchange.
-///
-/// Hash-partitioned routing is a later phase; only round-robin exists today.
-using ScatterPolicy = variant<RoundRobinAdaptive>;
-
 /// The fan-out endpoint of a scatter exchange.
 ///
 /// A `ScatterPush` is held by the single upstream operator and forwards each
 /// message to one or more of its `n` downstream lanes:
 ///
-/// - Data is routed by the `ScatterPolicy`. `RoundRobinAdaptive` splits event
-///   slices across lanes by row (via `routing::distribute_adaptive`) and
-///   round-robins non-event messages.
+/// - Data is routed round-robin with adaptive load balancing: event slices are
+///   split across lanes by row (via `routing::distribute_adaptive`) while other
+///   element types round-robin whole messages.
 /// - Signals are broadcast to every open lane, sequentially. Blocking on a slow
 ///   lane is correct: it applies backpressure.
 ///
@@ -127,11 +116,9 @@ using ScatterPolicy = variant<RoundRobinAdaptive>;
 template <class T>
 class ScatterPush final : public Push<OperatorMsg<T>> {
 public:
-  ScatterPush(std::vector<Box<Push<OperatorMsg<T>>>> lanes,
-              ScatterPolicy policy)
+  explicit ScatterPush(std::vector<Box<Push<OperatorMsg<T>>>> lanes)
     : lanes_{std::move(lanes)},
       open_(lanes_.size(), true),
-      policy_{policy},
       rows_assigned_(lanes_.size(), 0) {
     TENZIR_ASSERT(not lanes_.empty());
   }
@@ -166,12 +153,6 @@ public:
 
 private:
   auto route_data(T data) -> Task<void> {
-    return match(policy_, [&](const RoundRobinAdaptive&) -> Task<void> {
-      return route_round_robin(std::move(data));
-    });
-  }
-
-  auto route_round_robin(T data) -> Task<void> {
     if constexpr (std::same_as<T, table_slice>) {
       // Split the slice across open lanes by row, keeping load balanced.
       auto total = static_cast<uint64_t>(data.rows());
@@ -224,7 +205,6 @@ private:
 
   std::vector<Box<Push<OperatorMsg<T>>>> lanes_;
   std::vector<bool> open_;
-  ScatterPolicy policy_;
   std::vector<uint64_t> rows_assigned_;
   size_t rr_cursor_ = 0;
 };
@@ -316,8 +296,7 @@ auto run_gather(std::vector<Box<Pull<OperatorMsg<T>>>> lanes,
 /// `Pull`s. `make_channel` produces one internal SPSC channel per lane, e.g.
 /// `ExecCtx::make_channel<T>`.
 template <class T, class Factory>
-auto make_scatter(size_t lanes, ScatterPolicy policy, Factory make_channel,
-                  ChannelId id)
+auto make_scatter(size_t lanes, Factory make_channel, ChannelId id)
   -> std::pair<Box<Push<OperatorMsg<T>>>,
                std::vector<Box<Pull<OperatorMsg<T>>>>> {
   TENZIR_ASSERT(lanes > 0);
@@ -332,7 +311,7 @@ auto make_scatter(size_t lanes, ScatterPolicy policy, Factory make_channel,
     lane_pulls.push_back(std::move(pair.pull));
   }
   auto scatter
-    = Box<Push<OperatorMsg<T>>>{ScatterPush<T>{std::move(lane_pushes), policy}};
+    = Box<Push<OperatorMsg<T>>>{ScatterPush<T>{std::move(lane_pushes)}};
   return {std::move(scatter), std::move(lane_pulls)};
 }
 

--- a/libtenzir/src/async/routing.cpp
+++ b/libtenzir/src/async/routing.cpp
@@ -8,7 +8,10 @@
 
 #include "tenzir/async/routing.hpp"
 
+#include "tenzir/async/select_set.hpp"
+#include "tenzir/co_match.hpp"
 #include "tenzir/detail/assert.hpp"
+#include "tenzir/panic.hpp"
 
 #include <algorithm>
 #include <functional>
@@ -110,3 +113,143 @@ auto hash_runs(const multi_series& values, uint64_t jobs)
 }
 
 } // namespace tenzir::routing
+
+namespace tenzir {
+
+ScatterPush::ScatterPush(std::vector<Box<Push<OperatorMsg<table_slice>>>> lanes)
+  : lanes_{std::move(lanes)},
+    open_(lanes_.size(), true),
+    rows_assigned_(lanes_.size(), 0) {
+  TENZIR_ASSERT(not lanes_.empty());
+}
+
+auto ScatterPush::operator()(OperatorMsg<table_slice> msg) -> Task<void> {
+  // Note the `co_await`: `operator()` must itself be a coroutine so the
+  // handler lambda temporaries created by `co_match` stay alive across the
+  // suspension. A plain `return co_match(...)` would destroy them at the end
+  // of the full expression, leaving the returned (lazily-started) handler
+  // coroutine with a dangling reference to its captured `this`.
+  co_await co_match(
+    std::move(msg),
+    [this](Signal signal) -> Task<void> {
+      // Broadcast signals to every open lane, sequentially.
+      for (auto i = size_t{0}; i < lanes_.size(); ++i) {
+        if (open_[i]) {
+          co_await (*lanes_[i])(OperatorMsg<table_slice>{signal});
+        }
+      }
+    },
+    [this](table_slice data) -> Task<void> {
+      co_await route_data(std::move(data));
+    });
+}
+
+auto ScatterPush::close_lane(size_t lane) -> void {
+  TENZIR_ASSERT(lane < open_.size());
+  open_[lane] = false;
+}
+
+auto ScatterPush::open_lanes() const -> size_t {
+  return std::ranges::count(open_, true);
+}
+
+auto ScatterPush::route_data(table_slice data) -> Task<void> {
+  // Split the slice across open lanes by row, keeping load balanced.
+  auto total = static_cast<uint64_t>(data.rows());
+  if (total == 0) {
+    co_return;
+  }
+  // Distribute across open lanes only. Retired lanes are excluded from the
+  // load vector entirely, so they neither receive rows nor skew the
+  // fairness check (a pinned sentinel would reject every `k < n`, forcing
+  // needless fragmentation across all open lanes).
+  auto open_lane_ids = std::vector<size_t>{};
+  auto open_loads = std::vector<uint64_t>{};
+  for (auto i = size_t{0}; i < open_.size(); ++i) {
+    if (open_[i]) {
+      open_lane_ids.push_back(i);
+      open_loads.push_back(rows_assigned_[i]);
+    }
+  }
+  if (open_lane_ids.empty()) {
+    panic("scatter has no open lane to route to");
+  }
+  // `distribute_adaptive` updates `open_loads` in place for the lanes it
+  // fills; fold those back into the real per-lane load vector.
+  auto assignments = routing::distribute_adaptive(total, open_loads);
+  auto offset = size_t{0};
+  for (auto [compact, count] : assignments) {
+    auto lane = open_lane_ids[compact];
+    rows_assigned_[lane] = open_loads[compact];
+    auto slice = subslice(data, offset, offset + count);
+    offset += count;
+    co_await (*lanes_[lane])(OperatorMsg<table_slice>{std::move(slice)});
+  }
+}
+
+auto run_gather(std::vector<Box<Pull<OperatorMsg<table_slice>>>> lanes,
+                Box<Push<OperatorMsg<table_slice>>> out) -> Task<void> {
+  struct LaneMsg {
+    size_t lane;
+    Option<OperatorMsg<table_slice>> msg;
+  };
+  const auto n = lanes.size();
+  TENZIR_ASSERT(n > 0);
+  auto eod_count = size_t{0};
+  auto drained = size_t{0};
+  auto set = SelectSet<LaneMsg>{};
+  co_await set.activate([&]() -> Task<void> {
+    auto arm = [&](size_t lane) {
+      set.add([&lanes, lane]() -> Task<LaneMsg> {
+        co_return LaneMsg{lane, co_await (*lanes[lane])()};
+      });
+    };
+    for (auto lane = size_t{0}; lane < n; ++lane) {
+      arm(lane);
+    }
+    while (auto next = co_await set.next([](const LaneMsg&) {
+      return true;
+    })) {
+      auto lane = next->lane;
+      if (not next->msg) {
+        // The lane drained; do not re-arm it.
+        ++drained;
+        if (drained == n) {
+          break;
+        }
+        continue;
+      }
+      auto stop = co_await co_match(
+        std::move(*next->msg),
+        [&](table_slice data) -> Task<bool> {
+          co_await (*out)(OperatorMsg<table_slice>{std::move(data)});
+          arm(lane);
+          co_return false;
+        },
+        [&](Signal signal) -> Task<bool> {
+          co_return co_await co_match(
+            std::move(signal),
+            [&](EndOfData) -> Task<bool> {
+              // Emit a single aligned end-of-data once all lanes delivered it.
+              if (++eod_count == n) {
+                co_await (*out)(OperatorMsg<table_slice>{Signal{EndOfData{}}});
+                eod_count = 0;
+              }
+              // Keep polling the lane for its eventual drain.
+              arm(lane);
+              co_return false;
+            },
+            [&](Checkpoint) -> Task<bool> {
+              // Aligned barrier handling is deferred to the checkpointing epic.
+              TENZIR_TODO();
+              co_return true;
+            });
+        });
+      if (stop) {
+        break;
+      }
+    }
+  });
+}
+
+} // namespace tenzir

--- a/libtenzir/src/async/routing.cpp
+++ b/libtenzir/src/async/routing.cpp
@@ -1,0 +1,112 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "tenzir/async/routing.hpp"
+
+#include "tenzir/detail/assert.hpp"
+
+#include <algorithm>
+#include <functional>
+#include <numeric>
+
+namespace tenzir::routing {
+
+auto water_fill(uint64_t total, std::span<const size_t> sorted_indices,
+                std::span<const uint64_t> rows_assigned)
+  -> std::vector<uint64_t> {
+  auto k = sorted_indices.size();
+  auto alloc = std::vector<uint64_t>(k, 0);
+  auto remaining = total;
+  for (auto level = size_t{0}; level + 1 < k; ++level) {
+    auto gap = rows_assigned[sorted_indices[level + 1]]
+               - rows_assigned[sorted_indices[level]];
+    auto needed = gap * (level + 1);
+    if (needed <= remaining) {
+      for (auto j = size_t{0}; j <= level; ++j) {
+        alloc[j] += gap;
+      }
+      remaining -= needed;
+    } else {
+      auto per = remaining / (level + 1);
+      auto extra = remaining % (level + 1);
+      for (auto j = size_t{0}; j <= level; ++j) {
+        alloc[j] += per + (j < extra ? 1 : 0);
+      }
+      remaining = 0;
+      break;
+    }
+  }
+  if (remaining > 0) {
+    auto per = remaining / k;
+    auto extra = remaining % k;
+    for (auto j = size_t{0}; j < k; ++j) {
+      alloc[j] += per + (j < extra ? 1 : 0);
+    }
+  }
+  return alloc;
+}
+
+auto distribute_adaptive(uint64_t total_rows,
+                         std::vector<uint64_t>& rows_assigned)
+  -> std::vector<std::pair<size_t, uint64_t>> {
+  auto n = rows_assigned.size();
+  // Sort worker indices by rows_assigned ascending.
+  auto sorted = std::vector<size_t>(n);
+  std::iota(sorted.begin(), sorted.end(), size_t{0});
+  std::sort(sorted.begin(), sorted.end(), [&](size_t a, size_t b) {
+    return rows_assigned[a] < rows_assigned[b];
+  });
+  auto alloc = std::vector<uint64_t>{};
+  for (auto k = size_t{1}; k <= n; ++k) {
+    alloc = water_fill(total_rows, std::span{sorted.data(), k}, rows_assigned);
+    if (k == n) {
+      break;
+    }
+    // Check whether this distribution satisfies the fairness constraint.
+    auto new_totals = rows_assigned;
+    for (auto i = size_t{0}; i < k; ++i) {
+      new_totals[sorted[i]] += alloc[i];
+    }
+    auto [min_it, max_it]
+      = std::minmax_element(new_totals.begin(), new_totals.end());
+    auto is_fair = static_cast<double>(*max_it)
+                   <= static_cast<double>(*min_it) * fairness_factor;
+    if (is_fair) {
+      break;
+    }
+  }
+  auto result = std::vector<std::pair<size_t, uint64_t>>{};
+  for (auto i = size_t{0}; i < alloc.size(); ++i) {
+    if (alloc[i] > 0) {
+      rows_assigned[sorted[i]] += alloc[i];
+      result.emplace_back(sorted[i], alloc[i]);
+    }
+  }
+  return result;
+}
+
+auto hash_runs(const multi_series& values, uint64_t jobs)
+  -> std::vector<hash_run> {
+  TENZIR_ASSERT(jobs > 0);
+  auto result = std::vector<hash_run>{};
+  auto num_rows = values.length();
+  auto begin = int64_t{0};
+  while (begin < num_rows) {
+    auto bucket = std::hash<data_view3>{}(values.view3_at(begin)) % jobs;
+    auto end = begin + 1;
+    while (end < num_rows
+           and std::hash<data_view3>{}(values.view3_at(end)) % jobs == bucket) {
+      ++end;
+    }
+    result.push_back({bucket, begin, end});
+    begin = end;
+  }
+  return result;
+}
+
+} // namespace tenzir::routing

--- a/libtenzir/test/async/routing.cpp
+++ b/libtenzir/test/async/routing.cpp
@@ -1,0 +1,400 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "tenzir/async/routing.hpp"
+
+#include "tenzir/async/channel.hpp"
+#include "tenzir/series_builder.hpp"
+
+#include <folly/coro/BlockingWait.h>
+#include <folly/coro/Collect.h>
+#include <folly/executors/GlobalExecutor.h>
+
+#ifdef CHECK
+#  undef CHECK
+#endif
+#include "tenzir/test/test.hpp"
+
+#include <functional>
+#include <numeric>
+#include <set>
+#include <vector>
+
+namespace tenzir {
+
+namespace {
+
+using namespace tenzir::routing;
+
+auto make_sorted(std::span<const uint64_t> rows_assigned)
+  -> std::vector<size_t> {
+  auto sorted = std::vector<size_t>(rows_assigned.size());
+  std::iota(sorted.begin(), sorted.end(), size_t{0});
+  std::sort(sorted.begin(), sorted.end(), [&](size_t a, size_t b) {
+    return rows_assigned[a] < rows_assigned[b];
+  });
+  return sorted;
+}
+
+/// A `Push` backed by a channel `Sender`. Dropping it closes the channel.
+template <class T>
+class SenderPush final : public Push<OperatorMsg<T>> {
+public:
+  explicit SenderPush(Sender<OperatorMsg<T>> sender)
+    : sender_{std::move(sender)} {
+  }
+
+  auto operator()(OperatorMsg<T> x) -> Task<void> override {
+    return sender_.send(std::move(x));
+  }
+
+private:
+  Sender<OperatorMsg<T>> sender_;
+};
+
+/// A `Pull` backed by a channel `Receiver`.
+template <class T>
+class ReceiverPull final : public Pull<OperatorMsg<T>> {
+public:
+  explicit ReceiverPull(Receiver<OperatorMsg<T>> receiver)
+    : receiver_{std::move(receiver)} {
+  }
+
+  auto operator()() -> Task<Option<OperatorMsg<T>>> override {
+    return receiver_.recv();
+  }
+
+private:
+  Receiver<OperatorMsg<T>> receiver_;
+};
+
+template <class T>
+auto local_channel(ChannelId = ChannelId{}, size_t capacity = 128)
+  -> PushPull<OperatorMsg<T>> {
+  auto [sender, receiver] = channel<OperatorMsg<T>>(capacity);
+  return PushPull<OperatorMsg<T>>{
+    Box<Push<OperatorMsg<T>>>{SenderPush<T>{std::move(sender)}},
+    Box<Pull<OperatorMsg<T>>>{ReceiverPull<T>{std::move(receiver)}},
+  };
+}
+
+// A channel factory for `make_scatter` / `make_gather`.
+auto factory() {
+  return [](ChannelId id) {
+    return local_channel<int>(std::move(id));
+  };
+}
+
+// Runs a task body on the global CPU executor. The gather merge loop uses an
+// `async_scope`, which spawns lane-pull tasks onto the current executor; those
+// tasks must run concurrently with the merger blocking on `next()`, so we need
+// a multi-threaded executor rather than the single-threaded `blockingWait` one.
+template <class F>
+auto run(F&& f) -> void {
+  folly::coro::blockingWait(folly::coro::co_withExecutor(
+    folly::getGlobalCPUExecutor(), std::forward<F>(f)()));
+}
+
+} // namespace
+
+TEST("scatter round-robins data and broadcasts signals") {
+  run([&]() -> Task<void> {
+    auto [push, pulls]
+      = make_scatter<int>(2, RoundRobinAdaptive{}, factory(), ChannelId{});
+    co_await folly::coro::collectAll(
+      [&]() -> Task<void> {
+        for (auto i = 0; i < 4; ++i) {
+          co_await (*push)(OperatorMsg<int>{i});
+        }
+        co_await (*push)(OperatorMsg<int>{Signal{EndOfData{}}});
+        // Drop the scatter to close all lanes.
+        push = {};
+      }(),
+      [&]() -> Task<void> {
+        auto lane0 = std::vector<int>{};
+        while (auto msg = co_await (*pulls[0])()) {
+          if (auto* value = try_as<int>(*msg)) {
+            lane0.push_back(*value);
+          } else {
+            // The signal must be broadcast to this lane.
+            check(is<Signal>(*msg));
+          }
+        }
+        // Round-robin sends even indices to lane 0.
+        check_eq(lane0, (std::vector<int>{0, 2}));
+      }(),
+      [&]() -> Task<void> {
+        auto lane1 = std::vector<int>{};
+        auto got_signal = false;
+        while (auto msg = co_await (*pulls[1])()) {
+          if (auto* value = try_as<int>(*msg)) {
+            lane1.push_back(*value);
+          } else {
+            got_signal = true;
+          }
+        }
+        check_eq(lane1, (std::vector<int>{1, 3}));
+        check(got_signal);
+      }());
+  });
+}
+
+TEST("scatter stops routing data to a closed lane") {
+  run([&]() -> Task<void> {
+    auto [push, pulls]
+      = make_scatter<int>(2, RoundRobinAdaptive{}, factory(), ChannelId{});
+    // Retire lane 1 up front.
+    static_cast<ScatterPush<int>&>(*push).close_lane(1);
+    check_eq(static_cast<ScatterPush<int>&>(*push).open_lanes(), size_t{1});
+    co_await folly::coro::collectAll(
+      [&]() -> Task<void> {
+        for (auto i = 0; i < 3; ++i) {
+          co_await (*push)(OperatorMsg<int>{i});
+        }
+        push = {};
+      }(),
+      [&]() -> Task<void> {
+        auto lane0 = std::vector<int>{};
+        while (auto msg = co_await (*pulls[0])()) {
+          lane0.push_back(as<int>(*msg));
+        }
+        check_eq(lane0, (std::vector<int>{0, 1, 2}));
+      }(),
+      [&]() -> Task<void> {
+        auto count = 0;
+        while (auto msg = co_await (*pulls[1])()) {
+          ++count;
+        }
+        check_eq(count, 0);
+      }());
+  });
+}
+
+TEST("gather interleaves data from all lanes") {
+  run([&]() -> Task<void> {
+    auto parts = make_gather<int>(3, factory(), ChannelId{});
+    co_await folly::coro::collectAll(
+      std::move(parts.merger),
+      [lane = std::move(parts.lanes[0])]() mutable -> Task<void> {
+        for (auto i = 0; i < 3; ++i) {
+          co_await (*lane)(OperatorMsg<int>{i});
+        }
+        // Drop the lane to close its channel; otherwise the captured push
+        // outlives the coroutine until `collectAll` completes, which never
+        // happens because the merger waits for every lane to close.
+        lane = {};
+      }(),
+      [lane = std::move(parts.lanes[1])]() mutable -> Task<void> {
+        for (auto i = 10; i < 13; ++i) {
+          co_await (*lane)(OperatorMsg<int>{i});
+        }
+        lane = {};
+      }(),
+      [lane = std::move(parts.lanes[2])]() mutable -> Task<void> {
+        for (auto i = 20; i < 23; ++i) {
+          co_await (*lane)(OperatorMsg<int>{i});
+        }
+        lane = {};
+      }(),
+      [&]() -> Task<void> {
+        auto received = std::multiset<int>{};
+        while (auto msg = co_await (*parts.pull)()) {
+          received.insert(as<int>(*msg));
+        }
+        auto expected = std::multiset<int>{0, 1, 2, 10, 11, 12, 20, 21, 22};
+        check(received == expected);
+      }());
+  });
+}
+
+TEST("gather emits end-of-data exactly once after all lanes deliver it") {
+  run([&]() -> Task<void> {
+    auto parts = make_gather<int>(2, factory(), ChannelId{});
+    co_await folly::coro::collectAll(
+      std::move(parts.merger),
+      [lane = std::move(parts.lanes[0])]() mutable -> Task<void> {
+        co_await (*lane)(OperatorMsg<int>{1});
+        co_await (*lane)(OperatorMsg<int>{Signal{EndOfData{}}});
+        lane = {};
+      }(),
+      [lane = std::move(parts.lanes[1])]() mutable -> Task<void> {
+        co_await (*lane)(OperatorMsg<int>{2});
+        co_await (*lane)(OperatorMsg<int>{Signal{EndOfData{}}});
+        lane = {};
+      }(),
+      [&]() -> Task<void> {
+        auto data = 0;
+        auto eod = 0;
+        while (auto msg = co_await (*parts.pull)()) {
+          if (is<int>(*msg)) {
+            ++data;
+          } else {
+            check(is<Signal>(*msg));
+            check(is<EndOfData>(as<Signal>(*msg)));
+            ++eod;
+          }
+        }
+        check_eq(data, 2);
+        check_eq(eod, 1);
+      }());
+  });
+}
+
+TEST("gather drains without end-of-data") {
+  run([&]() -> Task<void> {
+    auto parts = make_gather<int>(2, factory(), ChannelId{});
+    co_await folly::coro::collectAll(
+      std::move(parts.merger),
+      [lane = std::move(parts.lanes[0])]() mutable -> Task<void> {
+        co_await (*lane)(OperatorMsg<int>{5});
+        lane = {};
+      }(),
+      [lane = std::move(parts.lanes[1])]() mutable -> Task<void> {
+        lane = {};
+        co_return;
+      }(),
+      [&]() -> Task<void> {
+        auto received = std::vector<int>{};
+        while (auto msg = co_await (*parts.pull)()) {
+          received.push_back(as<int>(*msg));
+        }
+        check_eq(received, (std::vector<int>{5}));
+      }());
+  });
+}
+
+TEST("water_fill levels up the least-loaded workers first") {
+  auto rows_assigned = std::vector<uint64_t>{100, 300, 500};
+  auto sorted = make_sorted(rows_assigned);
+  auto alloc = water_fill(1000, sorted, rows_assigned);
+  // See the worked example in the documentation of `water_fill`.
+  CHECK_EQUAL(alloc, (std::vector<uint64_t>{534, 333, 133}));
+}
+
+TEST("water_fill with equal load splits evenly") {
+  auto rows_assigned = std::vector<uint64_t>{0, 0, 0, 0};
+  auto sorted = make_sorted(rows_assigned);
+  auto alloc = water_fill(1000, sorted, rows_assigned);
+  CHECK_EQUAL(alloc, (std::vector<uint64_t>{250, 250, 250, 250}));
+}
+
+TEST("water_fill conserves the total across all allocations") {
+  auto rows_assigned = std::vector<uint64_t>{7, 3, 11, 0, 5};
+  auto sorted = make_sorted(rows_assigned);
+  for (auto total : {uint64_t{0}, uint64_t{1}, uint64_t{13}, uint64_t{999}}) {
+    auto alloc = water_fill(total, sorted, rows_assigned);
+    auto sum = std::accumulate(alloc.begin(), alloc.end(), uint64_t{0});
+    CHECK_EQUAL(sum, total);
+  }
+}
+
+TEST("water_fill with a single worker gets everything") {
+  auto rows_assigned = std::vector<uint64_t>{42};
+  auto sorted = make_sorted(rows_assigned);
+  auto alloc = water_fill(1000, sorted, rows_assigned);
+  CHECK_EQUAL(alloc, (std::vector<uint64_t>{1000}));
+}
+
+TEST("distribute_adaptive from empty spreads across all workers") {
+  auto rows_assigned = std::vector<uint64_t>{0, 0, 0, 0};
+  auto result = distribute_adaptive(1000, rows_assigned);
+  CHECK_EQUAL(rows_assigned, (std::vector<uint64_t>{250, 250, 250, 250}));
+  // All four workers received rows.
+  CHECK_EQUAL(result.size(), size_t{4});
+  auto sum = uint64_t{0};
+  for (auto [worker, count] : result) {
+    sum += count;
+  }
+  CHECK_EQUAL(sum, uint64_t{1000});
+}
+
+TEST("distribute_adaptive prefers few workers while staying fair") {
+  // 4 workers at [500, 300, 200, 100], distributing 400 rows. k=1 would be
+  // unfair (max/min = 2.5), so the second-smallest worker joins.
+  auto rows_assigned = std::vector<uint64_t>{500, 300, 200, 100};
+  auto result = distribute_adaptive(400, rows_assigned);
+  // Water-fill first closes the 100-row gap between workers 3 and 2, then
+  // splits the remaining 300 evenly: worker 3 gets 250, worker 2 gets 150.
+  CHECK_EQUAL(rows_assigned, (std::vector<uint64_t>{500, 300, 350, 350}));
+  // Only workers 2 and 3 (the two least-loaded) received rows.
+  CHECK_EQUAL(result.size(), size_t{2});
+  auto sum = uint64_t{0};
+  for (auto [worker, count] : result) {
+    CHECK(worker == 2 or worker == 3);
+    sum += count;
+  }
+  CHECK_EQUAL(sum, uint64_t{400});
+}
+
+TEST("distribute_adaptive sends everything to a single starved worker") {
+  auto rows_assigned = std::vector<uint64_t>{100, 100, 100, 0};
+  auto result = distribute_adaptive(50, rows_assigned);
+  // Worker 3 can absorb all 50 rows while staying within the fairness factor.
+  REQUIRE_EQUAL(result.size(), size_t{1});
+  CHECK_EQUAL(result[0].first, size_t{3});
+  CHECK_EQUAL(result[0].second, uint64_t{50});
+  CHECK_EQUAL(rows_assigned, (std::vector<uint64_t>{100, 100, 100, 50}));
+}
+
+TEST("distribute_adaptive omits zero-row assignments") {
+  auto rows_assigned = std::vector<uint64_t>{0, 0, 0};
+  auto result = distribute_adaptive(0, rows_assigned);
+  CHECK(result.empty());
+  CHECK_EQUAL(rows_assigned, (std::vector<uint64_t>{0, 0, 0}));
+}
+
+TEST("hash_runs partitions all rows in order") {
+  auto b = series_builder{};
+  for (auto v : {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}) {
+    b.data(int64_t{v});
+  }
+  auto values = multi_series{b.finish_assert_one_array()};
+  const auto jobs = uint64_t{3};
+  auto runs = hash_runs(values, jobs);
+  REQUIRE(not runs.empty());
+  // Runs cover [0, length) contiguously and in order.
+  CHECK_EQUAL(runs.front().begin, int64_t{0});
+  CHECK_EQUAL(runs.back().end, values.length());
+  for (auto i = size_t{0}; i < runs.size(); ++i) {
+    CHECK(runs[i].begin < runs[i].end);
+    CHECK(runs[i].bucket < jobs);
+    if (i + 1 < runs.size()) {
+      // Contiguous and maximal: adjacent runs abut and differ in bucket.
+      CHECK_EQUAL(runs[i].end, runs[i + 1].begin);
+      CHECK(runs[i].bucket != runs[i + 1].bucket);
+    }
+  }
+  // Every row's bucket matches hash(value) % jobs.
+  for (const auto& run : runs) {
+    for (auto row = run.begin; row < run.end; ++row) {
+      auto expected = std::hash<data_view3>{}(values.view3_at(row)) % jobs;
+      CHECK_EQUAL(run.bucket, expected);
+    }
+  }
+}
+
+TEST("hash_runs with one job yields a single run") {
+  auto b = series_builder{};
+  for (auto v : {1, 2, 3, 4, 5}) {
+    b.data(int64_t{v});
+  }
+  auto values = multi_series{b.finish_assert_one_array()};
+  auto runs = hash_runs(values, 1);
+  REQUIRE_EQUAL(runs.size(), size_t{1});
+  CHECK_EQUAL(runs[0].bucket, uint64_t{0});
+  CHECK_EQUAL(runs[0].begin, int64_t{0});
+  CHECK_EQUAL(runs[0].end, int64_t{5});
+}
+
+TEST("hash_runs on empty input yields no runs") {
+  auto values = multi_series{};
+  auto runs = hash_runs(values, 4);
+  CHECK(runs.empty());
+}
+
+} // namespace tenzir

--- a/libtenzir/test/async/routing.cpp
+++ b/libtenzir/test/async/routing.cpp
@@ -83,14 +83,7 @@ auto local_channel(ChannelId = ChannelId{}, size_t capacity = 128)
   };
 }
 
-// A channel factory for `make_scatter` / `make_gather`.
-auto factory() {
-  return [](ChannelId id) {
-    return local_channel<int>(std::move(id));
-  };
-}
-
-// A channel factory for `table_slice` scatter exchanges.
+// A channel factory for scatter/gather exchanges.
 auto slice_factory() {
   return [](ChannelId id) {
     return local_channel<table_slice>(std::move(id));
@@ -118,42 +111,45 @@ auto run(F&& f) -> void {
 
 } // namespace
 
-TEST("scatter round-robins data and broadcasts signals") {
+TEST("scatter distributes rows across lanes and broadcasts signals") {
   run([&]() -> Task<void> {
-    auto [push, pulls] = make_scatter<int>(2, factory(), ChannelId{});
+    auto [push, pulls] = make_scatter(2, slice_factory(), ChannelId{});
     co_await folly::coro::collectAll(
       [&]() -> Task<void> {
+        // Four single-row slices to two lanes: each lane should get two rows.
         for (auto i = 0; i < 4; ++i) {
-          co_await (*push)(OperatorMsg<int>{i});
+          co_await (*push)(OperatorMsg<table_slice>{make_slice(1)});
         }
-        co_await (*push)(OperatorMsg<int>{Signal{EndOfData{}}});
+        co_await (*push)(OperatorMsg<table_slice>{Signal{EndOfData{}}});
         // Drop the scatter to close all lanes.
         push = {};
       }(),
       [&]() -> Task<void> {
-        auto lane0 = std::vector<int>{};
+        auto rows = int64_t{0};
+        auto got_signal = false;
         while (auto msg = co_await (*pulls[0])()) {
-          if (auto* value = try_as<int>(*msg)) {
-            lane0.push_back(*value);
+          if (auto* slice = try_as<table_slice>(*msg)) {
+            rows += slice->rows();
           } else {
             // The signal must be broadcast to this lane.
             check(is<Signal>(*msg));
+            got_signal = true;
           }
         }
-        // Round-robin sends even indices to lane 0.
-        check_eq(lane0, (std::vector<int>{0, 2}));
+        check_eq(rows, int64_t{2});
+        check(got_signal);
       }(),
       [&]() -> Task<void> {
-        auto lane1 = std::vector<int>{};
+        auto rows = int64_t{0};
         auto got_signal = false;
         while (auto msg = co_await (*pulls[1])()) {
-          if (auto* value = try_as<int>(*msg)) {
-            lane1.push_back(*value);
+          if (auto* slice = try_as<table_slice>(*msg)) {
+            rows += slice->rows();
           } else {
             got_signal = true;
           }
         }
-        check_eq(lane1, (std::vector<int>{1, 3}));
+        check_eq(rows, int64_t{2});
         check(got_signal);
       }());
   });
@@ -161,42 +157,46 @@ TEST("scatter round-robins data and broadcasts signals") {
 
 TEST("scatter stops routing data to a closed lane") {
   run([&]() -> Task<void> {
-    auto [push, pulls] = make_scatter<int>(2, factory(), ChannelId{});
+    auto [push, pulls] = make_scatter(2, slice_factory(), ChannelId{});
     // Retire lane 1 up front.
-    static_cast<ScatterPush<int>&>(*push).close_lane(1);
-    check_eq(static_cast<ScatterPush<int>&>(*push).open_lanes(), size_t{1});
+    static_cast<ScatterPush&>(*push).close_lane(1);
+    check_eq(static_cast<ScatterPush&>(*push).open_lanes(), size_t{1});
     co_await folly::coro::collectAll(
       [&]() -> Task<void> {
         for (auto i = 0; i < 3; ++i) {
-          co_await (*push)(OperatorMsg<int>{i});
+          co_await (*push)(OperatorMsg<table_slice>{make_slice(1)});
         }
         push = {};
       }(),
       [&]() -> Task<void> {
-        auto lane0 = std::vector<int>{};
+        auto rows = int64_t{0};
         while (auto msg = co_await (*pulls[0])()) {
-          lane0.push_back(as<int>(*msg));
+          if (auto* slice = try_as<table_slice>(*msg)) {
+            rows += slice->rows();
+          }
         }
-        check_eq(lane0, (std::vector<int>{0, 1, 2}));
+        check_eq(rows, int64_t{3});
       }(),
       [&]() -> Task<void> {
-        auto count = 0;
+        auto rows = int64_t{0};
         while (auto msg = co_await (*pulls[1])()) {
-          ++count;
+          if (auto* slice = try_as<table_slice>(*msg)) {
+            rows += slice->rows();
+          }
         }
-        check_eq(count, 0);
+        check_eq(rows, int64_t{0});
       }());
   });
 }
 
 TEST("gather interleaves data from all lanes") {
   run([&]() -> Task<void> {
-    auto parts = make_gather<int>(3, factory(), ChannelId{});
+    auto parts = make_gather(3, slice_factory(), ChannelId{});
     co_await folly::coro::collectAll(
       std::move(parts.merger),
       [lane = std::move(parts.lanes[0])]() mutable -> Task<void> {
         for (auto i = 0; i < 3; ++i) {
-          co_await (*lane)(OperatorMsg<int>{i});
+          co_await (*lane)(OperatorMsg<table_slice>{make_slice(1)});
         }
         // Drop the lane to close its channel; otherwise the captured push
         // outlives the coroutine until `collectAll` completes, which never
@@ -204,56 +204,57 @@ TEST("gather interleaves data from all lanes") {
         lane = {};
       }(),
       [lane = std::move(parts.lanes[1])]() mutable -> Task<void> {
-        for (auto i = 10; i < 13; ++i) {
-          co_await (*lane)(OperatorMsg<int>{i});
+        for (auto i = 0; i < 3; ++i) {
+          co_await (*lane)(OperatorMsg<table_slice>{make_slice(1)});
         }
         lane = {};
       }(),
       [lane = std::move(parts.lanes[2])]() mutable -> Task<void> {
-        for (auto i = 20; i < 23; ++i) {
-          co_await (*lane)(OperatorMsg<int>{i});
+        for (auto i = 0; i < 3; ++i) {
+          co_await (*lane)(OperatorMsg<table_slice>{make_slice(1)});
         }
         lane = {};
       }(),
       [&]() -> Task<void> {
-        auto received = std::multiset<int>{};
+        auto total_rows = int64_t{0};
         while (auto msg = co_await (*parts.pull)()) {
-          received.insert(as<int>(*msg));
+          if (auto* slice = try_as<table_slice>(*msg)) {
+            total_rows += slice->rows();
+          }
         }
-        auto expected = std::multiset<int>{0, 1, 2, 10, 11, 12, 20, 21, 22};
-        check(received == expected);
+        check_eq(total_rows, int64_t{9});
       }());
   });
 }
 
 TEST("gather emits end-of-data exactly once after all lanes deliver it") {
   run([&]() -> Task<void> {
-    auto parts = make_gather<int>(2, factory(), ChannelId{});
+    auto parts = make_gather(2, slice_factory(), ChannelId{});
     co_await folly::coro::collectAll(
       std::move(parts.merger),
       [lane = std::move(parts.lanes[0])]() mutable -> Task<void> {
-        co_await (*lane)(OperatorMsg<int>{1});
-        co_await (*lane)(OperatorMsg<int>{Signal{EndOfData{}}});
+        co_await (*lane)(OperatorMsg<table_slice>{make_slice(1)});
+        co_await (*lane)(OperatorMsg<table_slice>{Signal{EndOfData{}}});
         lane = {};
       }(),
       [lane = std::move(parts.lanes[1])]() mutable -> Task<void> {
-        co_await (*lane)(OperatorMsg<int>{2});
-        co_await (*lane)(OperatorMsg<int>{Signal{EndOfData{}}});
+        co_await (*lane)(OperatorMsg<table_slice>{make_slice(1)});
+        co_await (*lane)(OperatorMsg<table_slice>{Signal{EndOfData{}}});
         lane = {};
       }(),
       [&]() -> Task<void> {
-        auto data = 0;
+        auto data_rows = int64_t{0};
         auto eod = 0;
         while (auto msg = co_await (*parts.pull)()) {
-          if (is<int>(*msg)) {
-            ++data;
+          if (auto* slice = try_as<table_slice>(*msg)) {
+            data_rows += slice->rows();
           } else {
             check(is<Signal>(*msg));
             check(is<EndOfData>(as<Signal>(*msg)));
             ++eod;
           }
         }
-        check_eq(data, 2);
+        check_eq(data_rows, int64_t{2});
         check_eq(eod, 1);
       }());
   });
@@ -265,9 +266,8 @@ TEST("scatter keeps a fair slice on one lane after closing a lane") {
   // lanes to [100, 100, 100]. A subsequent 10-row slice stays within the
   // fairness factor on a single lane instead of fragmenting across all three.
   run([&]() -> Task<void> {
-    auto [push, pulls]
-      = make_scatter<table_slice>(4, slice_factory(), ChannelId{});
-    static_cast<ScatterPush<table_slice>&>(*push).close_lane(3);
+    auto [push, pulls] = make_scatter(4, slice_factory(), ChannelId{});
+    static_cast<ScatterPush&>(*push).close_lane(3);
     co_await folly::coro::collectAll(
       [&]() -> Task<void> {
         co_await (*push)(OperatorMsg<table_slice>{make_slice(300)});
@@ -295,11 +295,11 @@ TEST("scatter keeps a fair slice on one lane after closing a lane") {
 
 TEST("gather drains without end-of-data") {
   run([&]() -> Task<void> {
-    auto parts = make_gather<int>(2, factory(), ChannelId{});
+    auto parts = make_gather(2, slice_factory(), ChannelId{});
     co_await folly::coro::collectAll(
       std::move(parts.merger),
       [lane = std::move(parts.lanes[0])]() mutable -> Task<void> {
-        co_await (*lane)(OperatorMsg<int>{5});
+        co_await (*lane)(OperatorMsg<table_slice>{make_slice(5)});
         lane = {};
       }(),
       [lane = std::move(parts.lanes[1])]() mutable -> Task<void> {
@@ -307,11 +307,13 @@ TEST("gather drains without end-of-data") {
         co_return;
       }(),
       [&]() -> Task<void> {
-        auto received = std::vector<int>{};
+        auto total_rows = int64_t{0};
         while (auto msg = co_await (*parts.pull)()) {
-          received.push_back(as<int>(*msg));
+          if (auto* slice = try_as<table_slice>(*msg)) {
+            total_rows += slice->rows();
+          }
         }
-        check_eq(received, (std::vector<int>{5}));
+        check_eq(total_rows, int64_t{5});
       }());
   });
 }

--- a/libtenzir/test/async/routing.cpp
+++ b/libtenzir/test/async/routing.cpp
@@ -120,8 +120,7 @@ auto run(F&& f) -> void {
 
 TEST("scatter round-robins data and broadcasts signals") {
   run([&]() -> Task<void> {
-    auto [push, pulls]
-      = make_scatter<int>(2, RoundRobinAdaptive{}, factory(), ChannelId{});
+    auto [push, pulls] = make_scatter<int>(2, factory(), ChannelId{});
     co_await folly::coro::collectAll(
       [&]() -> Task<void> {
         for (auto i = 0; i < 4; ++i) {
@@ -162,8 +161,7 @@ TEST("scatter round-robins data and broadcasts signals") {
 
 TEST("scatter stops routing data to a closed lane") {
   run([&]() -> Task<void> {
-    auto [push, pulls]
-      = make_scatter<int>(2, RoundRobinAdaptive{}, factory(), ChannelId{});
+    auto [push, pulls] = make_scatter<int>(2, factory(), ChannelId{});
     // Retire lane 1 up front.
     static_cast<ScatterPush<int>&>(*push).close_lane(1);
     check_eq(static_cast<ScatterPush<int>&>(*push).open_lanes(), size_t{1});
@@ -267,8 +265,8 @@ TEST("scatter keeps a fair slice on one lane after closing a lane") {
   // lanes to [100, 100, 100]. A subsequent 10-row slice stays within the
   // fairness factor on a single lane instead of fragmenting across all three.
   run([&]() -> Task<void> {
-    auto [push, pulls] = make_scatter<table_slice>(
-      4, RoundRobinAdaptive{}, slice_factory(), ChannelId{});
+    auto [push, pulls]
+      = make_scatter<table_slice>(4, slice_factory(), ChannelId{});
     static_cast<ScatterPush<table_slice>&>(*push).close_lane(3);
     co_await folly::coro::collectAll(
       [&]() -> Task<void> {

--- a/libtenzir/test/async/routing.cpp
+++ b/libtenzir/test/async/routing.cpp
@@ -90,6 +90,22 @@ auto factory() {
   };
 }
 
+// A channel factory for `table_slice` scatter exchanges.
+auto slice_factory() {
+  return [](ChannelId id) {
+    return local_channel<table_slice>(std::move(id));
+  };
+}
+
+// Builds a single `table_slice` with `rows` rows.
+auto make_slice(int64_t rows) -> table_slice {
+  auto b = series_builder{};
+  for (auto i = int64_t{0}; i < rows; ++i) {
+    b.record().field("x", i);
+  }
+  return b.finish_assert_one_slice();
+}
+
 // Runs a task body on the global CPU executor. The gather merge loop uses an
 // `async_scope`, which spawns lane-pull tasks onto the current executor; those
 // tasks must run concurrently with the merger blocking on `next()`, so we need
@@ -241,6 +257,40 @@ TEST("gather emits end-of-data exactly once after all lanes deliver it") {
         }
         check_eq(data, 2);
         check_eq(eod, 1);
+      }());
+  });
+}
+
+TEST("scatter keeps a fair slice on one lane after closing a lane") {
+  // Regression test: a retired lane must not skew the adaptive fairness check.
+  // With four lanes and lane 3 closed, sending 300 rows levels the three open
+  // lanes to [100, 100, 100]. A subsequent 10-row slice stays within the
+  // fairness factor on a single lane instead of fragmenting across all three.
+  run([&]() -> Task<void> {
+    auto [push, pulls] = make_scatter<table_slice>(
+      4, RoundRobinAdaptive{}, slice_factory(), ChannelId{});
+    static_cast<ScatterPush<table_slice>&>(*push).close_lane(3);
+    co_await folly::coro::collectAll(
+      [&]() -> Task<void> {
+        co_await (*push)(OperatorMsg<table_slice>{make_slice(300)});
+        co_await (*push)(OperatorMsg<table_slice>{make_slice(10)});
+        push = {};
+      }(),
+      [&]() -> Task<void> {
+        auto rows_per_lane = std::multiset<int64_t>{};
+        for (auto& pull : pulls) {
+          auto rows = int64_t{0};
+          while (auto msg = co_await (*pull)()) {
+            if (auto* slice = try_as<table_slice>(*msg)) {
+              rows += slice->rows();
+            }
+          }
+          rows_per_lane.insert(rows);
+        }
+        // Lane 3 is retired (0 rows); the 10-row slice lands entirely on one
+        // of the three open lanes, taking it to 110.
+        auto expected = std::multiset<int64_t>{0, 100, 100, 110};
+        check(rows_per_lane == expected);
       }());
   });
 }


### PR DESCRIPTION
Extract routing helpers (`water_fill` & `hash_runs`) from parallel2 and add scatter and gather channels.

## 💬 Review

- No behavior change — pure code consolidation.
- Merged unit tests pass (78 checks across exchange + routing).