### PR TITLE
Refactor IR operator spawning

### DIFF
--- a/libtenzir/builtins/operators/cache.cpp
+++ b/libtenzir/builtins/operators/cache.cpp
@@ -1373,11 +1373,11 @@ public:
     return {};
   }
 
-  auto spawn(element_type_tag input) && -> Option<AnyOperator> override {
+  auto spawn(element_type_tag input) const -> AnyOperator override {
     TENZIR_ASSERT(mode_value_);
     TENZIR_ASSERT(id_value_);
     auto args = CacheArgs{};
-    args.id = std::move(*id_value_);
+    args.id = *id_value_;
     args.mode = *mode_value_;
     args.capacity = capacity_value_;
     args.read_timeout

--- a/libtenzir/builtins/operators/fork_merge.cpp
+++ b/libtenzir/builtins/operators/fork_merge.cpp
@@ -178,9 +178,9 @@ public:
     return tag_v<table_slice>;
   }
 
-  auto spawn(element_type_tag input) && -> Option<AnyOperator> override {
+  auto spawn(element_type_tag input) const -> AnyOperator override {
     TENZIR_ASSERT(input.is<table_slice>());
-    return ForkMerge{std::move(args_)}.with_name("fork_merge");
+    return ForkMerge{args_}.with_name("fork_merge");
   }
 
   friend auto inspect(auto& f, ForkMergeIr& x) -> bool {

--- a/libtenzir/builtins/operators/from_to_2.cpp
+++ b/libtenzir/builtins/operators/from_to_2.cpp
@@ -178,9 +178,9 @@ public:
     return {};
   }
 
-  auto spawn(element_type_tag input) && -> Option<AnyOperator> override {
+  auto spawn(element_type_tag input) const -> AnyOperator override {
     TENZIR_ASSERT(input.is<void>());
-    return From{std::move(events_)}.with_name("from");
+    return From{events_}.with_name("from");
   }
 
   auto infer_type(element_type_tag input, diagnostic_handler& dh) const

--- a/libtenzir/builtins/operators/optimize_barrier.cpp
+++ b/libtenzir/builtins/operators/optimize_barrier.cpp
@@ -9,6 +9,7 @@
 #include <tenzir/async.hpp>
 #include <tenzir/compile_ctx.hpp>
 #include <tenzir/ir.hpp>
+#include <tenzir/panic.hpp>
 #include <tenzir/pipeline.hpp>
 #include <tenzir/plugin.hpp>
 #include <tenzir/substitute_ctx.hpp>
@@ -47,10 +48,8 @@ public:
 
   auto optimize(ir::optimize_filter filter,
                 event_order /*order*/) && -> ir::optimize_result override {
-    // Keep the barrier itself, pin the downstream filter right after it, and
-    // request the strictest ordering from upstream.
+    // Pin the filters and request the strictest ordering from upstream.
     auto replacement = std::vector<Box<ir::Operator>>{};
-    replacement.push_back(std::move(*this).move());
     for (auto& expr : filter) {
       replacement.push_back(make_where_ir(std::move(expr)));
     }
@@ -61,9 +60,9 @@ public:
     };
   }
 
-  auto spawn(element_type_tag) && -> Option<AnyOperator> override {
-    // IR-only: contributes no runtime operator.
-    return None{};
+  auto spawn(element_type_tag) const -> AnyOperator override {
+    panic("cannot spawn optimize_barrier; it must be removed during "
+          "optimization");
   }
 
   friend auto inspect(auto& f, OptimizeBarrierIr& x) -> bool {

--- a/libtenzir/builtins/operators/optimize_reorder.cpp
+++ b/libtenzir/builtins/operators/optimize_reorder.cpp
@@ -9,6 +9,7 @@
 #include <tenzir/async.hpp>
 #include <tenzir/compile_ctx.hpp>
 #include <tenzir/ir.hpp>
+#include <tenzir/panic.hpp>
 #include <tenzir/pipeline.hpp>
 #include <tenzir/plugin.hpp>
 #include <tenzir/substitute_ctx.hpp>
@@ -47,20 +48,18 @@ public:
 
   auto optimize(ir::optimize_filter filter,
                 event_order /*order*/) && -> ir::optimize_result override {
-    // Relax the upstream ordering requirement and forward the downstream filter
-    // unchanged. The operator keeps itself in the IR and is elided in `spawn()`.
-    auto replacement = std::vector<Box<ir::Operator>>{};
-    replacement.push_back(std::move(*this).move());
+    // Relax the upstream ordering requirement and forward the filters
+    // unchanged.
     return {
       std::move(filter),
       event_order::unordered,
-      ir::pipeline{{}, std::move(replacement)},
+      ir::pipeline{{}, {}},
     };
   }
 
-  auto spawn(element_type_tag) && -> Option<AnyOperator> override {
-    // IR-only: contributes no runtime operator.
-    return None{};
+  auto spawn(element_type_tag) const -> AnyOperator override {
+    panic("cannot spawn optimize_reorder; it must be removed during "
+          "optimization");
   }
 
   friend auto inspect(auto& f, OptimizeReorderIr& x) -> bool {

--- a/libtenzir/builtins/operators/summarize.cpp
+++ b/libtenzir/builtins/operators/summarize.cpp
@@ -1032,9 +1032,9 @@ public:
     return {};
   }
 
-  auto spawn(element_type_tag input) && -> Option<AnyOperator> override {
+  auto spawn(element_type_tag input) const -> AnyOperator override {
     TENZIR_ASSERT(input.is<table_slice>());
-    return Summarize{std::move(cfg_)}.with_name("summarize");
+    return Summarize{cfg_}.with_name("summarize");
   }
 
   auto infer_type(element_type_tag input, diagnostic_handler& dh) const

--- a/libtenzir/builtins/operators/unordered.cpp
+++ b/libtenzir/builtins/operators/unordered.cpp
@@ -69,7 +69,7 @@ public:
     };
   }
 
-  auto spawn(element_type_tag) && -> Option<AnyOperator> override {
+  auto spawn(element_type_tag) const -> AnyOperator override {
     panic("Cannot spawn unordered. It should have been optimized away.");
   }
 

--- a/libtenzir/builtins/operators/version.cpp
+++ b/libtenzir/builtins/operators/version.cpp
@@ -210,7 +210,7 @@ public:
     TENZIR_UNUSED(ctx, instantiate);
     return {};
   }
-  auto spawn(element_type_tag input) && -> Option<AnyOperator> override {
+  auto spawn(element_type_tag input) const -> AnyOperator override {
     TENZIR_ASSERT(input.is<void>());
     return Version{}.with_name("version");
   }

--- a/libtenzir/builtins/operators/where_map.cpp
+++ b/libtenzir/builtins/operators/where_map.cpp
@@ -876,9 +876,9 @@ public:
     return {};
   }
 
-  auto spawn(element_type_tag input) && -> Option<AnyOperator> override {
+  auto spawn(element_type_tag input) const -> AnyOperator override {
     TENZIR_ASSERT(input.is<table_slice>());
-    return Where{std::move(predicate_)}.with_name("where");
+    return Where{predicate_}.with_name("where");
   }
 
   auto infer_type(element_type_tag input, diagnostic_handler& dh) const

--- a/libtenzir/include/tenzir/ir.hpp
+++ b/libtenzir/include/tenzir/ir.hpp
@@ -76,11 +76,7 @@ public:
   /// The implementation may assume that the operator was previously
   /// instantiated, i.e., `substitute` was called with `instantiate == true`.
   /// However, other methods such as `optimize` may be called in between.
-  ///
-  /// Returns `None` if the operator has no runtime representation and shall be
-  /// elided when the pipeline is spawned. Such operators exist only in the IR,
-  /// for example to act as optimization barriers.
-  virtual auto spawn(element_type_tag input) && -> Option<AnyOperator> = 0;
+  virtual auto spawn(element_type_tag input) const -> AnyOperator = 0;
 
   /// Return the "main location" of the operator.
   ///
@@ -201,7 +197,7 @@ public:
   auto substitute(substitute_ctx ctx, bool instantiate)
     -> failure_or<void> override;
 
-  auto spawn(element_type_tag input) && -> Option<AnyOperator> override;
+  auto spawn(element_type_tag input) const -> AnyOperator override;
 
   auto optimize(optimize_filter filter,
                 event_order order) && -> optimize_result override;

--- a/libtenzir/src/ir.cpp
+++ b/libtenzir/src/ir.cpp
@@ -249,9 +249,9 @@ auto ir::SetIr::substitute(substitute_ctx ctx, bool instantiate)
   return {};
 }
 
-auto ir::SetIr::spawn(element_type_tag input) && -> Option<AnyOperator> {
+auto ir::SetIr::spawn(element_type_tag input) const -> AnyOperator {
   TENZIR_ASSERT(input.is<table_slice>());
-  return Set{std::move(assignments_), order_}.with_name("set");
+  return Set{assignments_, order_}.with_name("set");
 }
 
 namespace {
@@ -576,15 +576,15 @@ public:
     };
   }
 
-  auto spawn(element_type_tag input) && -> Option<AnyOperator> override {
+  auto spawn(element_type_tag input) const -> AnyOperator override {
     TENZIR_ASSERT(input.is<table_slice>());
     auto dh = null_diagnostic_handler{};
     auto output = infer_type(input, dh);
     TENZIR_ASSERT(output);
     if ((*output).is<void>()) {
-      return IfSink{std::move(args_)}.with_name("if");
+      return IfSink{args_}.with_name("if");
     }
-    return If{std::move(args_)}.with_name("if");
+    return If{args_}.with_name("if");
   }
 
   auto infer_type(element_type_tag input, diagnostic_handler& dh) const
@@ -877,9 +877,7 @@ auto ir::pipeline::spawn(element_type_tag input) && -> std::vector<AnyOperator> 
     auto dh = null_diagnostic_handler{};
     auto output = op->infer_type(input, dh);
     TENZIR_ASSERT(output);
-    if (auto spawned = std::move(*op).spawn(input)) {
-      result.push_back(std::move(*spawned));
-    }
+    result.push_back(op->spawn(input));
     input = *output;
   }
   return result;

--- a/libtenzir/src/ir_match.cpp
+++ b/libtenzir/src/ir_match.cpp
@@ -506,15 +506,15 @@ public:
     return {};
   }
 
-  auto spawn(element_type_tag input) && -> Option<AnyOperator> override {
+  auto spawn(element_type_tag input) const -> AnyOperator override {
     TENZIR_ASSERT(input.is<table_slice>());
     auto dh = null_diagnostic_handler{};
     auto output = infer_type(input, dh);
     TENZIR_ASSERT(output);
     if ((*output).is<void>()) {
-      return MatchSink{std::move(args_)}.with_name("match");
+      return MatchSink{args_}.with_name("match");
     }
-    return Match{std::move(args_)}.with_name("match");
+    return Match{args_}.with_name("match");
   }
 
   auto infer_type(element_type_tag input, diagnostic_handler& dh) const

--- a/libtenzir/src/operator_plugin.cpp
+++ b/libtenzir/src/operator_plugin.cpp
@@ -398,9 +398,7 @@ public:
     return failure::promise();
   }
 
-  auto spawn(element_type_tag input) && -> Option<AnyOperator> override {
-    // The spawner must be retrieved before filling args, because we move them
-    // out and thus the passed `DescribeCtx` would be incomplete.
+  auto spawn(element_type_tag input) const -> AnyOperator override {
     auto spawner = std::optional<AnySpawn>{};
     if (desc_->spawner) {
       auto noop_dh = null_diagnostic_handler{};
@@ -415,7 +413,7 @@ public:
     auto args = desc_->make_args();
     for (auto [idx, arg] : detail::enumerate(args_)) {
       match(
-        std::move(arg),
+        arg,
         [&]<class T>(T x) {
           // For variadic arguments, all args >= variadic_index map to
           // variadic_index
@@ -432,7 +430,7 @@ public:
     }
     for (auto& named_arg : named_args_) {
       match(
-        std::move(named_arg.value),
+        named_arg.value,
         [&]<class T>(T x) {
           TENZIR_ASSERT(named_arg.index < desc_->named.size());
           as<Setter<T>>(desc_->named[named_arg.index].setter)(args,
@@ -445,14 +443,14 @@ public:
     if (pipeline_) {
       // This is already checked in make().
       TENZIR_ASSERT(desc_->pipeline);
-      desc_->pipeline->setter(args, std::move(pipeline_->pipeline));
+      desc_->pipeline->setter(args, pipeline_->pipeline);
       for (const auto& [binding_idx, id] : pipeline_->let_ids) {
         auto& binding = desc_->pipeline->let_bindings[binding_idx];
         binding.setter(args, id);
       }
     }
     if (desc_->set_filter) {
-      (*desc_->set_filter)(args, std::move(filter_));
+      (*desc_->set_filter)(args, filter_);
     } else {
       TENZIR_ASSERT(filter_.empty());
     }

--- a/test/tests/compiler/opt/optimize_barrier_filter.diff
+++ b/test/tests/compiler/opt/optimize_barrier_filter.diff
@@ -22,9 +22,9 @@
          
        ]
      },
-     OptimizeBarrierIr {
-       loc: [1]:7..23 from 0
-     },
+-    OptimizeBarrierIr {
+-      loc: [1]:7..23 from 0
+-    },
      where_ir {
 -      self: [1]:24..29 from 0,
 +      self: [0]:0..0 from 0,

--- a/test/tests/compiler/opt/optimize_barrier_order.diff
+++ b/test/tests/compiler/opt/optimize_barrier_order.diff
@@ -22,9 +22,9 @@
          
        ]
      },
-     OptimizeBarrierIr {
-       loc: [1]:7..23 from 0
-     },
+-    OptimizeBarrierIr {
+-      loc: [1]:7..23 from 0
+-    },
      GenericIr {
        op: {
          path: [

--- a/test/tests/compiler/opt/optimize_reorder.diff
+++ b/test/tests/compiler/opt/optimize_reorder.diff
@@ -22,9 +22,9 @@
        named_args: [
          
        ]
-     },
-     OptimizeReorderIr {
-       loc: [1]:7..23 from 0
+-    },
+-    OptimizeReorderIr {
+-      loc: [1]:7..23 from 0
      },
      GenericIr {
        op: {


### PR DESCRIPTION
## 🔍 Problem

- `ir::Operator::spawn` consumes the IR node and returns an optional runtime
  operator.
- That makes the spawn contract harder to reuse for follow-up executor work
  that wants to materialize operators from planned IR state.

## 🛠️ Solution

- Make `ir::Operator::spawn` a `const` method that returns `AnyOperator`
  directly.
- Update spawn implementations to copy or share their stored state instead of
  moving from the IR node.
- Move IR-only operator elision for `optimize_barrier` and
  `optimize_reorder` into optimization and make spawning them an invariant
  violation.
- Keep the rest of 6e06709375b out of this branch.

## 💬 Review

- This is the refactoring subset only; it does not include the executor
  changes from the original commit.
- `just build` passes.
- No changelog entry: internal refactoring only.
