### PR TITLE
Refactor pipeline executor run functions

### DIFF
--- a/libtenzir/include/tenzir/async/executor.hpp
+++ b/libtenzir/include/tenzir/async/executor.hpp
@@ -24,6 +24,7 @@
 #include <folly/coro/Synchronized.h>
 #include <folly/executors/GlobalExecutor.h>
 
+#include <functional>
 #include <span>
 
 namespace tenzir {
@@ -276,33 +277,49 @@ public:
   virtual auto failure() -> failure_or<void> = 0;
 };
 
-/// Run a closed pipeline without external control.
+/// Drives an already-wired chain to completion. The caller owns all IO: the
+/// upstream/downstream endpoints and the control channels. Higher-level
+/// entry points (`run_pipeline`, `run_bounded_pipeline`) create that plumbing
+/// and then call this primitive.
+///
+/// When `fused` is set, the chain runs with fused channels: each input is fully
+/// processed through the entire chain before the next input is pulled.
+template <class Input, class Output>
+auto drive_chain(OperatorChain<Input, Output> chain,
+                 Box<Pull<OperatorMsg<Input>>> pull_upstream,
+                 Box<Push<OperatorMsg<Output>>> push_downstream,
+                 Receiver<FromControl> from_control,
+                 Sender<ToControl> to_control, PipeId id, ExecCtx& exec_ctx,
+                 caf::actor_system& sys, DiagHandler& dh, bool fused = false)
+  -> Task<void>;
+
+/// Runs a closed pipeline without external control. Creates the input/output
+/// channels and the control channels, then drives the chain, handling graceful
+/// stop and control messages.
 auto run_pipeline(OperatorChain<void, void> pipeline, ExecCtx& exec_ctx,
                   caf::actor_system& sys, DiagHandler& dh,
                   Notify* graceful_stop = nullptr) -> Task<void>;
 
-/// Run a right-open pipeline without external control.
-template <class Output>
-  requires(not std::same_as<Output, void>)
-auto run_pipeline(OperatorChain<void, Output> pipeline, caf::actor_system& sys,
-                  DiagHandler& dh) -> AsyncGenerator<Output>;
+/// Feeds input into a bounded pipeline.
+using PipelineFeeder
+  = std::function<Task<void>(Push<OperatorMsg<table_slice>>&)>;
 
-/// Run an open pipeline without external control.
-template <class Input, class Output>
-  requires(not std::same_as<Output, void> and not std::same_as<Input, void>)
-auto run_pipeline_with_input(AsyncGenerator<Input> input,
-                             OperatorChain<Input, Output> pipeline,
-                             caf::actor_system& sys, DiagHandler& dh)
-  -> AsyncGenerator<Output>;
+/// Drains output from a bounded pipeline.
+using PipelineDrainer
+  = std::function<Task<void>(Pull<OperatorMsg<table_slice>>&)>;
 
-/// Run a pipeline with external control.
-template <class Input, class Output>
-auto run_chain(OperatorChain<Input, Output> chain,
-               Box<Pull<OperatorMsg<Input>>> pull_upstream,
-               Box<Push<OperatorMsg<Output>>> push_downstream,
-               Receiver<FromControl> from_control, Sender<ToControl> to_control,
-               PipeId id, ExecCtx& exec_ctx, caf::actor_system& sys,
-               DiagHandler& dh) -> Task<void>;
+/// Runs a bounded `table_slice -> table_slice` chain with caller-provided IO.
+///
+/// Creates the input/output channels and drives the chain. The feeder receives
+/// the input push endpoint and should push all input slices followed by an
+/// `EndOfData` signal; the drainer receives the output pull endpoint and can
+/// process transformed slices incrementally. Unlike `run_pipeline`, there is no
+/// external controller: the only control signal acted on is `no_more_input`,
+/// which cancels the feeder.
+auto run_bounded_pipeline(OperatorChain<table_slice, table_slice> chain,
+                          ExecCtx& exec_ctx, caf::actor_system& sys,
+                          DiagHandler& dh, PipelineFeeder feed_input,
+                          PipelineDrainer drain_output) -> Task<void>;
 
 } // namespace tenzir
 

