### PR TITLE
Deliver activity metrics without importer delay

### DIFF
--- a/changelog/unreleased/prompt-live-event-delivery.md
+++ b/changelog/unreleased/prompt-live-event-delivery.md
@@ -1,0 +1,12 @@
+---
+title: Timely pipeline activity metrics
+type: bugfix
+authors:
+  - tobim
+prs:
+  - 6468
+created: 2026-07-22T13:46:31.749936Z
+---
+
+Pipeline activity metrics now reach the Tenzir Platform without waiting for the
+`tenzir.import-buffer-timeout` batching interval.

--- a/libtenzir/include/tenzir/actors.hpp
+++ b/libtenzir/include/tenzir/actors.hpp
@@ -184,9 +184,10 @@ using catalog_actor = typed_actor_fwd<
 struct importer_actor_traits {
   using signatures = caf::type_list<
     // Register a subscriber for table slices and/or get recently imported,
-    // unpersisted events, depending on the 'live' and 'recent' flags.
+    // unpersisted events. The 'eager' flag is for internal consumers that need
+    // buffered and new live slices without waiting for the importer flush.
     auto(atom::get, receiver_actor<table_slice>, bool internal, bool live,
-         bool recent)
+         bool recent, bool eager)
       ->caf::result<std::vector<table_slice>>,
     // Push buffered slices downstream to make the data available.
     auto(atom::flush)->caf::result<void>,
@@ -368,25 +369,27 @@ struct export_mode {
   bool internal = false;
   uint64_t parallel = 3;
   bool high_priority = false;
+  bool eager = false;
 
   export_mode() = default;
 
   export_mode(bool retro_, bool live_, bool internal_, uint64_t parallel_,
-              bool high_priority_ = false)
+              bool high_priority_ = false, bool eager_ = false)
     : retro{retro_},
       live{live_},
       internal{internal_},
       parallel{parallel_},
-      high_priority{high_priority_} {
+      high_priority{high_priority_},
+      eager{eager_} {
     TENZIR_ASSERT(live or retro);
+    TENZIR_ASSERT(not eager or live);
   }
 
   friend auto inspect(auto& f, export_mode& x) -> bool {
-    return f.object(x).fields(f.field("retro", x.retro),
-                              f.field("live", x.live),
-                              f.field("internal", x.internal),
-                              f.field("parallel", x.parallel),
-                              f.field("high_priority", x.high_priority));
+    return f.object(x).fields(
+      f.field("retro", x.retro), f.field("live", x.live),
+      f.field("internal", x.internal), f.field("parallel", x.parallel),
+      f.field("high_priority", x.high_priority), f.field("eager", x.eager));
   }
 };
 

--- a/libtenzir/include/tenzir/importer.hpp
+++ b/libtenzir/include/tenzir/importer.hpp
@@ -52,9 +52,14 @@ private:
   /// Buffered events waiting to be flushed.
   std::unordered_map<type, std::vector<table_slice>> unpersisted_events = {};
 
+  struct subscriber {
+    receiver_actor<table_slice> receiver;
+    bool internal;
+    bool eager;
+  };
+
   /// A list of subscribers for incoming events.
-  std::vector<std::pair<receiver_actor<table_slice>, bool /*internal*/>>
-    subscribers = {};
+  std::vector<subscriber> subscribers = {};
 };
 
 } // namespace tenzir

