### PR TITLE
Add new meta programming utilities

### DIFF
--- a/libtenzir/include/tenzir/concepts.hpp
+++ b/libtenzir/include/tenzir/concepts.hpp
@@ -131,4 +131,23 @@ concept none_of = not one_of<T, Ts...>;
 template <class T>
 concept unqualified = std::same_as<T, std::remove_cvref_t<T>>;
 
+template <typename T>
+concept complete = requires(T t) { requires sizeof(T) > 0; };
+
+namespace detail {
+
+template <typename T, template <typename...> class C>
+struct instantiation_of_impl : std::false_type {};
+
+template <template <typename...> class C, typename... Args>
+struct instantiation_of_impl<C<Args...>, C> : std::true_type {};
+
+} // namespace detail
+
+template <typename T, template <typename...> class C>
+concept instantiation_of = detail::instantiation_of_impl<T, C>::value;
+
+template <typename T, template <typename...> class... Cs>
+concept instantiation_of_one_of = (instantiation_of<T, Cs> or ...);
+
 } // namespace tenzir::concepts

--- a/libtenzir/include/tenzir/type_list.hpp
+++ b/libtenzir/include/tenzir/type_list.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include "tenzir/concepts.hpp"
+
+#include <optional>
+
+namespace tenzir {
+template <typename... Ts>
+struct TypeList;
+
+namespace detail {
+template <concepts::instantiation_of<TypeList> L, typename... Rs>
+struct JoinLists;
+
+template <typename... L, typename... R>
+struct JoinLists<TypeList<L...>, R...>
+  : std::type_identity<TypeList<L..., R...>> {};
+
+template <typename... L, typename... R>
+struct JoinLists<TypeList<L...>, TypeList<R...>>
+  : std::type_identity<TypeList<L..., R...>> {};
+
+template <typename T, typename... Ts>
+struct tuple_index;
+
+template <typename T, typename... Ts>
+consteval auto unique_index_of() noexcept -> std::size_t {
+  constexpr static std::array found = {std::same_as<T, Ts>...};
+  constexpr static auto size = std::size(found);
+  constexpr auto index = []() -> std::optional<std::size_t> {
+    auto last = std::optional<std::size_t>{};
+    for (std::size_t i = 0; i < size; ++i) {
+      if (found[i]) {
+        if (last) {
+          return std::nullopt;
+        }
+        last = i;
+      }
+    }
+    return last;
+  }();
+  static_assert(index, "T must be unique in type list");
+  return *index;
+}
+} // namespace detail
+
+template <typename... Ts>
+struct TypeList {
+  constexpr static auto size = sizeof...(Ts);
+
+  template <typename T>
+  constexpr static bool contains = concepts::one_of<T, Ts...>;
+
+  template <typename T>
+  constexpr static auto unique_index_of = detail::unique_index_of<T, Ts...>();
+
+  template <size_t I>
+    requires(I < size)
+  using at = std::tuple_element_t<I, std::tuple<Ts...>>;
+
+  template <template <typename...> class C>
+  using apply = C<Ts...>;
+
+  template <template <typename> class T>
+  using wrap = TypeList<T<Ts>...>;
+
+  template <template <typename> class T>
+  using transform = TypeList<typename T<Ts>::type...>;
+
+  template <template <typename> class T>
+  constexpr static bool all_of = (T<Ts>::value && ...);
+
+  template <typename... Rs>
+  using join = typename detail::JoinLists<TypeList<Ts...>, Rs...>::type;
+
+  constexpr static auto index_sequence = std::index_sequence_for<Ts...>{};
+};
+} // namespace tenzir

--- a/libtenzir/include/tenzir/type_traits.hpp
+++ b/libtenzir/include/tenzir/type_traits.hpp
@@ -9,13 +9,51 @@
 #pragma once
 
 #include <string_view>