--- a/libtenzir/include/tenzir/tql2/exec.hpp
+++ b/libtenzir/include/tenzir/tql2/exec.hpp
@@ -84,42 +84,18 @@ auto parse_and_compile(std::string_view source, session ctx)
 
 /// Run a closed pipeline from a list of operators.
 auto run_plan(OperatorChain<void, void> chain, caf::actor_system& sys,
-              DiagHandler& dh, Profiler profiler, bool has_terminal,
-              bool is_hidden, Notify* graceful_stop = nullptr)
-  -> Task<failure_or<void>>;
-
-auto run_plan(OperatorChain<void, void> chain, caf::actor_system& sys,
               DiagHandler& dh, Profiler profiler, bool is_hidden,
               Notify* graceful_stop = nullptr) -> Task<failure_or<void>>;
 
-/// Feeds input into a transform pipeline.
-using TransformFeeder
-  = std::function<Task<void>(Push<OperatorMsg<table_slice>>&)>;
-
-/// Drains output from a transform pipeline.
-using TransformDrainer
-  = std::function<Task<void>(Pull<OperatorMsg<table_slice>>&)>;
-
 /// Run a `table_slice -> table_slice` chain with caller-provided IO.
 ///
-/// The feeder receives the pipeline input push endpoint. It should push all
-/// input slices and then an `EndOfData` signal. The drainer receives the output
-/// pull endpoint and can process transformed slices incrementally.
+/// Wraps `run_bounded_pipeline` with a profiler and `failure_or` result. The
+/// feeder receives the pipeline input push endpoint. It should push all input
+/// slices and then an `EndOfData` signal. The drainer receives the output pull
+/// endpoint and can process transformed slices incrementally.
 auto run_transform(OperatorChain<table_slice, table_slice> chain,
                    caf::actor_system& sys, DiagHandler& dh, Profiler profiler,
-                   bool is_hidden, TransformFeeder feed_input,
-                   TransformDrainer drain_output) -> Task<failure_or<void>>;
-
-/// Run a `table_slice -> table_slice` chain over a fixed input vector.
-///
-/// Feeds the input slices into the head of the chain, runs the new
-/// coroutine executor, and returns the slices produced by the tail. Used by
-/// partition transformations (compaction, rebuild) that need to apply a
-/// pipeline to a pre-collected batch of events.
-auto run_transform(std::vector<table_slice> input,
-                   OperatorChain<table_slice, table_slice> chain,
-                   caf::actor_system& sys, DiagHandler& dh, Profiler profiler,
-                   bool is_hidden)
-  -> Task<failure_or<std::vector<table_slice>>>;
+                   bool is_hidden, PipelineFeeder feed_input,
+                   PipelineDrainer drain_output) -> Task<failure_or<void>>;
 
 } // namespace tenzir

--- a/libtenzir/src/async/executor.cpp
+++ b/libtenzir/src/async/executor.cpp
@@ -390,24 +390,6 @@ private:
   ExecCtx& inner_;
 };
 
-/// Run a pipeline with fused (run-to-completion) semantics.
-///
-/// Each input slice is fully processed through the entire operator chain
-/// before the next input is pulled. Internally creates a `FusedExecCtx` that
-/// replaces buffered channels with fused channels.
-template <class Input, class Output>
-auto run_chain_fused(OperatorChain<Input, Output> chain,
-                     Box<Pull<OperatorMsg<Input>>> pull_upstream,
-                     Box<Push<OperatorMsg<Output>>> push_downstream,
-                     Receiver<FromControl> from_control,
-                     Sender<ToControl> to_control, PipeId id, ExecCtx& exec_ctx,
-                     caf::actor_system& sys, DiagHandler& dh) -> Task<void> {
-  auto fused_ctx = FusedExecCtx{exec_ctx};
-  co_await run_chain(std::move(chain), std::move(pull_upstream),
-                     std::move(push_downstream), std::move(from_control),
-                     std::move(to_control), std::move(id), fused_ctx, sys, dh);
-}
-
 /// Core execution logic for a single operator.
 ///
 /// This is heavily inspired by "Asynchronous Barrier Snapshotting"[^1]. In the
@@ -874,16 +856,11 @@ private:
         auto [push_downstream, pull_downstream]
           = exec_ctx_.make_channel<Out>(sub_id.op(chain.size() - 1).to(id_));
         auto runner
