### PR TITLE
Await first context update on enrichment

### DIFF
--- a/changelog/unreleased/await-context-option-for-enrichment.md
+++ b/changelog/unreleased/await-context-option-for-enrichment.md
@@ -1,0 +1,31 @@
+---
+title: Waiting for contexts
+type: feature
+authors:
+  - IyeOnline
+  - claude
+prs:
+  - 6461
+created: 2026-07-20T22:00:13.593383Z
+---
+
+The `context::enrich` and `context::update` operators now support an
+`await_context` option that waits for the target context to exist and, for
+`context::enrich`, to receive its first update, instead of racing against a
+context that may not exist yet or may still be empty:
+
+```tql
+from {x: 1}
+context::enrich "my-context", key=x, await_context=true
+```
+
+```tql
+from {x: 1, note: "populated"}
+context::update "my-context", key=x, await_context=true
+```
+
+This is useful when a pipeline creates and populates a context concurrently
+with (or shortly before) a `context::enrich` or `context::update` step, where
+these operators previously could fail with "context not found" or, for
+`context::enrich`, return misses if they ran before the context existed or
+had any data.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -1,5 +1,5 @@
 {
-  "hash": "sha256-0ZaBIWMo5PMpnWpYikXkykcUAk5Mc89G99sbJEMyg74=",
+  "hash": "sha256-B3ocAmwXO9iZXprNPvldiGnOHuhsGGqZdz295Nr366A=",
   "name": "tenzir-plugins.tar.gz",
-  "url": "https://github.com/tenzir/tenzir-plugins/archive/0b0925172daa0bf749955d96c0603dad8e9a7b4e.tar.gz"
+  "url": "https://github.com/tenzir/tenzir-plugins/archive/5633b274e36630a38824ba85033aa02a87681cfb.tar.gz"
 }


### PR DESCRIPTION
Bumps the `contrib/tenzir-plugins` submodule to pull in the new
`await_context` option on `context::enrich` and `context::update`
(tenzir/tenzir-plugins#589), which makes both operators wait for the target
context to be ready — created and, for `context::enrich`, updated — instead
of racing against a context that isn't ready yet. Also adds the
corresponding changelog entry.

<sub>
📎 Implementation: tenzir/tenzir-plugins#589<br>
📚 Docs PR: tenzir/content#136
</sub>