-#include <utility>
 
 namespace tenzir {
 
-/// The return type of `std::forward_like<T>(u)`.
+template <typename T, typename U>
+struct transfer_qualifiers {
+private:
+  using R = std::remove_reference_t<T>;
+  using U0 = std::remove_reference_t<U>;
+  using U1 = std::conditional_t<std::is_const_v<R>, std::add_const_t<U0>, U0>;
+  using U2
+    = std::conditional_t<std::is_volatile_v<R>, std::add_volatile_t<U1>, U1>;
+  using U3 = std::conditional_t<std::is_lvalue_reference_v<T>,
+                                std::add_lvalue_reference_t<U2>, U2>;
+  using U4 = std::conditional_t<std::is_rvalue_reference_v<T>,
+                                std::add_rvalue_reference_t<U3>, U3>;
+
+public:
+  using type = U4;
+};
+
+template <typename T, typename U>
+struct forward_like_type {
+  constexpr static bool needs_const
+    = std::is_const_v<std::remove_reference_t<T>>
+      or std::is_const_v<std::remove_reference_t<U>>;
+  constexpr static bool lvalue_ref = std::is_lvalue_reference_v<T>;
+  using P = std::remove_const_t<std::remove_reference_t<U>>;
+  using with_const = std::conditional_t<needs_const, const P, P>;
+
+public:
+  using type = std::conditional_t<lvalue_ref, with_const&, with_const&&>;
+};
+
+template <typename T, typename U>
+using forward_like_type_t = typename forward_like_type<T, U>::type;
+
+// NOLINTBEGIN
+template <typename T, typename U>
+constexpr auto forward_like(U&& u) noexcept -> forward_like_type_t<T, U> {
+  return static_cast<forward_like_type_t<T, U>>(u);
+}
+// NOLINTEND
+
 template <class T, class U>
-using ForwardLike = decltype(std::forward_like<T>(std::declval<U>()));
+using ForwardLike = forward_like_type_t<T, U>;
 
 /// Returns a human-readable name for type `T`.
 template <typename T>

--- a/libtenzir/include/tenzir/variant_traits.hpp
+++ b/libtenzir/include/tenzir/variant_traits.hpp
@@ -155,7 +155,7 @@ constexpr auto variant_get(V&& v) -> decltype(auto) {
   using traits = variant_traits<std::remove_cvref_t<V>>;
   if constexpr (std::is_reference_v<decltype(traits::template get<I>(v))>) {
     // We call `as_mutable` here because `forward_like` never removes `const`.
-    return std::forward_like<V>(as_mutable(traits::template get<I>(v)));
+    return ::tenzir::forward_like<V>(as_mutable(traits::template get<I>(v)));
   } else {
     return traits::template get<I>(v);
   }

--- a/libtenzir/test/type_list.cpp
+++ b/libtenzir/test/type_list.cpp
@@ -1,0 +1,95 @@
+//
+//  ▀▀█▀▀ █▀▀▀ █▄  █ ▀▀▀█▀ ▀█▀ █▀▀▄
+//    █   █▀▀  █ ▀▄█  ▄▀    █  █▀▀▄
+//    ▀   ▀▀▀▀ ▀   ▀ ▀▀▀▀▀ ▀▀▀ ▀  ▀
+//
+// SPDX-FileCopyrightText: (c) 2026 The Tenzir Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "tenzir/type_list.hpp"
+
+#include "tenzir/test/test.hpp"
+
+#include <type_traits>
+#include <variant>
+
+namespace {
+
+using tenzir::TypeList;
+
+// -- size ---------------------------------------------------------------
+
+static_assert(TypeList<>::size == 0);
+static_assert(TypeList<int, double, float>::size == 3);
+
+// -- contains -------------------------------------------------------------
+
+static_assert(TypeList<int, double>::contains<int>);
+static_assert(not TypeList<int, double>::contains<float>);
+static_assert(not TypeList<>::contains<int>);
+
+// -- unique_index_of --------------------------------------------------------
+
+static_assert(TypeList<int, double, float>::unique_index_of<int> == 0);
+static_assert(TypeList<int, double, float>::unique_index_of<double> == 1);
+static_assert(TypeList<int, double, float>::unique_index_of<float> == 2);
+
+// -- at -----------------------------------------------------------------
+
+static_assert(std::is_same_v<TypeList<int, double, float>::at<0>, int>);
+static_assert(std::is_same_v<TypeList<int, double, float>::at<1>, double>);
+static_assert(std::is_same_v<TypeList<int, double, float>::at<2>, float>);
+
+// -- apply ----------------------------------------------------------------
+
+template <typename... Ts>
+struct count_types : std::integral_constant<std::size_t, sizeof...(Ts)> {};
+
+static_assert(TypeList<int, double, float>::apply<count_types>::value == 3);
+static_assert(std::is_same_v<TypeList<int, double>::apply<std::variant>,
+                             std::variant<int, double>>);
+
+// -- wrap -----------------------------------------------------------------
+
+static_assert(std::is_same_v<TypeList<int, double>::wrap<std::add_pointer_t>,
+                             TypeList<int*, double*>>);
+
+// -- transform ------------------------------------------------------------
+
+template <typename T>
+struct add_const_helper : std::type_identity<const T> {};
+
+static_assert(std::is_same_v<TypeList<int, double>::transform<add_const_helper>,
+                             TypeList<const int, const double>>);
+
+// -- all_of -----------------------------------------------------------------
+
+struct not_arithmetic {};
+
+static_assert(TypeList<int, double>::all_of<std::is_arithmetic>);
+static_assert(not TypeList<int, not_arithmetic>::all_of<std::is_arithmetic>);
+static_assert(TypeList<>::all_of<std::is_arithmetic>);
+
+// -- join -------------------------------------------------------------------
+
+static_assert(std::is_same_v<TypeList<int>::join<double, float>,
+                             TypeList<int, double, float>>);
+static_assert(std::is_same_v<TypeList<int>::join<TypeList<double, float>>,
+                             TypeList<int, double, float>>);
+static_assert(std::is_same_v<TypeList<>::join<TypeList<>>, TypeList<>>);
+
+// -- index_sequence -----------------------------------------------------------
+
+static_assert(
+  std::is_same_v<
+    std::remove_const_t<decltype(TypeList<int, double, float>::index_sequence)>,
+    std::index_sequence<0, 1, 2>>);
+static_assert(
+  std::is_same_v<std::remove_const_t<decltype(TypeList<>::index_sequence)>,
+                 std::index_sequence<>>);
+
+} // namespace
+
+TEST("TypeList dummy") {
+  // Empty test suites are not allowed.
+}


### PR DESCRIPTION
This simply adds a few metaprogramming utilities, such as a useful `TypeList`
and `forward_like` that actually has a return type.
