### PR TITLE
Bypass proxies for link-local metadata endpoints

### DIFF
--- a/changelog/unreleased/web-identity-token-retrieval-through-proxies.md
+++ b/changelog/unreleased/web-identity-token-retrieval-through-proxies.md
@@ -1,0 +1,14 @@
+---
+title: Web identity token retrieval through proxies
+type: bugfix
+authors:
+  - tobim
+  - codex
+prs:
+  - 6458
+created: 2026-07-20T14:42:53.876785Z
+---
+
+Nodes that use an outbound proxy now bypass it for IPv4 and IPv6 link-local
+metadata endpoints. This restores `aws_iam.web_identity.token_endpoint`
+authentication when the token is served from local instance metadata.

--- a/libtenzir/include/tenzir/proxy_settings.hpp
+++ b/libtenzir/include/tenzir/proxy_settings.hpp
@@ -73,7 +73,7 @@ auto get_proxy_settings() -> const proxy_settings&;
 
 /// Returns the comma-separated no-proxy list handed to backend APIs. This
 /// preserves the user-provided `tenzir.no-proxy` list but prepends Tenzir's
-/// implicit loopback and link-local IPv4 bypass entries.
+/// implicit loopback and link-local IPv4/IPv6 bypass entries.
 auto effective_no_proxy(proxy_settings const& settings) -> std::string;
 
 /// Returns true when `host` matches the `no-proxy` bypass list.

--- a/libtenzir/include/tenzir/proxy_settings.hpp
+++ b/libtenzir/include/tenzir/proxy_settings.hpp
@@ -73,7 +73,7 @@ auto get_proxy_settings() -> const proxy_settings&;
 
 /// Returns the comma-separated no-proxy list handed to backend APIs. This
 /// preserves the user-provided `tenzir.no-proxy` list but prepends Tenzir's
-/// implicit loopback bypass entries.
+/// implicit loopback and link-local IPv4 bypass entries.
 auto effective_no_proxy(proxy_settings const& settings) -> std::string;
 
 /// Returns true when `host` matches the `no-proxy` bypass list.

