### PR TITLE
Fix chunk lifetime and file truncation defects behind Feather store corruption

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,6 +371,11 @@ cmake_dependent_option(
   TENZIR_ENABLE_STATIC_EXECUTABLE "Link Tenzir statically."
   "$ENV{TENZIR_ENABLE_STATIC_EXECUTABLE}" "NOT BUILD_SHARED_LIBS" OFF)
 if (TENZIR_ENABLE_STATIC_EXECUTABLE)
+  # fizz discovers libsodium through its bundled FindSodium module. Ensure it
+  # selects the static archive before its package configuration is loaded.
+  set(sodium_USE_STATIC_LIBS
+      ON
+      CACHE BOOL "enable to statically link against sodium" FORCE)
   # Not desired on darwin.
   if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
     # This works with clang as well, so we don't need an extra condition here.

--- a/changelog/unreleased/fixes-for-corrupt-persisted-store-files.md
+++ b/changelog/unreleased/fixes-for-corrupt-persisted-store-files.md
@@ -1,0 +1,26 @@
+---
+title: Fixes for corrupt persisted store files
+type: bugfix
+authors:
+  - tobim
+  - claude
+prs:
+  - 6471
+created: 2026-07-24T10:29:01.085347Z
+---
+
+Tenzir nodes no longer risk writing stale memory or leftover file contents into
+persisted store files.
+
+Three defects that could corrupt data written to disk are fixed:
+
+- Overwriting an existing file with shorter content no longer leaves trailing
+  bytes from the previous version. This could previously produce store files
+  with garbage after the payload when a temporary file path was reused.
+- An internal buffer handle that had been moved from still appeared valid and
+  could hand out memory it no longer kept alive, allowing freed and reused
+  memory to end up in files written to disk. Moved-from handles now behave
+  like empty ones.
+- With `TENZIR_ALLOC_ACTOR_STATS=true`, the reported usable size of an
+  allocation included internal bookkeeping bytes, which could cause writes
+  beyond the actual allocation.

--- a/changelog/unreleased/fixes-for-corrupt-persisted-store-files.md
+++ b/changelog/unreleased/fixes-for-corrupt-persisted-store-files.md
@@ -12,7 +12,7 @@ created: 2026-07-24T10:29:01.085347Z
 Tenzir nodes no longer risk writing stale memory or leftover file contents into
 persisted store files.
 
-Three defects that could corrupt data written to disk are fixed:
+Two defects that could corrupt data written to disk are fixed:
 
 - Overwriting an existing file with shorter content no longer leaves trailing
   bytes from the previous version. This could previously produce store files
@@ -21,6 +21,3 @@ Three defects that could corrupt data written to disk are fixed:
   could hand out memory it no longer kept alive, allowing freed and reused
   memory to end up in files written to disk. Moved-from handles now behave
   like empty ones.
-- With `TENZIR_ALLOC_ACTOR_STATS=true`, the reported usable size of an
-  allocation included internal bookkeeping bytes, which could cause writes
-  beyond the actual allocation.

--- a/libtenzir/include/tenzir/allocator.hpp
+++ b/libtenzir/include/tenzir/allocator.hpp
@@ -842,7 +842,8 @@ public:
         std::_Exit(EXIT_FAILURE);
         return 0;
       }
-      return Traits::usable_size(storage_ptr);
+      return Traits::usable_size(storage_ptr)
+             - tag.source_identifier.alignment().value();
     }
     return Traits::usable_size(ptr);
   }

--- a/libtenzir/include/tenzir/chunk.hpp
+++ b/libtenzir/include/tenzir/chunk.hpp
@@ -63,11 +63,12 @@ public:
     // Clear the view explicitly so that using a moved-from chunk_ptr behaves
     // like using a null chunk_ptr instead of silently reading freed memory.
     proxy(proxy&& other) noexcept
