### PR TITLE
Add force-stop action for pipelines

### DIFF
--- a/changelog/unreleased/force-stop-action-for-pipelines.md
+++ b/changelog/unreleased/force-stop-action-for-pipelines.md
@@ -1,0 +1,18 @@
+---
+title: Force stop action for pipelines
+type: feature
+authors:
+  - aljazerzen
+  - claude
+created: 2026-07-13T08:43:36.753785Z
+---
+
+Pipelines now support a `force-stop` action that terminates a pipeline
+immediately instead of waiting for in-flight data to drain.
+
+A regular `stop` moves a running pipeline into the `stopping` state and lets it
+drain gracefully, which can take up to the configured
+`tenzir.shutdown-grace-period`.
+
+Sending `force-stop` to a pipeline that is already `stopping` cancels the grace
+period and kills it immediately.

--- a/changelog/unreleased/force-stop-action-for-pipelines.md
+++ b/changelog/unreleased/force-stop-action-for-pipelines.md
@@ -4,6 +4,8 @@ type: feature
 authors:
   - aljazerzen
   - claude
+prs:
+  - 6442
 created: 2026-07-13T08:43:36.753785Z
 ---
 

--- a/libtenzir/src/version.cpp
+++ b/libtenzir/src/version.cpp
@@ -86,6 +86,9 @@ auto tenzir_features(const record& cfg) -> std::vector<std::string> {
     "hr-pipeline-activity",
     // summarize supports streaming mode via the frequency option.
     "summarize_frequency",
+    // The pipeline manager supports the `force-stop` update action that kills a
+    // pipeline immediately instead of draining in-flight data.
+    "pipeline_force_stop",
   };
   return result;
 }

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -1,5 +1,5 @@
 {
-  "hash": "sha256-YkOXrjCs9YqjfSTuTfVtFN78iK/jbfuc0CaUfpa3pPg=",
+  "hash": "sha256-J+SG4giwXHFzC7oLd5sGHxjbm4R3PpozRYFqarHqg0Q=",
   "name": "tenzir-plugins.tar.gz",
-  "url": "https://github.com/tenzir/tenzir-plugins/archive/9baf088dd94e9a8cf2c0cede3d4dbe335b814a79.tar.gz"
+  "url": "https://github.com/tenzir/tenzir-plugins/archive/bdee1991d76c81d7d7a7f7090b0bbdbeaa126aa8.tar.gz"
 }

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -1,5 +1,5 @@
 {
-  "hash": "sha256-J+SG4giwXHFzC7oLd5sGHxjbm4R3PpozRYFqarHqg0Q=",
+  "hash": "sha256-iiQmv2a+S3k6zCS+kdvrXKbcFKDwZW8g1KU31tfMsEs=",
   "name": "tenzir-plugins.tar.gz",
-  "url": "https://github.com/tenzir/tenzir-plugins/archive/bdee1991d76c81d7d7a7f7090b0bbdbeaa126aa8.tar.gz"
+  "url": "https://github.com/tenzir/tenzir-plugins/archive/3c465c5b45b793f0692a3f07bb1a05f929fcec17.tar.gz"
 }

--- a/test/tests/node/pipeline_manager/neo_launch_update.py
+++ b/test/tests/node/pipeline_manager/neo_launch_update.py
@@ -525,6 +525,70 @@ def _check_full_buffer_stop_terminates_serve(base_url: str) -> None:
             _delete_pipeline(base_url, created_id)
 
 
+def _check_force_stop_terminates_pipeline(base_url: str) -> None:
+    # A `force-stop` skips the graceful drain and terminates a running pipeline
+    # immediately. Here we launch a continuously-running pipeline and assert it
+    # stops after a force-stop request.
+    created_id = ""
+    try:
+        status, body = _post_api(
+            base_url,
+            "/pipeline/launch",
+            {
+                "definition": ("//neo\nfrom {x: 1}\nrepeat\n"),
+                "name": "neo-force-stop",
+                "hidden": True,
+                "serve_id": "neo-force-stop",
+                "ttl": "60s",
+                "autostart": {"created": True},
+            },
+        )
+        assert status == 200, body
+        created_id = str(body.get("id", ""))
+        assert created_id, body
+        _wait_for_pipeline_state(base_url, created_id, "running")
+        status, body = _post_api(
+            base_url,
+            "/pipeline/update",
+            {"id": created_id, "action": "force-stop"},
+        )
+        assert status == 200, body
+        _wait_for_pipeline_stopped_or_deleted(base_url, created_id, timeout=10)
+        print("force-stop-terminates-pipeline: ok")
+    finally:
+        if created_id:
+            _delete_pipeline(base_url, created_id)
+
+
+def _check_invalid_action_rejected(base_url: str) -> None:
+    # Unknown actions must still be rejected so that clients get clear feedback.
+    created_id = ""
+    try:
+        status, body = _post_api(
+            base_url,
+            "/pipeline/create",
+            {
+                "definition": "from {x: 1} | discard",
+                "name": "invalid-action",
+            },
+        )
+        assert status == 200, body
+        created_id = str(body.get("id", ""))
+        assert created_id, body
+        status, body = _post_api(
+            base_url,
+            "/pipeline/update",
+            {"id": created_id, "action": "stahp"},
+        )
+        # The web layer surfaces the pipeline manager's rejection as an error
+        # body rather than a distinct HTTP status.
+        assert body.get("error"), {"status": status, "body": body}
+        print("invalid-action-rejected: ok")
+    finally:
+        if created_id:
+            _delete_pipeline(base_url, created_id)
+
+
 def main() -> None:
     with _running_web_server() as base_url:
         _check_launch_compile_diagnostics(base_url)
