### PR TITLE
Prevent S3 close failures from aborting nodes

### DIFF
--- a/changelog/unreleased/graceful-s3-close-failures-in-legacy-pipelines.md
+++ b/changelog/unreleased/graceful-s3-close-failures-in-legacy-pipelines.md
@@ -1,0 +1,14 @@
+---
+title: Graceful S3 close failures in legacy pipelines
+type: bugfix
+authors:
+  - jachris
+  - codex
+prs:
+  - 6457
+created: 2026-07-19T08:55:36.358905Z
+---
+
+Pipelines running with `neo: false` no longer abort the node when closing an
+S3 output stream fails, including S3-backed `to_hive` pipelines. The close
+failure now stops only the affected pipeline with an error.

--- a/plugins/s3/include/operator.hpp
+++ b/plugins/s3/include/operator.hpp
@@ -24,6 +24,8 @@
 #include <arrow/util/uri.h>
 #include <fmt/core.h>
 
+#include <tuple>
+
 namespace tenzir::plugins::s3 {
 
 namespace {
@@ -292,16 +294,9 @@ public:
         .emit(dh);
       co_return;
     }
-    auto stream_guard
-      = detail::scope_guard([this, &dh, output_stream]() noexcept {
-          auto status = output_stream.ValueUnsafe()->Close();
-          if (not status.ok()) {
-            diagnostic::error("failed to close stream: {}",
-                              status.ToStringWithoutContextLines())
-              .primary(args_.uri.source)
-              .emit(dh);
-          }
-        });
+    auto stream_guard = detail::scope_guard([output_stream]() noexcept {
+      std::ignore = output_stream.ValueUnsafe()->Close();
+    });
     for (const auto& chunk : input) {
       if (not chunk or chunk->size() == 0) {
         co_yield {};
@@ -317,6 +312,14 @@ public:
         co_return;
       }
       co_yield {};
+    }
+    stream_guard.disable();
+    auto status = output_stream.ValueUnsafe()->Close();
+    if (not status.ok()) {
+      diagnostic::error("failed to close stream: {}",
+                        status.ToStringWithoutContextLines())
+        .primary(args_.uri.source)
+        .emit(dh);
     }
   }
 


### PR DESCRIPTION
## 🔍 Problem

With `neo: false`, an S3 output stream close failure emits an error from a `noexcept` cleanup guard. The resulting exception terminates the process instead of failing the pipeline, notably for `to_hive` outputs.

## 🛠️ Solution

Use the guard only for non-throwing cleanup on exceptional exits. Close the stream explicitly after normal processing so failures propagate as pipeline errors.

## 💬 Review

Please focus on the split between best-effort guarded cleanup and the explicit close path.