-          = fused ? run_chain_fused(std::move(chain), std::move(pull_upstream),
-                                    std::move(push_downstream),
-                                    std::move(from_control_receiver),
-                                    std::move(to_control_sender),
-                                    std::move(sub_id), exec_ctx_, sys_, *sub_dh)
-                  : run_chain(std::move(chain), std::move(pull_upstream),
-                              std::move(push_downstream),
-                              std::move(from_control_receiver),
-                              std::move(to_control_sender), std::move(sub_id),
-                              exec_ctx_, sys_, *sub_dh);
+          = drive_chain(std::move(chain), std::move(pull_upstream),
+                        std::move(push_downstream),
+                        std::move(from_control_receiver),
+                        std::move(to_control_sender), std::move(sub_id),
+                        exec_ctx_, sys_, *sub_dh, fused);
         return {
           std::move(runner),
           AnyOpPush{std::move(push_upstream)},
@@ -1920,14 +1897,20 @@ private:
 };
 
 template <class Input, class Output>
-auto run_chain(OperatorChain<Input, Output> chain,
-               Box<Pull<OperatorMsg<Input>>> pull_upstream,
-               Box<Push<OperatorMsg<Output>>> push_downstream,
-               Receiver<FromControl> from_control, Sender<ToControl> to_control,
-               PipeId id, ExecCtx& exec_ctx, caf::actor_system& sys,
-               DiagHandler& dh) -> Task<void> {
+auto drive_chain(OperatorChain<Input, Output> chain,
+                 Box<Pull<OperatorMsg<Input>>> pull_upstream,
+                 Box<Push<OperatorMsg<Output>>> push_downstream,
+                 Receiver<FromControl> from_control,
+                 Sender<ToControl> to_control, PipeId id, ExecCtx& exec_ctx,
+                 caf::actor_system& sys, DiagHandler& dh, bool fused)
+  -> Task<void> {
   TENZIR_ASSERT(chain.size() != 0);
   co_await folly::coro::co_safe_point;
+  // Conditially use a fused ctx (that controls creation of new channels).
+  auto fused_ctx = Option<FusedExecCtx>{};
+  if (fused) {
+    fused_ctx.emplace(exec_ctx);
+  }
   co_await ChainRunner{
     std::move(chain).unwrap(),
     AnyOpPull{std::move(pull_upstream)},
@@ -1935,7 +1918,7 @@ auto run_chain(OperatorChain<Input, Output> chain,
     std::move(from_control),
     std::move(to_control),
     std::move(id),
-    exec_ctx,
+    fused_ctx ? static_cast<ExecCtx&>(*fused_ctx) : exec_ctx,
     sys,
     dh,
   }
@@ -1943,86 +1926,12 @@ auto run_chain(OperatorChain<Input, Output> chain,
 }
 
 template auto
-run_chain(OperatorChain<void, table_slice> chain,
-          Box<Pull<OperatorMsg<void>>> pull_upstream,
-          Box<Push<OperatorMsg<table_slice>>> push_downstream,
-          Receiver<FromControl> from_control, Sender<ToControl> to_control,
-          PipeId id, ExecCtx& exec_ctx, caf::actor_system& sys, DiagHandler& dh)
-  -> Task<void>;
-
-template auto
-run_chain(OperatorChain<chunk_ptr, table_slice> chain,
-          Box<Pull<OperatorMsg<chunk_ptr>>> pull_upstream,
-          Box<Push<OperatorMsg<table_slice>>> push_downstream,
-          Receiver<FromControl> from_control, Sender<ToControl> to_control,
-          PipeId id, ExecCtx& exec_ctx, caf::actor_system& sys, DiagHandler& dh)
-  -> Task<void>;
-
-template auto
-run_chain(OperatorChain<table_slice, table_slice> chain,
-          Box<Pull<OperatorMsg<table_slice>>> pull_upstream,
-          Box<Push<OperatorMsg<table_slice>>> push_downstream,
-          Receiver<FromControl> from_control, Sender<ToControl> to_control,
-          PipeId id, ExecCtx& exec_ctx, caf::actor_system& sys, DiagHandler& dh)
-  -> Task<void>;
-
-template auto
-run_chain(OperatorChain<void, void> chain,
-          Box<Pull<OperatorMsg<void>>> pull_upstream,
-          Box<Push<OperatorMsg<void>>> push_downstream,
-          Receiver<FromControl> from_control, Sender<ToControl> to_control,
-          PipeId id, ExecCtx& exec_ctx, caf::actor_system& sys, DiagHandler& dh)
-  -> Task<void>;
-
-template auto
-run_chain(OperatorChain<table_slice, void> chain,
-          Box<Pull<OperatorMsg<table_slice>>> pull_upstream,
-          Box<Push<OperatorMsg<void>>> push_downstream,
-          Receiver<FromControl> from_control, Sender<ToControl> to_control,
-          PipeId id, ExecCtx& exec_ctx, caf::actor_system& sys, DiagHandler& dh)
-  -> Task<void>;
-
-template auto
-run_chain(OperatorChain<chunk_ptr, void> chain,
-          Box<Pull<OperatorMsg<chunk_ptr>>> pull_upstream,
-          Box<Push<OperatorMsg<void>>> push_downstream,
-          Receiver<FromControl> from_control, Sender<ToControl> to_control,
-          PipeId id, ExecCtx& exec_ctx, caf::actor_system& sys, DiagHandler& dh)
-  -> Task<void>;
-
-template auto
-run_chain(OperatorChain<void, chunk_ptr> chain,
-          Box<Pull<OperatorMsg<void>>> pull_upstream,
-          Box<Push<OperatorMsg<chunk_ptr>>> push_downstream,
-          Receiver<FromControl> from_control, Sender<ToControl> to_control,
-          PipeId id, ExecCtx& exec_ctx, caf::actor_system& sys, DiagHandler& dh)
-  -> Task<void>;
-
-template auto
-run_chain(OperatorChain<chunk_ptr, chunk_ptr> chain,
-          Box<Pull<OperatorMsg<chunk_ptr>>> pull_upstream,
-          Box<Push<OperatorMsg<chunk_ptr>>> push_downstream,
-          Receiver<FromControl> from_control, Sender<ToControl> to_control,
-          PipeId id, ExecCtx& exec_ctx, caf::actor_system& sys, DiagHandler& dh)
-  -> Task<void>;
-
-template auto
-run_chain(OperatorChain<table_slice, chunk_ptr> chain,
-          Box<Pull<OperatorMsg<table_slice>>> pull_upstream,
-          Box<Push<OperatorMsg<chunk_ptr>>> push_downstream,
-          Receiver<FromControl> from_control, Sender<ToControl> to_control,
-          PipeId id, ExecCtx& exec_ctx, caf::actor_system& sys, DiagHandler& dh)
-  -> Task<void>;
-
-/// Run a potentially-open pipeline without external control.
-template <class Output>
-  requires(not std::same_as<Output, void>)
-auto run_open_pipeline(OperatorChain<void, Output> pipeline,
-                       caf::actor_system& sys, DiagHandler& dh)
-  -> AsyncGenerator<Output> {
-  TENZIR_UNUSED(pipeline, sys, dh);
-  TENZIR_TODO();
-}
+drive_chain(OperatorChain<table_slice, table_slice> chain,
+            Box<Pull<OperatorMsg<table_slice>>> pull_upstream,
+            Box<Push<OperatorMsg<table_slice>>> push_downstream,
+            Receiver<FromControl> from_control, Sender<ToControl> to_control,
+            PipeId id, ExecCtx& exec_ctx, caf::actor_system& sys,
+            DiagHandler& dh, bool fused) -> Task<void>;
 
 namespace {
 
@@ -2056,10 +1965,11 @@ auto run_pipeline(OperatorChain<void, void> pipeline, ExecCtx& exec_ctx,
     LOGV("creating pipeline queue scope");
     co_await driver.activate([&] -> Task<void> {
       driver.add([&] -> Task<Terminated> {
-        co_await run_chain(std::move(pipeline), std::move(pull_input),
-                           std::move(push_output),
-                           std::move(from_control_receiver),
-                           std::move(to_control_sender), id, exec_ctx, sys, dh);
+        co_await drive_chain(std::move(pipeline), std::move(pull_input),
+                             std::move(push_output),
+                             std::move(from_control_receiver),
+                             std::move(to_control_sender), id, exec_ctx, sys,
+                             dh);
         co_return Terminated{};
       });
       driver.add(pull_output());
@@ -2161,6 +2071,69 @@ auto run_pipeline(OperatorChain<void, void> pipeline, ExecCtx& exec_ctx,
   }
   diagnostic::error("uncaught exception in pipeline: {}", exception.what())
     .emit(dh);
+}
+
+auto run_bounded_pipeline(OperatorChain<table_slice, table_slice> chain,
+                          ExecCtx& exec_ctx, caf::actor_system& sys,
+                          DiagHandler& dh, PipelineFeeder feed_input,
+                          PipelineDrainer drain_output) -> Task<void> {
+  auto num_ops = chain.size();
+  TENZIR_ASSERT(num_ops > 0);
+  auto id = new_pipe_id();
+  auto [push_input, pull_input]
+    = exec_ctx.make_channel<table_slice>(ChannelId::first(id.op(0)));
+  auto [push_output, pull_output]
+    = exec_ctx.make_channel<table_slice>(ChannelId::last(id.op(num_ops - 1)));
+  // A bounded transform has no outside controller, so we keep only the
+  // receiver. The matching sender dies with the temporary tuple at the end of
+  // this statement, which closes the channel; the chain's
+  // `from_control_.recv()` then resolves with `None` instead of pinning the
+  // chain's `JoinSet` open forever.
+  auto from_ctl_recv = std::get<1>(channel<FromControl>(16));
+  auto [to_ctl_send, to_ctl_recv] = channel<ToControl>(16);
+  // Feeder cancellation. The chain's receiver may be dropped before the feeder
+  // pushes all input (for example, a `head N` operator inside the transform
+  // emits `no_more_input` after seeing N events). Because dropping a receiver
+  // does not close the channel (see `Receiver` in `channel.hpp`), the feeder
+  // would otherwise block on `push_input` once the buffer fills. We forward
+  // that signal here to cancel the feeder.
+  auto feed_cancel = folly::CancellationSource{};
+  co_await async_scope([&](AsyncScope& scope) -> Task<void> {
+    // Chain runner.
+    scope.spawn(folly::coro::co_invoke(
+      [chain = std::move(chain), pull_input = std::move(pull_input),
+       push_output = std::move(push_output),
+       from_ctl_recv = std::move(from_ctl_recv),
+       to_ctl_send = std::move(to_ctl_send), id, &exec_ctx, &sys,
+       &dh]() mutable -> Task<void> {
+        co_await drive_chain(std::move(chain), std::move(pull_input),
+                             std::move(push_output), std::move(from_ctl_recv),
+                             std::move(to_ctl_send), id, exec_ctx, sys, dh);
+      }));
+    // Feeder. Drops `push_input` on exit, closing the input channel. Honors
+    // `feed_cancel` so we exit promptly if the chain stops reading upstream.
+    scope.spawn(folly::coro::co_invoke(
+      [&feed_input, push_input = std::move(push_input),
+       token = feed_cancel.getToken()]() mutable -> Task<void> {
+        co_await folly::coro::co_withCancellation(
+          token, folly::coro::co_invoke([&]() mutable -> Task<void> {
+            co_await feed_input(*push_input);
+          }));
+      }));
+    // Drain control messages and react to `no_more_input` by cancelling the
+    // feeder. Other control signals (e.g., shutdown readiness, checkpoint
+    // bookkeeping) are not actionable for a bounded one-shot transform.
+    scope.spawn(folly::coro::co_invoke([to_ctl_recv = std::move(to_ctl_recv),
+                                        &feed_cancel]() mutable -> Task<void> {
+      while (auto msg = co_await to_ctl_recv.recv()) {
+        if (*msg == ToControl::no_more_input) {
+          feed_cancel.requestCancellation();
+        }
+      }
+    }));
+    co_await drain_output(*pull_output);
+    scope.cancel();
+  });
 }
 
 } // namespace tenzir

--- a/libtenzir/src/tql2/exec.cpp
+++ b/libtenzir/src/tql2/exec.cpp
@@ -2042,8 +2042,6 @@ auto run_profiler(Profiler const& profiler, TestExecCtx& exec_ctx,
     });
 }
 
-} // namespace
-
 auto run_plan(OperatorChain<void, void> chain, caf::actor_system& sys,
               DiagHandler& dh, Profiler profiler, bool has_terminal,
               bool is_hidden, Notify* graceful_stop) -> Task<failure_or<void>> {
@@ -2060,6 +2058,8 @@ auto run_plan(OperatorChain<void, void> chain, caf::actor_system& sys,
   co_return dh.failure();
 }
 
+} // namespace
+
 auto run_plan(OperatorChain<void, void> chain, caf::actor_system& sys,
               DiagHandler& dh, Profiler profiler, bool is_hidden,
               Notify* graceful_stop) -> Task<failure_or<void>> {
@@ -2069,115 +2069,18 @@ auto run_plan(OperatorChain<void, void> chain, caf::actor_system& sys,
 
 auto run_transform(OperatorChain<table_slice, table_slice> chain,
                    caf::actor_system& sys, DiagHandler& dh, Profiler profiler,
-                   bool is_hidden, TransformFeeder feed_input,
-                   TransformDrainer drain_output) -> Task<failure_or<void>> {
+                   bool is_hidden, PipelineFeeder feed_input,
+                   PipelineDrainer drain_output) -> Task<failure_or<void>> {
   auto exec_ctx = TestExecCtx{profiler, /*has_terminal=*/false, is_hidden};
   auto num_ops = chain.size();
-  TENZIR_ASSERT(num_ops > 0);
-  auto id = PipeId{fmt::to_string(uuid::random())};
-  auto [push_input, pull_input]
-    = exec_ctx.make_channel<table_slice>(ChannelId::first(id.op(0)));
-  auto [push_output, pull_output]
-    = exec_ctx.make_channel<table_slice>(ChannelId::last(id.op(num_ops - 1)));
-  // A bounded transform has no outside controller, so we keep only the
-  // receiver. The matching sender dies with the temporary tuple at the end of
-  // this statement, which closes the channel; the chain's
-  // `from_control_.recv()` then resolves with `None` instead of pinning the
-  // chain's `JoinSet` open forever.
-  auto from_ctl_recv = std::get<1>(channel<FromControl>(16));
-  auto [to_ctl_send, to_ctl_recv] = channel<ToControl>(16);
-  // Feeder cancellation. The chain's receiver may be dropped before the feeder
-  // pushes all input (for example, a `head N` operator inside the transform
-  // emits `no_more_input` after seeing N events). Because dropping a receiver
-  // does not close the channel (see `Receiver` in `channel.hpp`), the feeder
-  // would otherwise block on `push_input` once the buffer fills. We forward
-  // that signal here to cancel the feeder.
-  auto feed_cancel = folly::CancellationSource{};
   co_await async_scope([&](AsyncScope& scope) -> Task<void> {
     scope.spawn(run_profiler(profiler, exec_ctx, num_ops));
-    // Chain runner.
-    scope.spawn(folly::coro::co_invoke(
-      [chain = std::move(chain), pull_input = std::move(pull_input),
-       push_output = std::move(push_output),
-       from_ctl_recv = std::move(from_ctl_recv),
-       to_ctl_send = std::move(to_ctl_send), id, &exec_ctx, &sys,
-       &dh]() mutable -> Task<void> {
-        co_await run_chain(std::move(chain), std::move(pull_input),
-                           std::move(push_output), std::move(from_ctl_recv),
-                           std::move(to_ctl_send), id, exec_ctx, sys, dh);
-      }));
-    // Feeder. Drops `push_input` on exit, closing the input channel. Honors
-    // `feed_cancel` so we exit promptly if the chain stops reading upstream.
-    scope.spawn(folly::coro::co_invoke(
-      [&feed_input, push_input = std::move(push_input),
-       token = feed_cancel.getToken()]() mutable -> Task<void> {
-        co_await folly::coro::co_withCancellation(
-          token, folly::coro::co_invoke([&]() mutable -> Task<void> {
-            co_await feed_input(*push_input);
-          }));
-      }));
-    // Drain control messages and react to `no_more_input` by cancelling the
-    // feeder. Other control signals (e.g., shutdown readiness, checkpoint
-    // bookkeeping) are not actionable for a bounded one-shot transform.
-    scope.spawn(folly::coro::co_invoke([to_ctl_recv = std::move(to_ctl_recv),
-                                        &feed_cancel]() mutable -> Task<void> {
-      while (auto msg = co_await to_ctl_recv.recv()) {
-        if (*msg == ToControl::no_more_input) {
-          feed_cancel.requestCancellation();
-        }
-      }
-    }));
-    co_await drain_output(*pull_output);
+    co_await run_bounded_pipeline(std::move(chain), exec_ctx, sys, dh,
+                                  std::move(feed_input),
+                                  std::move(drain_output));
     scope.cancel();
   });
   co_return dh.failure();
-}
-
-auto run_transform(std::vector<table_slice> input,
-                   OperatorChain<table_slice, table_slice> chain,
-                   caf::actor_system& sys, DiagHandler& dh, Profiler profiler,
-                   bool is_hidden)
-  -> Task<failure_or<std::vector<table_slice>>> {
-  auto output_slices = std::vector<table_slice>{};
-  auto feed_input
-    = [input_slices = std::move(input)](
-        Push<OperatorMsg<table_slice>>& push_input) mutable -> Task<void> {
-    for (auto& slice : input_slices) {
-      if (slice.rows() == 0) {
-        continue;
-      }
-      co_await push_input(OperatorMsg<table_slice>{std::move(slice)});
-    }
-    co_await push_input(OperatorMsg<table_slice>{Signal{EndOfData{}}});
-  };
-  auto drain_output
-    = [&output_slices](
-        Pull<OperatorMsg<table_slice>>& pull_output) mutable -> Task<void> {
-    while (auto msg = co_await pull_output()) {
-      co_await co_match(
-        std::move(*msg),
-        [&](table_slice slice) -> Task<void> {
-          if (slice.rows() > 0) {
-            output_slices.push_back(std::move(slice));
-          }
-          co_return;
-        },
-        [&](Signal signal) -> Task<void> {
-          co_await co_match(
-            signal,
-            [&](EndOfData) -> Task<void> {
-              co_return;
-            },
-            [&](Checkpoint) -> Task<void> {
-              co_return;
-            });
-        });
-    }
-  };
-  CO_TRY(co_await run_transform(std::move(chain), sys, dh, std::move(profiler),
-                                is_hidden, std::move(feed_input),
-                                std::move(drain_output)));
-  co_return output_slices;
 }
 
 namespace {


### PR DESCRIPTION
## 🔍 Problem

The pipeline executor exposed several overlapping entry points with confusing,
synonymous names (`run_chain` / `run_pipeline` / `run_plan`) plus dead
declarations and a redundant fused-variant wrapper:

- `run_chain` and `run_chain_fused` differed only in wrapping the execution
  context in a `FusedExecCtx`.
- The bounded transform driver lived in `tql2/exec.cpp` while its sibling
  closed-pipeline driver lived in the executor, so the two were split across
  files with asymmetric shapes.
- A right-open `run_pipeline` overload and a `run_transform` vector overload
  were declared but never defined.
- Explicit `run_chain` instantiations covered the full boundary-type matrix,
  though only one specialization is used across translation units.

## 🛠️ Solution

- Rename the low-level primitive `run_chain` → `drive_chain` and fold
  `run_chain_fused` into a `fused` parameter on it.
- Add `run_bounded_pipeline` next to `run_pipeline` in the executor and reduce
  `run_plan` / `run_transform` to symmetric thin wrappers that only add the
  profiler, execution context, and `failure_or` result.
- Remove the dead right-open `run_pipeline` and `run_transform(vector)`
  declarations.
- Trim explicit `drive_chain` instantiations to the single
  `table_slice -> table_slice` specialization actually used across TUs.

## 💬 Review

- Internal refactor only: no TQL, CLI, config, or documented behavior changes,
  hence no changelog entry.
- Focus on `drive_chain`'s new `fused` handling (stack-local
  `std::optional<FusedExecCtx>` must outlive the `ChainRunner`) and the
  `run_bounded_pipeline` extraction vs. the previous inline body in
  `run_transform`.
- Verified with a full build; storage/partition tests (exercise
  `run_bounded_pipeline`) and node tests (exercise `run_pipeline`) pass; fused
  and non-fused pipelines run correctly.
