### PR TITLE
Fix `fanout_counter` running both continuations

### DIFF
--- a/changelog/unreleased/compactor-no-longer-abandons-continuation-handlers-spuriously.md
+++ b/changelog/unreleased/compactor-no-longer-abandons-continuation-handlers-spuriously.md
@@ -1,0 +1,16 @@
+---
+title: Compactor no longer abandons continuation handlers spuriously
+type: bugfix
+authors:
+  - IyeOnline
+prs:
+  - 6470
+created: 2026-07-23T14:35:31.329568Z
+---
+
+The compactor no longer logs spurious "*compactor abandons continuation handler
+for run N because it is not the current run anymore*" messages during temporal
+and spatial compaction runs.
+
+These log messages were harmless overall, caused by a failure during compaction
+which did not properly stop the compaction run.

--- a/libtenzir/include/tenzir/detail/fanout_counter.hpp
+++ b/libtenzir/include/tenzir/detail/fanout_counter.hpp
@@ -87,6 +87,7 @@ private:
         } else {
           error(errors);
         }
+        return;
       }
       then();
     } else {
@@ -96,6 +97,7 @@ private:
         } else {
           error(std::move(state_), errors);
         }
+        return;
       }
       then(std::move(state_));
     }


### PR DESCRIPTION
The `detail::fanout_counter` could erroneously run both the success
and error continuation.

In the concrete case, this would trigger a compaction run to both be
finished due to error and continued, which then led to the compactor
abandoning its continuations since the run was (also) finished.