-      : ptr_{std::move(other.ptr_)}, view_{std::exchange(other.view_, {})} {
+      : ptr_{std::exchange(other.ptr_, {})},
+        view_{std::exchange(other.view_, {})} {
     }
 
     auto operator=(proxy&& other) noexcept -> proxy& {
-      ptr_ = std::move(other.ptr_);
+      ptr_ = std::exchange(other.ptr_, {});
       view_ = std::exchange(other.view_, {});
       return *this;
     }

--- a/libtenzir/include/tenzir/chunk.hpp
+++ b/libtenzir/include/tenzir/chunk.hpp
@@ -54,6 +54,26 @@ public:
       : ptr_{std::move(ptr)}, view_{view} {
     }
 
+    proxy(const proxy&) = default;
+    auto operator=(const proxy&) -> proxy& = default;
+
+    // The implicit member-wise move would null `ptr_` but leave `view_`
+    // intact, making a moved-from proxy indistinguishable from a valid
+    // non-owning view while it no longer keeps the pointed-to data alive.
+    // Clear the view explicitly so that using a moved-from chunk_ptr behaves
+    // like using a null chunk_ptr instead of silently reading freed memory.
+    proxy(proxy&& other) noexcept
+      : ptr_{std::move(other.ptr_)}, view_{std::exchange(other.view_, {})} {
+    }
+
+    auto operator=(proxy&& other) noexcept -> proxy& {
+      ptr_ = std::move(other.ptr_);
+      view_ = std::exchange(other.view_, {});
+      return *this;
+    }
+
+    ~proxy() = default;
+
     auto view() const noexcept -> view_type {
       return view_;
     }

--- a/libtenzir/include/tenzir/file.hpp
+++ b/libtenzir/include/tenzir/file.hpp
@@ -56,7 +56,10 @@ public:
   /// Opens the file.
   /// @param mode How to open the file. If not equal to `read_only`, the
   ///             function attempts to create non-existing parent directories.
-  /// @param append If `false`, the first write truncates the file.
+  ///             Opening an existing file in `write_only` mode truncates it
+  ///             unless *append* is `true`; `read_write` opens are
+  ///             non-destructive.
+  /// @param append If `true`, all writes go to the end of the file.
   /// @returns `true` on success.
   caf::expected<void> open(open_mode mode = read_write, bool append = false);
 

--- a/libtenzir/src/file.cpp
+++ b/libtenzir/src/file.cpp
@@ -70,7 +70,7 @@ caf::expected<void> file::open(open_mode mode, bool append) {
   }
   if (append) {
     flags |= O_APPEND;
-  } else if (mode != read_only) {
+  } else if (mode == write_only) {
     flags |= O_TRUNC;
   }
   errno = 0;

--- a/libtenzir/src/file.cpp
+++ b/libtenzir/src/file.cpp
@@ -70,6 +70,8 @@ caf::expected<void> file::open(open_mode mode, bool append) {
   }
   if (append) {
     flags |= O_APPEND;
+  } else if (mode != read_only) {
+    flags |= O_TRUNC;
   }
   errno = 0;
   std::error_code err{};

--- a/libtenzir/test/CMakeLists.txt
+++ b/libtenzir/test/CMakeLists.txt
@@ -21,6 +21,26 @@ list(SORT test_headers)
 
 # Add tenzir-unit-test executable.
 add_executable(tenzir-unit-test ${test_sources} ${test_headers})
+if (TENZIR_ENABLE_STATIC_EXECUTABLE
+    AND NOT "${TENZIR_ALLOCATOR}" STREQUAL "none"
+    AND NOT APPLE)
+  target_sources(
+    tenzir-unit-test PRIVATE "${PROJECT_SOURCE_DIR}/tenzir/operator_new.cpp"
+                             "${PROJECT_SOURCE_DIR}/tenzir/malloc.cpp")
+  target_link_options(
+    tenzir-unit-test
+    BEFORE
+    PRIVATE
+    LINKER:--wrap=malloc
+    LINKER:--wrap=calloc
+    LINKER:--wrap=realloc
+    LINKER:--wrap=reallocarray
+    LINKER:--wrap=aligned_alloc
+    LINKER:--wrap=malloc_usable_size
+    LINKER:--wrap=memalign
+    LINKER:--wrap=posix_memalign
+    LINKER:--wrap=free)
+endif ()
 TenzirTargetEnableTooling(tenzir-unit-test)
 target_link_libraries(
   tenzir-unit-test PRIVATE tenzir::test tenzir::libtenzir tenzir::internal

--- a/libtenzir/test/chunk.cpp
+++ b/libtenzir/test/chunk.cpp
@@ -101,6 +101,29 @@ TEST("as_bytes") {
   CHECK_EQUAL(bytes, as_bytes(x));
 }
 
+TEST("moved-from chunk_ptr is empty") {
+  auto x = chunk::make(std::string{"foobarbaz"});
+  REQUIRE(x);
+  // Move construction must not leave the source pointing at data it no
+  // longer keeps alive.
+  auto y = std::move(x);
+  CHECK(y);
+  CHECK(not x);                             // NOLINT(bugprone-use-after-move)
+  CHECK_EQUAL(as_bytes(x).size(), 0u);      // NOLINT(bugprone-use-after-move)
+  CHECK_EQUAL(as_bytes(x).data(), nullptr); // NOLINT(bugprone-use-after-move)
+  // The same holds for move assignment.
+  auto z = chunk::make(std::string{"quxquux"});
+  z = std::move(y);
+  CHECK(z);
+  CHECK(not y);                        // NOLINT(bugprone-use-after-move)
+  CHECK_EQUAL(as_bytes(y).size(), 0u); // NOLINT(bugprone-use-after-move)
+  // Slices of a moved-from chunk_ptr are unaffected.
+  auto s = z->slice(3, 3);
+  auto w = std::move(z);
+  CHECK_EQUAL(s->size(), 3u);
+  CHECK_EQUAL(w->size(), 9u);
+}
+
 namespace {
 
 struct fixture : public fixtures::filesystem {


### PR DESCRIPTION
## 🔍 Problem

Static-build deployments produced corrupt Feather store files. Byte-level analysis of five quarantined stores shows writes whose source span is displaced from the true Arrow buffer by small offsets at the start and/or end, with the foreign bytes being raw in-process heap memory (contiguous `partition_info` runs from active rebuilds, live pointers). This points at a stale `chunk_ptr` span outliving its owner, with the freed memory reused before the write. Details in the investigation notes on this branch's context.

Additionally, the static unit-test binary linked against the system allocator instead of the production allocator wrappers, so allocator-dependent bugs were untestable, and two independent defects surfaced during the investigation.

## 🛠️ Solution

- `chunk_ptr`: define the proxy's move operations explicitly so moving clears the span. Previously the implicit move nulled the intrusive pointer but kept the span, so a moved-from `chunk_ptr` still compared as valid and handed out a span it no longer kept alive — turning any use-after-move into a silent read of freed (and possibly reused) memory instead of a crash.
- `file::open()`: add `O_TRUNC` for non-read-only, non-append opens. A stale, longer `<filename>.tmp` from `io::save()` previously left trailing garbage after a shorter payload written to the same path — reproduces one of the observed corruption shapes (valid Feather footer followed by stale bytes).
- Allocator: with actor stats enabled, `size()` now subtracts the allocation-tag prefix so `malloc_usable_size` no longer reports bytes outside the user allocation as usable.
- Build: link `tenzir-unit-test` with the same `--wrap` allocator options as the static executable, and force static libsodium in static builds.

## 💬 Review

- The `chunk_ptr` move fix changes moved-from semantics from "valid-looking view" to "null". Code relying on the old behavior was already broken; a new unit test covers move construction, assignment, and slices.
- No specific use-after-move call site has been pinned down yet, so the corruption root cause is strongly suspected but not proven; the other fixes are independently correct.
- Full static-release unit suite passes (116 suites, 7793 checks) with the allocator wrappers now active.
