### PR TITLE
Document Nix packaging workflow

### DIFF
--- a/.agents/references/nix.md
+++ b/.agents/references/nix.md
@@ -1,0 +1,25 @@
+# Nix
+
+## Development
+
+Enter the development shell before running the project's pinned tools:
+
+```sh
+nix develop
+```
+
+## Dependencies
+
+Add direct dependencies to the appropriate input list in
+`nix/dependencies.nix`. Add a package to `nix/overlay.nix` only when Nixpkgs
+does not provide it or when Tenzir needs to override it.
+
+## Build packages
+
+The flake exposes these common package outputs:
+
+- `nix build .#tenzir` builds the edition with additional closed-source plugins.
+- `nix build .#tenzir-de` builds the developer edition without those plugins.
+- `nix build .#tenzir-static` builds a musl-linked static binary on Linux.
+- `nix build .#tenzir-static^package` builds the installable package artifacts:
+  DEB, RPM, and tar.gz files on Linux, or a `.pkg` file on macOS.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,6 +198,7 @@ when they model the same concept.
 
 ### Tooling
 
+- [nix.md](.agents/references/nix.md): Packaging and dependencies
 - [external-files.md](.agents/references/external-files.md): Third-party code integration
 - [utilities.md](.agents/references/utilities.md): Helpers in tenzir::detail
 - [hashing.md](.agents/references/hashing.md): Hashing infrastructure


### PR DESCRIPTION
## 🔍 Problem

- Agents lacked repository-specific guidance for the Nix development shell, dependency placement, and package outputs.

## 🛠️ Solution

- Add a focused Nix reference and link it from `AGENTS.md`.

## 💬 Review

- Confirm the documented commands and dependency boundaries match the flake and package definitions.