### PR TITLE
Fix /serve polls racing serve operator startup

### DIFF
--- a/libtenzir/builtins/operators/serve.cpp
+++ b/libtenzir/builtins/operators/serve.cpp
@@ -79,6 +79,7 @@
 #include <caf/typed_event_based_actor.hpp>
 #include <folly/coro/BoundedQueue.h>
 
+#include <chrono>
 #include <sstream>
 
 namespace tenzir::plugins::serve {
@@ -608,6 +609,24 @@ struct serve_manager_state {
   /// messages to the user.
   std::unordered_map<std::string, caf::error> expired_ids = {};
 
+  /// A first-page get request that arrived before its serve operator
+  /// registered. Parked until registration, a flush, or its timeout.
+  struct pending_get {
+    uint64_t id = {};
+    single_serve_request request = {};
+    caf::typed_response_promise<serve_response> rp = {};
+    caf::disposable timeout = {};
+    std::chrono::steady_clock::time_point deadline = {};
+  };
+
+  /// Parked first-page get requests, keyed by serve id. A pipeline reports
+  /// running before its operators finished starting, so a poll may arrive
+  /// before the serve operator registered its id.
+  std::unordered_map<std::string, std::vector<pending_get>> pending_gets = {};
+
+  /// Monotonic id generator for parked get requests.
+  uint64_t next_pending_get_id = {};
+
   // Distinguishes a genuine pipeline failure from a clean teardown. A failing
   // pipeline propagates a diagnostic; a pipeline that merely finished -- by
   // exhausting its input, a user shutdown, or the executor tearing down its
@@ -712,6 +731,15 @@ struct serve_manager_state {
     self->monitor(std::move(watched), [this, addr](const caf::error& err) {
       handle_down_msg(addr, err);
     });
+    // Replay polls that arrived before this registration, with the remainder
+    // of their timeout budget.
+    const auto now = std::chrono::steady_clock::now();
+    for (auto& get : take_parked(serve_id)) {
+      get.request.timeout
+        = std::max(duration::zero(),
+                   std::chrono::duration_cast<duration>(get.deadline - now));
+      get_registered(ops.back(), std::move(get.request), std::move(get.rp));
+    }
     return {};
   }
 
@@ -863,52 +891,122 @@ struct serve_manager_state {
         }
         return std::make_tuple(std::string{}, std::vector<table_slice>{});
       }
-      return caf::make_error(ec::invalid_argument,
-                             fmt::format("{} got request for events with "
-                                         "unknown serve id {}",
-                                         *self, request.serve_id));
+      // A first-page poll may race the serve operator's startup: a pipeline
+      // reports running before its operators finished starting. Park the
+      // request until the operator registers instead of failing, and report
+      // an unknown serve id only when the timeout fires first. A generated
+      // token can never become valid through a future registration (a fresh
+      // registration always starts at the initial token), so fail fast then.
+      if (request.continuation_token == initial_continuation_token) {
+        return park_get(std::move(request));
+      }
+      return unknown_serve_id_error(request.serve_id);
     }