@@ -533,6 +597,8 @@ def main() -> None:
         _check_every_stop_terminates_serve(base_url)
         _check_hidden_diagnostics_stop_terminates_serve(base_url)
         _check_full_buffer_stop_terminates_serve(base_url)
+        _check_force_stop_terminates_pipeline(base_url)
+        _check_invalid_action_rejected(base_url)
 
 
 if __name__ == "__main__":

--- a/test/tests/node/pipeline_manager/neo_launch_update.py
+++ b/test/tests/node/pipeline_manager/neo_launch_update.py
@@ -341,18 +341,37 @@ def _background_serve_request(
 
     def worker() -> None:
         try:
-            status, response = _post_api(
-                base_url,
-                "/serve",
-                {
+            # `/serve` long-polls, but it may hand back an early empty page
+            # (with a continuation token and state `running`) before any events
+            # or a terminal state. Keep polling until we either observe events
+            # or the pipeline terminates (`next_continuation_token` is null),
+            # so `done` is set only when the stream has genuinely ended. This
+            # avoids a race where an early empty page looks like the serve
+            # request returned before the pipeline was stopped.
+            token: str | None = None
+            while True:
+                payload: dict[str, Any] = {
                     "serve_id": serve_id,
                     "timeout": "10s",
                     "min_events": 1,
                     "max_events": 1,
                     "schema": "never",
-                },
-            )
-            results.append(_ServeResult(status, response))
+                }
+                if token is not None:
+                    payload["continuation_token"] = token
+                status, response = _post_api(base_url, "/serve", payload)
+                if status != 200 or not isinstance(response, dict):
+                    results.append(_ServeResult(status, response))
+                    return
+                events = response.get("events") or []
+                token = response.get("next_continuation_token")
+                state = response.get("state")
+                if events or token is None or state != "running":
+                    results.append(_ServeResult(status, response))
+                    return
+                # Guard against a tight loop if the endpoint returns empty
+                # pages without honoring the long-poll timeout.
+                time.sleep(0.05)
         except BaseException as exc:  # pragma: no cover - surfaced below
             errors.append(exc)
         finally:

--- a/test/tests/node/pipeline_manager/neo_launch_update.txt
+++ b/test/tests/node/pipeline_manager/neo_launch_update.txt
@@ -4,3 +4,5 @@ update-accepts-legacy-and-neo-definitions: ok
 every-stop-terminates-serve: ok
 hidden-diagnostics-stop-terminates-serve: ok
 full-buffer-stop-terminates-serve: ok
+force-stop-terminates-pipeline: ok
+invalid-action-rejected: ok


### PR DESCRIPTION
## 🔍 Problem

A graceful `stop` moves a running pipeline into the `stopping` state and drains
in-flight data, which can take up to the configured
`tenzir.shutdown-grace-period`. Users had no way to halt a pipeline that is
stuck draining.

## 🛠️ Solution

- Add a `force-stop` action to `/pipeline/update` that terminates the pipeline
  immediately. On a pipeline already `stopping`, it cancels the grace period
  and kills the executor right away.
- Advertise a `pipeline_force_stop` node feature so the app can gate the UI.
- Bump the `tenzir-plugins` submodule to pull in the pipeline-manager change.

```json
{ "id": "<pipeline-id>", "action": "force-stop" }
```

## 💬 Review

- Submodule change: tenzir/tenzir-plugins#582.
- Integration coverage lives in `neo_launch_update.py` (force-stop terminates a
  running pipeline; unknown actions are rejected).

<sub>
✅ Closes TNZ-760<br>
📎 Related: tenzir/tenzir-plugins#582<br>
📎 Related: tenzir/platform-internal companion PR for the app UI
</sub>
