### PR TITLE
Emit cast parse warnings once per batch

### DIFF
--- a/changelog/unreleased/warnings-for-invalid-ints-now-show-the-invalid-value.md
+++ b/changelog/unreleased/warnings-for-invalid-ints-now-show-the-invalid-value.md
@@ -1,0 +1,16 @@
+---
+title: Warnings for invalid ints now show the invalid value
+type: bugfix
+authors:
+  - zedoraps
+  - claude
+prs:
+  - 6465
+created: 2026-07-22T13:45:34.279251Z
+---
+
+Warnings from `int()` and `uint()` now show the invalid value:
+
+```text
+= note: tried to convert: invalid
+```

--- a/libtenzir/builtins/functions/duration.cpp
+++ b/libtenzir/builtins/functions/duration.cpp
@@ -40,6 +40,7 @@ public:
       [expr = std::move(expr)](evaluator eval, session ctx) -> series {
         auto b = duration_type::make_arrow_builder(arrow_memory_pool());
         check(b->Reserve(eval.length()));
+        auto failed = std::optional<std::string>{};
         for (auto& arg : eval(expr)) {
           const auto f = detail::overload{
             [&](const arrow::NullArray& arg) {
@@ -61,10 +62,9 @@ public:
                   check(b->Append(result.count()));
                   continue;
                 }
-                diagnostic::warning("failed to parse string")
-                  .primary(expr)
-                  .note(fmt::format("tried to convert: {}", arg.GetView(i)))
-                  .emit(ctx);
+                if (not failed) {
+                  failed = std::string{arg.GetView(i)};
+                }
                 check(b->AppendNull());
               }
             },
@@ -77,6 +77,12 @@ public:
             },
           };
           match(*arg.array, f);
+        }
+        if (failed) {
+          diagnostic::warning("failed to parse string")
+            .primary(expr)
+            .note(fmt::format("tried to convert: {}", *failed))
+            .emit(ctx);
         }
         return series{duration_type{}, finish(*b)};
       });

--- a/libtenzir/builtins/functions/float.cpp
+++ b/libtenzir/builtins/functions/float.cpp
@@ -36,8 +36,8 @@ public:
           .parse(inv, ctx));
     return function_use::make(
       [expr = std::move(expr), this](auto eval, session ctx) {
-        return map_series(eval(expr), [&](series value) {
-          auto failed = std::optional<std::string>{};
+        auto failed = std::optional<std::string>{};
+        auto result = map_series(eval(expr), [&](series value) {
           const auto f = detail::overload{
             [](const arrow::NullArray& arg) {
               auto b = arrow::DoubleBuilder{tenzir::arrow_memory_pool()};
@@ -93,15 +93,15 @@ public:
               return finish(b);
             },
             };
-          auto result = match(*value.array, f);
-          if (failed) {
-            diagnostic::warning("failed to parse string")
-              .primary(expr)
-              .note(fmt::format("tried to convert: {}", *failed))
-              .emit(ctx);
-          }
-          return series{double_type{}, std::move(result)};
+          return series{double_type{}, match(*value.array, f)};
         });
+        if (failed) {
+          diagnostic::warning("failed to parse string")
+            .primary(expr)
+            .note(fmt::format("tried to convert: {}", *failed))
+            .emit(ctx);
+        }
+        return result;
       });
   }
 };

