### PR TITLE
Make infer_type non-optional

### DIFF
--- a/libtenzir/builtins/operators/accept_http.cpp
+++ b/libtenzir/builtins/operators/accept_http.cpp
@@ -746,7 +746,7 @@ public:
       if (output.is_error()) {
         return {};
       }
-      if (not *output or (*output)->is_not<table_slice>()) {
+      if (output->is_not<table_slice>()) {
         diagnostic::error("pipeline must return events")
           .primary(parser.source.subloc(0, 1))
           .emit(ctx);

--- a/libtenzir/builtins/operators/accept_tcp.cpp
+++ b/libtenzir/builtins/operators/accept_tcp.cpp
@@ -583,7 +583,7 @@ public:
       if (output.is_error()) {
         return {};
       }
-      if (not *output or (*output)->is_not<table_slice>()) {
+      if (output->is_not<table_slice>()) {
         diagnostic::error("pipeline must return events")
           .primary(pipeline.source.subloc(0, 1))
           .emit(ctx);

--- a/libtenzir/builtins/operators/accept_unix_socket.cpp
+++ b/libtenzir/builtins/operators/accept_unix_socket.cpp
@@ -211,7 +211,7 @@ public:
       if (output.is_error()) {
         return {};
       }
-      if (not *output or (*output)->is_not<table_slice>()) {
+      if (output->is_not<table_slice>()) {
         diagnostic::error("pipeline must return events")
           .primary(pipeline.source.subloc(0, 1))
           .emit(ctx);

--- a/libtenzir/builtins/operators/cache.cpp
+++ b/libtenzir/builtins/operators/cache.cpp
@@ -1221,10 +1221,12 @@ public:
   }
 
   auto infer_type(element_type_tag input, diagnostic_handler& dh) const
-    -> failure_or<std::optional<element_type_tag>> override {
+    -> failure_or<element_type_tag> override {
     if (not mode_value_) {
-      // Mode not yet resolved; defer type inference.
-      return std::optional<element_type_tag>{};
+      diagnostic::error("`cache --mode` must be a constant")
+        .primary(op_loc_)
+        .emit(dh);
+      return failure::promise();
     }
     if (*mode_value_ == "write") {
       if (input.is_not<table_slice>()) {

--- a/libtenzir/builtins/operators/cron.cpp
+++ b/libtenzir/builtins/operators/cron.cpp
@@ -121,7 +121,7 @@ public:
       if (auto pipe = ctx.get(pipe_arg)) {
         auto output = pipe->inner.infer_type(tag_v<void>, ctx);
         if (not output.is_error()) {
-          if (not *output or (*output)->is_not<table_slice>()) {
+          if (output->is_not<table_slice>()) {
             diagnostic::error("pipeline must return events")
               .primary(pipe->source.subloc(0, 1))
               .emit(ctx);

--- a/libtenzir/builtins/operators/each.cpp
+++ b/libtenzir/builtins/operators/each.cpp
@@ -159,18 +159,18 @@ public:
         TRY(auto p, ctx.get(pipe));
         auto null_dh = null_diagnostic_handler{};
         auto result = p.inner.infer_type(tag_v<void>, null_dh);
-        if (not result or not *result) {
+        if (not result) {
           diagnostic::error("pipeline inside `each` must be a source")
             .primary(p.source)
             .emit(ctx);
           return failure::promise();
         }
-        if (**result == tag_v<table_slice>) {
+        if (*result == tag_v<table_slice>) {
           return [](EachArgs args) {
             return Each{std::move(args)};
           };
         }
-        if (**result == tag_v<void>) {
+        if (*result == tag_v<void>) {
           return [](EachArgs args) {
             return EachSink{std::move(args)};
           };

--- a/libtenzir/builtins/operators/every.cpp
+++ b/libtenzir/builtins/operators/every.cpp
@@ -390,14 +390,8 @@ public:
       } else {
         TRY(auto p, ctx.get(pipe));
         TRY(auto output, p.inner.infer_type(tag_v<Input>, ctx));
-        if (not output) {
-          // Output type not yet determined; default to events.
-          return [](EveryArgs args) {
-            return Every<Input, table_slice>{std::move(args)};
-          };
-        }
         return match(
-          *output,
+          output,
           [](tag<table_slice>)
             -> failure_or<Option<SpawnWith<EveryArgs, Input>>> {
             return [](EveryArgs args) {

--- a/libtenzir/builtins/operators/fork.cpp
+++ b/libtenzir/builtins/operators/fork.cpp
@@ -332,10 +332,10 @@ public:
     d.validate([pipe](DescribeCtx& ctx) -> Empty {
       TRY(auto p, ctx.get(pipe));
       auto output = p.inner.infer_type(tag_v<table_slice>, ctx);
-      if (output.is_error() or not output->has_value()) {
+      if (output.is_error()) {
         return {};
       }
-      if (output->value().is_not<void>()) {
+      if (output->is_not<void>()) {
         diagnostic::error("subpipeline must end in a sink")
           .primary(p.source)
           .emit(ctx);

--- a/libtenzir/builtins/operators/fork_merge.cpp
+++ b/libtenzir/builtins/operators/fork_merge.cpp
@@ -159,7 +159,7 @@ public:
   }
 
   auto infer_type(element_type_tag input, diagnostic_handler& dh) const
-    -> failure_or<std::optional<element_type_tag>> override {
+    -> failure_or<element_type_tag> override {
     if (input.is_not<table_slice>()) {
       diagnostic::error("`fork_merge` expects events as input")
         .primary(args_.keyword)
@@ -168,10 +168,7 @@ public:
     }
     for (auto i = size_t{0}; i < args_.branches.size(); ++i) {
       TRY(auto branch_ty, args_.branches[i].infer_type(input, dh));
-      if (not branch_ty) {
-        continue;
-      }
-      if (branch_ty->is_not<table_slice>()) {
+      if (branch_ty.is_not<table_slice>()) {
         diagnostic::error("`fork_merge` subpipelines must produce events")
           .primary(args_.locations[i])
           .emit(dh);

--- a/libtenzir/builtins/operators/from_ftp.cpp
+++ b/libtenzir/builtins/operators/from_ftp.cpp
@@ -279,7 +279,7 @@ public:
       if (output.is_error()) {
         return {};
       }
-      if (not *output or (*output)->is_not<table_slice>()) {
+      if (output->is_not<table_slice>()) {
         diagnostic::error("pipeline must return events")
           .primary(parser.source.subloc(0, 1))
           .emit(ctx);

--- a/libtenzir/builtins/operators/from_http.cpp
+++ b/libtenzir/builtins/operators/from_http.cpp
@@ -1395,7 +1395,7 @@ public:
       if (auto parser = ctx.get(parser_arg)) {
         auto output = parser->inner.infer_type(tag_v<chunk_ptr>, ctx);
         if (not output.is_error()) {
-          if (not *output or (*output)->is_not<table_slice>()) {
+          if (output->is_not<table_slice>()) {
             diagnostic::error("pipeline must return events")
               .primary(parser->source.subloc(0, 1))
               .emit(ctx);

--- a/libtenzir/builtins/operators/from_stdin.cpp
+++ b/libtenzir/builtins/operators/from_stdin.cpp
@@ -346,9 +346,8 @@ public:
       if (output.is_error()) {
         return {};
       }
-      // XXX: When can output be nullopt?
       // FIXME: `spawn_sub` cannot spawn pipelines returning void.
-      if (*output and (*output)->is_not<table_slice>()) {
+      if (output->is_not<table_slice>()) {
         diagnostic::error("pipeline must return events")
           .primary(pipe.source.subloc(0, 1))
           .emit(ctx);

--- a/libtenzir/builtins/operators/from_tcp.cpp
+++ b/libtenzir/builtins/operators/from_tcp.cpp
@@ -242,7 +242,7 @@ public:
       if (output.is_error()) {
         return {};
       }
-      if (not *output or (*output)->is_not<table_slice>()) {
+      if (output->is_not<table_slice>()) {
         diagnostic::error("pipeline must return events")
           .primary(pipeline.source.subloc(0, 1))
           .emit(ctx);

--- a/libtenzir/builtins/operators/from_to_2.cpp
+++ b/libtenzir/builtins/operators/from_to_2.cpp
@@ -184,7 +184,7 @@ public:
   }
 
   auto infer_type(element_type_tag input, diagnostic_handler& dh) const
-    -> failure_or<std::optional<element_type_tag>> override {
+    -> failure_or<element_type_tag> override {
     if (input.is_not<void>()) {
       diagnostic::error("expected void, got {}", input).primary(self_).emit(dh);
       return failure::promise();

--- a/libtenzir/builtins/operators/from_unix_socket.cpp
+++ b/libtenzir/builtins/operators/from_unix_socket.cpp
@@ -136,7 +136,7 @@ public:
       if (output.is_error()) {
         return {};
       }
-      if (not *output or (*output)->is_not<table_slice>()) {
+      if (output->is_not<table_slice>()) {
         diagnostic::error("pipeline must return events")
           .primary(pipeline.source.subloc(0, 1))
           .emit(ctx);

--- a/libtenzir/builtins/operators/group.cpp
+++ b/libtenzir/builtins/operators/group.cpp
@@ -176,14 +176,8 @@ public:
       if constexpr (std::same_as<Input, table_slice>) {
         TRY(auto pipe, ctx.get(pipe));
         TRY(auto output, pipe.inner.infer_type(tag_v<table_slice>, ctx));
-        if (not output) {
-          diagnostic::error("subpipeline must not produce bytes")
-            .primary(pipe.source)
-            .emit(ctx);
-          return failure::promise();
-        }
         return match(
-          *output,
+          output,
           [](tag<table_slice>)
             -> failure_or<Option<SpawnWith<GroupArgs, Input>>> {
             return [](GroupArgs args) {

--- a/libtenzir/builtins/operators/load_balance.cpp
+++ b/libtenzir/builtins/operators/load_balance.cpp
@@ -544,10 +544,10 @@ public:
       }
       TRY(auto p, ctx.get(pipe));
       auto output = p.inner.infer_type(tag_v<table_slice>, ctx);
-      if (output.is_error() or not output->has_value()) {
+      if (output.is_error()) {
         return {};
       }
-      if (output->value().is_not<void>()) {
+      if (output->is_not<void>()) {
         diagnostic::error("pipeline must currently end with a sink")
           .primary(p.source)
           .emit(ctx);

--- a/libtenzir/builtins/operators/optimize_barrier.cpp
+++ b/libtenzir/builtins/operators/optimize_barrier.cpp
@@ -41,7 +41,7 @@ public:
   }
 
   auto infer_type(element_type_tag input, diagnostic_handler&) const
-    -> failure_or<std::optional<element_type_tag>> override {
+    -> failure_or<element_type_tag> override {
     return input;
   }
 

--- a/libtenzir/builtins/operators/optimize_reorder.cpp
+++ b/libtenzir/builtins/operators/optimize_reorder.cpp
@@ -41,7 +41,7 @@ public:
   }
 
   auto infer_type(element_type_tag input, diagnostic_handler&) const
-    -> failure_or<std::optional<element_type_tag>> override {
+    -> failure_or<element_type_tag> override {
     return input;
   }
 

--- a/libtenzir/builtins/operators/serve_http.cpp
+++ b/libtenzir/builtins/operators/serve_http.cpp
@@ -687,7 +687,7 @@ public:
       if (output.is_error()) {
         return {};
       }
-      if (not *output or (*output)->is_not<chunk_ptr>()) {
+      if (output->is_not<chunk_ptr>()) {
         diagnostic::error("pipeline must return bytes")
           .primary(printer.source)
           .emit(ctx);

--- a/libtenzir/builtins/operators/serve_tcp.cpp
+++ b/libtenzir/builtins/operators/serve_tcp.cpp
@@ -572,7 +572,7 @@ public:
       if (output.is_error()) {
         return {};
       }
-      if (not *output or (*output)->is_not<chunk_ptr>()) {
+      if (output->is_not<chunk_ptr>()) {
         diagnostic::error("pipeline must return bytes")
           .primary(printer.source.subloc(0, 1))
           .emit(ctx);

--- a/libtenzir/builtins/operators/strict.cpp
+++ b/libtenzir/builtins/operators/strict.cpp
@@ -243,11 +243,8 @@ struct strict : public virtual operator_plugin2<strict_operator>,
                 -> failure_or<Option<SpawnWith<StrictArgs, Input>>> {
       TRY(auto p, ctx.get(pipe));
       TRY(auto output, p.inner.infer_type(tag_v<Input>, ctx));
-      if (not output) {
-        return {};
-      }
       return match(
-        *output,
+        output,
         [](tag<table_slice>)
           -> failure_or<Option<SpawnWith<StrictArgs, Input>>> {
           return [](StrictArgs args) {

--- a/libtenzir/builtins/operators/summarize.cpp
+++ b/libtenzir/builtins/operators/summarize.cpp
@@ -1038,7 +1038,7 @@ public:
   }
 
   auto infer_type(element_type_tag input, diagnostic_handler& dh) const
-    -> failure_or<std::optional<element_type_tag>> override {
+    -> failure_or<element_type_tag> override {
     if (input.is_not<table_slice>()) {
       diagnostic::error("operator expects events").primary(self_).emit(dh);
       return failure::promise();

--- a/libtenzir/builtins/operators/to_ftp.cpp
+++ b/libtenzir/builtins/operators/to_ftp.cpp
@@ -362,7 +362,7 @@ public:
       if (output.is_error()) {
         return {};
       }
-      if (not *output or (*output)->is_not<chunk_ptr>()) {
+      if (output->is_not<chunk_ptr>()) {
         diagnostic::error("pipeline must return bytes")
           .primary(printer.source.subloc(0, 1))
           .emit(ctx);

--- a/libtenzir/builtins/operators/to_http.cpp
+++ b/libtenzir/builtins/operators/to_http.cpp
@@ -780,7 +780,7 @@ public:
       if (output.is_error()) {
         return {};
       }
-      if (not *output or (*output)->is_not<chunk_ptr>()) {
+      if (output->is_not<chunk_ptr>()) {
         diagnostic::error("pipeline must return bytes")
           .primary(printer.source.subloc(0, 1))
           .emit(ctx);

--- a/libtenzir/builtins/operators/to_stdout.cpp
+++ b/libtenzir/builtins/operators/to_stdout.cpp
@@ -394,7 +394,7 @@ public:
       if (output.is_error()) {
         return {};
       }
-      if (not *output or (*output)->is_not<chunk_ptr>()) {
+      if (output->is_not<chunk_ptr>()) {
         diagnostic::error("pipeline must return bytes")
           .primary(pipe->source.subloc(0, 1))
           .emit(ctx);

--- a/libtenzir/builtins/operators/to_tcp.cpp
+++ b/libtenzir/builtins/operators/to_tcp.cpp
@@ -200,7 +200,7 @@ public:
       if (output.is_error()) {
         return {};
       }
-      if (not *output or (*output)->is_not<chunk_ptr>()) {
+      if (output->is_not<chunk_ptr>()) {
         diagnostic::error("pipeline must return bytes")
           .primary(printer.source.subloc(0, 1))
           .emit(ctx);

--- a/libtenzir/builtins/operators/to_unix_socket.cpp
+++ b/libtenzir/builtins/operators/to_unix_socket.cpp
@@ -149,7 +149,7 @@ public:
       if (output.is_error()) {
         return {};
       }
-      if (not *output or (*output)->is_not<chunk_ptr>()) {
+      if (output->is_not<chunk_ptr>()) {
         diagnostic::error("pipeline must return bytes")
           .primary(printer.source.subloc(0, 1))
           .emit(ctx);

--- a/libtenzir/builtins/operators/unordered.cpp
+++ b/libtenzir/builtins/operators/unordered.cpp
@@ -45,7 +45,7 @@ public:
   }
 
   auto infer_type(element_type_tag input, diagnostic_handler& dh) const
-    -> failure_or<std::optional<element_type_tag>> override {
+    -> failure_or<element_type_tag> override {
     return pipeline_.infer_type(input, dh);
   }
 

--- a/libtenzir/builtins/operators/version.cpp
+++ b/libtenzir/builtins/operators/version.cpp
@@ -216,7 +216,7 @@ public:
   }
 
   auto infer_type(element_type_tag input, diagnostic_handler& dh) const
-    -> failure_or<std::optional<element_type_tag>> override {
+    -> failure_or<element_type_tag> override {
     // TODO: Refactor.
     if (not input.is<void>()) {
       diagnostic::error("expected void, got {}", input)

--- a/libtenzir/builtins/operators/where_map.cpp
+++ b/libtenzir/builtins/operators/where_map.cpp
@@ -882,7 +882,7 @@ public:
   }
 
   auto infer_type(element_type_tag input, diagnostic_handler& dh) const
-    -> failure_or<std::optional<element_type_tag>> override {
+    -> failure_or<element_type_tag> override {
     if (input.is_not<table_slice>()) {
       // TODO: Do not duplicate these messages across the codebase.
       diagnostic::error("operator expects events").primary(self_).emit(dh);

--- a/libtenzir/builtins/operators/window.cpp
+++ b/libtenzir/builtins/operators/window.cpp
@@ -540,14 +540,8 @@ public:
       if constexpr (std::same_as<Input, table_slice>) {
         TRY(auto p, ctx.get(pipe));
         TRY(auto output, p.inner.infer_type(tag_v<table_slice>, ctx));
-        if (not output) {
-          diagnostic::error("subpipeline must not produce bytes")
-            .primary(p.source)
-            .emit(ctx);
-          return failure::promise();
-        }
         return match(
-          *output,
+          output,
           [](tag<table_slice>)
             -> failure_or<Option<SpawnWith<WindowArgs, Input>>> {
             return [](WindowArgs args) {

--- a/libtenzir/include/tenzir/arrow_fs.hpp
+++ b/libtenzir/include/tenzir/arrow_fs.hpp
@@ -95,7 +95,7 @@ struct FromArrowFsArgs {
       if (output.is_error()) {
         return {};
       }
-      if (*output and (*output)->template is<chunk_ptr>()) {
+      if (output->template is<chunk_ptr>()) {
         diagnostic::error("pipeline must not return bytes")
           .primary(pipe)
           .emit(ctx);
@@ -386,7 +386,7 @@ struct ToArrowFsArgs {
       if (output.is_error()) {
         return {};
       }
-      if (not *output or (*output)->template is_not<chunk_ptr>()) {
+      if (output->template is_not<chunk_ptr>()) {
         diagnostic::error("pipeline must return bytes").primary(pipe).emit(ctx);
       }
       extra(ctx);

--- a/libtenzir/include/tenzir/ir.hpp
+++ b/libtenzir/include/tenzir/ir.hpp
@@ -48,11 +48,11 @@ public:
 
   /// Return the output type of this operator for a given input type.
   ///
-  /// The operator is responsible to report any type mismatches. If the
-  /// operator could potentially accept the given input type, but the output
-  /// type is not known yet, then `std::nullopt` may be returned.
+  /// The operator is responsible to report any type mismatches. This is only
+  /// called after instantiation, so the output type is always determinable.
   virtual auto infer_type(element_type_tag input, diagnostic_handler& dh) const
-    -> failure_or<std::optional<element_type_tag>>;
+    -> failure_or<element_type_tag>
+    = 0;
 
   /// Substitute variables from the context and potentially instantiate `this`.
   ///
@@ -135,7 +135,7 @@ struct pipeline {
 
   /// @see Operator
   auto infer_type(element_type_tag input, diagnostic_handler& dh) const
-    -> failure_or<std::optional<element_type_tag>>;
+    -> failure_or<element_type_tag>;
 
   // TODO: How do we take care that we don't propagate $-vars past the point
   // where they will be defined?
@@ -207,7 +207,7 @@ public:
                 event_order order) && -> optimize_result override;
 
   auto infer_type(element_type_tag input, diagnostic_handler& dh) const
-    -> failure_or<std::optional<element_type_tag>> override;
+    -> failure_or<element_type_tag> override;
 
   template <class Inspector>
   friend auto inspect(Inspector& f, SetIr& x) -> bool;

--- a/libtenzir/src/async/executor.cpp
+++ b/libtenzir/src/async/executor.cpp
@@ -834,17 +834,16 @@ private:
     // type-checks against `input`. And since optimizations are type-preserving,
     // we know that this cannot fail.
     TENZIR_ASSERT(output);
-    TENZIR_ASSERT(*output);
     auto spawned = std::move(pipe).spawn(input);
     if (spawned.empty()) {
-      TENZIR_ASSERT(**output == input);
+      TENZIR_ASSERT(*output == input);
       spawned.push_back(make_identity_operator(input));
     }
     auto [from_control_sender, from_control_receiver]
       = channel<FromControl>(16);
     auto [to_control_sender, to_control_receiver] = channel<ToControl>(16);
     auto [runner, push_sub, pull_sub] = match(
-      std::tie(input, **output),
+      std::tie(input, *output),
       [&]<class In, class Out>(
         tag<In>, tag<Out>) -> std::tuple<Task<void>, AnyOpPush, AnyOpPull> {
         auto chain

--- a/libtenzir/src/ir.cpp
+++ b/libtenzir/src/ir.cpp
@@ -298,7 +298,7 @@ auto ir::SetIr::optimize(ir::optimize_filter filter,
 }
 
 auto ir::SetIr::infer_type(element_type_tag input, diagnostic_handler& dh) const
-  -> failure_or<std::optional<element_type_tag>> {
+  -> failure_or<element_type_tag> {
   if (input.is_not<table_slice>()) {
     diagnostic::error("set operator expected events").emit(dh);
     return failure::promise();
@@ -541,7 +541,7 @@ public:
     auto null_dh = null_diagnostic_handler{};
     auto outputs_events = [&](ir::pipeline const& pipe) -> bool {
       auto t = pipe.infer_type(tag_v<table_slice>, null_dh);
-      return t and *t and (**t).is<table_slice>();
+      return t and (*t).is<table_slice>();
     };
     auto optimize_branch
       = [&](ir::pipeline& branch, ir::optimize_filter f) -> event_order {
@@ -580,15 +580,15 @@ public:
     TENZIR_ASSERT(input.is<table_slice>());
     auto dh = null_diagnostic_handler{};
     auto output = infer_type(input, dh);
-    TENZIR_ASSERT(output and *output);
-    if ((**output).is<void>()) {
+    TENZIR_ASSERT(output);
+    if ((*output).is<void>()) {
       return IfSink{std::move(args_)}.with_name("if");
     }
     return If{std::move(args_)}.with_name("if");
   }
 
   auto infer_type(element_type_tag input, diagnostic_handler& dh) const
-    -> failure_or<std::optional<element_type_tag>> override {
+    -> failure_or<element_type_tag> override {
     // A branch may be empty (or contain only `let`s), in which case it has no
     // operator to point at. Fall back to the condition's location, which is
     // always present.
@@ -599,41 +599,35 @@ public:
       return args_.condition.get_location();
     };
     TRY(auto then_ty, args_.consequence.infer_type(input, dh));
-    auto else_ty = std::optional{input};
+    auto else_ty = input;
     if (args_.alternative) {
       TRY(else_ty, args_.alternative->infer_type(input, dh));
     }
-    if (then_ty and then_ty->is<chunk_ptr>()) {
+    if (then_ty.is<chunk_ptr>()) {
       diagnostic::error("branches must not return bytes")
         .primary(branch_location(args_.consequence))
         .emit(dh);
       return failure::promise();
     }
-    if (args_.alternative and else_ty and else_ty->is<chunk_ptr>()) {
+    if (args_.alternative and else_ty.is<chunk_ptr>()) {
       diagnostic::error("branches must not return bytes")
         .primary(branch_location(*args_.alternative))
         .emit(dh);
       return failure::promise();
     }
-    if (not then_ty) {
-      return else_ty;
-    }
-    if (not else_ty) {
+    if (then_ty == else_ty) {
       return then_ty;
     }
-    if (*then_ty == *else_ty) {
-      return then_ty;
-    }
-    if (then_ty->is<void>()) {
+    if (then_ty.is<void>()) {
       return else_ty;
     }
-    if (else_ty->is<void>()) {
+    if (else_ty.is<void>()) {
       return then_ty;
     }
     // TODO: Improve diagnostic.
     auto diag = diagnostic::error("incompatible branch output types: {} and {}",
-                                  operator_type_name(*then_ty),
-                                  operator_type_name(*else_ty))
+                                  operator_type_name(then_ty),
+                                  operator_type_name(else_ty))
                   .primary(branch_location(args_.consequence));
     if (args_.alternative) {
       diag = std::move(diag).secondary(branch_location(*args_.alternative));
@@ -883,21 +877,19 @@ auto ir::pipeline::spawn(element_type_tag input) && -> std::vector<AnyOperator> 
     auto dh = null_diagnostic_handler{};
     auto output = op->infer_type(input, dh);
     TENZIR_ASSERT(output);
-    TENZIR_ASSERT(*output);
     if (auto spawned = std::move(*op).spawn(input)) {
       result.push_back(std::move(*spawned));
     }
-    input = **output;
+    input = *output;
   }
   return result;
 }
 
 auto ir::pipeline::infer_type(element_type_tag input,
                               diagnostic_handler& dh) const
-  -> failure_or<std::optional<element_type_tag>> {
+  -> failure_or<element_type_tag> {
   for (auto& op : operators) {
-    TRY(auto output, op->infer_type(input, dh));
-    TRY(input, output);
+    TRY(input, op->infer_type(input, dh));
     // TODO: What if we get void in the middle?
   }
   return input;
@@ -961,14 +953,6 @@ auto ir::Operator::copy() const -> Box<Operator> {
 auto ir::Operator::move() && -> Box<Operator> {
   // TODO: This should be overriden by something like CRTP.
   return copy();
-}
-
-auto ir::Operator::infer_type(element_type_tag input,
-                              diagnostic_handler& dh) const
-  -> failure_or<std::optional<element_type_tag>> {
-  // TODO: Is this a good default to have? Should probably be pure virtual.
-  (void)input, (void)dh;
-  return std::nullopt;
 }
 
 auto operator_compiler_plugin::operator_name() const -> std::string {

--- a/libtenzir/src/ir_match.cpp
+++ b/libtenzir/src/ir_match.cpp
@@ -510,15 +510,15 @@ public:
     TENZIR_ASSERT(input.is<table_slice>());
     auto dh = null_diagnostic_handler{};
     auto output = infer_type(input, dh);
-    TENZIR_ASSERT(output and *output);
-    if ((**output).is<void>()) {
+    TENZIR_ASSERT(output);
+    if ((*output).is<void>()) {
       return MatchSink{std::move(args_)}.with_name("match");
     }
     return Match{std::move(args_)}.with_name("match");
   }
 
   auto infer_type(element_type_tag input, diagnostic_handler& dh) const
-    -> failure_or<std::optional<element_type_tag>> override {
+    -> failure_or<element_type_tag> override {
     if (input.is_not<table_slice>()) {
       diagnostic::error("match operator expected events").emit(dh);
       return failure::promise();
@@ -528,7 +528,7 @@ public:
     for (auto const& arm : args_.arms) {
       has_wildcard = has_wildcard or arm.wildcard;
       TRY(auto branch_ty, arm.pipeline.infer_type(input, dh));
-      if (branch_ty and branch_ty->is<chunk_ptr>()) {
+      if (branch_ty.is<chunk_ptr>()) {
         diagnostic::error("branches must not return bytes")
           .primary(arm.source)
           .emit(dh);
@@ -538,7 +538,9 @@ public:
           combine_branch_types(result, branch_ty, args_.match_keyword, dh));
     }
     TENZIR_ASSERT(has_wildcard);
-    return result;
+    // A match always has a wildcard arm, so at least one branch contributed.
+    TENZIR_ASSERT(result);
+    return *result;
   }
 
   friend auto inspect(auto& f, MatchIr& x) -> bool {

--- a/libtenzir/src/operator_plugin.cpp
+++ b/libtenzir/src/operator_plugin.cpp
@@ -364,7 +364,7 @@ public:
   }
 
   auto infer_type(element_type_tag input, diagnostic_handler& dh) const
-    -> failure_or<std::optional<element_type_tag>> override {
+    -> failure_or<element_type_tag> override {
     if (desc_->spawner) {
       auto ctx = DescribeCtx{args_,  named_args_,     pipeline_,
                              *desc_, main_location(), dh};

--- a/libtenzir/src/partition_transformer.cpp
+++ b/libtenzir/src/partition_transformer.cpp
@@ -396,15 +396,10 @@ auto compile_table_slice_transform(ast::pipeline ast, diagnostic_handler& dh)
   auto sub_ctx = substitute_ctx{b_ctx, nullptr};
   TRY(ir.substitute(sub_ctx, true));
   TRY(auto output, ir.infer_type(tag_v<table_slice>, dh));
-  if (not output) {
-    diagnostic::error("partition transform: pipeline output type is unknown")
-      .emit(dh);
-    return failure::promise();
-  }
-  if (not output->is<table_slice>()) {
+  if (not output.is<table_slice>()) {
     diagnostic::error("partition transform: pipeline must produce events, "
                       "got {}",
-                      *output)
+                      output)
       .emit(dh);
     return failure::promise();
   }

--- a/libtenzir/src/tql2/exec.cpp
+++ b/libtenzir/src/tql2/exec.cpp
@@ -2283,15 +2283,13 @@ auto exec_with_ir(ast::pipeline ast, const exec_config& cfg, session ctx,
   auto null_dh = null_diagnostic_handler{};
   auto output = Option<element_type_tag>{};
   auto implicit_source = Option<std::string_view>{};
-  if (auto inferred = ir.infer_type(tag_v<void>, null_dh);
-      inferred and *inferred) {
-    output = **inferred;
+  if (auto inferred = ir.infer_type(tag_v<void>, null_dh); inferred) {
+    output = *inferred;
   } else if (auto inferred = ir.infer_type(tag_v<chunk_ptr>, null_dh);
-             inferred and *inferred and not cfg.implicit_bytes_source.empty()) {
+             inferred and not cfg.implicit_bytes_source.empty()) {
     implicit_source = cfg.implicit_bytes_source;
   } else if (auto inferred = ir.infer_type(tag_v<table_slice>, null_dh);
-             inferred and *inferred
-             and not cfg.implicit_events_source.empty()) {
+             inferred and not cfg.implicit_events_source.empty()) {
     implicit_source = cfg.implicit_events_source;
   } else {
     TRY(output, ir.infer_type(tag_v<void>, ctx));
@@ -2304,8 +2302,7 @@ auto exec_with_ir(ast::pipeline ast, const exec_config& cfg, session ctx,
     ir.operators.insert(ir.operators.begin(),
                         std::move_iterator{implicit.operators.begin()},
                         std::move_iterator{implicit.operators.end()});
-    TRY(auto inferred_after_source, ir.infer_type(tag_v<void>, ctx));
-    output = *inferred_after_source;
+    TRY(output, ir.infer_type(tag_v<void>, ctx));
   }
   if (output.is_none()) {
     // TODO: Improve?

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -1,5 +1,5 @@
 {
-  "hash": "sha256-Uj8S1nPba/jG/N08hLQo9b5zBcjSP5dVWKJVGxT0oYw=",
+  "hash": "sha256-HcXiepW5B7nrnq0U80Fao4ovOz0HesI+rKf+A/POtmk=",
   "name": "tenzir-plugins.tar.gz",
-  "url": "https://github.com/tenzir/tenzir-plugins/archive/c8e5a1a47086865d83c52dccabaf7c32ef87212e.tar.gz"
+  "url": "https://github.com/tenzir/tenzir-plugins/archive/17d24999a4404619993ed46a27519291a5589388.tar.gz"
 }

--- a/plugins/nic/builtins/from_nic.cpp
+++ b/plugins/nic/builtins/from_nic.cpp
@@ -540,7 +540,7 @@ public:
         if (output.is_error()) {
           return {};
         }
-        if (not *output or (*output)->is_not<table_slice>()) {
+        if (output->is_not<table_slice>()) {
           diagnostic::error("pipeline must return events")
             .primary(parser_value->source.subloc(0, 1))
             .emit(ctx);

--- a/plugins/zmq/builtins/from_zmq.cpp
+++ b/plugins/zmq/builtins/from_zmq.cpp
@@ -347,7 +347,7 @@ public:
       if (output.is_error()) {
         return {};
       }
-      if (not *output or (*output)->template is_not<table_slice>()) {
+      if (output->template is_not<table_slice>()) {
         diagnostic::error("pipeline must return events")
           .primary(parser.source.subloc(0, 1))
           .emit(ctx);


### PR DESCRIPTION
## 🔍 Problem

`ir::Operator::infer_type` used to be able to return `std::optional`, which was supposed to mean "cannot be inferred yet". This is not really needed - only usage was `cache --mode`, which does not need to be dynamic.

## 🛠️ Solution

- `infer_type` now returns `failure_or<element_type_tag>` directly and is pure virtual.
- All operator implementations drop the `std::nullopt` / "unknown type" arms.
- `cache` returns a diagnostic error when its mode is not yet resolved (the one remaining path that cannot determine the type), cleanly covering the static type-probing codepath.

## 💬 Review

Mostly mechanical: every `infer_type` override changes its return type and drops the optional layer. The only non-trivial case is `cache`, which now returns an error instead of `std::nullopt` when mode resolution hasn't happened yet — reviewers should confirm this is the right behavior for the static probing path.

<sub>
📎 Related: tenzir/tenzir-plugins#585
</sub>