+    auto rp = self->make_response_promise<serve_response>();
+    get_registered(*found, std::move(request), rp);
+    return rp;
+  }
+
+  auto unknown_serve_id_error(std::string_view serve_id) const -> caf::error {
+    return caf::make_error(ec::invalid_argument,
+                           fmt::format("{} got request for events with "
+                                       "unknown serve id {}",
+                                       *self, serve_id));
+  }
+
+  /// Extracts all parked polls for a serve id and cancels their timeouts.
+  auto take_parked(const std::string& serve_id) -> std::vector<pending_get> {
+    auto pending = pending_gets.extract(serve_id);
+    if (pending.empty()) {
+      return {};
+    }
+    for (auto& get : pending.mapped()) {
+      get.timeout.dispose();
+    }
+    return std::move(pending.mapped());
+  }
+
+  /// Parks a first-page get request whose serve id is not registered yet.
+  /// `start()` replays it, `flush()` completes it, or its timeout fails it.
+  auto park_get(single_serve_request request) -> caf::result<serve_response> {
+    auto rp = self->make_response_promise<serve_response>();
+    const auto id = next_pending_get_id++;
+    const auto deadline = std::chrono::steady_clock::now() + request.timeout;
+    auto timeout = detail::weak_run_delayed(
+      self, request.timeout, [this, id, serve_id = request.serve_id]() {
+        const auto pending = pending_gets.find(serve_id);
+        if (pending == pending_gets.end()) {
+          return;
+        }
+        const auto found
+          = std::ranges::find(pending->second, id, &pending_get::id);
+        if (found == pending->second.end()) {
+          return;
+        }
+        found->rp.deliver(unknown_serve_id_error(serve_id));
+        pending->second.erase(found);
+        if (pending->second.empty()) {
+          pending_gets.erase(pending);
+        }
+      });
+    auto serve_id = request.serve_id;
+    pending_gets[std::move(serve_id)].push_back({
+      .id = id,
+      .request = std::move(request),
+      .rp = rp,
+      .timeout = std::move(timeout),
+      .deadline = deadline,
+    });
+    return rp;
+  }
+
+  /// Answers a get request for a registered serve operator on `rp`.
+  auto get_registered(managed_serve_operator& op, single_serve_request request,
+                      caf::typed_response_promise<serve_response> rp) -> void {
     // Re-fetch of the most recently delivered batch: the client retried with
     // the token of its previous request because the response was lost or its
     // poll was cancelled. This covers the first page (whose token is the
     // well-known initial token) and the final batch of a completed pipeline.
     // `last_continuation_token` stays empty until the first delivery, and the
     // request token is never empty here, so a fresh serve cannot match.
-    if (found->last_continuation_token == request.continuation_token) {
-      return std::make_tuple(
-        found->continuation_token,
-        split(found->last_results, request.max_events).first);
+    if (op.last_continuation_token == request.continuation_token) {
+      rp.deliver(
+        std::make_tuple(op.continuation_token,
+                        split(op.last_results, request.max_events).first));
+      return;
     }
-    if (found->continuation_token != request.continuation_token) {
+    if (op.continuation_token != request.continuation_token) {
       // A serve that reached a terminal state reports completion instead of an
       // unknown-token error, so that a client retrying the first page or
       // polling with the previously advertised token after a graceful shutdown
       // sees a completed stream. All paths that terminally clear the
       // continuation token also set `done`, so this covers lingering serves.
-      if (found->done) {
-        return std::make_tuple(std::string{}, std::vector<table_slice>{});
+      if (op.done) {
+        rp.deliver(std::make_tuple(std::string{}, std::vector<table_slice>{}));
+        return;
       }
-      return caf::make_error(
+      rp.deliver(caf::make_error(
         ec::invalid_argument,
         fmt::format("{} got request for events with unknown continuation token "
                     "{} for serve id {}",
-                    *self, request.continuation_token, request.serve_id));
+                    *self, request.continuation_token, request.serve_id)));
+      return;
     }
-    if (found->done and found->buffer.empty()) {
-      return std::make_tuple(std::string{}, std::vector<table_slice>{});
+    if (op.done and op.buffer.empty()) {
+      rp.deliver(std::make_tuple(std::string{}, std::vector<table_slice>{}));
+      return;
     }
-    auto rp = self->make_response_promise<serve_response>();
-    found->get_rps.push_back(rp);
-    found->requested = request.max_events;
-    found->min_events = request.min_events;
+    op.get_rps.push_back(rp);
+    op.requested = request.max_events;
+    op.min_events = request.min_events;
     // Once the source is gone, no more data will arrive, so deliver whatever
     // remains buffered immediately rather than waiting for `min_events`.
-    const auto delivered = found->try_deliver_results(found->done);
+    const auto delivered = op.try_deliver_results(op.done);
     if (delivered) {
-      return rp;
+      return;
     }
-    found->delayed_attempt.dispose();
-    found->delayed_attempt = detail::weak_run_delayed(
+    op.delayed_attempt.dispose();
+    op.delayed_attempt = detail::weak_run_delayed(
       self, request.timeout,
       [this, serve_id = request.serve_id,
        continuation_token = request.continuation_token]() mutable {
@@ -928,10 +1026,15 @@ struct serve_manager_state {
         const auto delivered = found->try_deliver_results(true);
         TENZIR_ASSERT(delivered);
       });
-    return rp;
   }
 
   auto flush(std::string serve_id) -> caf::result<void> {
+    // Complete parked polls for a not-yet-registered serve id with an empty
+    // first page, so a group poll is not held back until their timeout.
+    for (auto& get : take_parked(serve_id)) {
+      get.rp.deliver(std::make_tuple(std::string{initial_continuation_token},
+                                     std::vector<table_slice>{}));
+    }
     const auto found = std::ranges::find_if(ops, [&](const auto& op) {
       return op.serve_id == serve_id;
     });

--- a/libtenzir/builtins/operators/serve.cpp
+++ b/libtenzir/builtins/operators/serve.cpp
@@ -485,8 +485,7 @@ struct request_meta {
 struct request_base {
   std::string serve_id = {};
   std::string continuation_token = {};
-  /// Per-request schema override. Falls back to the request-wide default when
-  /// unset.
+  /// Overrides the request-wide default `schema` when set.
   std::optional<enum schema> schema_override = {};
 };
 
@@ -610,7 +609,7 @@ struct serve_manager_state {
   std::unordered_map<std::string, caf::error> expired_ids = {};
 
   /// A first-page get request that arrived before its serve operator
-  /// registered. Parked until registration, a flush, or its timeout.
+  /// registered.
   struct pending_get {
     uint64_t id = {};
     single_serve_request request = {};
@@ -627,12 +626,9 @@ struct serve_manager_state {
   /// Monotonic id generator for parked get requests.
   uint64_t next_pending_get_id = {};
 
-  // Distinguishes a genuine pipeline failure from a clean teardown. A failing
-  // pipeline propagates a diagnostic; a pipeline that merely finished -- by
-  // exhausting its input, a user shutdown, or the executor tearing down its
-  // now-unreachable nodes (`exit_reason::unreachable`) -- does not. Only
-  // genuine failures are surfaced as errors; clean completions are retained so
-  // a client can retry its final poll.
+  // A genuine pipeline failure propagates a diagnostic; a clean teardown --
+  // input exhaustion, user shutdown, or the executor tearing down unreachable
+  // nodes -- does not.
   static auto is_pipeline_failure(const caf::error& err) -> bool {
     // A clean exit passes an empty error; `context()` must not be called on it.
     if (not err.valid()) {
@@ -677,22 +673,16 @@ struct serve_manager_state {
         ops.erase(found);
       }
     };
-    // A pipeline that failed with a diagnostic is removed right away. A
-    // pipeline that finished cleanly keeps its last result set available for
-    // `retention_time`, so a client that lost or cancelled the response to its
-    // final poll can still retry and re-fetch it.
+    // Failures are removed right away; clean completions linger for
+    // `retention_time` so a client can retry its final poll.
     if (is_pipeline_failure(err)) {
       delete_serve();
       return;
     }
-    // Answer any in-flight poll immediately with a completion response instead
-    // of making it wait for the long-poll timeout or the retention timer.
+    // Answer any in-flight poll with the remaining buffer immediately instead
+    // of leaving it to the long-poll timeout.
     if (not found->get_rps.empty()) {
-      found->delayed_attempt.dispose();
-      for (auto&& get_rp : std::exchange(found->get_rps, {})) {
-        get_rp.deliver(
-          serve_response{std::string{}, std::vector<table_slice>{}});
-      }
+      found->try_deliver_results(/*force_underful=*/true);
     }
     detail::weak_run_delayed(self, defaults::api::serve::retention_time,
                              delete_serve);
@@ -882,21 +872,16 @@ struct serve_manager_state {
       const auto expired_id = expired_ids.find(request.serve_id);
       if (expired_id != expired_ids.end()) {
         const auto& err = expired_id->second;
-        // A pipeline that failed with a diagnostic surfaces that error. One
-        // that completed cleanly is reported as completed, not as an internal
-        // error: a client may retry its final poll after losing or cancelling
-        // the response, even past the retention window.
+        // Clean completions report as completed rather than an error so a
+        // client can retry its final poll even past the retention window.
         if (is_pipeline_failure(err)) {
           return err;
         }
         return std::make_tuple(std::string{}, std::vector<table_slice>{});
       }
-      // A first-page poll may race the serve operator's startup: a pipeline
-      // reports running before its operators finished starting. Park the
-      // request until the operator registers instead of failing, and report
-      // an unknown serve id only when the timeout fires first. A generated
-      // token can never become valid through a future registration (a fresh
-      // registration always starts at the initial token), so fail fast then.
+      // Park a first-page poll that raced the serve operator's startup. A
+      // generated token can never become valid through a future registration,
+      // which always starts at the initial token, so fail fast instead.
       if (request.continuation_token == initial_continuation_token) {
         return park_get(std::move(request));
       }
@@ -963,12 +948,9 @@ struct serve_manager_state {
   /// Answers a get request for a registered serve operator on `rp`.
   auto get_registered(managed_serve_operator& op, single_serve_request request,
                       caf::typed_response_promise<serve_response> rp) -> void {
-    // Re-fetch of the most recently delivered batch: the client retried with
-    // the token of its previous request because the response was lost or its
-    // poll was cancelled. This covers the first page (whose token is the
-    // well-known initial token) and the final batch of a completed pipeline.
-    // `last_continuation_token` stays empty until the first delivery, and the
-    // request token is never empty here, so a fresh serve cannot match.
+    // A client whose response was lost re-sent its previous token: re-deliver
+    // the last batch. A fresh serve cannot match, as `last_continuation_token`
+    // is empty until the first delivery and the request token is never empty.
     if (op.last_continuation_token == request.continuation_token) {
       rp.deliver(
         std::make_tuple(op.continuation_token,
@@ -976,11 +958,8 @@ struct serve_manager_state {
       return;
     }
     if (op.continuation_token != request.continuation_token) {
-      // A serve that reached a terminal state reports completion instead of an
-      // unknown-token error, so that a client retrying the first page or
-      // polling with the previously advertised token after a graceful shutdown
-      // sees a completed stream. All paths that terminally clear the
-      // continuation token also set `done`, so this covers lingering serves.
+      // A done serve reports completion instead of an unknown-token error;
+      // every path that terminally clears the continuation token sets `done`.
       if (op.done) {
         rp.deliver(std::make_tuple(std::string{}, std::vector<table_slice>{}));
         return;
@@ -1038,12 +1017,9 @@ struct serve_manager_state {
     const auto found = std::ranges::find_if(ops, [&](const auto& op) {
       return op.serve_id == serve_id;
     });
-    // Unknown/expired serve, or no request is currently waiting: nothing to do.
     if (found == ops.end() or found->get_rps.empty()) {
       return {};
     }
-    // Deliver immediately with whatever is buffered (possibly empty),
-    // cancelling the pending long-poll timer via try_deliver_results.
     found->try_deliver_results(/*force_underful=*/true);
     return {};
   }
@@ -1154,36 +1130,51 @@ struct serve_handler_state {
     caf::error detail;
   };
 
-  // Parses and validates an optional `schema` parameter, returning nullopt when
-  // it is absent or null. A null value is treated as unset because TQL list
-  // unification fills an omitted per-request `schema` with null when a sibling
-  // request specifies one.
-  static auto try_extract_schema(const tenzir::record& params)
-    -> std::variant<std::optional<enum schema>, parse_error> {
-    const auto it = params.find("schema");
+  // Returns a pointer to the string value of `key`, or nullptr when the key
+  // is absent or null. Null is treated as unset because TQL list unification
+  // fills an omitted field with null when a sibling record specifies it.
+  static auto
+  try_get_nullable_string(const tenzir::record& params, std::string_view key)
+    -> std::variant<const std::string*, parse_error> {
+    const auto it = params.find(key);
     if (it == params.end() or is<caf::none_t>(it->second)) {
-      return std::optional<enum schema>{};
+      return static_cast<const std::string*>(nullptr);
     }
     const auto* str = try_as<std::string>(&it->second);
     if (not str) {
       return parse_error{
-        .message = "failed to read schema parameter",
+        .message = fmt::format("failed to read {} parameter", key),
         .detail = caf::make_error(
           ec::invalid_argument,
           fmt::format("expected a string, got params {}", params))};
     }
-    auto opt = from_string<enum schema>(*str);
+    return str;
+  }
+
+  // Parses and validates an optional `schema` parameter, returning nullopt
+  // when it is absent or null.
+  static auto try_extract_schema(const tenzir::record& params)
+    -> std::variant<std::optional<enum schema>, parse_error> {
+    auto str = try_get_nullable_string(params, "schema");
+    if (auto* err = try_as<parse_error>(str)) {
+      return std::move(*err);
+    }
+    const auto* value = as<const std::string*>(str);
+    if (not value) {
+      return std::optional<enum schema>{};
+    }
+    auto opt = from_string<enum schema>(*value);
     if (not opt) {
       return parse_error{.message = "invalid schema parameter",
                          .detail
                          = caf::make_error(ec::invalid_argument,
-                                           fmt::format("got `{}`", *str))};
+                                           fmt::format("got `{}`", *value))};
     }
     return *opt;
   }
 
   // Extracts `serve_id`, `continuation_token`, and the optional per-request
-  // `schema` override by moving out of `params`.
+  // `schema` override from `params`.
   static auto try_extract_request_base(tenzir::record& params)
     -> std::variant<request_base, parse_error> {
     auto result = request_base{};
@@ -1202,20 +1193,12 @@ struct serve_handler_state {
                                   fmt::format("got parameters {}", params))};
     }
     result.serve_id = std::move(**serve_id);
-    // Treat both an absent key and an explicit null as unset: TQL list
-    // unification fills an omitted per-request `continuation_token` with null
-    // when a sibling request specifies one.
-    if (const auto it = params.find("continuation_token");
-        it != params.end() and not is<caf::none_t>(it->second)) {
-      const auto* str = try_as<std::string>(&it->second);
-      if (not str) {
-        return parse_error{
-          .message = "failed to read continuation_token",
-          .detail = caf::make_error(
-            ec::invalid_argument,
-            fmt::format("expected a string, got parameters {}", params))};
-      }
-      result.continuation_token = *str;
+    auto token = try_get_nullable_string(params, "continuation_token");
+    if (auto* err = try_as<parse_error>(token)) {
+      return std::move(*err);
+    }
+    if (const auto* value = as<const std::string*>(token)) {
+      result.continuation_token = *value;
     }
     auto schema = try_extract_schema(params);
     if (auto* err = try_as<parse_error>(schema)) {
@@ -1495,6 +1478,15 @@ struct serve_handler_state {
     enum schema schema;
   };
 
+  /// State shared between the continuations of one /serve-multi request.
+  struct multi_request_state {
+    std::unordered_map<std::string, serve_response_with_state> results;
+    /// All serve ids in the request, so a flush can target the other serves.
+    std::vector<std::string> serve_ids;
+    /// Set once the first serve returns events; guards against flushing twice.
+    bool flush_triggered = false;
+  };
+
   /// Handles a request to /serve-multi by
   /// * "parsing" `params`
   /// * Performing a fanout over all `serve_id` in params.requests, making a
@@ -1510,29 +1502,23 @@ struct serve_handler_state {
     }
     auto& request = as<multi_serve_request>(maybe_requests);
     auto rp = self->make_response_promise<rest_response>();
-    const auto min_events_per_request
-      = round_up_to_multiple(request.min_events, request.requests.size())
-        / request.requests.size();
-    const auto max_events_per_request
-      = round_up_to_multiple(request.max_events, request.requests.size())
-        / request.requests.size();
-    auto result_map = std::make_shared<
-      std::unordered_map<std::string, serve_response_with_state>>();
-    // Set once the first serve returns events; guards against flushing twice.
-    auto triggered = std::make_shared<bool>(false);
-    // Copy of all serve ids so the flush can target the *other* serves. Must be
-    // a shared copy because `request` is local and the continuations outlive it.
-    auto all_ids = std::make_shared<std::vector<std::string>>();
-    all_ids->reserve(request.requests.size());
+    const auto per_request = [&](uint64_t total) {
+      return round_up_to_multiple(total, request.requests.size())
+             / request.requests.size();
+    };
+    const auto min_events_per_request = per_request(request.min_events);
+    const auto max_events_per_request = per_request(request.max_events);
+    auto st = std::make_shared<multi_request_state>();
+    st->serve_ids.reserve(request.requests.size());
     for (const auto& r : request.requests) {
-      all_ids->push_back(r.serve_id);
+      st->serve_ids.push_back(r.serve_id);
     }
     auto fan = detail::make_fanout_counter(
       request.requests.size(),
-      [rp, result_map]() mutable {
+      [rp, st]() mutable {
         auto json_text = std::string{'{'};
         auto first = true;
-        for (auto& [id, result] : *result_map) {
+        for (auto& [id, result] : st->results) {
           const auto& [response, state, schema] = result;
           const auto& [next_token, data] = response;
           if (not first) {
@@ -1555,22 +1541,20 @@ struct serve_handler_state {
                min_events_per_request, request.timeout, max_events_per_request)
         .request(serve_manager, caf::infinite)
         .then(
-          [self = self, serve_manager = serve_manager, fan, id = r.serve_id,
-           result_map, triggered, all_ids,
+          [self = self, serve_manager = serve_manager, fan, id = r.serve_id, st,
            effective_schema](serve_response& result) mutable {
             auto& [continuation_token, data] = result;
             const auto has_events = rows(data) > 0;
             const auto state = continuation_token.empty()
                                  ? serve_state::completed
                                  : serve_state::running;
-            const auto [_, success] = result_map->try_emplace(
+            const auto [_, success] = st->results.try_emplace(
               id, std::move(result), state, effective_schema);
             TENZIR_ASSERT(success);
-            // As soon as any serve has data, stop waiting on the others: flush
-            // their currently-buffered events instead of long-polling to the
-            // timeout.
-            if (has_events and not std::exchange(*triggered, true)) {
-              for (const auto& other : *all_ids) {
+            // Once any serve has data, flush the others' buffers instead of
+            // long-polling to the timeout.
+            if (has_events and not std::exchange(st->flush_triggered, true)) {
+              for (const auto& other : st->serve_ids) {
                 if (other != id) {
                   self->mail(atom::flush_v, other).send(serve_manager);
                 }
@@ -1578,7 +1562,7 @@ struct serve_handler_state {
             }
             fan->receive_success();
           },
-          [fan, id = r.serve_id, result_map,
+          [fan, id = r.serve_id, st,
            effective_schema](caf::error& err) mutable {
             if (err == caf::exit_reason::user_shutdown
                 or err.context().match_elements<diagnostic>()) {
@@ -1590,7 +1574,7 @@ struct serve_handler_state {
               const auto state = err == caf::exit_reason::user_shutdown
                                    ? serve_state::completed
                                    : serve_state::failed;
-              const auto [_, success] = result_map->try_emplace(
+              const auto [_, success] = st->results.try_emplace(
                 std::move(id), serve_response{}, state, effective_schema);
               TENZIR_ASSERT(success);
               fan->receive_success();

--- a/test/tests/operators/serve/11_serve_poll_before_registration.py
+++ b/test/tests/operators/serve/11_serve_poll_before_registration.py
@@ -1,0 +1,282 @@
+# runner: python
+# timeout: 120
+
+"""Polling /serve before the serve operator registered must not fail.
+
+A pipeline reports "running" before its operators finished starting, so a
+client that launches a pipeline and immediately polls /serve can reach the
+serve-manager before the serve operator registered its id. Such first-page
+polls are parked until the operator registers (or the timeout fires) instead
+of failing with an unknown-serve-id error.
+
+Flow, launching hidden //neo pipelines through /pipeline/launch:
+  1. Poll /serve for an id with no pipeline at all, then launch the pipeline
+     while the poll is parked -> the poll delivers the pipeline's events.
+  2. Poll /serve-multi for a just-launched stream and a never-registered one
+     -> the response arrives as soon as the live stream has events; the
+     never-registered stream reports an empty running first page.
+  3. Poll /serve for a never-registered id -> the unknown-serve-id error
+     arrives only after the requested timeout.
+
+Tokens are runtime values, so we drive the REST API directly from Python and
+assert only on the stable `n` payloads and the completion state.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import socket
+import subprocess
+import threading
+import time
+import urllib.error
+import urllib.request
+import uuid
+from collections.abc import Mapping
+from pathlib import Path
+
+API = "/api/v0"
+
+NIL_TOKEN = "00000000-0000-0000-0000-000000000000"
+
+# Serve ids must be unique per attempt: a timed-out attempt leaks its hidden
+# pipelines until their ttl, and a retry reusing the same serve id would race
+# the leaked registration.
+SUFFIX = uuid.uuid4().hex[:8]
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _post(url: str, path: str, body: dict | None = None) -> tuple[int, dict]:
+    data = json.dumps(body or {}).encode()
+    req = urllib.request.Request(
+        f"{url}{API}{path}",
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            return r.status, json.loads(r.read().decode() or "{}")
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read().decode() or "{}")
+
+
+def _wait_for_api(proc: subprocess.Popen[str], url: str, timeout: int = 60) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            _, stderr = proc.communicate()
+            raise RuntimeError(
+                f"web server exited with {proc.returncode}: {stderr[-2000:]}"
+            )
+        try:
+            status, _ = _post(url, "/ping")
+            if status == 200:
+                return
+        except (urllib.error.URLError, ConnectionError, OSError):
+            pass
+        time.sleep(0.2)
+    raise RuntimeError("REST API did not come up")
+
+
+def start_web_server(
+    env: Mapping[str, str],
+) -> tuple[subprocess.Popen[str], str]:
+    binary = shlex.split(env["TENZIR_NODE_CLIENT_BINARY"])
+    tenzir_ctl = str(Path(binary[0]).with_name("tenzir-ctl"))
+    endpoint = env["TENZIR_NODE_CLIENT_ENDPOINT"]
+    port = _free_port()
+    proc = subprocess.Popen(
+        [
+            tenzir_ctl,
+            "--bare-mode",
+            "--console-verbosity=warning",
+            f"--endpoint={endpoint}",
+            "web",
+            "server",
+            "--mode=dev",
+            "--bind=127.0.0.1",
+            f"--port={port}",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    api_url = f"http://127.0.0.1:{port}"
+    try:
+        _wait_for_api(proc, api_url)
+    except Exception:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait()
+        raise
+    return proc, api_url
+
+
+def _launch(api: str, name: str, definition: str, serve_id: str) -> str:
+    """Launches a hidden //neo pipeline ending in `serve` and returns its id."""
+    status, body = _post(
+        api,
+        "/pipeline/launch",
+        {
+            "definition": f"//neo\n{definition}",
+            "name": name,
+            "hidden": True,
+            "serve_id": serve_id,
+            "ttl": "5m",
+            "autostart": {"created": True},
+        },
+    )
+    assert status == 200, f"launch of {name} failed ({status}): {body}"
+    pipeline_id = str(body.get("id", ""))
+    assert pipeline_id, f"launch of {name} returned no id: {body}"
+    return pipeline_id
+
+
+def _delete_pipeline(api: str, pipeline_id: str) -> None:
+    if pipeline_id:
+        _post(api, "/pipeline/delete", {"id": pipeline_id})
+
+
+def _payloads(resp: dict) -> list[int]:
+    """The `n` field of each returned event, in order."""
+    return [e["data"]["n"] for e in resp.get("events", [])]
+
+
+def _serve(api: str, serve_id: str, token: str | None, **kwargs) -> tuple[int, dict]:
+    body: dict = {
+        "serve_id": serve_id,
+        "max_events": 4,
+        "min_events": 4,
+        "timeout": "10s",
+        "schema": "never",
+        **kwargs,
+    }
+    if token is not None:
+        body["continuation_token"] = token
+    return _post(api, "/serve", body)
+
+
+def _drain(api: str, serve_id: str, token: str | None) -> str:
+    """Follows the continuation token until the stream completes."""
+    state = "completed"
+    for _ in range(10):
+        if not token:
+            break
+        status, resp = _serve(api, serve_id, token, min_events=1, timeout="5s")
+        assert status == 200, f"drain poll failed ({status}): {resp}"
+        state = resp["state"]
+        token = resp["next_continuation_token"]
+    return state
+
+
+def check_parked_poll_delivers(api: str) -> None:
+    """A first-page poll parked before registration delivers the events."""
+    serve_id = f"park_deliver_{SUFFIX}"
+    result: list[tuple[int, dict]] = []
+
+    def poll() -> None:
+        result.append(_serve(api, serve_id, None))
+
+    poller = threading.Thread(target=poll)
+    poller.start()
+    # Give the poll time to reach the serve-manager and park; only then launch
+    # the pipeline whose serve operator resolves it.
+    time.sleep(1.0)
+    pipeline_id = _launch(
+        api,
+        "park-deliver",
+        "from {n: 1}, {n: 2}, {n: 3}, {n: 4}",
+        serve_id,
+    )
+    try:
+        poller.join(timeout=30)
+        assert not poller.is_alive(), "parked poll did not return"
+        status, resp = result[0]
+        assert status == 200, f"parked poll failed ({status}): {resp}"
+        assert "next_continuation_token" in resp, f"parked poll errored: {resp}"
+        print(f"parked-events: {_payloads(resp)}")
+        state = _drain(api, serve_id, resp["next_continuation_token"])
+        print(f"parked-final-state: {state}")
+    finally:
+        _delete_pipeline(api, pipeline_id)
+
+
+def check_multi_flush_pending(api: str) -> None:
+    """A group poll is not held back by a never-registered serve id."""
+    live_id = f"park_live_{SUFFIX}"
+    ghost_id = f"park_ghost_{SUFFIX}"
+    pipeline_id = _launch(
+        api,
+        "park-live",
+        "from {n: 5}, {n: 6}, {n: 7}, {n: 8}",
+        live_id,
+    )
+    try:
+        start = time.monotonic()
+        status, resp = _post(
+            api,
+            "/serve-multi",
+            {
+                "requests": [
+                    {"serve_id": live_id, "continuation_token": NIL_TOKEN},
+                    {"serve_id": ghost_id, "continuation_token": NIL_TOKEN},
+                ],
+                "max_events": 8,
+                "min_events": 1,
+                "timeout": "10s",
+                "schema": "never",
+            },
+        )
+        elapsed = time.monotonic() - start
+        assert status == 200, f"multi poll failed ({status}): {resp}"
+        assert live_id in resp and ghost_id in resp, f"bad response: {resp}"
+        live = resp[live_id]
+        ghost = resp[ghost_id]
+        print(f"multi-live-events: {_payloads(live)}")
+        print(f"multi-ghost-events: {_payloads(ghost)}")
+        print(f"multi-ghost-state: {ghost['state']}")
+        token_is_initial = ghost["next_continuation_token"] == NIL_TOKEN
+        print(f"multi-ghost-token-is-initial: {token_is_initial}")
+        print(f"multi-returned-before-timeout: {elapsed < 8.0}")
+        _drain(api, live_id, live["next_continuation_token"])
+    finally:
+        _delete_pipeline(api, pipeline_id)
+
+
+def check_unknown_id_fails_after_timeout(api: str) -> None:
+    """A poll for a never-registered id errors only after the timeout."""
+    start = time.monotonic()
+    status, resp = _serve(api, f"park_never_{SUFFIX}", None, timeout="2s", min_events=1)
+    elapsed = time.monotonic() - start
+    error = json.dumps(resp)
+    print(f"never-waited-for-timeout: {elapsed >= 1.5}")
+    print(f"never-mentions-unknown-id: {'unknown serve id' in error}")
+    print(f"never-has-events: {'events' in resp}")
+
+
+def main() -> None:
+    proc, api = start_web_server(os.environ)
+    try:
+        check_parked_poll_delivers(api)
+        check_multi_flush_pending(api)
+        check_unknown_id_fails_after_timeout(api)
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/tests/operators/serve/11_serve_poll_before_registration.txt
+++ b/test/tests/operators/serve/11_serve_poll_before_registration.txt
@@ -1,0 +1,10 @@
+parked-events: [1, 2, 3, 4]
+parked-final-state: completed
+multi-live-events: [5, 6, 7, 8]
+multi-ghost-events: []
+multi-ghost-state: running
+multi-ghost-token-is-initial: True
+multi-returned-before-timeout: True
+never-waited-for-timeout: True
+never-mentions-unknown-id: True
+never-has-events: False


### PR DESCRIPTION
## 🔍 Problem

- A pipeline reports `running` before its operators finished starting: the executor delivers the start response and only then schedules the plan coroutine that runs `ServeImpl::start()`, which registers the serve id at the serve-manager.
- The serve-manager answered `/serve` requests for unregistered ids with an immediate `unknown serve id` error, so the launch-then-poll pattern (the platform's flow) intermittently fails. Measured registration lag reaches ~1.5 s even on an idle machine.
- This made the serve-stop checks in `neo_launch_update.py` flaky on CI (first seen on `main` in run 29108005327), and forces every real client to retry around the error.

## 🛠️ Solution

- Park first-page `/serve` requests for unregistered serve ids in the serve-manager instead of failing, and replay them when the operator registers, with the remainder of their timeout budget.
- Report the `unknown serve id` error only when the request's `timeout` fires before a registration.
- Complete parked polls with an empty running first page on `flush`, so a `/serve-multi` group response is not held back by a still-starting serve.
- Requests with a generated continuation token still fail fast: a fresh registration always starts at the initial token, so waiting can never make them valid.
- Add a regression test that launches hidden `//neo` pipelines via `/pipeline/launch` and polls before/immediately after launch.

## 💬 Review

- Focus: the park/replay lifecycle (`park_get`, replay in `start()`, completion in `flush()`) and the remaining-timeout handling.
- Trade-off: a poll for a typo'd serve id now errors after the request timeout instead of immediately.
- Verified locally against a CE static build: full serve suite green (8 repeat runs), and 20/20 runs of the previously flaky `neo_launch_update` test.