### PR TITLE
Log workspace and node id on platform connect

### DIFF
--- a/changelog/unreleased/workspace-and-node-id-in-platform-connection-logs.md
+++ b/changelog/unreleased/workspace-and-node-id-in-platform-connection-logs.md
@@ -1,0 +1,17 @@
+---
+title: Workspace and node id in platform connection logs
+type: change
+authors:
+  - lava
+prs:
+  - 6450
+created: 2026-07-15T14:11:30.97802Z
+---
+
+The log message emitted when a node connects to the Tenzir Platform now names
+the workspace it authenticated into. Nodes that self-register with a workspace
+registration key additionally print their own node id:
+
+```
+node connected to platform via wss://ws.tenzir.app:443/production into workspace t-abcd1234 as node ne-1a2b3c4d
+```

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -1,5 +1,5 @@
 {
-  "hash": "sha256-9ZT2VWZqlj/FNPUTIpxW6f+yCv1wxgG0ugiv6R5i4u8=",
+  "hash": "sha256-vRH9M/1kjwu+9spMeXjg2t2ZEjRbN10bEoEOTAx5tGg=",
   "name": "tenzir-plugins.tar.gz",
-  "url": "https://github.com/tenzir/tenzir-plugins/archive/517a9d152611b21c14a8e2a603b034783d6cf8d4.tar.gz"
+  "url": "https://github.com/tenzir/tenzir-plugins/archive/acc5d128ba4abc91f461581ca1d0aefdf5195be6.tar.gz"
 }


### PR DESCRIPTION
## 🔍 Problem

The "node connected to platform" log line only names the control endpoint, so logs don't show which workspace a node authenticated into or which node identity it assumed.

## 🛠️ Solution

Bump the `tenzir-plugins` submodule so the platform plugin logs the workspace and, for self-registered nodes, its own node id after a successful connection:

```
node connected to platform via wss://… into workspace <id> as node ne-…
```

Nodes authenticating with an api key print only the workspace, since the platform manages their node id and never sends it back during the handshake.

## 💬 Review

- Submodule bump plus changelog entry only; the code change is in the companion plugins PR.

<sub>
📎 Related: tenzir/tenzir-plugins#586
</sub>