--- a/libtenzir/src/export_bridge.cpp
+++ b/libtenzir/src/export_bridge.cpp
@@ -272,14 +272,16 @@ auto make_bridge(export_bridge_actor::stateful_pointer<bridge_state> self,
                        caf::actor_cast<receiver_actor<table_slice>>(self),
                        self->state().mode.internal,
                        /*live=*/self->state().mode.live,
-                       /*recent=*/self->state().mode.retro)
+                       /*recent=*/self->state().mode.retro,
+                       /*eager=*/self->state().mode.eager)
                 .urgent());
   } else {
     subscribe(self->mail(atom::get_v,
                          caf::actor_cast<receiver_actor<table_slice>>(self),
                          self->state().mode.internal,
                          /*live=*/self->state().mode.live,
-                         /*recent=*/self->state().mode.retro));
+                         /*recent=*/self->state().mode.retro,
+                         /*eager=*/self->state().mode.eager));
   }
   // If we're retro, then we can query the catalog immediately.
   if (mode.retro) {

--- a/libtenzir/src/importer.cpp
+++ b/libtenzir/src/importer.cpp
@@ -35,24 +35,33 @@ importer::~importer() noexcept {
 void importer::handle_slice(table_slice&& slice) {
   const auto rows = slice.rows();
   TENZIR_ASSERT(rows > 0);
-  // If we're in "unbuffered" mode, we flush immediately.
-  if (import_buffer_timeout == duration::zero()) {
-    flush();
-    return;
+  const auto is_internal = slice.schema().attribute("internal").has_value();
+  auto events = std::optional<table_slice>{};
+  for (const auto& subscriber : subscribers) {
+    if (subscriber.eager and subscriber.internal == is_internal) {
+      if (not events) {
+        events.emplace(slice);
+        events->import_time(time::clock::now());
+      }
+      self->mail(*events).send(subscriber.receiver);
+    }
   }
-  // Otherwise, we buffer the slice first, and register it for flushing after
-  // some timeout.
   auto schema = slice.schema();
   auto it = unpersisted_events.find(schema);
   if (it == unpersisted_events.end()) {
     it
       = unpersisted_events.emplace_hint(it, schema, std::vector<table_slice>{});
-    self->run_delayed_weak(import_buffer_timeout,
-                           [this, schema = std::move(schema)]() mutable {
-                             flush(std::move(schema));
-                           });
+    if (import_buffer_timeout != duration::zero()) {
+      self->run_delayed_weak(import_buffer_timeout,
+                             [this, schema = std::move(schema)]() mutable {
+                               flush(std::move(schema));
+                             });
+    }
   }
   it->second.push_back(std::move(slice));
+  if (import_buffer_timeout == duration::zero()) {
+    flush(std::move(schema));
+  }
 }
 
 void importer::flush(std::optional<type> schema) {
@@ -80,9 +89,9 @@ void importer::flush(std::optional<type> schema) {
           if (not is_internal) {
             schema_counters[events.schema()] += events.rows();
           }
-          for (const auto& [subscriber, wants_internal] : subscribers) {
-            if (is_internal == wants_internal) {
-              self->mail(events).send(subscriber);
+          for (const auto& subscriber : subscribers) {
+            if (not subscriber.eager and is_internal == subscriber.internal) {
+              self->mail(events).send(subscriber.receiver);
             }
           }
           if (retention_policy.should_be_persisted(events)) {
@@ -183,18 +192,31 @@ auto importer::make_behavior() -> importer_actor::behavior_type {
       return {};
     },
     [this](atom::get, receiver_actor<table_slice>& subscriber, bool internal,
-           bool live, bool recent) -> caf::result<std::vector<table_slice>> {
+           bool live, bool recent,
+           bool eager) -> caf::result<std::vector<table_slice>> {
       auto rp = self->make_response_promise<std::vector<table_slice>>();
       if (live) {
         self->monitor(subscriber, [this, source = subscriber->address()](
                                     const caf::error&) {
-          const auto it = std::remove_if(subscribers.begin(), subscribers.end(),
-                                         [&](const auto& sub) {
-                                           return sub.first.address() == source;
-                                         });
+          const auto it = std::remove_if(
+            subscribers.begin(), subscribers.end(), [&](const auto& sub) {
+              return sub.receiver.address() == source;
+            });
           subscribers.erase(it, subscribers.end());
         });
-        subscribers.emplace_back(std::move(subscriber), internal);
+        subscribers.emplace_back(std::move(subscriber), internal, eager);
+        if (eager) {
+          for (const auto& [schema, buffered] : unpersisted_events) {
+            if (schema.attribute("internal").has_value() != internal) {
+              continue;
+            }
+            for (const auto& slice : buffered) {
+              auto events = slice;
+              events.import_time(time::clock::now());
+              self->mail(events).send(subscribers.back().receiver);
+            }
+          }
+        }
       }
       // We must call the index ourselves here in order to return a consistent
       // state if both `live` and `recent` are set.

--- a/nix/tenzir/plugins/source.json
+++ b/nix/tenzir/plugins/source.json
@@ -1,5 +1,5 @@
 {
-  "hash": "sha256-aZzYCnBsHQvoGtZbwcvH/2o4/SxtQk+6dFbFk7ZpRLk=",
+  "hash": "sha256-gDd+o/5EdiEg+mISM+vv1N5lHKmtqQ0P4RFKfTlJ6nE=",
   "name": "tenzir-plugins.tar.gz",
-  "url": "https://github.com/tenzir/tenzir-plugins/archive/5a6f7fdd3cd07e7f262bb415c47c89b73ee40d92.tar.gz"
+  "url": "https://github.com/tenzir/tenzir-plugins/archive/07c0dfd5fae411602bffec35355eaf784f76c7cd.tar.gz"
 }

--- a/test/tests/node/importer/live_delivery.py
+++ b/test/tests/node/importer/live_delivery.py
@@ -1,0 +1,71 @@
+# fixtures: [node]
+# timeout: 30
+
+"""Verify that regular live exports retain flush-time delivery."""
+
+from __future__ import annotations
+
+import json
+import select
+import shlex
+import subprocess
+import time
+
+
+def start_pipeline(env: dict[str, str], source: str) -> subprocess.Popen[str]:
+    return subprocess.Popen(
+        [
+            *shlex.split(env["TENZIR_NODE_CLIENT_BINARY"]),
+            "--bare-mode",
+            "--console-verbosity=warning",
+            "--multi",
+            f"--endpoint={env['TENZIR_NODE_CLIENT_ENDPOINT']}",
+            source,
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def read_line(process: subprocess.Popen[str], timeout: float) -> str | None:
+    assert process.stdout is not None
+    readable, _, _ = select.select([process.stdout], [], [], timeout)
+    return process.stdout.readline() if readable else None
+
+
+def stop(process: subprocess.Popen[str]) -> None:
+    if process.poll() is None:
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
+
+
+node = acquire_fixture("node")
+node.start()
+processes: list[subprocess.Popen[str]] = []
+
+try:
+    live = start_pipeline(
+        node.env,
+        'export live=true\nwhere value == "live"\nwrite_ndjson\n',
+    )
+    importer = start_pipeline(node.env, "read_ndjson\nimport\n")
+    processes.extend([live, importer])
+    time.sleep(0.2)
+    assert importer.stdin is not None
+    importer.stdin.write(json.dumps({"value": "live"}) + "\n")
+    importer.stdin.flush()
+
+    assert read_line(live, 0.5) is None, "live export bypassed the import buffer"
+    event = read_line(live, 5)
+    assert event and json.loads(event)["value"] == "live"
+    print("ok: regular live exports retain flush-time delivery")
+finally:
+    for process in reversed(processes):
+        stop(process)
+    node.stop()

--- a/test/tests/node/importer/live_delivery.txt
+++ b/test/tests/node/importer/live_delivery.txt
@@ -1,0 +1,1 @@
+ok: regular live exports retain flush-time delivery

--- a/test/tests/node/importer/tenzir-node.yaml
+++ b/test/tests/node/importer/tenzir-node.yaml
@@ -1,0 +1,2 @@
+tenzir:
+  import-buffer-timeout: 3s

--- a/test/tests/node/importer/unbuffered/tenzir-node.yaml
+++ b/test/tests/node/importer/unbuffered/tenzir-node.yaml
@@ -1,0 +1,2 @@
+tenzir:
+  import-buffer-timeout: 0s

--- a/test/tests/node/importer/unbuffered/unbuffered.py
+++ b/test/tests/node/importer/unbuffered/unbuffered.py
@@ -1,0 +1,23 @@
+# fixtures: [node]
+# timeout: 30
+
+"""Verify that an unbuffered importer still retains imported events."""
+
+from __future__ import annotations
+
+import json
+
+
+node = acquire_fixture("node")
+node.start()
+tenzir = Executor.from_env(node.env)
+
+try:
+    result = tenzir.run('from {value: "unbuffered"}\nimport\n')
+    assert result.returncode == 0, result.stderr.decode()
+    result = tenzir.run('export\nwhere value == "unbuffered"\nwrite_ndjson\n')
+    assert result.returncode == 0, result.stderr.decode()
+    assert json.loads(result.stdout.decode())["value"] == "unbuffered"
+    print("ok: unbuffered import persists events")
+finally:
+    node.stop()

--- a/test/tests/node/importer/unbuffered/unbuffered.txt
+++ b/test/tests/node/importer/unbuffered/unbuffered.txt
@@ -1,0 +1,1 @@
+ok: unbuffered import persists events


### PR DESCRIPTION
## 🔍 Problem

Pipeline activity metrics are delayed by the importer batching interval. Making
ordinary export bridges eager would change their retro/live delivery semantics.

## 🛠️ Solution

- Add an internal eager importer subscription used by pipeline activity only.
- Preserve the existing flush-time path for ordinary exports and metrics.
- Retain slices when `tenzir.import-buffer-timeout` is `0s`.

## 💬 Review

Focus on the eager subscriber split: it receives buffered and incoming slices
directly, while normal bridges keep the established flush-time behavior.

<sub>
📎 Related: tenzir/tenzir-plugins#591
</sub>