--- a/libtenzir/builtins/functions/float.cpp
+++ b/libtenzir/builtins/functions/float.cpp
@@ -37,6 +37,7 @@ public:
     return function_use::make(
       [expr = std::move(expr), this](auto eval, session ctx) {
         return map_series(eval(expr), [&](series value) {
+          auto failed = std::optional<std::string>{};
           const auto f = detail::overload{
             [](const arrow::NullArray& arg) {
               auto b = arrow::DoubleBuilder{tenzir::arrow_memory_pool()};
@@ -75,10 +76,9 @@ public:
                   check(b.Append(result));
                   continue;
                 }
-                diagnostic::warning("failed to parse string")
-                  .primary(expr)
-                  .note(fmt::format("tried to convert: {}", arg.GetView(row)))
-                  .emit(ctx);
+                if (not failed) {
+                  failed = std::string{arg.GetView(row)};
+                }
                 check(b.AppendNull());
               }
               return finish(b);
@@ -93,7 +93,14 @@ public:
               return finish(b);
             },
             };
-          return series{double_type{}, match(*value.array, f)};
+          auto result = match(*value.array, f);
+          if (failed) {
+            diagnostic::warning("failed to parse string")
+              .primary(expr)
+              .note(fmt::format("tried to convert: {}", *failed))
+              .emit(ctx);
+          }
+          return series{double_type{}, std::move(result)};
         });
       });
   }

--- a/libtenzir/builtins/functions/int.cpp
+++ b/libtenzir/builtins/functions/int.cpp
@@ -114,7 +114,7 @@ public:
             return finish(b);
           },
           [&](const arrow::StringArray& arg) {
-            auto report = false;
+            auto failed = std::optional<std::string>{};
             auto b = Builder{tenzir::arrow_memory_pool()};
             check(b.Reserve(value.length()));
             constexpr auto p = std::invoke([] {
@@ -158,14 +158,15 @@ public:
                     TENZIR_UNREACHABLE();
                 }
                 check(b.AppendNull());
-                report = true;
+                if (not failed) {
+                  failed = std::string{arg.GetView(row)};
+                }
               }
             }
-            if (report) {
-              // TODO: It would be helpful to know what string, but then
-              // deduplication doesn't work.
+            if (failed) {
               diagnostic::warning("`{}` failed to convert some string", name())
                 .primary(expr)
+                .note(fmt::format("tried to convert: {}", *failed))
                 .emit(ctx);
             }
             return finish(b);

--- a/libtenzir/builtins/functions/int.cpp
+++ b/libtenzir/builtins/functions/int.cpp
@@ -47,7 +47,8 @@ public:
     }
     return function_use::make([this, expr = std::move(expr),
                                base = base.inner](auto eval, session ctx) {
-      return map_series(eval(expr), [&](series value) {
+      auto failed = std::optional<std::string>{};
+      auto result = map_series(eval(expr), [&](series value) {
         auto f = detail::overload{
           [](const arrow::NullArray& arg) {
             auto b = Builder{tenzir::arrow_memory_pool()};
@@ -114,7 +115,6 @@ public:
             return finish(b);
           },
           [&](const arrow::StringArray& arg) {
-            auto failed = std::optional<std::string>{};
             auto b = Builder{tenzir::arrow_memory_pool()};
             check(b.Reserve(value.length()));
             constexpr auto p = std::invoke([] {
@@ -163,12 +163,6 @@ public:
                 }
               }
             }
-            if (failed) {
-              diagnostic::warning("`{}` failed to convert some string", name())
-                .primary(expr)
-                .note(fmt::format("tried to convert: {}", *failed))
-                .emit(ctx);
-            }
             return finish(b);
           },
           [&](const auto&) -> std::shared_ptr<Array> {
@@ -184,6 +178,13 @@ public:
           };
         return series{Type{}, match(*value.array, f)};
       });
+      if (failed) {
+        diagnostic::warning("`{}` failed to convert some string", name())
+          .primary(expr)
+          .note(fmt::format("tried to convert: {}", *failed))
+          .emit(ctx);
+      }
+      return result;
     });
   }
 };

--- a/test/tests/functions/duration/invalid_input_dedup.tql
+++ b/test/tests/functions/duration/invalid_input_dedup.tql
@@ -1,0 +1,8 @@
+from {
+  x: "not a duration",
+}, {
+  x: "still not a duration",
+}, {
+  x: "also not a duration",
+}
+x = x.duration()

