### PR TITLE
Make pubsub shutdown signaling/draining explicit

### DIFF
--- a/changelog/unreleased/subscribers-no-longer-stop-early-when-one-publisher-finishes.md
+++ b/changelog/unreleased/subscribers-no-longer-stop-early-when-one-publisher-finishes.md
@@ -1,0 +1,18 @@
+---
+title: Subscribers no longer stop early when one publisher finishes
+type: bugfix
+authors:
+  - IyeOnline
+prs:
+  - 6467
+created: 2026-07-22T15:28:27.793555Z
+---
+
+Subscribers to internal pub/sub topics (used by the `subscribe` and `publish`
+operators) no longer stop early just because one publisher for that topic
+finished. Previously, a `publish` pipeline completing normally could cause
+the node to signal "topic exhausted" to all subscribers of that topic, even
+while the node kept running and another publisher for the same topic could
+still start later. This could make a running `subscribe "topic"` pipeline
+terminate prematurely. Subscribers are now only told a topic is exhausted
+when the node itself is actually shutting down.

--- a/libtenzir/include/tenzir/pipeline_manager_shutdown.hpp
+++ b/libtenzir/include/tenzir/pipeline_manager_shutdown.hpp
@@ -1,0 +1,18 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "tenzir/actors.hpp"
+
+namespace tenzir {
+
+using pipeline_manager_shutdown_receiver = typed_actor_fwd<
+  // Send a shutdown signal
+  auto(atom::shutdown, atom::signal)->caf::result<void>>::unwrap;
+}

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -1,5 +1,5 @@
 {
-  "hash": "sha256-dluH5cvXrtHU5m1KydzIB6GqWi3QBRjgz9pS/uCzu9A=",
+  "hash": "sha256-OADBuCcT0X/+6uQAwJEVkBt7G5lKHFrR7VmsmxiSDVg=",
   "name": "tenzir-plugins.tar.gz",
-  "url": "https://github.com/tenzir/tenzir-plugins/archive/a5aae1bb3dfd088853faf7fb8604b5798d797c0e.tar.gz"
+  "url": "https://github.com/tenzir/tenzir-plugins/archive/811d996634e8670b50993e2101867da73b6df5dd.tar.gz"
 }


### PR DESCRIPTION
Subscribers could shut down prematurely: whenever a `publish` operator finished (e.g. its pipeline finalized normally), the router treated that as the topic being fully "done" and notified subscribers accordingly even though the node wasn't shutting down and another publisher for the same topic could still show up later. This could cause a `subscribe "topic"` pipeline to exit early just because one unrelated publisher stopped.

This PR adds `pipeline_manager_shutdown_receiver`, a minimal actor interface (`atom::shutdown, atom::signal`) that lets the pipeline manager tell node components when the node is actually tearing down.

<sub>
📎 Related: tenzir/tenzir-plugins#590
</sub>