### PR TITLE
Fix crash when stopping a pipeline with no executor

### DIFF
--- a/changelog/unreleased/pipeline-force-stop-null-executor.md
+++ b/changelog/unreleased/pipeline-force-stop-null-executor.md
@@ -1,0 +1,10 @@
+---
+title: Stopping a recovered pipeline no longer crashes the node
+type: bugfix
+authors:
+  - aljazerzen
+created: 2026-06-29T00:00:00Z
+---
+
+Fixes a node crash (`assertion 'pipeline.executor' failed`) that could occur
+when stopping or force-stopping a pipeline that had no live executor.

--- a/changelog/unreleased/pipeline-force-stop-null-executor.md
+++ b/changelog/unreleased/pipeline-force-stop-null-executor.md
@@ -3,6 +3,8 @@ title: Stopping a recovered pipeline no longer crashes the node
 type: bugfix
 authors:
   - aljazerzen
+prs:
+  - 6456
 created: 2026-06-29T00:00:00Z
 ---
 

--- a/changelog/unreleased/pipeline-force-stop-null-executor.md
+++ b/changelog/unreleased/pipeline-force-stop-null-executor.md
@@ -9,4 +9,5 @@ created: 2026-06-29T00:00:00Z
 ---
 
 Fixes a node crash (`assertion 'pipeline.executor' failed`) that could occur
-when stopping or force-stopping a pipeline that had no live executor.
+when stopping or force-stopping a pipeline that was previously placed in an
+invalid "half-stopped" state.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -1,5 +1,5 @@
 {
-  "hash": "sha256-KjQgRjmVXxZP9XaDMZ0UKatDWVDq4++0fHZ3ffGTcfE=",
+  "hash": "sha256-ZzIOjVeLZF7Va74JALmyaraKJUXeQEcrmYvvd19k67M=",
   "name": "tenzir-plugins.tar.gz",
-  "url": "https://github.com/tenzir/tenzir-plugins/archive/2fc9d9db6ba10f3bf155f4b27cc08433e38a8683.tar.gz"
+  "url": "https://github.com/tenzir/tenzir-plugins/archive/5719ec791620a441798cefd5854a680f90913593.tar.gz"
 }


### PR DESCRIPTION
## 🔍 Problem

Stopping or force-stopping a pipeline that had no live executor aborted the node:

```
assertion `pipeline.executor` failed
source: pipeline-manager/src/pipeline_manager.cpp:1575
```

This happened for package/configuration pipelines that were persisted as `running` and then failed their start-time checks on recovery — they lingered as `running` with a null executor, so a later stop request tripped the assertion.

A related (but non-crashing) variant: updating a running pipeline to a definition that fails the start-time check stranded the pipeline in `stopping`, leaked its analytics collector, and caused the node to disconnect.

## 🛠️ Solution

Four targeted fixes in the submodule (tenzir/tenzir-plugins#588):

- **`stop_pipeline`**: guard on a missing executor and settle cleanly instead of asserting.
- **`start_pipeline`**: a `fail_start` helper used by every pre-executor early return exits the freshly-spawned analytics collector and propagates the error.
- **`create_pipeline`**: reconcile a recovered non-runtime pipeline to `failed` when its start fails so it cannot linger as `running` with no executor.
- **`restart_after_shutdown`**: mark the pipeline `failed` instead of stranding it in `stopping` when a deferred restart fails.

## 💬 Review

The `stop_pipeline` guard (defensive) directly prevents the crash. The other three fixes eliminate the conditions that produce a null executor in the first place.

<sub>
📎 Submodule PR: tenzir/tenzir-plugins#588<br>
✅ Closes TNZ-829
</sub>