--- a/test/tests/functions/duration/invalid_input_dedup.txt
+++ b/test/tests/functions/duration/invalid_input_dedup.txt
@@ -1,0 +1,16 @@
+{
+  x: null,
+}
+{
+  x: null,
+}
+{
+  x: null,
+}
+warning: failed to parse string
+ --> tests/functions/duration/invalid_input_dedup.tql:8:5
+  |
+8 | x = x.duration()
+  |     ~ 
+  |
+  = note: tried to convert: not a duration

--- a/test/tests/functions/float/invalid_input_dedup.tql
+++ b/test/tests/functions/float/invalid_input_dedup.tql
@@ -1,8 +1,8 @@
 from {
   x: "not a float",
 }, {
-  x: "still not a float",
+  x: 0,
 }, {
-  x: "also not a float",
+  x: "still not a float",
 }
 x = x.float()

--- a/test/tests/functions/float/invalid_input_dedup.tql
+++ b/test/tests/functions/float/invalid_input_dedup.tql
@@ -1,0 +1,8 @@
+from {
+  x: "not a float",
+}, {
+  x: "still not a float",
+}, {
+  x: "also not a float",
+}
+x = x.float()

--- a/test/tests/functions/float/invalid_input_dedup.txt
+++ b/test/tests/functions/float/invalid_input_dedup.txt
@@ -2,7 +2,7 @@
   x: null,
 }
 {
-  x: null,
+  x: 0.0,
 }
 {
   x: null,

--- a/test/tests/functions/float/invalid_input_dedup.txt
+++ b/test/tests/functions/float/invalid_input_dedup.txt
@@ -1,0 +1,16 @@
+{
+  x: null,
+}
+{
+  x: null,
+}
+{
+  x: null,
+}
+warning: failed to parse string
+ --> tests/functions/float/invalid_input_dedup.tql:8:5
+  |
+8 | x = x.float()
+  |     ~ 
+  |
+  = note: tried to convert: not a float

--- a/test/tests/functions/int/invalid_input_dedup.tql
+++ b/test/tests/functions/int/invalid_input_dedup.tql
@@ -1,8 +1,8 @@
 from {
   x: "not an int",
 }, {
-  x: "still not an int",
+  x: 0,
 }, {
-  x: "also not an int",
+  x: "still not an int",
 }
 x = x.int()

--- a/test/tests/functions/int/invalid_input_dedup.tql
+++ b/test/tests/functions/int/invalid_input_dedup.tql
@@ -1,0 +1,8 @@
+from {
+  x: "not an int",
+}, {
+  x: "still not an int",
+}, {
+  x: "also not an int",
+}
+x = x.int()

--- a/test/tests/functions/int/invalid_input_dedup.txt
+++ b/test/tests/functions/int/invalid_input_dedup.txt
@@ -2,7 +2,7 @@
   x: null,
 }
 {
-  x: null,
+  x: 0,
 }
 {
   x: null,

--- a/test/tests/functions/int/invalid_input_dedup.txt
+++ b/test/tests/functions/int/invalid_input_dedup.txt
@@ -1,0 +1,16 @@
+{
+  x: null,
+}
+{
+  x: null,
+}
+{
+  x: null,
+}
+warning: `int` failed to convert some string
+ --> tests/functions/int/invalid_input_dedup.tql:8:5
+  |
+8 | x = x.int()
+  |     ~ 
+  |
+  = note: tried to convert: not an int


### PR DESCRIPTION
## 🔍 Problem

- `float()` and `duration()` construct and emit a parse warning for every failing row, even though the diagnostics layer deduplicates what users see.
- `int()` and `uint()` parse warnings do not identify the rejected string.

## 🛠️ Solution

- Retain the first parse failure and emit one warning after evaluating the batch.
- Include the first rejected string as a diagnostic note for integer casts.
- Add three-row golden tests that verify one warning and the first rejected value.

## 💬 Review

- Warning messages remain unchanged, and existing batch-level overflow warnings are untouched.
- This addresses [jachris's inline comment](https://github.com/tenzir/tenzir/pull/6464#discussion_r3628359509) that cast warnings should emit once per incoming batch.

<sub>
📎 Related: tenzir/tenzir#6464
</sub>
