### PR TITLE
Silence avoidable build warnings

### DIFF
--- a/changelog/unreleased/cleaner-source-builds-on-macos.md
+++ b/changelog/unreleased/cleaner-source-builds-on-macos.md
@@ -1,0 +1,12 @@
+---
+title: Cleaner source builds on macOS
+type: bugfix
+authors:
+  - mavam
+  - codex
+prs:
+  - 6441
+created: 2026-07-13T06:33:03.366701Z
+---
+
+Source builds on macOS no longer print avoidable warnings from platform-specific code, fmt 12 integration, or bundled dependencies. This makes new compiler diagnostics easier to spot.

--- a/libtenzir/CMakeLists.txt
+++ b/libtenzir/CMakeLists.txt
@@ -20,7 +20,21 @@ if (NOT tsl-robin-map_FOUND)
       STATUS
         "Cannot find installed tsl-robin-map; falling back to bundled version")
   endif ()
+  if (DEFINED CMAKE_WARN_DEPRECATED)
+    set(_tenzir_prev_warn_deprecated "${CMAKE_WARN_DEPRECATED}")
+  endif ()
+  set(CMAKE_WARN_DEPRECATED
+      OFF
+      CACHE BOOL "" FORCE)
   add_subdirectory(aux/robin-map)
+  if (DEFINED _tenzir_prev_warn_deprecated)
+    set(CMAKE_WARN_DEPRECATED
+        "${_tenzir_prev_warn_deprecated}"
+        CACHE BOOL "" FORCE)
+  else ()
+    unset(CMAKE_WARN_DEPRECATED CACHE)
+  endif ()
+  unset(_tenzir_prev_warn_deprecated)
   dependency_summary("robin-map" "${CMAKE_CURRENT_SOURCE_DIR}/aux/robin-map"
                      "Dependencies")
   export(

--- a/libtenzir/aux/facebook/CMakeLists.txt
+++ b/libtenzir/aux/facebook/CMakeLists.txt
@@ -235,8 +235,9 @@ target_compile_options(proxygen PRIVATE -include gflags/gflags.h)
 # older OpenSSL and c-ares releases. Newer dependency versions mark those APIs
 # as deprecated, but migrating the vendored implementations is an upstream
 # concern. Suppress those diagnostics, and platform-specific unused parameters,
-# on every target created by the bundle so that they do not obscure warnings in
-# Tenzir code.
+# on every compilable target created by the bundle so that they do not obscure
+# warnings in Tenzir code. Do not attach them to interface targets because
+# their usage requirements propagate to consumers.
 function (tenzir_suppress_bundled_facebook_warnings directory)
   get_property(
     targets
@@ -244,24 +245,18 @@ function (tenzir_suppress_bundled_facebook_warnings directory)
     PROPERTY BUILDSYSTEM_TARGETS)
   foreach (target IN LISTS targets)
     get_target_property(type "${target}" TYPE)
-    if (type STREQUAL "INTERFACE_LIBRARY")
-      set(visibility INTERFACE)
-    elseif (
-      type
-      MATCHES
-      "^(EXECUTABLE|STATIC_LIBRARY|SHARED_LIBRARY|MODULE_LIBRARY|OBJECT_LIBRARY)$"
+    if (type
+        MATCHES
+        "^(EXECUTABLE|STATIC_LIBRARY|SHARED_LIBRARY|MODULE_LIBRARY|OBJECT_LIBRARY)$"
     )
-      set(visibility PRIVATE)
-    else ()
-      continue()
+      target_compile_options(
+        "${target}"
+        PRIVATE
+          $<$<CXX_COMPILER_ID:Clang,AppleClang>:-Wno-deprecated-declarations
+          -Wno-unused-parameter>
+          $<$<CXX_COMPILER_ID:GNU>:-Wno-deprecated-declarations
+          -Wno-unused-parameter>)
     endif ()
-    target_compile_options(
-      "${target}"
-      ${visibility}
-      $<$<CXX_COMPILER_ID:Clang,AppleClang>:-Wno-deprecated-declarations
-      -Wno-unused-parameter>
-      $<$<CXX_COMPILER_ID:GNU>:-Wno-deprecated-declarations
-      -Wno-unused-parameter>)
   endforeach ()
   get_property(
     subdirectories

--- a/libtenzir/aux/facebook/CMakeLists.txt
+++ b/libtenzir/aux/facebook/CMakeLists.txt
@@ -102,6 +102,24 @@ set(BUILD_SHARED_LIBS OFF)
 set(_tenzir_prev_skip_install_rules "${CMAKE_SKIP_INSTALL_RULES}")
 set(CMAKE_SKIP_INSTALL_RULES ON)
 
+# The bundled projects support CMake releases older than Tenzir does and ship
+# find modules whose package-name casing predates current CMake diagnostics.
+# Keep those warnings scoped to the upstream projects instead of suppressing
+# developer and deprecation warnings for Tenzir itself.
+if (DEFINED CMAKE_WARN_DEPRECATED)
+  set(_tenzir_prev_warn_deprecated "${CMAKE_WARN_DEPRECATED}")
+endif ()
+if (DEFINED CMAKE_SUPPRESS_DEVELOPER_WARNINGS)
+  set(_tenzir_prev_suppress_developer_warnings
+      "${CMAKE_SUPPRESS_DEVELOPER_WARNINGS}")
+endif ()
+set(CMAKE_WARN_DEPRECATED
+    OFF
+    CACHE BOOL "" FORCE)
+set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS
+    ON
+    CACHE BOOL "" FORCE)
+
 # ---- 1. FOLLY ----
 add_subdirectory(folly SYSTEM)
 target_compile_options(
@@ -165,7 +183,7 @@ target_include_directories(
 # upstream CMakeLists.txt is missing the dependency declaration.
 if (TARGET wangle_acceptor AND TARGET folly_io_async_fdsock_async_fd_socket)
   target_link_libraries(wangle_acceptor
-    PUBLIC folly_io_async_fdsock_async_fd_socket)
+                        PUBLIC folly_io_async_fdsock_async_fd_socket)
 endif ()
 if (NOT TARGET wangle::wangle)
   add_library(wangle::wangle ALIAS wangle)
@@ -212,6 +230,48 @@ add_subdirectory(proxygen SYSTEM)
 # <glog/logging.h>. Proxygen source files use raw DEFINE_int32/DEFINE_bool
 # macros without explicitly including gflags. Force-include the header.
 target_compile_options(proxygen PRIVATE -include gflags/gflags.h)
+
+# The bundled Facebook libraries intentionally retain compatibility code for
+# older OpenSSL and c-ares releases. Newer dependency versions mark those APIs
+# as deprecated, but migrating the vendored implementations is an upstream
+# concern. Suppress those diagnostics, and platform-specific unused parameters,
+# on every target created by the bundle so that they do not obscure warnings in
+# Tenzir code.
+function (tenzir_suppress_bundled_facebook_warnings directory)
+  get_property(
+    targets
+    DIRECTORY "${directory}"
+    PROPERTY BUILDSYSTEM_TARGETS)
+  foreach (target IN LISTS targets)
+    get_target_property(type "${target}" TYPE)
+    if (type STREQUAL "INTERFACE_LIBRARY")
+      set(visibility INTERFACE)
+    elseif (
+      type
+      MATCHES
+      "^(EXECUTABLE|STATIC_LIBRARY|SHARED_LIBRARY|MODULE_LIBRARY|OBJECT_LIBRARY)$"
+    )
+      set(visibility PRIVATE)
+    else ()
+      continue()
+    endif ()
+    target_compile_options(
+      "${target}"
+      ${visibility}
+      $<$<CXX_COMPILER_ID:Clang,AppleClang>:-Wno-deprecated-declarations
+      -Wno-unused-parameter>
+      $<$<CXX_COMPILER_ID:GNU>:-Wno-deprecated-declarations
+      -Wno-unused-parameter>)
+  endforeach ()
+  get_property(
+    subdirectories
+    DIRECTORY "${directory}"
+    PROPERTY SUBDIRECTORIES)
+  foreach (subdirectory IN LISTS subdirectories)
+    tenzir_suppress_bundled_facebook_warnings("${subdirectory}")
+  endforeach ()
+endfunction ()
+tenzir_suppress_bundled_facebook_warnings("${CMAKE_CURRENT_SOURCE_DIR}")
 TenzirSystemizeTarget(proxygen_coro_client)
 # proxygen_utils_trace calls getTraceEventTypeString/getTraceFieldTypeString
 # from proxygen_utils_trace_event_types but does not declare the dependency.
@@ -244,6 +304,22 @@ unset(_tenzir_fb_install_stub_dir)
 # export/install of individual targets needed.
 set(CMAKE_SKIP_INSTALL_RULES "${_tenzir_prev_skip_install_rules}")
 unset(_tenzir_prev_skip_install_rules)
+if (DEFINED _tenzir_prev_warn_deprecated)
+  set(CMAKE_WARN_DEPRECATED
+      "${_tenzir_prev_warn_deprecated}"
+      CACHE BOOL "" FORCE)
+else ()
+  unset(CMAKE_WARN_DEPRECATED CACHE)
+endif ()
+if (DEFINED _tenzir_prev_suppress_developer_warnings)
+  set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS
+      "${_tenzir_prev_suppress_developer_warnings}"
+      CACHE BOOL "" FORCE)
+else ()
+  unset(CMAKE_SUPPRESS_DEVELOPER_WARNINGS CACHE)
+endif ()
+unset(_tenzir_prev_warn_deprecated)
+unset(_tenzir_prev_suppress_developer_warnings)
 
 # Bundle public headers from vendored Facebook libraries into the Tenzir
 # development package so downstream consumers can compile against tenzir's
@@ -276,7 +352,8 @@ install(
   COMPONENT Development
   OPTIONAL)
 install(
-  FILES "${CMAKE_CURRENT_BINARY_DIR}/wangle/wangle/generated/wangle/wangle-config.h"
+  FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/wangle/wangle/generated/wangle/wangle-config.h"
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/wangle"
   COMPONENT Development
   OPTIONAL)

--- a/libtenzir/include/tenzir/detail/debug_writer.hpp
+++ b/libtenzir/include/tenzir/detail/debug_writer.hpp
@@ -208,7 +208,7 @@ public:
   template <class... Args>
   [[nodiscard]] auto fmt_value(fmt::format_string<Args...> fs, Args&&... args)
     -> bool {
-    return fmt_value_impl(fs, fmt::make_format_args(args...));
+    return fmt_value_impl(fs.get(), fmt::make_format_args(args...));
   }
 
   /// Augments the following value with a string.
@@ -217,7 +217,7 @@ public:
   template <class... Args>
   [[nodiscard]] auto
   prepend(fmt::format_string<Args...> fs, const Args&... args) -> bool {
-    return prepend_impl(fs, fmt::make_format_args(args...));
+    return prepend_impl(fs.get(), fmt::make_format_args(args...));
   }
 
   /// Augments the preceding value with a string.
@@ -226,7 +226,7 @@ public:
   template <class... Args>
   [[nodiscard]] auto append(fmt::format_string<Args...> fs, const Args&... args)
     -> bool {
-    return append_impl(fs, fmt::make_format_args(args...));
+    return append_impl(fs.get(), fmt::make_format_args(args...));
   }
 
   // Enters a new level of nesting.

--- a/libtenzir/src/detail/available_memory.cpp
+++ b/libtenzir/src/detail/available_memory.cpp
@@ -75,6 +75,8 @@ auto read_cgroup_memory_available(const std::filesystem::path& dir,
   };
 }
 
+#if TENZIR_LINUX
+
 auto relative_cgroup_path(std::string_view raw) -> std::filesystem::path {
   while (raw.starts_with('/')) {
     raw.remove_prefix(1);
@@ -88,7 +90,6 @@ struct cgroup2_mount {
 };
 
 auto find_cgroup2_mount() -> std::optional<cgroup2_mount> {
-#if TENZIR_LINUX
   try {
     for (const auto& mount : pfs::procfs{}.get_task().get_mountinfo()) {
       if (mount.filesystem_type != "cgroup2") {
@@ -101,7 +102,6 @@ auto find_cgroup2_mount() -> std::optional<cgroup2_mount> {
     }
   } catch (const std::exception&) {
   }
-#endif
   return std::nullopt;
 }
 
@@ -159,6 +159,8 @@ auto cgroup2_memory_available(const std::filesystem::path& path)
   }
   return result;
 }
+
+#endif
 
 auto cgroup_memory_available() -> std::optional<available_memory_info> {
 #if TENZIR_LINUX


### PR DESCRIPTION
## 🔍 Problem

- Clean macOS builds emit warnings from Tenzir code after the fmt 12 update.
- Bundled dependencies emit deprecation and developer warnings that obscure actionable diagnostics.

## 🛠️ Solution

- Use fmt's explicit string-view accessor and compile cgroup helpers only on Linux.
- Scope compiler and CMake warning suppression to bundled dependencies.

## 💬 Review

- Verify that warning suppression remains limited to vendored targets and does not leak into Tenzir targets or the CMake cache.

<sub>
🎫 References TNZ-769
</sub>
