### PR TITLE
Add changelog entry for context::enrich await_context option

### DIFF
--- a/changelog/unreleased/await-context-option-for-enrichment.md
+++ b/changelog/unreleased/await-context-option-for-enrichment.md
@@ -1,0 +1,20 @@
+---
+title: Await context option for enrichment
+type: feature
+authors:
+  - IyeOnline
+created: 2026-07-20T22:00:13.593383Z
+---
+
+The `context::enrich` operator now supports an `await_context` option that
+waits for the target context to receive its first update before enriching,
+instead of racing against a possibly still-empty context:
+
+```tql
+from {x: 1}
+context::enrich "my-context", key=x, await_context=true
+```
+
+This is useful when a pipeline creates and populates a context concurrently
+with (or shortly before) an `context::enrich` step, where the enrichment
+previously could return misses if it ran before the context had any data.

--- a/changelog/unreleased/await-context-option-for-enrichment.md
+++ b/changelog/unreleased/await-context-option-for-enrichment.md
@@ -3,6 +3,8 @@ title: Await context option for enrichment
 type: feature
 authors:
   - IyeOnline
+prs:
+  - 6460
 created: 2026-07-20T22:00:13.593383Z
 ---
 


### PR DESCRIPTION
## 🔍 Problem

The `context::enrich` operator can run against a context that hasn't
received any data yet, returning misses instead of waiting for it to be
populated. `tenzir/tenzir-plugins#589` adds an `await_context` option to fix
this, but the change needs a changelog entry in this repo per the shared
changelog workspace.

## 🛠️ Solution

- Add a `feature` changelog entry documenting the new `await_context` option
  on `context::enrich`.

## 💬 Review

- No code changes here — the implementation lives in
  `tenzir/tenzir-plugins#589`.
- `prs` metadata is not yet set on the entry since this repo's own PR number
  wasn't known when the entry was authored; add it once this PR is opened
  and the number is final.

<sub>
📎 Related: tenzir/tenzir-plugins#589
</sub>