### PR TITLE
Modernize c-ares channel handles

### DIFF
--- a/libtenzir/builtins/operators/dns_lookup.cpp
+++ b/libtenzir/builtins/operators/dns_lookup.cpp
@@ -92,7 +92,7 @@ public:
   ares_channel_wrapper(const ares_channel_wrapper&) = delete;
   ares_channel_wrapper& operator=(const ares_channel_wrapper&) = delete;
 
-  auto get() const -> ares_channel {
+  auto get() const -> ares_channel_t* {
     return channel_;
   }
 
@@ -105,7 +105,7 @@ public:
   }
 
 private:
-  ares_channel channel_ = nullptr;
+  ares_channel_t* channel_ = nullptr;
   ares_status_t status_;
 };
 

--- a/libtenzir/src/async/dns.cpp
+++ b/libtenzir/src/async/dns.cpp
@@ -132,7 +132,7 @@ public:
     return channel_ != nullptr;
   }
 
-  [[nodiscard]] auto get() const -> ares_channel {
+  [[nodiscard]] auto get() const -> ares_channel_t* {
     return channel_;
   }
 
@@ -141,7 +141,7 @@ public:
   }
 
 private:
-  ares_channel channel_ = nullptr;
+  ares_channel_t* channel_ = nullptr;
   ares_status_t status_ = ARES_ENOTINITIALIZED;
 };
 


### PR DESCRIPTION
## 🔍 Problem

- c-ares labels the `ares_channel` pointer typedef as legacy.
- The DNS resolver wrappers still use that legacy spelling.

## 🛠️ Solution

- Use the current `ares_channel_t*` type consistently.
- Preserve channel lifetime and DNS lookup behavior.

## 💬 Review

- This is a type-only compatibility cleanup.
- Focus on compatibility with the currently supported c-ares API.