--- a/libtenzir/src/proxy_settings.cpp
+++ b/libtenzir/src/proxy_settings.cpp
@@ -298,7 +298,8 @@ auto get_proxy_settings() -> proxy_settings const& {
 }
 
 auto effective_no_proxy(proxy_settings const& settings) -> std::string {
-  auto result = std::string{"localhost,127.0.0.1,127.0.0.0/8,::1"};
+  auto result
+    = std::string{"localhost,127.0.0.1,127.0.0.0/8,169.254.0.0/16,::1"};
   if (settings.no_proxy) {
     append_no_proxy_entries(result, *settings.no_proxy);
   }

--- a/libtenzir/src/proxy_settings.cpp
+++ b/libtenzir/src/proxy_settings.cpp
@@ -377,11 +377,9 @@ auto bypass_proxy(std::string_view host) -> bool {
   if (is_loopback(normalized)) {
     return true;
   }
-  if (not ps.no_proxy) {
-    return false;
-  }
   auto host_address = to<ip>(normalized);
-  for (auto part : std::views::split(*ps.no_proxy, ',')) {
+  auto no_proxy = effective_no_proxy(ps);
+  for (auto part : std::views::split(no_proxy, ',')) {
     auto raw = std::string_view{part.begin(), part.end()};
     auto entry = parse_no_proxy_entry(raw);
     if (entry.empty()) {

--- a/libtenzir/src/proxy_settings.cpp
+++ b/libtenzir/src/proxy_settings.cpp
@@ -298,8 +298,8 @@ auto get_proxy_settings() -> proxy_settings const& {
 }
 
 auto effective_no_proxy(proxy_settings const& settings) -> std::string {
-  auto result
-    = std::string{"localhost,127.0.0.1,127.0.0.0/8,169.254.0.0/16,::1"};
+  auto result = std::string{
+    "localhost,127.0.0.1,127.0.0.0/8,169.254.0.0/16,::1,fe80::/10"};
   if (settings.no_proxy) {
     append_no_proxy_entries(result, *settings.no_proxy);
   }
@@ -308,11 +308,18 @@ auto effective_no_proxy(proxy_settings const& settings) -> std::string {
 
 namespace {
 
-// Strips IPv6 brackets so `[::1]` and `::1` compare equal.
+// Strips IPv6 brackets and interface scopes before comparing IP literals.
 auto canonicalize_host(std::string_view host) -> std::string {
   if (host.size() >= 2 and host.front() == '[' and host.back() == ']') {
     host.remove_prefix(1);
     host.remove_suffix(1);
+  }
+  if (auto scope = host.find('%'); scope != std::string_view::npos) {
+    auto unscoped = host.substr(0, scope);
+    if (auto address = to<ip>(std::string{unscoped});
+        address and address->is_v6()) {
+      host = unscoped;
+    }
   }
   return to_lower(host);
 }
@@ -390,7 +397,7 @@ auto bypass_proxy(std::string_view host) -> bool {
       }
       continue;
     }
-    auto normalized_entry = to_lower(entry);
+    auto normalized_entry = canonicalize_host(entry);
     if (normalized_entry.starts_with('.')) {
       normalized_entry.erase(0, 1);
     }

--- a/libtenzir/test/proxy_settings.cpp
+++ b/libtenzir/test/proxy_settings.cpp
@@ -264,6 +264,16 @@ TEST("no-proxy CIDR entries match IP literals") {
   CHECK(not bypass_proxy("2001:db9::1"));
 }
 
+TEST("link-local IPv4 addresses always bypass proxies") {
+  auto settings = caf::settings{};
+  caf::put(settings, "tenzir.http-proxy",
+           std::string{"http://proxy.example:3128"});
+  REQUIRE_EQUAL(initialize_proxy_settings(settings), caf::error{});
+  CHECK(not proxy_for_target("http", "169.254.169.254"));
+  CHECK(not proxy_for_target("http", "169.254.170.2"));
+  CHECK(proxy_for_target("http", "169.253.255.255"));
+}
+
 TEST("no-proxy CIDR entries do not resolve DNS names") {
   auto settings = caf::settings{};
   caf::put(settings, "tenzir.no-proxy", std::string{"10.0.0.0/8"});

--- a/libtenzir/test/proxy_settings.cpp
+++ b/libtenzir/test/proxy_settings.cpp
@@ -285,6 +285,8 @@ TEST("link-local addresses always bypass proxies") {
   caf::put(settings, "tenzir.http-proxy",
            std::string{"http://proxy.example:3128"});
   REQUIRE_EQUAL(initialize_proxy_settings(settings), caf::error{});
+  CHECK(bypass_proxy("169.254.169.254"));
+  CHECK(bypass_proxy("fe80::1%eth0"));
   CHECK(not proxy_for_target("http", "169.254.169.254"));
   CHECK(not proxy_for_target("http", "169.254.170.2"));
   CHECK(not proxy_for_target("http", "fe80::1%eth0"));

--- a/libtenzir/test/proxy_settings.cpp
+++ b/libtenzir/test/proxy_settings.cpp
@@ -264,14 +264,33 @@ TEST("no-proxy CIDR entries match IP literals") {
   CHECK(not bypass_proxy("2001:db9::1"));
 }
 
-TEST("link-local IPv4 addresses always bypass proxies") {
+TEST("no-proxy CIDR entries match scoped IPv6 literals") {
+  auto settings = caf::settings{};
+  caf::put(settings, "tenzir.no-proxy", std::string{"fe80::/10"});
+  REQUIRE_EQUAL(initialize_proxy_settings(settings), caf::error{});
+  CHECK(bypass_proxy("fe80::1%eth0"));
+  CHECK(bypass_proxy("[fe80::1%25eth0]"));
+  CHECK(not bypass_proxy("fec0::1%eth0"));
+}
+
+TEST("no-proxy preserves percent-encoded hostnames") {
+  auto settings = caf::settings{};
+  caf::put(settings, "tenzir.no-proxy", std::string{"example.com"});
+  REQUIRE_EQUAL(initialize_proxy_settings(settings), caf::error{});
+  CHECK(not bypass_proxy("example%2ecom"));
+}
+
+TEST("link-local addresses always bypass proxies") {
   auto settings = caf::settings{};
   caf::put(settings, "tenzir.http-proxy",
            std::string{"http://proxy.example:3128"});
   REQUIRE_EQUAL(initialize_proxy_settings(settings), caf::error{});
   CHECK(not proxy_for_target("http", "169.254.169.254"));
   CHECK(not proxy_for_target("http", "169.254.170.2"));
+  CHECK(not proxy_for_target("http", "fe80::1%eth0"));
+  CHECK(not proxy_for_target("http", "[fe80::1%25eth0]"));
   CHECK(proxy_for_target("http", "169.253.255.255"));
+  CHECK(proxy_for_target("http", "fec0::1%eth0"));
 }
 
 TEST("no-proxy CIDR entries do not resolve DNS names") {

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -51,7 +51,7 @@ tenzir:
   # and subdomains on a label boundary (`internal` matches `internal`,
   # `host.internal`, and `a.b.internal`, but not `notinternal`); `*` matches
   # everything; CIDR entries match IP-literal hosts only; `localhost`,
-  # IPv4/IPv6 loopback, and IPv4 link-local addresses always bypass.
+  # IPv4/IPv6 loopback, and IPv4/IPv6 link-local addresses always bypass.
   # Falls back to `TENZIR_NO_PROXY`, `NO_PROXY`, or `no_proxy` from the
   # environment when unset, in that order. An explicitly empty
   # `TENZIR_NO_PROXY` or configured `no-proxy` value disables fallback to the

--- a/tenzir.yaml.example
+++ b/tenzir.yaml.example
@@ -50,8 +50,8 @@ tenzir:
   # semantics as libcurl's `NO_PROXY`: domain entries match the hostname itself
   # and subdomains on a label boundary (`internal` matches `internal`,
   # `host.internal`, and `a.b.internal`, but not `notinternal`); `*` matches
-  # everything; CIDR entries match IP-literal hosts only; `localhost` and
-  # IPv4/IPv6 loopback addresses always bypass.
+  # everything; CIDR entries match IP-literal hosts only; `localhost`,
+  # IPv4/IPv6 loopback, and IPv4 link-local addresses always bypass.
   # Falls back to `TENZIR_NO_PROXY`, `NO_PROXY`, or `no_proxy` from the
   # environment when unset, in that order. An explicitly empty
   # `TENZIR_NO_PROXY` or configured `no-proxy` value disables fallback to the


### PR DESCRIPTION
## 🔍 Problem

Web-identity token endpoints on link-local metadata addresses are routed through configured outbound proxies. Scoped IPv6 literals also fail CIDR-based proxy bypass matching.

## 🛠️ Solution

- Bypass IPv4 and IPv6 link-local address ranges by default.
- Normalize IPv6 interface scopes before evaluating `no-proxy` CIDRs.

## 💬 Review

Review the proxy-bypass scope: it is limited to loopback and link-local addresses, while public AWS STS and SQS traffic remains proxied.